### PR TITLE
Run `clang_format_test`, not `clang_format` on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           -DJSONTOOLKIT_BACKEND=${{ matrix.platform.backend }}
           -DJSONTOOLKIT_CONTRIB=ON
           -DJSONTOOLKIT_TESTS=ON
-      - run: cmake --build ./build --config Release --target clang_format
+      - run: cmake --build ./build --config Release --target clang_format_test
       - run: cmake --build ./build --config Release
       # Not every CTest version supports the --test-dir option. If such option
       # is not recognized, `ctest` will successfully exit finding no tests.

--- a/test/jsonschema/jsonschema_walker_test.cc
+++ b/test/jsonschema/jsonschema_walker_test.cc
@@ -476,7 +476,7 @@ TEST(jsonschema, walker_flat_const) {
 }
 
 TEST(jsonschema, walker_flat_non_const) {
-  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::parse(R"JSON({
+  const std::string json{R"JSON({
     "$schema": "https://sourcemeta.com/test-metaschema",
     "schema": {
       "schema": { "foo": 1 }
@@ -486,8 +486,9 @@ TEST(jsonschema, walker_flat_non_const) {
         "schema": { "foo": 2 }
       }
     }
-  })JSON")};
+  })JSON"};
 
+  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::parse(json)};
   std::vector<sourcemeta::jsontoolkit::JSON> subschemas;
   for (sourcemeta::jsontoolkit::Value &subschema :
        sourcemeta::jsontoolkit::flat_subschema_iterator(document, test_walker,
@@ -505,7 +506,7 @@ TEST(jsonschema, walker_flat_non_const) {
 }
 
 TEST(jsonschema, walker_flat_non_const_modify) {
-  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::parse(R"JSON({
+  const std::string json{R"JSON({
     "$schema": "https://sourcemeta.com/test-metaschema",
     "schema": {
       "schema": { "foo": 1 }
@@ -515,8 +516,9 @@ TEST(jsonschema, walker_flat_non_const_modify) {
         "schema": { "foo": 2 }
       }
     }
-  })JSON")};
+  })JSON"};
 
+  sourcemeta::jsontoolkit::JSON document{sourcemeta::jsontoolkit::parse(json)};
   for (sourcemeta::jsontoolkit::Value &subschema :
        sourcemeta::jsontoolkit::flat_subschema_iterator(document, test_walker,
                                                         test_resolver)) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
