### PR TITLE
Avoid exporting templated classes

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_array.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_array.h
@@ -1,20 +1,13 @@
 #ifndef SOURCEMETA_JSONTOOLKIT_JSON_ARRAY_H_
 #define SOURCEMETA_JSONTOOLKIT_JSON_ARRAY_H_
 
-#if defined(__EMSCRIPTEN__) || defined(__Unikraft__)
-#define SOURCEMETA_JSONTOOLKIT_JSON_EXPORT
-#else
-#include "json_export.h"
-#endif
-
 #include <initializer_list> // std::initializer_list
 #include <vector>           // std::vector
 
 namespace sourcemeta::jsontoolkit {
 
 /// @ingroup json
-template <typename Value, typename Allocator>
-class SOURCEMETA_JSONTOOLKIT_JSON_EXPORT GenericArray {
+template <typename Value, typename Allocator> class GenericArray {
 public:
   using Container = std::vector<Value, Allocator>;
   GenericArray() : data{} {}

--- a/src/json/include/sourcemeta/jsontoolkit/json_object.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_object.h
@@ -1,12 +1,6 @@
 #ifndef SOURCEMETA_JSONTOOLKIT_JSON_OBJECT_H_
 #define SOURCEMETA_JSONTOOLKIT_JSON_OBJECT_H_
 
-#if defined(__EMSCRIPTEN__) || defined(__Unikraft__)
-#define SOURCEMETA_JSONTOOLKIT_JSON_EXPORT
-#else
-#include "json_export.h"
-#endif
-
 #include <functional>       // std::less
 #include <initializer_list> // std::initializer_list
 #include <map>              // std::map
@@ -15,7 +9,7 @@ namespace sourcemeta::jsontoolkit {
 
 /// @ingroup json
 template <typename Key, typename Value, typename Allocator>
-class SOURCEMETA_JSONTOOLKIT_JSON_EXPORT GenericObject {
+class GenericObject {
 public:
   // Constructors & operators
   using Container = std::map<Key, Value, std::less<Key>, Allocator>;

--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -1,12 +1,6 @@
 #ifndef SOURCEMETA_JSONTOOLKIT_JSON_VALUE_H_
 #define SOURCEMETA_JSONTOOLKIT_JSON_VALUE_H_
 
-#if defined(__EMSCRIPTEN__) || defined(__Unikraft__)
-#define SOURCEMETA_JSONTOOLKIT_JSON_EXPORT
-#else
-#include "json_export.h"
-#endif
-
 #include <sourcemeta/jsontoolkit/json_array.h>
 #include <sourcemeta/jsontoolkit/json_object.h>
 
@@ -29,7 +23,7 @@ namespace sourcemeta::jsontoolkit {
 /// @ingroup json
 template <typename CharT, typename Traits,
           template <typename T> typename Allocator>
-class SOURCEMETA_JSONTOOLKIT_JSON_EXPORT GenericValue {
+class GenericValue {
 public:
   /// The character traits used by the JSON document.
   using CharTraits = Traits;

--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
@@ -1,12 +1,6 @@
 #ifndef JSONTOOLKIT_JSONPOINTER_POINTER_H_
 #define JSONTOOLKIT_JSONPOINTER_POINTER_H_
 
-#if defined(__EMSCRIPTEN__) || defined(__Unikraft__)
-#define SOURCEMETA_JSONTOOLKIT_JSONPOINTER_EXPORT
-#else
-#include "jsonpointer_export.h"
-#endif
-
 #include <sourcemeta/jsontoolkit/jsonpointer_token.h>
 
 #include <cassert>          // assert
@@ -19,7 +13,7 @@ namespace sourcemeta::jsontoolkit {
 /// @ingroup jsonpointer
 template <typename CharT, typename Traits,
           template <typename T> typename Allocator>
-class SOURCEMETA_JSONTOOLKIT_JSONPOINTER_EXPORT GenericPointer {
+class GenericPointer {
 public:
   using Token = GenericToken<CharT, Traits, Allocator>;
   using Value = typename Token::Value;

--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_token.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_token.h
@@ -1,12 +1,6 @@
 #ifndef JSONTOOLKIT_JSONPOINTER_TOKEN_H_
 #define JSONTOOLKIT_JSONPOINTER_TOKEN_H_
 
-#if defined(__EMSCRIPTEN__) || defined(__Unikraft__)
-#define SOURCEMETA_JSONTOOLKIT_JSONPOINTER_EXPORT
-#else
-#include "jsonpointer_export.h"
-#endif
-
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonpointer_grammar.h>
 
@@ -19,7 +13,7 @@ namespace sourcemeta::jsontoolkit {
 /// @ingroup jsonpointer
 template <typename CharT, typename Traits,
           template <typename T> typename Allocator>
-class SOURCEMETA_JSONTOOLKIT_JSONPOINTER_EXPORT GenericToken {
+class GenericToken {
 public:
   using Value = GenericValue<CharT, Traits, Allocator>;
   using Property = typename Value::String;

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -170,8 +170,7 @@ auto vocabularies(const JSON &schema, const schema_resolver_t &resolver,
 // We inline the definition of this class in this file to avoid a circular
 // dependency
 /// @ingroup jsonschema
-template <typename ValueT>
-class SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT SchemaWalker {
+template <typename ValueT> class SchemaWalker {
 private:
   using internal = typename std::vector<std::reference_wrapper<ValueT>>;
 


### PR DESCRIPTION
While GCC and Clang gracefully ignore the declarations, MSVC complains.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
