### PR TITLE
Add an assertion to confirm there is one base dialect only in `frame()`

### DIFF
--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -117,6 +117,7 @@ auto sourcemeta::jsontoolkit::frame(
 
     const auto effective_dialects{
         find_nearest_bases(base_dialects, pointer, root_dialect)};
+    assert(effective_dialects.size() == 1);
 
     // Handle schema identifiers
     const std::optional<std::string> id{


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
