### PR TITLE
Take small enough `std::uint64_t` as input in `from()`

### DIFF
--- a/include/jsontoolkit/json/rapidjson/read.h
+++ b/include/jsontoolkit/json/rapidjson/read.h
@@ -5,10 +5,11 @@
 
 #include <cassert>     // assert
 #include <cstddef>     // std::size_t
-#include <cstdint>     // std::int64_t
+#include <cstdint>     // std::int64_t, std::uint64_t
 #include <istream>     // std::basic_istream
+#include <limits>      // std::numeric_limits
 #include <ostream>     // std::basic_ostream
-#include <stdexcept>   // std::domain_error
+#include <stdexcept>   // std::domain_error, std::overflow_error
 #include <string>      // std::string
 #include <type_traits> // std::enable_if_t, std::is_same_v
 
@@ -66,6 +67,21 @@ template <typename T>
 typename std::enable_if_t<std::is_same_v<T, std::int64_t>, JSON> from(T value) {
   rapidjson::Document document;
   document.SetInt64(value);
+  return document;
+}
+
+template <typename T>
+typename std::enable_if_t<std::is_same_v<T, std::uint64_t>, JSON>
+from(T value) {
+  rapidjson::Document document;
+
+  // Safe to cast
+  if (value <= std::numeric_limits<std::int64_t>::max()) {
+    document.SetInt64(static_cast<std::int64_t>(value));
+  } else {
+    throw std::overflow_error("The input unsigned integer is too large");
+  }
+
   return document;
 }
 

--- a/test/json/json_read_test.cc
+++ b/test/json/json_read_test.cc
@@ -1,5 +1,7 @@
+#include <cstdint> // std::uint64_t, std::int64_t
 #include <gtest/gtest.h>
 #include <jsontoolkit/json/read.h>
+#include <limits>  // std::numeric_limits
 #include <sstream> // std::istringstream
 #include <utility> // std::move
 
@@ -1458,4 +1460,25 @@ TEST(JSON, make_array_top_level) {
   sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::make_array()};
   EXPECT_TRUE(sourcemeta::jsontoolkit::is_array(document));
   EXPECT_EQ(sourcemeta::jsontoolkit::size(document), 0);
+}
+
+TEST(JSON, unsigned_integer) {
+  const std::uint64_t value{10};
+  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::from(value)};
+  EXPECT_TRUE(sourcemeta::jsontoolkit::is_integer(document));
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(document), 10);
+}
+
+TEST(JSON, unsigned_integer_64_bit_signed_max) {
+  const std::uint64_t value{std::numeric_limits<std::int64_t>::max()};
+  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::from(value)};
+  EXPECT_TRUE(sourcemeta::jsontoolkit::is_integer(document));
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_integer(document),
+            std::numeric_limits<std::int64_t>::max());
+}
+
+TEST(JSON, unsigned_integer_64_bit_signed_max_plus_1_fails) {
+  const std::uint64_t value{
+      static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1};
+  EXPECT_THROW(sourcemeta::jsontoolkit::from(value), std::overflow_error);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
