### PR TITLE
Allow `ParseError` to be exported on Windows

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_error.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_error.h
@@ -8,6 +8,13 @@
 
 namespace sourcemeta::jsontoolkit {
 
+// Exporting symbols that depends on the standard C++ library is considered
+// safe.
+// https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170&redirectedfrom=MSDN
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251 4275)
+#endif
+
 /// @ingroup json
 /// This class represents a parsing error.
 class SOURCEMETA_JSONTOOLKIT_JSON_EXPORT ParseError : public std::exception {
@@ -32,6 +39,10 @@ private:
   std::uint64_t line_;
   std::uint64_t column_;
 };
+
+#if defined(_MSC_VER)
+#pragma warning(default : 4251 4275)
+#endif
 
 } // namespace sourcemeta::jsontoolkit
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
