### PR TITLE
Add a `copy()` overload to duplicate entire containers

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -604,8 +604,13 @@ assert(sourcemeta::jsontoolkit::at(collection, 2), 3);
 
 `void copy(Iterator begin, Iterator end, Iterator output)`
 
-This function copies JSON documents inside a container into another container,
-using iterators. For example:
+`Container copy(const Container &container)`
+
+The first function copies JSON documents inside a container into another
+container, using iterators. The second function is a utility to duplicate an
+entire JSON container.
+
+For example:
 
 ```c++
 #include <jsontoolkit/json.h>
@@ -618,9 +623,14 @@ documents.push_back(sourcemeta::jsontoolkit::from("foo"));
 documents.push_back(sourcemeta::jsontoolkit::from("bar"));
 documents.push_back(sourcemeta::jsontoolkit::from("baz"));
 
+// With iterators
 std::vector<sourcemeta::jsontoolkit::JSON> result;
 sourcemeta::jsontoolkit::copy(documents.cbegin(), documents.cend(),
                               std::back_inserter(result));
+
+// With container utility
+std::vector<sourcemeta::jsontoolkit::JSON> result{
+  sourcemeta::jsontoolkit::copy(result)};
 
 assert(documents.size() == result.size());
 ```

--- a/src/json/include/jsontoolkit/json/read.h
+++ b/src/json/include/jsontoolkit/json/read.h
@@ -8,6 +8,7 @@
 #endif
 
 #include <algorithm> // std::any_of, std::transform
+#include <iterator>  // std::cbegin, std::cend, std::back_inserter
 
 namespace sourcemeta::jsontoolkit {
 
@@ -36,6 +37,14 @@ template <typename InputIt, typename OutputIt>
 auto copy(InputIt begin, InputIt end, OutputIt output) -> void {
   std::transform(begin, end, output,
                  [](const auto &json) { return from(json); });
+}
+
+template <typename Container>
+auto copy(const Container &container) -> Container {
+  Container output;
+  sourcemeta::jsontoolkit::copy(std::cbegin(container), std::cend(container),
+                                std::back_inserter(output));
+  return output;
 }
 
 } // namespace sourcemeta::jsontoolkit

--- a/test/json/json_read_test.cc
+++ b/test/json/json_read_test.cc
@@ -1845,7 +1845,7 @@ TEST(JSON, compare_object_object_different) {
   EXPECT_FALSE(sourcemeta::jsontoolkit::compare(right, left));
 }
 
-TEST(JSON, copy_json_vector) {
+TEST(JSON, copy_json_vector_iterators) {
   std::vector<sourcemeta::jsontoolkit::JSON> documents;
   documents.push_back(sourcemeta::jsontoolkit::from("foo"));
   documents.push_back(sourcemeta::jsontoolkit::from("bar"));
@@ -1854,6 +1854,26 @@ TEST(JSON, copy_json_vector) {
   std::vector<sourcemeta::jsontoolkit::JSON> result;
   sourcemeta::jsontoolkit::copy(documents.cbegin(), documents.cend(),
                                 std::back_inserter(result));
+
+  EXPECT_EQ(documents.size(), 3);
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(0)), "foo");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(1)), "bar");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(2)), "baz");
+
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(result.at(0)), "foo");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(result.at(1)), "bar");
+  EXPECT_EQ(sourcemeta::jsontoolkit::to_string(result.at(2)), "baz");
+}
+
+TEST(JSON, copy_json_vector) {
+  std::vector<sourcemeta::jsontoolkit::JSON> documents;
+  documents.push_back(sourcemeta::jsontoolkit::from("foo"));
+  documents.push_back(sourcemeta::jsontoolkit::from("bar"));
+  documents.push_back(sourcemeta::jsontoolkit::from("baz"));
+
+  std::vector<sourcemeta::jsontoolkit::JSON> result{
+      sourcemeta::jsontoolkit::copy(documents)};
 
   EXPECT_EQ(documents.size(), 3);
   EXPECT_EQ(sourcemeta::jsontoolkit::to_string(documents.at(0)), "foo");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
