### PR TITLE
Properly test `id()` across dialects

### DIFF
--- a/src/jsonschema/jsonschema.cc
+++ b/src/jsonschema/jsonschema.cc
@@ -33,6 +33,7 @@ auto sourcemeta::jsontoolkit::id(
       base_dialect == "http://json-schema.org/draft-03/schema#" ||
       base_dialect == "http://json-schema.org/draft-04/hyper-schema#" ||
       base_dialect == "http://json-schema.org/draft-04/schema#") {
+    std::promise<std::optional<std::string>> promise;
     if (schema.is_object() && schema.defines("id")) {
       const sourcemeta::jsontoolkit::JSON &id{schema.at("id")};
       if (!id.is_string() || id.empty()) {
@@ -40,10 +41,12 @@ auto sourcemeta::jsontoolkit::id(
             "The value of the id property is not valid");
       }
 
-      std::promise<std::optional<std::string>> promise;
       promise.set_value(id.to_string());
-      return promise.get_future();
+    } else {
+      promise.set_value(std::nullopt);
     }
+
+    return promise.get_future();
   }
 
   if (schema.is_object() && schema.defines("$id")) {

--- a/test/jsonschema/CMakeLists.txt
+++ b/test/jsonschema/CMakeLists.txt
@@ -1,4 +1,13 @@
 add_executable(sourcemeta_jsontoolkit_jsonschema_unit
+  jsonschema_id_2020_12_test.cc
+  jsonschema_id_2019_09_test.cc
+  jsonschema_id_draft7_test.cc
+  jsonschema_id_draft6_test.cc
+  jsonschema_id_draft4_test.cc
+  jsonschema_id_draft3_test.cc
+  jsonschema_id_draft2_test.cc
+  jsonschema_id_draft1_test.cc
+  jsonschema_id_draft0_test.cc
   jsonschema_id_test.cc
   jsonschema_is_schema_test.cc
   jsonschema_dialect_test.cc

--- a/test/jsonschema/jsonschema_id_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_id_2019_09_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "$id": "https://sourcemeta.com/metaschema",
+      "$schema": "https://json-schema.org/draft/2019-09/schema"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_2019_09, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_2019_09, old_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2019_09, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2019-09/schema")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2019_09, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2019-09/schema")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2019_09, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_2019_09, old_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2019_09, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-04/schema#")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_id_2020_12_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "$id": "https://sourcemeta.com/metaschema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_2020_12, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_2020_12, old_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2020_12, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2020_12, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2020_12, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_2020_12, old_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_2020_12, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-04/schema#")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft0_test.cc
+++ b/test/jsonschema/jsonschema_id_draft0_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-00/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft0, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft0, new_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft0, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-00/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft0, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-00/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft0, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-00/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft0, new_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-00/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft0, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-00/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft1_test.cc
+++ b/test/jsonschema/jsonschema_id_draft1_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-01/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft1, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft1, new_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft1, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-01/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft1, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-01/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft1, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-01/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft1, new_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-01/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft1, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-01/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft2_test.cc
+++ b/test/jsonschema/jsonschema_id_draft2_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-02/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft2, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft2, new_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft2, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-02/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft2, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-02/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft2, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-02/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft2, new_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-02/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft2, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-02/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft3_test.cc
+++ b/test/jsonschema/jsonschema_id_draft3_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-03/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft3, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft3, new_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft3, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-03/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft3, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-03/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft3, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-03/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft3, new_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-03/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft3, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-03/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft4_test.cc
+++ b/test/jsonschema/jsonschema_id_draft4_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-04/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft4, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft4, new_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft4, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-04/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft4, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-04/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft4, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-04/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft4, new_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-04/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft4, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-04/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(
+          document, sourcemeta::jsontoolkit::official_resolver,
+          "https://json-schema.org/draft/2020-12/schema")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft6_test.cc
+++ b/test/jsonschema/jsonschema_id_draft6_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "$id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-06/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft6, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft6, old_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft6, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-06/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft6, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-06/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft6, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-06/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft6, old_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-06/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft6, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-06/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-04/schema#")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_draft7_test.cc
+++ b/test/jsonschema/jsonschema_id_draft7_test.cc
@@ -1,0 +1,105 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver(std::string_view identifier)
+    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+
+  if (identifier == "https://sourcemeta.com/metaschema") {
+    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      "$id": "https://sourcemeta.com/metaschema",
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    })JSON"));
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+
+  return promise.get_future();
+}
+
+TEST(JSONSchema_id_draft7, valid_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft7, old_one_hop) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "https://sourcemeta.com/metaschema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft7, id_boolean_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-07/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft7, empty_object_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-07/schema#")
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft7, valid_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
+TEST(JSONSchema_id_draft7, old_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id_draft7, default_dialect_precedence) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver,
+                                  "http://json-schema.org/draft-04/schema#")
+          .get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}

--- a/test/jsonschema/jsonschema_id_test.cc
+++ b/test/jsonschema/jsonschema_id_test.cc
@@ -2,11 +2,7 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-// TODO: Test passing a default dialect, and its precedence over $schema
-// TODO: Test that we always use "$id" or "id" correctly depending on the
-// dialect, and we don't just fallback
-
-TEST(JSONSchema, id_boolean) {
+TEST(JSONSchema_id, boolean_no_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
   std::optional<std::string> id{
       sourcemeta::jsontoolkit::id(document,
@@ -15,7 +11,15 @@ TEST(JSONSchema, id_boolean) {
   EXPECT_FALSE(id.has_value());
 }
 
-TEST(JSONSchema, id_empty_object) {
+TEST(JSONSchema_id, boolean_unknown_dialect) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  EXPECT_THROW(sourcemeta::jsontoolkit::id(
+                   document, sourcemeta::jsontoolkit::official_resolver,
+                   "https://www.sourcemeta.com/invalid-dialect"),
+               sourcemeta::jsontoolkit::SchemaResolutionError);
+}
+
+TEST(JSONSchema_id, empty_object_no_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
   std::optional<std::string> id{
@@ -25,10 +29,31 @@ TEST(JSONSchema, id_empty_object) {
   EXPECT_FALSE(id.has_value());
 }
 
-TEST(JSONSchema, id_object_with_id_with_no_dialect) {
+TEST(JSONSchema_id, empty_object_unknown_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{}");
+  EXPECT_THROW(sourcemeta::jsontoolkit::id(
+                   document, sourcemeta::jsontoolkit::official_resolver,
+                   "https://www.sourcemeta.com/invalid-dialect"),
+               sourcemeta::jsontoolkit::SchemaResolutionError);
+}
+
+TEST(JSONSchema_id, object_with_dollar_id_with_no_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$id": "https://example.com/my-schema"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::id(document,
+                                  sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_id, object_with_id_with_no_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema"
   })JSON");
   std::optional<std::string> id{
       sourcemeta::jsontoolkit::id(document,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
