### PR TITLE
Support from() when passing a zero literal

### DIFF
--- a/include/jsontoolkit/json/rapidjson/read.h
+++ b/include/jsontoolkit/json/rapidjson/read.h
@@ -62,13 +62,19 @@ inline auto from(const std::string &value) -> JSON {
   return document;
 }
 
-inline auto from(std::nullptr_t) -> JSON { return parse("null"); }
-
-inline auto from(std::int64_t value) -> JSON {
+template <typename T>
+typename std::enable_if_t<std::is_same_v<T, std::int64_t>, JSON> from(T value) {
   rapidjson::Document document;
   document.SetInt64(value);
   return document;
 }
+
+template <typename T>
+typename std::enable_if_t<std::is_same_v<T, int>, JSON> from(T value) {
+  return from(static_cast<std::int64_t>(value));
+}
+
+inline auto from(std::nullptr_t) -> JSON { return parse("null"); }
 
 template <typename T>
 typename std::enable_if_t<std::is_same_v<T, double>, JSON> from(T value) {

--- a/test/json/json_read_test.cc
+++ b/test/json/json_read_test.cc
@@ -379,6 +379,13 @@ TEST(JSON, array_equality_with_padding) {
   EXPECT_FALSE(right == extra);
 }
 
+TEST(JSON, from_zero) {
+  const sourcemeta::jsontoolkit::JSON document{
+      sourcemeta::jsontoolkit::from(0)};
+  EXPECT_TRUE(sourcemeta::jsontoolkit::is_integer(document));
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(document), 0);
+}
+
 TEST(JSON, from_real_number) {
   const sourcemeta::jsontoolkit::JSON document{
       sourcemeta::jsontoolkit::from(3.4)};


### PR DESCRIPTION
C++ otherwise considers the call ambiguous between `std::int64_t` and
`std::nullptr_t`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
