### PR TITLE
Use underscores in library output names

### DIFF
--- a/src/json/CMakeLists.txt
+++ b/src/json/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(sourcemeta_jsontoolkit_json
 add_library(sourcemeta::jsontoolkit::json ALIAS sourcemeta_jsontoolkit_json)
 set_target_properties(sourcemeta_jsontoolkit_json
   PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/sourcemeta/jsontoolkit/json.h"
-  OUTPUT_NAME sourcemeta-jsontoolkit-json
+  OUTPUT_NAME sourcemeta_jsontoolkit_json
   EXPORT_NAME jsontoolkit::json)
 target_include_directories(sourcemeta_jsontoolkit_json
   INTERFACE

--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(sourcemeta_jsontoolkit_jsonschema
 add_library(sourcemeta::jsontoolkit::jsonschema ALIAS sourcemeta_jsontoolkit_jsonschema)
 set_target_properties(sourcemeta_jsontoolkit_jsonschema
   PROPERTIES PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/sourcemeta/jsontoolkit/jsonschema.h"
-  OUTPUT_NAME sourcemeta-jsontoolkit-jsonschema
+  OUTPUT_NAME sourcemeta_jsontoolkit_jsonschema
   EXPORT_NAME jsontoolkit::jsonschema)
 
 target_include_directories(sourcemeta_jsontoolkit_jsonschema


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
