### PR TITLE
Turn `ReferenceFrame` into a proper class

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -23,8 +23,46 @@ namespace sourcemeta::jsontoolkit {
 /// A JSON Schema reference frame is a mapping of URIs to schema identifiers,
 /// JSON Pointers within the schema, and subschemas dialects. We call it
 /// reference frame as this mapping is essential for resolving references.
-using ReferenceFrame =
-    std::map<std::string, std::tuple<std::string, Pointer, std::string>>;
+class SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT ReferenceFrame {
+public:
+  /// Get the identifier of the root JSON Schema that declares the schema
+  /// registered at the given URI.
+  auto base(const std::string &uri) const -> const std::string &;
+
+  /// Get the JSON Pointer that must be used to get the schema registered at a
+  /// given URI, relative to its base schema
+  auto pointer(const std::string &uri) const -> const Pointer &;
+
+  /// Get the dialect that must be used to evaluate the schema registered at a
+  /// given URI
+  auto dialect(const std::string &uri) const -> const std::string &;
+
+  /// Check whether the reference frame defines a given URI
+  auto defines(const std::string &uri) const -> bool;
+
+  /// Check the number of entries stored in the reference frame
+  auto size() const -> std::size_t;
+
+  /// Check whether the reference frame is empty or not
+  auto empty() const -> bool;
+
+  /// Store a new entry in the reference frame
+  auto store(const std::string &uri, const std::string &base_identifier,
+             const Pointer &pointer_from_base, const std::string &dialect)
+      -> void;
+
+private:
+// Exporting symbols that depends on the standard C++ library is considered
+// safe.
+// https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170&redirectedfrom=MSDN
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+  std::map<std::string, std::tuple<std::string, Pointer, std::string>> data;
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
+};
 
 // TODO: Support dynamic anchors too
 

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -17,13 +17,13 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -45,13 +45,13 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -75,44 +75,37 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 4);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_TRUE(
-      static_frame.contains("https://www.sourcemeta.com/test/qux#test"));
-  EXPECT_EQ(
-      std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(
-      std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
-  EXPECT_EQ(
-      std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      "https://json-schema.org/draft/2019-09/schema");
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux#test"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux#test"),
+            "https://www.sourcemeta.com/test/qux");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux#test"),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux#test"),
+            "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux#bar"));
-  EXPECT_EQ(
-      std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux#bar")),
-      "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(
-      std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux#bar")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
-  EXPECT_EQ(
-      std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux#bar")),
-      "https://json-schema.org/draft/2019-09/schema");
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux#bar"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux#bar"),
+            "https://www.sourcemeta.com/test/qux");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux#bar"),
+            sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux#bar"),
+            "https://json-schema.org/draft/2019-09/schema");
 }
 
 TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
@@ -134,20 +127,20 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "https://json-schema.org/draft/2019-09/schema");
 }
 
@@ -186,70 +179,67 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo#test"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/bar"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/baz"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/baz#extra"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/qux"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/bar#xxx"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo#test"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz#extra"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/qux"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar#xxx"));
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo#test"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo#test"),
             sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo#test"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/bar"),
             sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/bar"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/baz")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/baz"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/baz")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/baz"),
             sourcemeta::jsontoolkit::Pointer({"properties", "baz"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/baz")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/baz"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(
-      std::get<0>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(
-      std::get<1>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
-  EXPECT_EQ(
-      std::get<2>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      "https://json-schema.org/draft/2019-09/schema");
-
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/qux")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/baz#extra"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/baz#extra"),
+            sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/baz#extra"),
+            "https://json-schema.org/draft/2019-09/schema");
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/qux"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/qux"),
             sourcemeta::jsontoolkit::Pointer({"properties", "foo", "items"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/qux"),
             "https://json-schema.org/draft/2019-09/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar#xxx")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar#xxx"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar#xxx")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/bar#xxx"),
             sourcemeta::jsontoolkit::Pointer({"properties", "bar", "items"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar#xxx")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/bar#xxx"),
             "https://json-schema.org/draft/2019-09/schema");
 }
 

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 #include <sourcemeta/jsontoolkit/json.h>
-#include <sourcemeta/jsontoolkit/jsonpointer.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 TEST(JSONSchema_frame_2020_12, empty_schema) {
@@ -17,12 +16,12 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -44,12 +43,12 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -72,33 +71,29 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 3);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_TRUE(
-      static_frame.contains("https://www.sourcemeta.com/test/qux#test"));
-  EXPECT_EQ(
-      std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(
-      std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
-  EXPECT_EQ(
-      std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux#test")),
-      "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux#test"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux#test"),
+            "https://www.sourcemeta.com/test/qux");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux#test"),
+            sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux#test"),
+            "https://json-schema.org/draft/2020-12/schema");
 }
 
 TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
@@ -120,20 +115,20 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "https://json-schema.org/draft/2020-12/schema");
 }
 
@@ -169,64 +164,61 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 7);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo#test"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/bar"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/baz"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/baz#extra"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/qux"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo#test"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz#extra"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/qux"));
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo#test"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo#test"),
             sourcemeta::jsontoolkit::Pointer({"properties", "foo"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo#test")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo#test"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/bar"),
             sourcemeta::jsontoolkit::Pointer({"properties", "bar"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/bar"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/baz")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/baz"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/baz")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/baz"),
             sourcemeta::jsontoolkit::Pointer({"properties", "baz"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/baz")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/baz"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_EQ(
-      std::get<0>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(
-      std::get<1>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
-  EXPECT_EQ(
-      std::get<2>(static_frame.at("https://www.sourcemeta.com/baz#extra")),
-      "https://json-schema.org/draft/2020-12/schema");
-
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/qux")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/baz#extra"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/baz#extra"),
+            sourcemeta::jsontoolkit::Pointer({"properties", "baz", "items"}));
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/baz#extra"),
+            "https://json-schema.org/draft/2020-12/schema");
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/qux"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/qux"),
             sourcemeta::jsontoolkit::Pointer({"properties", "foo", "items"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/qux"),
             "https://json-schema.org/draft/2020-12/schema");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-00/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-00/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-00/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-00/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-00/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-00/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-01/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-01/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-01/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-01/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-01/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-01/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-02/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-02/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-02/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-02/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-02/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-02/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-03/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-03/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-03/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-03/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-03/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-03/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-04/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-04/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-04/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-06/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-06/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-06/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-06/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-06/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-06/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -17,12 +17,12 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-07/schema#");
 }
 
@@ -44,12 +44,12 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-07/schema#");
 }
 
@@ -69,20 +69,20 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test/qux"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test/qux"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test/qux"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test/qux"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test/qux")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test/qux"),
             "http://json-schema.org/draft-07/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test/qux");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-07/schema#");
 }
 
@@ -105,20 +105,20 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
 
   EXPECT_EQ(static_frame.size(), 2);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "http://json-schema.org/draft-07/schema#");
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer{"items"});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-07/schema#");
 }
 

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -30,30 +30,30 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
 
   EXPECT_EQ(static_frame.size(), 3);
 
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/foo"));
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/bar"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar"));
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/test")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test"),
             "https://www.sourcemeta.com/test");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/test")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/test"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/test")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/test"),
             "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/test");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/foo"),
             sourcemeta::jsontoolkit::Pointer({"$defs", "foo"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/foo")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/foo"),
             "http://json-schema.org/draft-04/schema#");
 
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar"),
             "https://www.sourcemeta.com/test");
   EXPECT_EQ(
-      std::get<1>(static_frame.at("https://www.sourcemeta.com/bar")),
+      static_frame.pointer("https://www.sourcemeta.com/bar"),
       sourcemeta::jsontoolkit::Pointer({"$defs", "foo", "definitions", "bar"}));
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/bar")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/bar"),
             "http://json-schema.org/draft-04/schema#");
 }
 
@@ -89,11 +89,11 @@ TEST(JSONSchema_frame, no_id_with_default) {
       .wait();
 
   EXPECT_EQ(static_frame.size(), 1);
-  EXPECT_TRUE(static_frame.contains("https://www.sourcemeta.com/schema"));
-  EXPECT_EQ(std::get<0>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(std::get<1>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
             sourcemeta::jsontoolkit::Pointer{});
-  EXPECT_EQ(std::get<2>(static_frame.at("https://www.sourcemeta.com/schema")),
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
             "https://json-schema.org/draft/2020-12/schema");
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
