### PR TITLE
Implement an `anchors()` function similar to `id()`

### DIFF
--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -4,6 +4,7 @@ configure_file(official_resolver.in.cc official_resolver.cc @ONLY)
 set(JSONSCHEMA_PUBLIC_HEADERS
   include/sourcemeta/jsontoolkit/jsonschema.h)
 set(JSONSCHEMA_PRIVATE_HEADERS
+  include/sourcemeta/jsontoolkit/jsonschema_anchor.h
   include/sourcemeta/jsontoolkit/jsonschema_resolver.h
   include/sourcemeta/jsontoolkit/jsonschema_walker.h
   include/sourcemeta/jsontoolkit/jsonschema_error.h
@@ -12,7 +13,7 @@ set(JSONSCHEMA_PRIVATE_HEADERS
 add_library(sourcemeta_jsontoolkit_jsonschema
   ${JSONSCHEMA_PUBLIC_HEADERS}
   ${JSONSCHEMA_PRIVATE_HEADERS}
-  jsonschema.cc default_walker.cc walker.cc
+  jsonschema.cc default_walker.cc anchor.cc walker.cc
   "${CMAKE_CURRENT_BINARY_DIR}/official_resolver.cc")
 sourcemeta_jsontoolkit_add_compile_options(sourcemeta_jsontoolkit_jsonschema)
 add_library(sourcemeta::jsontoolkit::jsonschema ALIAS sourcemeta_jsontoolkit_jsonschema)

--- a/src/jsonschema/anchor.cc
+++ b/src/jsonschema/anchor.cc
@@ -1,0 +1,48 @@
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+#include <cassert> // assert
+#include <utility> // std::move
+
+namespace sourcemeta::jsontoolkit {
+
+auto anchors(const JSON &schema, const SchemaResolver &resolver,
+             const std::optional<std::string> &default_dialect)
+    -> std::future<std::map<std::string, AnchorType>> {
+  const std::map<std::string, bool> vocabularies{
+      sourcemeta::jsontoolkit::vocabularies(schema, resolver, default_dialect)
+          .get()};
+  std::promise<std::map<std::string, AnchorType>> promise;
+  std::map<std::string, AnchorType> result;
+
+  // 2020-12
+  if (vocabularies.contains(
+          "https://json-schema.org/draft/2020-12/vocab/core")) {
+    // A dynamic anchor takes precedence over a static anchor
+    if (schema.defines("$dynamicAnchor")) {
+      const auto &anchor{schema.at("$dynamicAnchor")};
+      assert(anchor.is_string());
+      result.insert({anchor.to_string(), AnchorType::Dynamic});
+    }
+
+    if (schema.defines("$anchor")) {
+      const auto &anchor{schema.at("$anchor")};
+      assert(anchor.is_string());
+      result.insert({anchor.to_string(), AnchorType::Static});
+    }
+  }
+
+  // 2019-09
+  if (vocabularies.contains(
+          "https://json-schema.org/draft/2019-09/vocab/core")) {
+    if (schema.defines("$anchor")) {
+      const auto &anchor{schema.at("$anchor")};
+      assert(anchor.is_string());
+      result.insert({anchor.to_string(), AnchorType::Static});
+    }
+  }
+
+  promise.set_value(std::move(result));
+  return promise.get_future();
+}
+
+} // namespace sourcemeta::jsontoolkit

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -8,6 +8,7 @@
 #endif
 
 #include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema_anchor.h>
 #include <sourcemeta/jsontoolkit/jsonschema_error.h>
 #include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
 #include <sourcemeta/jsontoolkit/jsonschema_walker.h>

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_anchor.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_anchor.h
@@ -1,0 +1,56 @@
+#ifndef SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_ANCHOR_H_
+#define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_ANCHOR_H_
+
+#if defined(__EMSCRIPTEN__) || defined(__Unikraft__)
+#define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
+#else
+#include "jsonschema_export.h"
+#endif
+
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
+
+#include <future>   // std::promise, std::future
+#include <map>      // std::map
+#include <optional> // std::optional
+#include <string>   // std::string
+
+namespace sourcemeta::jsontoolkit {
+
+/// @ingroup jsonschema
+/// The anchor type
+enum class AnchorType { Static, Dynamic };
+
+/// @ingroup jsonschema
+///
+/// This function returns the anchors of the given schema, if any. A given
+/// subschema might have more than two anchors if, for example, declares both
+/// `$anchor` and `$dynamicAnchor` (in 2020-12). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/jsontoolkit/json.h>
+/// #include <sourcemeta/jsontoolkit/jsonschema.h>
+/// #include <cassert>
+///
+/// const sourcemeta::jsontoolkit::JSON document =
+///     sourcemeta::jsontoolkit::parse(R"JSON({
+///   "$schema": "https://json-schema.org/draft/2020-12/schema",
+///   "$id": "https://sourcemeta.com/example-schema",
+///   "$anchor": "foo"
+/// })JSON");
+///
+/// const auto anchors{sourcemeta::jsontoolkit::anchors(
+///   document, sourcemeta::jsontoolkit::official_resolver).get()};
+/// assert(anchors.size() == 1);
+/// assert(anchors.contains("foo"));
+/// // This is a static anchor
+/// assert(anchors.at("foo") == sourcemeta::jsontoolkit::AnchorType::Static);
+/// ```
+SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
+auto anchors(const JSON &schema, const SchemaResolver &resolver,
+             const std::optional<std::string> &default_dialect = std::nullopt)
+    -> std::future<std::map<std::string, AnchorType>>;
+
+} // namespace sourcemeta::jsontoolkit
+
+#endif

--- a/test/jsonschema/CMakeLists.txt
+++ b/test/jsonschema/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_executable(sourcemeta_jsontoolkit_jsonschema_unit
+  jsonschema_anchor_2020_12_test.cc
+  jsonschema_anchor_2019_09_test.cc
   jsonschema_id_2020_12_test.cc
   jsonschema_id_2019_09_test.cc
   jsonschema_id_draft7_test.cc

--- a/test/jsonschema/jsonschema_anchor_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2019_09_test.cc
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+TEST(JSONSchema_anchor_2019_09, top_level_no_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_TRUE(anchors.empty());
+}
+
+TEST(JSONSchema_anchor_2019_09, top_level_static_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$anchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_EQ(anchors.size(), 1);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
+}
+
+TEST(JSONSchema_anchor_2019_09, top_level_dynamic_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$dynamicAnchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_TRUE(anchors.empty());
+}
+
+TEST(JSONSchema_anchor_2019_09, nested_static_with_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$anchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver,
+                         "https://json-schema.org/draft/2019-09/schema")
+                         .get()};
+  EXPECT_EQ(anchors.size(), 1);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
+}

--- a/test/jsonschema/jsonschema_anchor_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2020_12_test.cc
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+TEST(JSONSchema_anchor_2020_12, top_level_no_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_TRUE(anchors.empty());
+}
+
+TEST(JSONSchema_anchor_2020_12, top_level_static_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$anchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_EQ(anchors.size(), 1);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
+}
+
+TEST(JSONSchema_anchor_2020_12, top_level_dynamic_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$dynamicAnchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_EQ(anchors.size(), 1);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Dynamic);
+}
+
+TEST(JSONSchema_anchor_2020_12, top_level_static_and_dynamic_anchor) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$anchor": "bar",
+    "$dynamicAnchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver)
+                         .get()};
+  EXPECT_EQ(anchors.size(), 2);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_TRUE(anchors.contains("bar"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Dynamic);
+  EXPECT_EQ(anchors.at("bar"), sourcemeta::jsontoolkit::AnchorType::Static);
+}
+
+TEST(JSONSchema_anchor_2020_12, nested_static_with_default_dialect) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$anchor": "foo"
+  })JSON");
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver,
+                         "https://json-schema.org/draft/2020-12/schema")
+                         .get()};
+  EXPECT_EQ(anchors.size(), 1);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
