### PR TITLE
Return a `string_view` when fetching the id of a `SchemaResolutionError`

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_error.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_error.h
@@ -45,7 +45,7 @@ public:
     return this->message_.c_str();
   }
 
-  [[nodiscard]] auto id() const noexcept -> const std::string & {
+  [[nodiscard]] auto id() const noexcept -> std::string_view {
     return this->identifier_;
   }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
