### PR TITLE
Fix crash on .assign() with move semantics

### DIFF
--- a/test/json_write_test.cc
+++ b/test/json_write_test.cc
@@ -477,45 +477,10 @@ TEST(CATEGORY, array_push_front) {
             2);
 }
 
-// TEST(CATEGORY, map_copy_constructor) {
-// const sourcemeta::jsontoolkit::JSON
-// document{sourcemeta::jsontoolkit::parse("{\"foo\":1}")};
-// EXPECT_TRUE(sourcemeta::jsontoolkit::is_object(document));
-// EXPECT_EQ(sourcemeta::jsontoolkit::size(document), 1);
-// EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "foo"));
-// EXPECT_TRUE(document.at("foo").is_integer());
-// const std::map<std::string, sourcemeta::jsontoolkit::JSON<std::string>>
-// value{
-// {"bar", 5}};
-// document.assign("xxx", value);
-// EXPECT_EQ(sourcemeta::jsontoolkit::size(document), 2);
-// EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "foo"));
-// EXPECT_TRUE(document.at("foo").is_integer());
-// EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "xxx"));
-// EXPECT_TRUE(document.at("xxx").is_object());
-// EXPECT_EQ(document.at("xxx").size(), 1);
-// EXPECT_TRUE(document.at("xxx").defines(document, "bar"));
-// EXPECT_TRUE(document.at("xxx").at("bar").is_integer());
-// EXPECT_EQ(document.at("xxx").at("bar"), 5);
-// }
-
-// TEST(CATEGORY, map_move_constructor) {
-// const sourcemeta::jsontoolkit::JSON
-// document{sourcemeta::jsontoolkit::parse("{\"foo\":1}")};
-// EXPECT_TRUE(sourcemeta::jsontoolkit::is_object(document));
-// EXPECT_EQ(sourcemeta::jsontoolkit::size(document), 1);
-// EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "foo"));
-// EXPECT_TRUE(document.at("foo").is_integer());
-// std::map<std::string, sourcemeta::jsontoolkit::JSON<std::string>> value{
-// {"bar", 5}};
-// document.assign("xxx", std::move(value));
-// EXPECT_EQ(sourcemeta::jsontoolkit::size(document), 2);
-// EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "foo"));
-// EXPECT_TRUE(document.at("foo").is_integer());
-// EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "xxx"));
-// EXPECT_TRUE(document.at("xxx").is_object());
-// EXPECT_EQ(document.at("xxx").size(), 1);
-// EXPECT_TRUE(document.at("xxx").defines(document, "bar"));
-// EXPECT_TRUE(document.at("xxx").at("bar").is_integer());
-// EXPECT_EQ(document.at("xxx").at("bar"), 5);
-// }
+TEST(CATEGORY, assign_move_empty_object) {
+  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::parse("{}")};
+  EXPECT_TRUE(sourcemeta::jsontoolkit::empty(document));
+  sourcemeta::jsontoolkit::assign(document, "foo",
+                                  sourcemeta::jsontoolkit::from(true));
+  EXPECT_TRUE(sourcemeta::jsontoolkit::defines(document, "foo"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
