### PR TITLE
Check vocabularies at every step in `subschema_iterator()`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1150,11 +1150,11 @@ default schema walker.
 
 #### Walk subschemas
 
-`SchemaWalker subschema_iterator(const JSON & | const Value &, const schema_walker_t &, const std::unordered_map<std::string, bool> &vocabularies)`
+`SchemaWalker subschema_iterator(const JSON & | const Value &, const schema_walker_t &, const schema_resolver_t &)`
 
 Return an read-only iterator over the subschemas of a given JSON Schema
 definition according to the applicators understood by the provided walker
-function and the vocabularies in use.
+function.
 
 For example:
 
@@ -1180,13 +1180,9 @@ const sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::parse(R"JS
 static auto my_resolver(const std::string &)
     -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> { ... }
 
-// Fetch the vocabularies in use
-const std::unordered_map<std::string, bool> vocabularies{
-    sourcemeta::jsontoolkit::vocabularies(document, my_resolver).get()};
-
 // Print every subschema
 for (const auto &subschema : sourcemeta::jsontoolkit::subschema_iterator(
-         document, sourcemeta::jsontoolkit::default_schema_walker, vocabularies)) {
+         document, sourcemeta::jsontoolkit::default_schema_walker, my_resolver)) {
   sourcemeta::jsontoolkit::prettify(subschema, std::cout);
   std::cout << "\n";
 }

--- a/contrib/jsonschema-walker/walker.cc
+++ b/contrib/jsonschema-walker/walker.cc
@@ -115,12 +115,9 @@ static auto walk(std::basic_istream<CharT, Traits> &stream) -> int {
                  "only assume the presence of the 'core' vocabulary\n";
   }
 
-  const std::unordered_map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, resolver).get()};
-
   for (const auto &subschema : sourcemeta::jsontoolkit::subschema_iterator(
            document, sourcemeta::jsontoolkit::default_schema_walker,
-           vocabularies)) {
+           resolver)) {
     sourcemeta::jsontoolkit::prettify(subschema, std::cout);
     std::cout << "\n";
   }

--- a/include/jsontoolkit/jsonschema.h
+++ b/include/jsontoolkit/jsonschema.h
@@ -21,9 +21,10 @@ auto vocabularies(
     const Value &schema, const schema_resolver_t &resolver,
     const std::optional<std::string> &default_metaschema = std::nullopt)
     -> std::future<std::unordered_map<std::string, bool>>;
-auto subschema_iterator(
-    const Value &schema, const schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) -> SchemaWalker;
+auto subschema_iterator(const Value &schema, const schema_walker_t &walker,
+                        const schema_resolver_t &resolver,
+                        const std::optional<std::string> &default_metaschema =
+                            std::nullopt) -> SchemaWalker;
 
 } // namespace sourcemeta::jsontoolkit
 

--- a/include/jsontoolkit/jsonschema/walker.h
+++ b/include/jsontoolkit/jsonschema/walker.h
@@ -2,8 +2,10 @@
 #define JSONTOOLKIT_JSONSCHEMA_WALKER_H_
 
 #include <jsontoolkit/json.h>
+#include <jsontoolkit/jsonschema/resolver.h>
 
 #include <functional>    // std::function
+#include <optional>      // std::optional
 #include <string>        // std::string
 #include <unordered_map> // std::unordered_map
 #include <vector>        // std::vector
@@ -26,7 +28,8 @@ using schema_walker_t = std::function<schema_walker_strategy_t(
 class SchemaWalker {
 public:
   SchemaWalker(const Value &input, const schema_walker_t &walker,
-               const std::unordered_map<std::string, bool> &vocabularies);
+               const schema_resolver_t &resolver,
+               const std::optional<std::string> &default_metaschema);
   inline auto begin() const -> decltype(auto) {
     return this->subschemas.cbegin();
   }
@@ -34,16 +37,17 @@ public:
 
 private:
   auto walk(const Value &subschema, const schema_walker_t &walker,
-            const std::unordered_map<std::string, bool> &vocabularies) -> void;
+            const schema_resolver_t &resolver, const std::string &metaschema)
+      -> void;
   auto walk_array(const Value &array, const schema_walker_t &walker,
-                  const std::unordered_map<std::string, bool> &vocabularies)
-      -> void;
+                  const schema_resolver_t &resolver,
+                  const std::string &metaschema) -> void;
   auto walk_object(const Value &object, const schema_walker_t &walker,
-                   const std::unordered_map<std::string, bool> &vocabularies)
-      -> void;
+                   const schema_resolver_t &resolver,
+                   const std::string &metaschema) -> void;
   auto walk_schema(const Value &schema, const schema_walker_t &walker,
-                   const std::unordered_map<std::string, bool> &vocabularies)
-      -> void;
+                   const schema_resolver_t &resolver,
+                   const std::string &metaschema) -> void;
   std::vector<std::reference_wrapper<const Value>> subschemas;
 };
 

--- a/src/jsonschema.cc
+++ b/src/jsonschema.cc
@@ -132,6 +132,8 @@ auto sourcemeta::jsontoolkit::vocabularies(
 auto sourcemeta::jsontoolkit::subschema_iterator(
     const sourcemeta::jsontoolkit::Value &schema,
     const sourcemeta::jsontoolkit::schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) -> SchemaWalker {
-  return sourcemeta::jsontoolkit::SchemaWalker{schema, walker, vocabularies};
+    const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
+    const std::optional<std::string> &default_metaschema) -> SchemaWalker {
+  return sourcemeta::jsontoolkit::SchemaWalker{schema, walker, resolver,
+                                               default_metaschema};
 }

--- a/src/jsonschema/walker.cc
+++ b/src/jsonschema/walker.cc
@@ -1,5 +1,5 @@
 #include <jsontoolkit/json.h>
-#include <jsontoolkit/jsonschema/walker.h>
+#include <jsontoolkit/jsonschema.h>
 
 #include <cassert> // assert
 #include <string>  // std::string
@@ -7,14 +7,29 @@
 sourcemeta::jsontoolkit::SchemaWalker::SchemaWalker(
     const sourcemeta::jsontoolkit::Value &input,
     const sourcemeta::jsontoolkit::schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) {
-  this->walk(input, walker, vocabularies);
+    const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
+    const std::optional<std::string> &default_metaschema) {
+  const std::optional<std::string> metaschema{
+      sourcemeta::jsontoolkit::metaschema(input)};
+
+  // If the given schema declares no metaschema and the user didn't
+  // not pass a default, then there is nothing we can do. We know
+  // the current schema is a subschema, but cannot walk any further.
+  if (!metaschema.has_value() && !default_metaschema.has_value()) {
+    this->subschemas.push_back(input);
+  } else {
+    const std::string &effective_metaschema{metaschema.has_value()
+                                                ? metaschema.value()
+                                                : default_metaschema.value()};
+    this->walk(input, walker, resolver, effective_metaschema);
+  }
 }
 
 auto sourcemeta::jsontoolkit::SchemaWalker::walk(
     const sourcemeta::jsontoolkit::Value &subschema,
     const sourcemeta::jsontoolkit::schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) -> void {
+    const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
+    const std::string &metaschema) -> void {
   this->subschemas.push_back(subschema);
 
   // We can't recurse any further
@@ -22,38 +37,50 @@ auto sourcemeta::jsontoolkit::SchemaWalker::walk(
     return;
   }
 
+  // Recalculate the metaschema and its vocabularies at every step.
+  // This is needed for correctly traversing through schemas that
+  // contains subschemas that use different metaschemas/vocabularies.
+  // This is often the case for bundled schemas.
+  const std::optional<std::string> current_metaschema{
+      sourcemeta::jsontoolkit::metaschema(subschema)};
+  const std::string &new_metaschema{
+      current_metaschema.has_value() ? current_metaschema.value() : metaschema};
+  const std::unordered_map<std::string, bool> vocabularies{
+      sourcemeta::jsontoolkit::vocabularies(subschema, resolver, new_metaschema)
+          .get()};
+
   for (const auto &pair : sourcemeta::jsontoolkit::object_iterator(subschema)) {
     switch (walker(sourcemeta::jsontoolkit::key(pair), vocabularies)) {
     case sourcemeta::jsontoolkit::schema_walker_strategy_t::Value:
-      this->walk_schema(sourcemeta::jsontoolkit::value(pair), walker,
-                        vocabularies);
+      this->walk_schema(sourcemeta::jsontoolkit::value(pair), walker, resolver,
+                        new_metaschema);
       break;
     case sourcemeta::jsontoolkit::schema_walker_strategy_t::Elements:
-      this->walk_array(sourcemeta::jsontoolkit::value(pair), walker,
-                       vocabularies);
+      this->walk_array(sourcemeta::jsontoolkit::value(pair), walker, resolver,
+                       new_metaschema);
       break;
     case sourcemeta::jsontoolkit::schema_walker_strategy_t::Members:
-      this->walk_object(sourcemeta::jsontoolkit::value(pair), walker,
-                        vocabularies);
+      this->walk_object(sourcemeta::jsontoolkit::value(pair), walker, resolver,
+                        new_metaschema);
       break;
     case sourcemeta::jsontoolkit::schema_walker_strategy_t::ValueOrElements:
       if (sourcemeta::jsontoolkit::is_array(
               sourcemeta::jsontoolkit::value(pair))) {
-        this->walk_array(sourcemeta::jsontoolkit::value(pair), walker,
-                         vocabularies);
+        this->walk_array(sourcemeta::jsontoolkit::value(pair), walker, resolver,
+                         new_metaschema);
       } else {
         this->walk_schema(sourcemeta::jsontoolkit::value(pair), walker,
-                          vocabularies);
+                          resolver, new_metaschema);
       }
       break;
     case sourcemeta::jsontoolkit::schema_walker_strategy_t::ElementsOrMembers:
       if (sourcemeta::jsontoolkit::is_array(
               sourcemeta::jsontoolkit::value(pair))) {
-        this->walk_array(sourcemeta::jsontoolkit::value(pair), walker,
-                         vocabularies);
+        this->walk_array(sourcemeta::jsontoolkit::value(pair), walker, resolver,
+                         new_metaschema);
       } else {
         this->walk_object(sourcemeta::jsontoolkit::value(pair), walker,
-                          vocabularies);
+                          resolver, new_metaschema);
       }
       break;
     default:
@@ -64,35 +91,39 @@ auto sourcemeta::jsontoolkit::SchemaWalker::walk(
 
 auto sourcemeta::jsontoolkit::SchemaWalker::walk_array(
     const Value &array, const schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) -> void {
+    const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
+    const std::string &metaschema) -> void {
   if (!sourcemeta::jsontoolkit::is_array(array)) {
     return;
   }
 
   for (const auto &element : sourcemeta::jsontoolkit::array_iterator(array)) {
-    this->walk(element, walker, vocabularies);
+    this->walk(element, walker, resolver, metaschema);
   }
 }
 
 auto sourcemeta::jsontoolkit::SchemaWalker::walk_object(
     const Value &object, const schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) -> void {
+    const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
+    const std::string &metaschema) -> void {
   if (!sourcemeta::jsontoolkit::is_object(object)) {
     return;
   }
 
   for (const auto &pair : sourcemeta::jsontoolkit::object_iterator(object)) {
-    this->walk(sourcemeta::jsontoolkit::value(pair), walker, vocabularies);
+    this->walk(sourcemeta::jsontoolkit::value(pair), walker, resolver,
+               metaschema);
   }
 }
 
 auto sourcemeta::jsontoolkit::SchemaWalker::walk_schema(
     const Value &schema, const schema_walker_t &walker,
-    const std::unordered_map<std::string, bool> &vocabularies) -> void {
+    const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
+    const std::string &metaschema) -> void {
   if (!sourcemeta::jsontoolkit::is_object(schema) &&
       !sourcemeta::jsontoolkit::is_boolean(schema)) {
     return;
   }
 
-  this->walk(schema, walker, vocabularies);
+  this->walk(schema, walker, resolver, metaschema);
 }

--- a/test/contrib/example-2020-12-subschemas.txt
+++ b/test/contrib/example-2020-12-subschemas.txt
@@ -5,18 +5,36 @@
     "title": "Person",
     "type": "object",
     "properties": {
-        "firstName": {
-            "type": "string",
-            "description": "The person's first name."
-        },
-        "lastName": {
-            "type": "string",
-            "description": "The person's last name."
+        "name": {
+            "type": "object",
+            "properties": {
+                "first": {
+                    "type": "string",
+                    "description": "The person's first name."
+                },
+                "last": {
+                    "type": "string",
+                    "description": "The person's last name."
+                }
+            }
         },
         "age": {
             "description": "Age in years which must be equal to or greater than zero.",
             "type": "integer",
             "minimum": 0
+        }
+    }
+}
+{
+    "type": "object",
+    "properties": {
+        "first": {
+            "type": "string",
+            "description": "The person's first name."
+        },
+        "last": {
+            "type": "string",
+            "description": "The person's last name."
         }
     }
 }

--- a/test/contrib/example-2020-12.json
+++ b/test/contrib/example-2020-12.json
@@ -5,13 +5,18 @@
   "title": "Person",
   "type": "object",
   "properties": {
-    "firstName": {
-      "type": "string",
-      "description": "The person's first name."
-    },
-    "lastName": {
-      "type": "string",
-      "description": "The person's last name."
+    "name": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "description": "The person's first name."
+        },
+        "last": {
+          "type": "string",
+          "description": "The person's last name."
+        }
+      }
     },
     "age": {
       "description": "Age in years which must be equal to or greater than zero.",


### PR DESCRIPTION
To account for bundled schemas with different vocabularies in use within
the same top-level schema.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
