### PR TITLE
Enable `-Wswitch-enum` warning on GCC and Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 if(MSVC)
   add_compile_options(/options:strict /W4 /WX /WL /sdl /DNOMINMAX)
 else()
-  add_compile_options(-Wall -Wextra -Werror -Wpedantic
+  add_compile_options(-Wall -Wextra -Werror -Wpedantic -Wswitch -Wswitch-enum
     -Wshadow -Wdouble-promotion -Wconversion -Wunused-parameter)
 endif()
 

--- a/src/jsonschema/include/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/jsontoolkit/jsonschema.h
@@ -128,6 +128,8 @@ private:
                             level);
         }
         break;
+      case schema_walker_strategy_t::None:
+        break;
       default:
         break;
       }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
