### PR TITLE
Add easy-to-use range-based for loop support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -693,6 +693,8 @@ always refer to these types using `auto`.
 
 `Iterator end_object(JSON & | Value &)`
 
+`ObjectIteratorWrapper object_iterator(JSON & | Value &)`
+
 These functions provide mutable
 [random-access](https://en.cppreference.com/w/cpp/iterator/random_access_iterator)
 object iterators. The iteration order is not guaranteed. These functions are
@@ -715,11 +717,29 @@ std::for_each(sourcemeta::jsontoolkit::begin_object(document),
               });
 ```
 
+The third function provides a convenience interface to range-based `for` loops.
+For example:
+
+```c++
+#include <jsontoolkit/json.h>
+#include <iostream>
+
+sourcemeta::jsontoolkit::JSON document{
+  sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }")};
+
+for (auto &pair : sourcemeta::jsontoolkit::object_iterator(document)) {
+  std::cout << sourcemeta::jsontoolkit::key(pair) << ": "
+    << sourcemeta::jsontoolkit::to_integer(sourcemeta::jsontoolkit::value(pair)) << "\n";
+}
+```
+
 #### Const object iterators
 
 `ConstIterator cbegin_object(const JSON & | const Value &)`
 
 `ConstIterator cend_object(const JSON & | const Value &)`
+
+`ConstObjectIteratorWrapper object_iterator(const JSON & | const Value &)`
 
 These functions provide immutable
 [random-access](https://en.cppreference.com/w/cpp/iterator/random_access_iterator)
@@ -743,11 +763,29 @@ std::for_each(sourcemeta::jsontoolkit::cbegin_object(document),
               });
 ```
 
+The third function provides a convenience interface to range-based `for` loops.
+For example:
+
+```c++
+#include <jsontoolkit/json.h>
+#include <iostream>
+
+const sourcemeta::jsontoolkit::JSON document{
+  sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }")};
+
+for (const auto &pair : sourcemeta::jsontoolkit::object_iterator(document)) {
+  std::cout << sourcemeta::jsontoolkit::key(pair) << ": "
+    << sourcemeta::jsontoolkit::to_integer(sourcemeta::jsontoolkit::value(pair)) << "\n";
+}
+```
+
 #### Mutable array iterators
 
 `Iterator begin_array(JSON & | Value &)`
 
 `Iterator end_array(JSON & | Value &)`
+
+`ArrayIteratorWrapper array_iterator(JSON & | Value &)`
 
 These functions provide mutable
 [bidirectional](https://en.cppreference.com/w/cpp/iterator/bidirectional_iterator)
@@ -768,6 +806,21 @@ std::for_each(sourcemeta::jsontoolkit::begin_array(document),
                   sourcemeta::jsontoolkit::set(
                     document, element, sourcemeta::jsontoolkit::from(current + 1));
               });
+```
+
+The third function provides a convenience interface to range-based `for` loops.
+For example:
+
+```c++
+#include <jsontoolkit/json.h>
+#include <iostream>
+
+sourcemeta::jsontoolkit::JSON document{
+  sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]")};
+
+for (auto &element : sourcemeta::jsontoolkit::array_iterator(document)) {
+  std::cout << sourcemeta::jsontoolkit::to_integer(element) << "\n";
+}
 ```
 
 #### Reverse mutable array iterators
@@ -803,6 +856,8 @@ std::for_each(sourcemeta::jsontoolkit::rbegin_array(document),
 
 `ConstIterator cend_array(const JSON & | const Value &)`
 
+`ConstArrayIteratorWrapper array_iterator(const JSON & | const Value &)`
+
 These functions provide immutable
 [bidirectional](https://en.cppreference.com/w/cpp/iterator/bidirectional_iterator)
 array iterators. The iteration order is from start to end. These functions are
@@ -823,6 +878,21 @@ std::for_each(sourcemeta::jsontoolkit::cbegin_array(document),
                           << sourcemeta::jsontoolkit::to_integer(element)
                           << "\n";
               });
+```
+
+The third function provides a convenience interface to range-based `for` loops.
+For example:
+
+```c++
+#include <jsontoolkit/json.h>
+#include <iostream>
+
+const sourcemeta::jsontoolkit::JSON document{
+  sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]")};
+
+for (const auto &element : sourcemeta::jsontoolkit::array_iterator(document)) {
+  std::cout << sourcemeta::jsontoolkit::to_integer(element) << "\n";
+}
 ```
 
 #### Reverse const array iterators

--- a/include/jsontoolkit/json/iterators.h
+++ b/include/jsontoolkit/json/iterators.h
@@ -7,4 +7,70 @@
 #error Unknown JSON Toolkit backend
 #endif
 
+namespace sourcemeta::jsontoolkit {
+
+class ArrayIteratorWrapper {
+public:
+  ArrayIteratorWrapper(Value &input) : data{input} { assert(is_array(input)); }
+  auto begin() -> decltype(auto) { return begin_array(this->data); }
+  auto end() -> decltype(auto) { return end_array(this->data); }
+
+private:
+  Value &data;
+};
+
+class ConstArrayIteratorWrapper {
+public:
+  ConstArrayIteratorWrapper(const Value &input) : data{input} {
+    assert(is_array(input));
+  }
+  auto begin() const -> decltype(auto) { return cbegin_array(this->data); }
+  auto end() const -> decltype(auto) { return cend_array(this->data); }
+
+private:
+  const Value &data;
+};
+
+inline auto array_iterator(const Value &value) -> ConstArrayIteratorWrapper {
+  return ConstArrayIteratorWrapper{value};
+}
+
+inline auto array_iterator(Value &value) -> ArrayIteratorWrapper {
+  return ArrayIteratorWrapper{value};
+}
+
+class ObjectIteratorWrapper {
+public:
+  ObjectIteratorWrapper(Value &input) : data{input} {
+    assert(is_object(input));
+  }
+  auto begin() -> decltype(auto) { return begin_object(this->data); }
+  auto end() -> decltype(auto) { return end_object(this->data); }
+
+private:
+  Value &data;
+};
+
+class ConstObjectIteratorWrapper {
+public:
+  ConstObjectIteratorWrapper(const Value &input) : data{input} {
+    assert(is_object(input));
+  }
+  auto begin() const -> decltype(auto) { return cbegin_object(this->data); }
+  auto end() const -> decltype(auto) { return cend_object(this->data); }
+
+private:
+  const Value &data;
+};
+
+inline auto object_iterator(const Value &value) -> ConstObjectIteratorWrapper {
+  return ConstObjectIteratorWrapper{value};
+}
+
+inline auto object_iterator(Value &value) -> ObjectIteratorWrapper {
+  return ObjectIteratorWrapper{value};
+}
+
+} // namespace sourcemeta::jsontoolkit
+
 #endif

--- a/test/json/json_iterators_test.cc
+++ b/test/json/json_iterators_test.cc
@@ -2,6 +2,9 @@
 #include <gtest/gtest.h>
 #include <jsontoolkit/json/iterators.h>
 #include <jsontoolkit/json/read.h>
+#include <map>    // std::map
+#include <string> // std::string
+#include <vector> // std::vector
 
 TEST(JSON, array_const_iterator_for_each) {
   const sourcemeta::jsontoolkit::JSON document{
@@ -119,4 +122,63 @@ TEST(JSON, object_all_of_with_key_false) {
       sourcemeta::jsontoolkit::end_object(document),
       [](auto &pair) { return sourcemeta::jsontoolkit::key(pair).size() > 2; });
   EXPECT_FALSE(result);
+}
+
+TEST(JSON, const_array_iterator) {
+  std::vector<std::int64_t> result;
+  const sourcemeta::jsontoolkit::JSON document{
+      sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]")};
+  for (const auto &element :
+       sourcemeta::jsontoolkit::array_iterator(document)) {
+    result.push_back(sourcemeta::jsontoolkit::to_integer(element));
+  }
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_EQ(result.at(0), 1);
+  EXPECT_EQ(result.at(1), 2);
+  EXPECT_EQ(result.at(2), 3);
+}
+
+TEST(JSON, array_iterator) {
+  std::vector<std::int64_t> result;
+  sourcemeta::jsontoolkit::JSON document{
+      sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]")};
+  for (auto &element : sourcemeta::jsontoolkit::array_iterator(document)) {
+    result.push_back(sourcemeta::jsontoolkit::to_integer(element));
+  }
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_EQ(result.at(0), 1);
+  EXPECT_EQ(result.at(1), 2);
+  EXPECT_EQ(result.at(2), 3);
+}
+
+TEST(JSON, const_object_iterator) {
+  std::map<std::string, std::int64_t> result;
+  const sourcemeta::jsontoolkit::JSON document{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }")};
+  for (const auto &pair : sourcemeta::jsontoolkit::object_iterator(document)) {
+    result.insert({sourcemeta::jsontoolkit::key(pair),
+                   sourcemeta::jsontoolkit::to_integer(
+                       sourcemeta::jsontoolkit::value(pair))});
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_EQ(result.at("foo"), 1);
+  EXPECT_EQ(result.at("bar"), 2);
+}
+
+TEST(JSON, object_iterator) {
+  std::map<std::string, std::int64_t> result;
+  sourcemeta::jsontoolkit::JSON document{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }")};
+  for (auto &pair : sourcemeta::jsontoolkit::object_iterator(document)) {
+    result.insert({sourcemeta::jsontoolkit::key(pair),
+                   sourcemeta::jsontoolkit::to_integer(
+                       sourcemeta::jsontoolkit::value(pair))});
+  }
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_EQ(result.at("foo"), 1);
+  EXPECT_EQ(result.at("bar"), 2);
 }


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsontoolkit/issues/49
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
