### PR TITLE
Gracefully take boolean schemas in `anchors()`

### DIFF
--- a/src/jsonschema/anchor.cc
+++ b/src/jsonschema/anchor.cc
@@ -15,7 +15,8 @@ auto anchors(const JSON &schema, const SchemaResolver &resolver,
   std::map<std::string, AnchorType> result;
 
   // 2020-12
-  if (vocabularies.contains(
+  if (schema.is_object() &&
+      vocabularies.contains(
           "https://json-schema.org/draft/2020-12/vocab/core")) {
     // A dynamic anchor takes precedence over a static anchor
     if (schema.defines("$dynamicAnchor")) {
@@ -32,7 +33,8 @@ auto anchors(const JSON &schema, const SchemaResolver &resolver,
   }
 
   // 2019-09
-  if (vocabularies.contains(
+  if (schema.is_object() &&
+      vocabularies.contains(
           "https://json-schema.org/draft/2019-09/vocab/core")) {
     if (schema.defines("$anchor")) {
       const auto &anchor{schema.at("$anchor")};

--- a/test/jsonschema/jsonschema_anchor_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2019_09_test.cc
@@ -2,6 +2,16 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
+TEST(JSONSchema_anchor_2019_09, boolean_schema) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("true");
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver,
+                         "https://json-schema.org/draft/2019-09/schema")
+                         .get()};
+  EXPECT_TRUE(anchors.empty());
+}
+
 TEST(JSONSchema_anchor_2019_09, top_level_no_anchor) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_anchor_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2020_12_test.cc
@@ -2,6 +2,16 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
+TEST(JSONSchema_anchor_2020_12, boolean_schema) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("true");
+  const auto anchors{sourcemeta::jsontoolkit::anchors(
+                         document, sourcemeta::jsontoolkit::official_resolver,
+                         "https://json-schema.org/draft/2020-12/schema")
+                         .get()};
+  EXPECT_TRUE(anchors.empty());
+}
+
 TEST(JSONSchema_anchor_2020_12, top_level_no_anchor) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
