### PR TITLE
Remove obsolete Makefile ctest comment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ compile: .always
 lint: .always
 	$(CMAKE) --build ./build --config $(PRESET) --target clang_tidy
 
-# Not every CTest version supports the --test-dir option
 test: .always
 	$(CMAKE) -E env UBSAN_OPTIONS=print_stacktrace=1 \
 		$(CTEST) --test-dir ./build --build-config $(PRESET) \


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
