### PR TITLE
Quiet `argv` pointer ClangTidy warnings until we are in C++20

### DIFF
--- a/contrib/jsonschema_keywords/main.cc
+++ b/contrib/jsonschema_keywords/main.cc
@@ -73,12 +73,16 @@ auto scan(const std::filesystem::path &directory) -> int {
 
 auto main(int argc, char *argv[]) -> int {
   if (argc <= 1) {
+    // TODO: Use std::span on C++20
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     std::cerr << "Usage: " << std::string{argv[0]} << " <directory>\n";
     return EXIT_FAILURE;
   }
 
   try {
     // Make sure the directory indeed exists
+    // TODO: Use std::span on C++20
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     return scan(std::filesystem::canonical(std::filesystem::path{argv[1]}));
   } catch (const std::exception &error) {
     std::cerr << "Error: " << error.what() << "\n";

--- a/contrib/jsonschema_walker/walker.cc
+++ b/contrib/jsonschema_walker/walker.cc
@@ -54,17 +54,25 @@ auto help(const std::string &program) -> void {
 
 auto main(int argc, char *argv[]) -> int {
   if (argc == 1) {
+    // TODO: Use std::span on C++20
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     help(argv[0]);
     return EXIT_FAILURE;
   }
 
   try {
     if (argc == 2) {
+      // TODO: Use std::span on C++20
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       return walk(argv[1], std::cin);
     } else {
+      // TODO: Use std::span on C++20
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       const std::filesystem::path input{argv[2]};
       std::ifstream stream{std::filesystem::canonical(input)};
       stream.exceptions(std::ios_base::badbit);
+      // TODO: Use std::span on C++20
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       return walk(argv[1], stream);
     }
   } catch (const std::exception &error) {

--- a/contrib/minify/minify.cc
+++ b/contrib/minify/minify.cc
@@ -23,6 +23,8 @@ auto main(int argc, char *argv[]) -> int {
     if (argc == 1) {
       return minify(std::cin);
     } else {
+      // TODO: Use std::span on C++20
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       const std::filesystem::path input{argv[1]};
       std::ifstream stream{std::filesystem::canonical(input)};
       stream.exceptions(std::ios_base::badbit);

--- a/contrib/prettify/prettify.cc
+++ b/contrib/prettify/prettify.cc
@@ -23,6 +23,8 @@ auto main(int argc, char *argv[]) -> int {
     if (argc == 1) {
       return prettify(std::cin);
     } else {
+      // TODO: Use std::span on C++20
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       const std::filesystem::path input{argv[1]};
       std::ifstream stream{std::filesystem::canonical(input)};
       stream.exceptions(std::ios_base::badbit);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
