### PR TITLE
Implement a `copy()` function for JSON containers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -600,6 +600,31 @@ assert(sourcemeta::jsontoolkit::at(collection, 1), 2);
 assert(sourcemeta::jsontoolkit::at(collection, 2), 3);
 ```
 
+#### Copy
+
+`void copy(Iterator begin, Iterator end, Iterator output)`
+
+This function copies JSON documents inside a container into another container,
+using iterators. For example:
+
+```c++
+#include <jsontoolkit/json.h>
+#include <cassert>
+#include <vector>
+#include <iterator>
+
+std::vector<sourcemeta::jsontoolkit::JSON> documents;
+documents.push_back(sourcemeta::jsontoolkit::from("foo"));
+documents.push_back(sourcemeta::jsontoolkit::from("bar"));
+documents.push_back(sourcemeta::jsontoolkit::from("baz"));
+
+std::vector<sourcemeta::jsontoolkit::JSON> result;
+sourcemeta::jsontoolkit::copy(documents.cbegin(), documents.cend(),
+                              std::back_inserter(result));
+
+assert(documents.size() == result.size());
+```
+
 ### Writing
 
 A set of functions to write to JSON instance. To accomodate for the memory

--- a/src/json/include/jsontoolkit/json/read.h
+++ b/src/json/include/jsontoolkit/json/read.h
@@ -7,7 +7,7 @@
 #error Unknown JSON Toolkit backend
 #endif
 
-#include <algorithm> // std::any_of
+#include <algorithm> // std::any_of, std::transform
 
 namespace sourcemeta::jsontoolkit {
 
@@ -30,6 +30,12 @@ inline auto defines_any(const Value &value,
 template <typename T>
 auto defines_any(const Value &value, const T &keys) -> bool {
   return defines_any(value, std::cbegin(keys), std::cend(keys));
+}
+
+template <typename InputIt, typename OutputIt>
+auto copy(InputIt begin, InputIt end, OutputIt output) -> void {
+  std::transform(begin, end, output,
+                 [](const auto &json) { return from(json); });
 }
 
 } // namespace sourcemeta::jsontoolkit

--- a/test/json/json_read_test.cc
+++ b/test/json/json_read_test.cc
@@ -1,5 +1,6 @@
 #include <cstdint> // std::uint64_t, std::int64_t
 #include <gtest/gtest.h>
+#include <iterator> // std::back_inserter
 #include <jsontoolkit/json/read.h>
 #include <limits>  // std::numeric_limits
 #include <set>     // std::set
@@ -1842,4 +1843,25 @@ TEST(JSON, compare_object_object_different) {
       sourcemeta::jsontoolkit::parse("{\"foo\":1, \"bar\":2}")};
   EXPECT_TRUE(sourcemeta::jsontoolkit::compare(left, right));
   EXPECT_FALSE(sourcemeta::jsontoolkit::compare(right, left));
+}
+
+TEST(JSON, copy_json_vector) {
+  std::vector<sourcemeta::jsontoolkit::JSON> documents;
+  documents.push_back(sourcemeta::jsontoolkit::from("foo"));
+  documents.push_back(sourcemeta::jsontoolkit::from("bar"));
+  documents.push_back(sourcemeta::jsontoolkit::from("baz"));
+
+  std::vector<sourcemeta::jsontoolkit::JSON> result;
+  sourcemeta::jsontoolkit::copy(documents.cbegin(), documents.cend(),
+                                std::back_inserter(result));
+
+  EXPECT_EQ(documents.size(), 3);
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(0)), "foo");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(1)), "bar");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(2)), "baz");
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(result.at(0)), "foo");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(result.at(1)), "bar");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(result.at(2)), "baz");
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
