### PR TITLE
Simplify `id()` ternary logic in `frame()`

### DIFF
--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -55,13 +55,9 @@ auto sourcemeta::jsontoolkit::frame(
 
     // Handle schema identifiers
     const std::optional<std::string> id{
-        pointer.empty()
-            ? sourcemeta::jsontoolkit::id(subschema, resolver,
-                                          effective_dialect, default_id)
-                  .get()
-            : sourcemeta::jsontoolkit::id(subschema, resolver,
-                                          effective_dialect)
-                  .get()};
+        sourcemeta::jsontoolkit::id(subschema, resolver, effective_dialect,
+                                    pointer.empty() ? default_id : std::nullopt)
+            .get()};
     if (id.has_value()) {
       const sourcemeta::jsontoolkit::URI base{
           find_base(base_uris, pointer, id)};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
