### PR TITLE
Store the top-level schema id on `frame()` entries

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -23,7 +23,8 @@ namespace sourcemeta::jsontoolkit {
 /// A JSON Schema reference frame is a mapping of URIs to JSON Pointers within a
 /// schema. We call it reference frame as this mapping is essential for
 /// resolving references.
-using ReferenceFrame = std::map<std::string, std::tuple<Pointer, std::string>>;
+using ReferenceFrame =
+    std::map<std::string, std::tuple<std::string, Pointer, std::string>>;
 
 // TODO: Support dynamic anchors too
 

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -33,6 +33,8 @@ auto sourcemeta::jsontoolkit::frame(
   std::map<sourcemeta::jsontoolkit::Pointer, std::string> base_uris;
   std::map<sourcemeta::jsontoolkit::Pointer, std::string> base_dialects;
 
+  const std::optional<std::string> root_id{
+      sourcemeta::jsontoolkit::id(schema, resolver, default_dialect).get()};
   const std::optional<std::string> root_dialect{
       sourcemeta::jsontoolkit::dialect(schema, default_dialect)};
   assert(root_dialect.has_value());
@@ -58,7 +60,10 @@ auto sourcemeta::jsontoolkit::frame(
           find_base(base_uris, pointer, id)};
       const sourcemeta::jsontoolkit::URI relative{id.value()};
       const std::string new_id{relative.resolve_from(base)};
-      if (!static_frame.insert({new_id, {pointer, effective_dialect}}).second) {
+      assert(root_id.has_value());
+      if (!static_frame
+               .insert({new_id, {root_id.value(), pointer, effective_dialect}})
+               .second) {
         std::ostringstream error;
         error << "Schema identifier already exists: " << new_id;
         throw sourcemeta::jsontoolkit::SchemaError(error.str());
@@ -76,7 +81,10 @@ auto sourcemeta::jsontoolkit::frame(
           find_base(base_uris, pointer, id)};
       const auto result{anchor_uri.resolve_from(anchor_base)};
       if (type == sourcemeta::jsontoolkit::AnchorType::Static) {
-        if (!static_frame.insert({result, {pointer, effective_dialect}})
+        assert(root_id.has_value());
+        if (!static_frame
+                 .insert(
+                     {result, {root_id.value(), pointer, effective_dialect}})
                  .second) {
           std::ostringstream error;
           error << "Schema anchor already exists: " << name;

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -18,9 +18,12 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
 
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
+
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -43,9 +46,12 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
+
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -71,31 +77,41 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_TRUE(
       static_frame.contains("https://www.sourcemeta.com/test/qux#test"));
   EXPECT_EQ(
       std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+      "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(
       std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
+      sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(
+      std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
       "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux#bar"));
   EXPECT_EQ(
       std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux#bar")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+      "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(
       std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux#bar")),
+      sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+  EXPECT_EQ(
+      std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux#bar")),
       "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -120,14 +136,18 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -176,45 +196,60 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/bar#xxx"));
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo#test")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo#test")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/baz")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "baz"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/baz")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "baz"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/baz")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_EQ(
       std::get<0>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
+      "https://www.sourcemeta.com/schema");
   EXPECT_EQ(
       std::get<1>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
+      sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
+  EXPECT_EQ(
+      std::get<2>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
       "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/qux")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "foo", "items"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/qux")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo", "items"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/qux")),
             "https://json-schema.org/draft/2019-09/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar#xxx")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "bar", "items"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar#xxx")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "bar", "items"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar#xxx")),
             "https://json-schema.org/draft/2019-09/schema");
 }
 

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -70,23 +74,30 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_TRUE(
       static_frame.contains("https://www.sourcemeta.com/test/qux#test"));
   EXPECT_EQ(
       std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+      "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(
       std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
+      sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(
+      std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
       "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -111,14 +122,18 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -163,40 +178,55 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/qux"));
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo#test")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo#test")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/baz")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "baz"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/baz")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "baz"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/baz")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(
       std::get<0>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
+      "https://www.sourcemeta.com/schema");
   EXPECT_EQ(
       std::get<1>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
+      sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
+  EXPECT_EQ(
+      std::get<2>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
       "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/qux")),
-            sourcemeta::jsontoolkit::Pointer({"properties", "foo", "items"}));
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/qux")),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo", "items"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/qux")),
             "https://json-schema.org/draft/2020-12/schema");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-00/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-00/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-00/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-00/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-00/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-00/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-01/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-01/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-01/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-01/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-01/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-01/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-02/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-02/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-02/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-02/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-02/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-02/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-03/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-03/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-03/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-03/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-03/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-03/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-04/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-04/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-04/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-06/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-06/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-06/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-06/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-06/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-06/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -19,8 +19,10 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-07/schema#");
 }
 
@@ -44,8 +46,10 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
   EXPECT_EQ(static_frame.size(), 1);
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-07/schema#");
 }
 
@@ -67,14 +71,18 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
             "http://json-schema.org/draft-07/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/test/qux");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-07/schema#");
 }
 
@@ -99,14 +107,18 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
             "http://json-schema.org/draft-07/schema#");
 
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer{"items"});
+            "https://www.sourcemeta.com/schema");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer{"items"});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-07/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -35,19 +35,25 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
   EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/bar"));
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test")),
-            sourcemeta::jsontoolkit::Pointer{});
+            "https://www.sourcemeta.com/test");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test")),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test")),
             "https://json-schema.org/draft/2020-12/schema");
 
   EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
-            sourcemeta::jsontoolkit::Pointer({"$defs", "foo"}));
+            "https://www.sourcemeta.com/test");
   EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+            sourcemeta::jsontoolkit::Pointer({"$defs", "foo"}));
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
             "http://json-schema.org/draft-04/schema#");
 
+  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
+            "https://www.sourcemeta.com/test");
   EXPECT_EQ(
-      std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
+      std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
       sourcemeta::jsontoolkit::Pointer({"$defs", "foo", "definitions", "bar"}));
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar")),
             "http://json-schema.org/draft-04/schema#");
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
