### PR TITLE
Make `id()` taker a resolver and a default dialect

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -64,12 +64,15 @@ auto is_schema(const JSON &schema) -> bool;
 ///   "$id": "https://sourcemeta.com/example-schema"
 /// })JSON");
 ///
-/// std::optional<std::string> id{sourcemeta::jsontoolkit::id(document)};
+/// std::optional<std::string> id{sourcemeta::jsontoolkit::id(
+///   document, sourcemeta::jsontoolkit::official_resolver).get()};
 /// assert(id.has_value());
 /// assert(id.value() == "https://sourcemeta.com/example-schema");
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
-auto id(const JSON &schema) -> std::optional<std::string>;
+auto id(const JSON &schema, const SchemaResolver &resolver,
+        const std::optional<std::string> &default_dialect = std::nullopt)
+    -> std::future<std::optional<std::string>>;
 
 /// @ingroup jsonschema
 ///

--- a/test/jsonschema/jsonschema_id_test.cc
+++ b/test/jsonschema/jsonschema_id_test.cc
@@ -2,16 +2,24 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
+// TODO: Test passing a default dialect, and its precedence over $schema
+
 TEST(JSONSchema, id_boolean) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{sourcemeta::jsontoolkit::id(document)};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema, id_empty_object) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{sourcemeta::jsontoolkit::id(document)};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -20,7 +28,10 @@ TEST(JSONSchema, id_object_with_id) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{sourcemeta::jsontoolkit::id(document)};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }

--- a/test/jsonschema/jsonschema_official_resolver_test.cc
+++ b/test/jsonschema/jsonschema_official_resolver_test.cc
@@ -9,7 +9,10 @@
     EXPECT_TRUE(result.has_value());                                           \
     const sourcemeta::jsontoolkit::JSON &document{result.value()};             \
     EXPECT_TRUE(sourcemeta::jsontoolkit::is_schema(document));                 \
-    std::optional<std::string> id{sourcemeta::jsontoolkit::id(document)};      \
+    std::optional<std::string> id{                                             \
+        sourcemeta::jsontoolkit::id(                                           \
+            document, sourcemeta::jsontoolkit::official_resolver)              \
+            .get()};                                                           \
     EXPECT_TRUE(id.has_value());                                               \
     EXPECT_EQ(id.value(), identifier);                                         \
   }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
