### PR TITLE
Exercise `frame()` when passing an explicit equal default id

### DIFF
--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -277,3 +277,29 @@ TEST(JSONSchema_frame_2019_09, static_anchor_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "https://json-schema.org/draft/2019-09/schema",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "https://json-schema.org/draft/2019-09/schema");
+}

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -256,3 +256,29 @@ TEST(JSONSchema_frame_2020_12, static_anchor_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "https://json-schema.org/draft/2020-12/schema",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "https://json-schema.org/draft/2020-12/schema");
+}

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft0, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-00/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-00/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-00/schema#");
+}

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft1, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-01/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-01/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-01/schema#");
+}

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft2, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-02/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-02/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-02/schema#");
+}

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft3, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-03/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-03/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-03/schema#");
+}

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft4, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-04/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-04/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-04/schema#");
+}

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft6, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-06/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-06/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-06/schema#");
+}

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -138,3 +138,29 @@ TEST(JSONSchema_frame_draft7, id_override) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::frame(document, static_frame,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-07/schema#",
+                                 "https://www.sourcemeta.com/schema")
+      .wait();
+
+  EXPECT_EQ(static_frame.size(), 1);
+  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
+
+  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+            "https://www.sourcemeta.com/schema");
+  EXPECT_EQ(static_frame.pointer("https://www.sourcemeta.com/schema"),
+            sourcemeta::jsontoolkit::Pointer{});
+  EXPECT_EQ(static_frame.dialect("https://www.sourcemeta.com/schema"),
+            "http://json-schema.org/draft-07/schema#");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
