### PR TITLE
Handle "None" schema walker strategy on the `switch` case

### DIFF
--- a/src/jsonschema/include/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/jsontoolkit/jsonschema.h
@@ -128,6 +128,8 @@ private:
                             level);
         }
         break;
+      case schema_walker_strategy_t::None:
+        break;
       default:
         break;
       }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
