### PR TITLE
Perform URI canonicalization on `ReferenceFrame::defines`

### DIFF
--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -27,7 +27,8 @@ static auto find_bases(const std::map<sourcemeta::jsontoolkit::Pointer,
 
 auto sourcemeta::jsontoolkit::ReferenceFrame::defines(
     const std::string &uri) const -> bool {
-  return this->data.contains(uri);
+  const auto canonical{sourcemeta::jsontoolkit::URI{uri}.canonicalize()};
+  return this->data.contains(canonical);
 }
 
 auto sourcemeta::jsontoolkit::ReferenceFrame::size() const -> std::size_t {

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -130,3 +130,16 @@ TEST(JSONSchema_frame, uri_iterators) {
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/test#foo"));
 }
+
+TEST(JSONSchema_frame, reference_frame_uri_canonicalize) {
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  frame.store("https://example.com#", "https://example.com#",
+              sourcemeta::jsontoolkit::empty_pointer,
+              "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_EQ(frame.size(), 1);
+  EXPECT_TRUE(frame.defines("https://example.com"));
+  // This is canonicalized
+  EXPECT_TRUE(frame.defines("https://example.com#"));
+  // This must not be canonicalized
+  EXPECT_EQ(frame.base("https://example.com"), "https://example.com#");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
