### PR TITLE
Overload the `<` operator for `Pointer`

### DIFF
--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
@@ -195,6 +195,13 @@ public:
     return this->data == other.data;
   }
 
+  /// Overload to support ordering of JSON Pointers. Typically for sorting
+  /// reasons.
+  auto operator<(const GenericPointer<CharT, Traits, Allocator> &other)
+      const noexcept -> bool {
+    return this->data < other.data;
+  }
+
 private:
   Container data;
 };

--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_token.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_token.h
@@ -190,6 +190,14 @@ public:
     return this->data == other.data;
   }
 
+  /// Overload to support ordering of JSON Pointer token. Typically for sorting
+  /// reasons.
+  auto
+  operator<(const GenericToken<CharT, Traits, Allocator> &other) const noexcept
+      -> bool {
+    return this->data < other.data;
+  }
+
 private:
   std::variant<Property, Index> data;
 };

--- a/test/jsonpointer/jsonpointer_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_pointer_test.cc
@@ -130,3 +130,12 @@ TEST(JSONPointer_pointer, pop_back_empty) {
   pointer.pop_back();
   EXPECT_EQ(pointer.size(), 0);
 }
+
+TEST(JSONPointer_pointer, ordering_less_than) {
+  const sourcemeta::jsontoolkit::Pointer pointer_1{"foo", "bar"};
+  const sourcemeta::jsontoolkit::Pointer pointer_2{"foo"};
+  const sourcemeta::jsontoolkit::Pointer pointer_3{"baz"};
+  EXPECT_TRUE(pointer_2 < pointer_1);
+  EXPECT_TRUE(pointer_3 < pointer_1);
+  EXPECT_TRUE(pointer_3 < pointer_2);
+}

--- a/test/jsonpointer/jsonpointer_token_test.cc
+++ b/test/jsonpointer/jsonpointer_token_test.cc
@@ -70,3 +70,12 @@ TEST(JSONPointer_token, hyphen_char_token) {
   EXPECT_FALSE(token.is_index());
   EXPECT_TRUE(token.is_hyphen());
 }
+
+TEST(JSONPointer_token, ordering_less_than) {
+  const sourcemeta::jsontoolkit::Pointer::Token token_1{"foo"};
+  const sourcemeta::jsontoolkit::Pointer::Token token_2{"bar"};
+  const sourcemeta::jsontoolkit::Pointer::Token token_3{"baz"};
+  EXPECT_TRUE(token_2 < token_1);
+  EXPECT_TRUE(token_3 < token_1);
+  EXPECT_TRUE(token_2 < token_3);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
