### PR TITLE
Use `std::map` instead of `std::unordered_map` in JSON Schema

### DIFF
--- a/contrib/jsonschema_keywords/main.cc
+++ b/contrib/jsonschema_keywords/main.cc
@@ -1,22 +1,21 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <algorithm>     // std::sort
-#include <cstdlib>       // EXIT_SUCCESS, EXIT_FAILURE
-#include <exception>     // std::exception
-#include <filesystem>    // std::filesystem
-#include <fstream>       // std::ifstream
-#include <ios>           // std::ios_base
-#include <iostream>      // std::cout, std::cerr
-#include <span>          // std::span
-#include <unordered_map> // std::unordered_map
-#include <utility>       // std::pair
-#include <vector>        // std::vector
+#include <algorithm>  // std::sort
+#include <cstdlib>    // EXIT_SUCCESS, EXIT_FAILURE
+#include <exception>  // std::exception
+#include <filesystem> // std::filesystem
+#include <fstream>    // std::ifstream
+#include <ios>        // std::ios_base
+#include <iostream>   // std::cout, std::cerr
+#include <map>        // std::map
+#include <span>       // std::span
+#include <utility>    // std::pair
+#include <vector>     // std::vector
 
 namespace {
 auto analyze(const sourcemeta::jsontoolkit::JSON &schema,
-             std::unordered_map<std::string, unsigned long> &accumulator)
-    -> void {
+             std::map<std::string, unsigned long> &accumulator) -> void {
   const sourcemeta::jsontoolkit::DefaultResolver resolver;
   for (const sourcemeta::jsontoolkit::JSON &subschema :
        sourcemeta::jsontoolkit::subschema_iterator(
@@ -37,7 +36,7 @@ auto analyze(const sourcemeta::jsontoolkit::JSON &schema,
 }
 
 auto scan(const std::filesystem::path &directory) -> int {
-  std::unordered_map<std::string, unsigned long> accumulator;
+  std::map<std::string, unsigned long> accumulator;
   for (const std::filesystem::directory_entry &directory_entry :
        std::filesystem::recursive_directory_iterator(directory)) {
     if (std::filesystem::is_directory(directory_entry.path()) ||

--- a/contrib/jsonschema_walker/walker.cc
+++ b/contrib/jsonschema_walker/walker.cc
@@ -1,14 +1,14 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <cstdlib>       // EXIT_FAILURE, EXIT_SUCCESS
-#include <exception>     // std::exception
-#include <filesystem>    // std::filesystem::path, std::filesystem::canonical
-#include <fstream>       // std::ifstream
-#include <iostream>      // std::cerr, std::cout, std::cin
-#include <istream>       // std::basic_istream
-#include <span>          // std::span
-#include <unordered_map> // std::unordered_map
+#include <cstdlib>    // EXIT_FAILURE, EXIT_SUCCESS
+#include <exception>  // std::exception
+#include <filesystem> // std::filesystem::path, std::filesystem::canonical
+#include <fstream>    // std::ifstream
+#include <iostream>   // std::cerr, std::cout, std::cin
+#include <istream>    // std::basic_istream
+#include <map>        // std::map
+#include <span>       // std::span
 
 namespace {
 template <typename CharT, typename Traits>

--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -2,15 +2,15 @@
 
 // Because standard "contains()" is introduced in C++20
 namespace {
-auto contains(const std::unordered_map<std::string, bool> &map,
-              const std::string &key) -> bool {
+auto contains(const std::map<std::string, bool> &map, const std::string &key)
+    -> bool {
   return map.find(key) != map.end();
 }
 } // namespace
 
 // A stub walker that doesn't walk
 auto sourcemeta::jsontoolkit::schema_walker_none(
-    const std::string &, const std::unordered_map<std::string, bool> &)
+    const std::string &, const std::map<std::string, bool> &)
     -> sourcemeta::jsontoolkit::schema_walker_strategy_t {
   return sourcemeta::jsontoolkit::schema_walker_strategy_t::None;
 }
@@ -18,8 +18,7 @@ auto sourcemeta::jsontoolkit::schema_walker_none(
 // TODO: Extend this default walker to recognize as many official
 // JSON Schema vocabularies as possible.
 auto sourcemeta::jsontoolkit::default_schema_walker(
-    const std::string &keyword,
-    const std::unordered_map<std::string, bool> &vocabularies)
+    const std::string &keyword, const std::map<std::string, bool> &vocabularies)
     -> sourcemeta::jsontoolkit::schema_walker_strategy_t {
   if (::contains(vocabularies,
                  "https://json-schema.org/draft/2020-12/vocab/core") &&

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -10,12 +10,12 @@
 #include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
 #include <sourcemeta/jsontoolkit/jsonschema_walker.h>
 
-#include <future>        // std::promise, std::future
-#include <optional>      // std::optional
-#include <stdexcept>     // std::invalid_argument
-#include <string>        // std::string
-#include <unordered_map> // std::unordered_map
-#include <vector>        // std::vector
+#include <future>    // std::promise, std::future
+#include <map>       // std::map
+#include <optional>  // std::optional
+#include <stdexcept> // std::invalid_argument
+#include <string>    // std::string
+#include <vector>    // std::vector
 
 /// @defgroup jsonschema JSON Schema
 /// @brief A set of JSON Schema utilities across draft versions.
@@ -147,7 +147,7 @@ auto draft(const JSON &schema, const schema_resolver_t &resolver,
 /// })JSON");
 ///
 /// sourcemeta::jsontoolkit::DefaultResolver resolver;
-/// const std::unordered_map<std::string, bool> vocabularies{
+/// const std::map<std::string, bool> vocabularies{
 ///     sourcemeta::jsontoolkit::vocabularies(document, resolver).get()};
 ///
 /// assert(vocabularies.at("https://json-schema.org/draft/2020-12/vocab/core"));
@@ -159,10 +159,9 @@ auto draft(const JSON &schema, const schema_resolver_t &resolver,
 /// assert(vocabularies.at("https://json-schema.org/draft/2020-12/vocab/content"));
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
-auto vocabularies(
-    const JSON &schema, const schema_resolver_t &resolver,
-    const std::optional<std::string> &default_metaschema = std::nullopt)
-    -> std::future<std::unordered_map<std::string, bool>>;
+auto vocabularies(const JSON &schema, const schema_resolver_t &resolver,
+                  const std::optional<std::string> &default_metaschema =
+                      std::nullopt) -> std::future<std::map<std::string, bool>>;
 
 // We inline the definition of this class in this file to avoid a circular
 // dependency
@@ -232,7 +231,7 @@ private:
     const std::string &new_metaschema{current_metaschema.has_value()
                                           ? current_metaschema.value()
                                           : metaschema};
-    const std::unordered_map<std::string, bool> vocabularies{
+    const std::map<std::string, bool> vocabularies{
         sourcemeta::jsontoolkit::vocabularies(subschema, resolver,
                                               new_metaschema)
             .get()};

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_default_walker.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_default_walker.h
@@ -13,15 +13,14 @@ namespace sourcemeta::jsontoolkit {
 /// A stub walker that doesn't walk
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto schema_walker_none(const std::string &,
-                        const std::unordered_map<std::string, bool> &)
+                        const std::map<std::string, bool> &)
     -> sourcemeta::jsontoolkit::schema_walker_strategy_t;
 
 /// @ingroup jsonschema
 /// A default schema walker with support for a wide range of drafs
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
-auto default_schema_walker(
-    const std::string &keyword,
-    const std::unordered_map<std::string, bool> &vocabularies)
+auto default_schema_walker(const std::string &keyword,
+                           const std::map<std::string, bool> &vocabularies)
     -> sourcemeta::jsontoolkit::schema_walker_strategy_t;
 
 } // namespace sourcemeta::jsontoolkit

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
@@ -1,9 +1,9 @@
 #ifndef SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_WALKER_H_
 #define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_WALKER_H_
 
-#include <functional>    // std::function
-#include <string>        // std::string
-#include <unordered_map> // std::unordered_map
+#include <functional> // std::function
+#include <map>        // std::map
+#include <string>     // std::string
 
 namespace sourcemeta::jsontoolkit {
 
@@ -55,7 +55,7 @@ enum class schema_walker_strategy_t {
 /// - sourcemeta::jsontoolkit::default_schema_walker
 /// - sourcemeta::jsontoolkit::schema_walker_none
 using schema_walker_t = std::function<schema_walker_strategy_t(
-    const std::string &, const std::unordered_map<std::string, bool> &)>;
+    const std::string &, const std::map<std::string, bool> &)>;
 
 /// @ingroup jsonschema
 enum class schema_walker_type_t { Deep, Flat };

--- a/src/jsonschema/jsonschema.cc
+++ b/src/jsonschema/jsonschema.cc
@@ -129,15 +129,15 @@ auto sourcemeta::jsontoolkit::vocabularies(
     const sourcemeta::jsontoolkit::JSON &schema,
     const sourcemeta::jsontoolkit::schema_resolver_t &resolver,
     const std::optional<std::string> &default_metaschema)
-    -> std::future<std::unordered_map<std::string, bool>> {
-  std::promise<std::unordered_map<std::string, bool>> promise;
+    -> std::future<std::map<std::string, bool>> {
+  std::promise<std::map<std::string, bool>> promise;
 
   // If the meta-schema, as referenced by the schema, is not recognized, or is
   // missing, then the behavior is implementation-defined. If the
   // implementation proceeds with processing the schema, it MUST assume the
   // use of the vocabulary from the core specification.
   // See https://json-schema.org/draft/2020-12/json-schema-core.html#section-8
-  std::unordered_map<std::string, bool> result;
+  std::map<std::string, bool> result;
 
   /*
    * (1) Identify the schema's metaschema

--- a/test/jsonschema/jsonschema_default_walker_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_test.cc
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-static const std::unordered_map<std::string, bool> VOCABULARIES_2020_12{
+static const std::map<std::string, bool> VOCABULARIES_2020_12{
     {"https://json-schema.org/draft/2020-12/vocab/core", true},
     {"https://json-schema.org/draft/2020-12/vocab/applicator", true},
     {"https://json-schema.org/draft/2020-12/vocab/unevaluated", true},

--- a/test/jsonschema/jsonschema_vocabulary_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_test.cc
@@ -100,23 +100,23 @@ static auto test_resolver(const std::string &identifier)
   return promise.get_future();
 }
 
-static auto EXPECT_VOCABULARY_REQUIRED(
-    const std::unordered_map<std::string, bool> &vocabularies,
-    const std::string &vocabulary) -> void {
+static auto
+EXPECT_VOCABULARY_REQUIRED(const std::map<std::string, bool> &vocabularies,
+                           const std::string &vocabulary) -> void {
   EXPECT_TRUE(vocabularies.find(vocabulary) != vocabularies.end());
   EXPECT_TRUE(vocabularies.at(vocabulary));
 }
 
-static auto EXPECT_VOCABULARY_OPTIONAL(
-    const std::unordered_map<std::string, bool> &vocabularies,
-    const std::string &vocabulary) -> void {
+static auto
+EXPECT_VOCABULARY_OPTIONAL(const std::map<std::string, bool> &vocabularies,
+                           const std::string &vocabulary) -> void {
   EXPECT_TRUE(vocabularies.find(vocabulary) != vocabularies.end());
   EXPECT_FALSE(vocabularies.at(vocabulary));
 }
 
-static auto EXPECT_VOCABULARY_MISSING(
-    const std::unordered_map<std::string, bool> &vocabularies,
-    const std::string &vocabulary) -> void {
+static auto
+EXPECT_VOCABULARY_MISSING(const std::map<std::string, bool> &vocabularies,
+                          const std::string &vocabulary) -> void {
   EXPECT_TRUE(vocabularies.find(vocabulary) == vocabularies.end());
 }
 
@@ -128,7 +128,7 @@ TEST(JSONSchema_vocabulary, core_vocabularies_boolean_without_default) {
 
 TEST(JSONSchema_vocabulary, core_vocabularies_boolean_with_default) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
           document, test_resolver,
           "https://sourcemeta.com/2020-12-custom-vocabularies")
@@ -144,7 +144,7 @@ TEST(JSONSchema_vocabulary, core_vocabularies_boolean_with_default) {
 
 TEST(JSONSchema_vocabulary, default_metaschema_with_boolean) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
           document, test_resolver,
           "https://sourcemeta.com/2020-12-custom-vocabularies")
@@ -160,7 +160,7 @@ TEST(JSONSchema_vocabulary, default_metaschema_with_boolean) {
 
 TEST(JSONSchema_vocabulary, not_random_vocabulary_boolean) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
           document, test_resolver,
           "https://sourcemeta.com/2020-12-custom-vocabularies")
@@ -201,7 +201,7 @@ TEST(JSONSchema_vocabulary, real_metaschema_takes_precedence_over_default) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2020-12-no-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
           document, test_resolver,
           "https://sourcemeta.com/2020-12-custom-vocabularies")
@@ -246,7 +246,7 @@ TEST(JSONSchema_vocabulary, no_vocabularies_2020_12) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2020-12-no-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 6);
   EXPECT_VOCABULARY_REQUIRED(
@@ -268,7 +268,7 @@ TEST(JSONSchema_vocabulary, no_vocabularies_2020_12_hyper) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2020-12-hyper-no-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 6);
   EXPECT_VOCABULARY_REQUIRED(
@@ -290,7 +290,7 @@ TEST(JSONSchema_vocabulary, hyper_2020_12) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/hyper-schema"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 8);
   EXPECT_VOCABULARY_REQUIRED(
@@ -318,7 +318,7 @@ TEST(JSONSchema_vocabulary, no_vocabularies_2019_09) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2019-09-no-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 6);
   EXPECT_VOCABULARY_REQUIRED(
@@ -340,7 +340,7 @@ TEST(JSONSchema_vocabulary, no_vocabularies_2019_09_hyper) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2019-09-hyper-no-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 6);
   EXPECT_VOCABULARY_REQUIRED(
@@ -362,7 +362,7 @@ TEST(JSONSchema_vocabulary, hyper_2019_09) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/hyper-schema"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 7);
   EXPECT_VOCABULARY_REQUIRED(
@@ -386,7 +386,7 @@ TEST(JSONSchema_vocabulary, custom_vocabularies_2020_12) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2020-12-custom-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 3);
   EXPECT_VOCABULARY_REQUIRED(
@@ -402,7 +402,7 @@ TEST(JSONSchema_vocabulary, custom_vocabularies_2019_09) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://sourcemeta.com/2019-09-custom-vocabularies"
   })JSON");
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
   EXPECT_EQ(vocabularies.size(), 3);
   EXPECT_VOCABULARY_REQUIRED(

--- a/test/jsonschema/jsonschema_walker_test.cc
+++ b/test/jsonschema/jsonschema_walker_test.cc
@@ -38,9 +38,8 @@ static auto test_resolver(const std::string &identifier)
   return promise.get_future();
 }
 
-static auto
-test_walker(const std::string &keyword,
-            const std::unordered_map<std::string, bool> &vocabularies)
+static auto test_walker(const std::string &keyword,
+                        const std::map<std::string, bool> &vocabularies)
     -> sourcemeta::jsontoolkit::schema_walker_strategy_t {
   if (vocabularies.find("https://sourcemeta.com/vocab/test-1") !=
       vocabularies.end()) {
@@ -567,7 +566,7 @@ TEST(JSONSchema, walker_flat_non_const_no_metaschema) {
 }
 
 TEST(JSONSchema, schema_walker_none_never_walks) {
-  const std::unordered_map<std::string, bool> vocabularies{
+  const std::map<std::string, bool> vocabularies{
       {"https://json-schema.org/draft/2020-12/vocab/core", true},
       {"https://json-schema.org/draft/2020-12/vocab/applicator", true},
       {"https://json-schema.org/draft/2020-12/vocab/unevaluated", true},


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
