### PR TITLE
Rename `base()` to `root()` in `ReferenceFrame`

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -28,10 +28,10 @@ class SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT ReferenceFrame {
 public:
   /// Get the identifier of the root JSON Schema that declares the schema
   /// registered at the given URI.
-  auto base(const std::string &uri) const -> const std::string &;
+  auto root(const std::string &uri) const -> const std::string &;
 
   /// Get the JSON Pointer that must be used to get the schema registered at a
-  /// given URI, relative to its base schema
+  /// given URI, relative to its root schema
   auto pointer(const std::string &uri) const -> const Pointer &;
 
   /// Get the dialect that must be used to evaluate the schema registered at a
@@ -48,8 +48,8 @@ public:
   auto empty() const -> bool;
 
   /// Store a new entry in the reference frame
-  auto store(const std::string &uri, const std::string &base_identifier,
-             const Pointer &pointer_from_base, const std::string &dialect)
+  auto store(const std::string &uri, const std::string &root,
+             const Pointer &pointer_from_root, const std::string &dialect)
       -> void;
 
   /// Get a begin iterator on the URIs registered in the static frame

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -24,7 +24,7 @@ auto sourcemeta::jsontoolkit::ReferenceFrame::empty() const -> bool {
   return this->data.empty();
 }
 
-auto sourcemeta::jsontoolkit::ReferenceFrame::base(const std::string &uri) const
+auto sourcemeta::jsontoolkit::ReferenceFrame::root(const std::string &uri) const
     -> const std::string & {
   assert(this->defines(uri));
   return std::get<0>(this->data.at(uri));
@@ -43,12 +43,11 @@ auto sourcemeta::jsontoolkit::ReferenceFrame::dialect(
 }
 
 auto sourcemeta::jsontoolkit::ReferenceFrame::store(
-    const std::string &uri, const std::string &base_identifier,
-    const sourcemeta::jsontoolkit::Pointer &pointer_from_base,
+    const std::string &uri, const std::string &root_id,
+    const sourcemeta::jsontoolkit::Pointer &pointer_from_root,
     const std::string &dialect) -> void {
   const auto canonical{sourcemeta::jsontoolkit::URI{uri}.canonicalize()};
-  if (!this->data
-           .insert({canonical, {base_identifier, pointer_from_base, dialect}})
+  if (!this->data.insert({canonical, {root_id, pointer_from_root, dialect}})
            .second) {
     std::ostringstream error;
     error << "Schema identifier already exists: " << uri;

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_2019_09(frame, reference, base_id, expected_pointer)      \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_2019_09(frame, reference, root_id, expected_pointer)      \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "https://json-schema.org/draft/2019-09/schema");
 
 TEST(JSONSchema_frame_2019_09, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_2020_12(frame, reference, base_id, expected_pointer)      \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_2020_12(frame, reference, root_id, expected_pointer)      \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "https://json-schema.org/draft/2020-12/schema");
 
 TEST(JSONSchema_frame_2020_12, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT0(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT0(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-00/schema#");
 
 TEST(JSONSchema_frame_draft0, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT1(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT1(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-01/schema#");
 
 TEST(JSONSchema_frame_draft1, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT2(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT2(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-02/schema#");
 
 TEST(JSONSchema_frame_draft2, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT3(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT3(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-03/schema#");
 
 TEST(JSONSchema_frame_draft3, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT4(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT4(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-04/schema#");
 
 TEST(JSONSchema_frame_draft4, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT6(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT6(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-06/schema#");
 
 TEST(JSONSchema_frame_draft6, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -6,8 +6,8 @@
 
 #include "jsonschema_test_utils.h"
 
-#define EXPECT_FRAME_DRAFT7(frame, reference, base_id, expected_pointer)       \
-  EXPECT_FRAME(frame, reference, base_id, expected_pointer,                    \
+#define EXPECT_FRAME_DRAFT7(frame, reference, root_id, expected_pointer)       \
+  EXPECT_FRAME(frame, reference, root_id, expected_pointer,                    \
                "http://json-schema.org/draft-07/schema#");
 
 TEST(JSONSchema_frame_draft7, empty_schema) {

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -215,5 +215,5 @@ TEST(JSONSchema_frame, reference_frame_uri_canonicalize) {
   // This is canonicalized
   EXPECT_TRUE(frame.defines("https://example.com#"));
   // This must not be canonicalized
-  EXPECT_EQ(frame.base("https://example.com"), "https://example.com#");
+  EXPECT_EQ(frame.root("https://example.com"), "https://example.com#");
 }

--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -1,10 +1,10 @@
 #ifndef SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_TEST_UTILS_H_
 #define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_TEST_UTILS_H_
 
-#define EXPECT_FRAME(frame, reference, base_id, expected_pointer,              \
+#define EXPECT_FRAME(frame, reference, root_id, expected_pointer,              \
                      expected_dialect)                                         \
   EXPECT_TRUE((frame).defines((reference)));                                   \
-  EXPECT_EQ((frame).base((reference)), (base_id));                             \
+  EXPECT_EQ((frame).root((reference)), (root_id));                             \
   EXPECT_EQ((frame).pointer((reference)),                                      \
             sourcemeta::jsontoolkit::to_pointer(                               \
                 sourcemeta::jsontoolkit::JSON((expected_pointer))));           \


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
