### PR TITLE
Extend `.frame()` to receive `ReferenceMap` argument

### DIFF
--- a/contrib/jsonschema_frame/main.cc
+++ b/contrib/jsonschema_frame/main.cc
@@ -17,7 +17,9 @@ auto frame(std::basic_istream<CharT, Traits> &stream) -> int {
       sourcemeta::jsontoolkit::parse(stream);
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(schema, static_frame,
+  // TODO: Print out references
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(schema, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -107,6 +107,7 @@ static auto find_every_base(const std::map<sourcemeta::jsontoolkit::Pointer,
 auto sourcemeta::jsontoolkit::frame(
     const sourcemeta::jsontoolkit::JSON &schema,
     sourcemeta::jsontoolkit::ReferenceFrame &static_frame,
+    sourcemeta::jsontoolkit::ReferenceMap &,
     const sourcemeta::jsontoolkit::SchemaWalker &walker,
     const sourcemeta::jsontoolkit::SchemaResolver &resolver,
     const std::optional<std::string> &default_dialect,
@@ -218,6 +219,7 @@ auto sourcemeta::jsontoolkit::frame(
 
       if (bases.empty()) {
         if (type == sourcemeta::jsontoolkit::AnchorType::Static) {
+          // TODO: Resolve anchor and insert to `references`
           static_frame.store(anchor_uri.recompose(), root_id, "", pointer,
                              effective_dialects.front());
         }
@@ -231,6 +233,7 @@ auto sourcemeta::jsontoolkit::frame(
               continue;
             }
 
+            // TODO: Resolve anchor and insert to `references`
             static_frame.store(result, root_id, base_string, pointer,
                                effective_dialects.front());
           }

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2019_09(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/type",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
@@ -117,7 +127,8 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -189,6 +200,10 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/type",
                        "https://www.sourcemeta.com/test/qux",
                        "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
@@ -203,7 +218,8 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -246,6 +262,10 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
                        "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_2019_09(static_frame, "#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, nested_schemas) {
@@ -274,7 +294,8 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -424,6 +445,11 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
   EXPECT_FRAME_2019_09(static_frame, "#/properties/baz/items/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/items/$anchor");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, id_override) {
@@ -435,8 +461,9 @@ TEST(JSONSchema_frame_2019_09, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -453,8 +480,9 @@ TEST(JSONSchema_frame_2019_09, static_anchor_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -469,7 +497,8 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2019-09/schema",
@@ -494,6 +523,10 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2019_09(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
@@ -517,10 +550,12 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "https://json-schema.org/draft/2019-09/schema", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "https://json-schema.org/draft/2019-09/schema",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 50);
@@ -630,4 +665,9 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
   EXPECT_FRAME_2019_09(static_frame, "#/properties/two/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$anchor");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2020_12(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/type",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
@@ -117,7 +127,8 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -189,6 +200,11 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/type",
                        "https://www.sourcemeta.com/test/qux",
                        "/properties/foo/type");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
@@ -203,7 +219,8 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -242,6 +259,10 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
                        "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_2020_12(static_frame, "#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, nested_schemas) {
@@ -270,7 +291,8 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -420,6 +442,11 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
   EXPECT_FRAME_2020_12(static_frame, "#/properties/baz/items/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/items/$anchor");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, id_override) {
@@ -431,8 +458,9 @@ TEST(JSONSchema_frame_2020_12, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -449,8 +477,9 @@ TEST(JSONSchema_frame_2020_12, static_anchor_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -465,7 +494,8 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
@@ -490,6 +520,10 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2020_12(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
@@ -513,10 +547,12 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "https://json-schema.org/draft/2020-12/schema", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "https://json-schema.org/draft/2020-12/schema",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 50);
@@ -626,4 +662,9 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
   EXPECT_FRAME_2020_12(static_frame, "#/properties/two/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$anchor");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -42,6 +43,10 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
                       "/id");
   EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
@@ -56,7 +61,8 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -104,6 +110,10 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT0(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
@@ -115,7 +125,8 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -159,6 +170,10 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT0(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
@@ -173,7 +188,8 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -216,6 +232,10 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT0(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft0, id_override) {
@@ -227,8 +247,9 @@ TEST(JSONSchema_frame_draft0, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -243,7 +264,8 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-00/schema#",
@@ -269,6 +291,10 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
                       "/id");
   EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
@@ -287,10 +313,12 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-00/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-00/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -358,4 +386,8 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT0(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
                       "/id");
   EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT1(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
@@ -114,7 +124,8 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -158,6 +169,10 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT1(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
@@ -172,7 +187,8 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -215,6 +231,10 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT1(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft1, id_override) {
@@ -226,8 +246,9 @@ TEST(JSONSchema_frame_draft1, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -242,7 +263,8 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-01/schema#",
@@ -268,6 +290,10 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
                       "/id");
   EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
@@ -286,10 +312,12 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-01/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-01/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -357,4 +385,8 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT1(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
                       "/id");
   EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT2(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
@@ -114,7 +124,8 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -158,6 +169,10 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT2(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
@@ -172,7 +187,8 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -215,6 +231,10 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT2(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft2, id_override) {
@@ -226,8 +246,9 @@ TEST(JSONSchema_frame_draft2, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -242,7 +263,8 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-02/schema#",
@@ -268,6 +290,10 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
                       "/id");
   EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
@@ -286,10 +312,12 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-02/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-02/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -357,4 +385,8 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT2(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
                       "/id");
   EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT3(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
@@ -114,7 +124,8 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -158,6 +169,10 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT3(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
@@ -172,7 +187,8 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -215,6 +231,10 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT3(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft3, id_override) {
@@ -226,8 +246,9 @@ TEST(JSONSchema_frame_draft3, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -242,7 +263,8 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-03/schema#",
@@ -268,6 +290,10 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
                       "/id");
   EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
@@ -286,10 +312,12 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-03/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-03/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -357,4 +385,8 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT3(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
                       "/id");
   EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT4(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
@@ -114,7 +124,8 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -158,6 +169,10 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT4(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
@@ -172,7 +187,8 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -215,6 +231,10 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT4(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft4, id_override) {
@@ -226,8 +246,9 @@ TEST(JSONSchema_frame_draft4, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -242,7 +263,8 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-04/schema#",
@@ -268,6 +290,10 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
                       "/id");
   EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
@@ -286,10 +312,12 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-04/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-04/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -357,4 +385,8 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT4(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT6(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
@@ -114,7 +124,8 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -158,6 +169,10 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
@@ -172,7 +187,8 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -215,6 +231,10 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft6, id_override) {
@@ -226,8 +246,9 @@ TEST(JSONSchema_frame_draft6, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -242,7 +263,8 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-06/schema#",
@@ -268,6 +290,10 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
@@ -286,10 +312,12 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-06/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-06/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -357,4 +385,8 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT6(static_frame, "#/properties/two/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/$id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -18,7 +18,8 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -41,6 +42,10 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
@@ -55,7 +60,8 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -103,6 +109,10 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT7(static_frame, "#/properties/foo/type",
                       "https://www.sourcemeta.com/schema",
                       "/properties/foo/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
@@ -114,7 +124,8 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -158,6 +169,10 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
@@ -172,7 +187,8 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -215,6 +231,10 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
                       "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft7, id_override) {
@@ -226,8 +246,9 @@ TEST(JSONSchema_frame_draft7, id_override) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame,
+                   document, static_frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -242,7 +263,8 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-07/schema#",
@@ -267,6 +289,10 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
@@ -285,10 +311,12 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-07/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-07/schema#",
+                                 "https://www.example.com")
       .wait();
 
   EXPECT_EQ(static_frame.size(), 30);
@@ -356,4 +384,8 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
   EXPECT_FRAME_DRAFT7(static_frame, "#/properties/two/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/$id");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -28,7 +28,8 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -202,6 +203,10 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
                "https://www.sourcemeta.com/test",
                "/$defs/foo/definitions/bar/type",
                "http://json-schema.org/draft-04/schema#");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame, no_id) {
@@ -221,7 +226,8 @@ TEST(JSONSchema_frame, no_id) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -263,6 +269,11 @@ TEST(JSONSchema_frame, no_id) {
   EXPECT_ANONYMOUS_FRAME(static_frame, "https://example.com#/$anchor",
                          "/properties/bar/$anchor",
                          "https://json-schema.org/draft/2020-12/schema");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame, no_id_with_default) {
@@ -273,7 +284,8 @@ TEST(JSONSchema_frame, no_id_with_default) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
@@ -316,6 +328,10 @@ TEST(JSONSchema_frame, no_id_with_default) {
             "https://www.sourcemeta.com/schema");
   EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema#/items/type"),
             "https://www.sourcemeta.com/schema");
+
+  // References
+
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame, anchor_on_absolute_subid) {
@@ -332,7 +348,8 @@ TEST(JSONSchema_frame, anchor_on_absolute_subid) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -421,6 +438,11 @@ TEST(JSONSchema_frame, anchor_on_absolute_subid) {
             "https://www.example.org");
   EXPECT_EQ(static_frame.base("https://www.example.org#/items/$anchor"),
             "https://www.example.org");
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame, uri_iterators) {
@@ -436,7 +458,8 @@ TEST(JSONSchema_frame, uri_iterators) {
   })JSON");
 
   sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::frame(document, static_frame,
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, static_frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -470,6 +493,11 @@ TEST(JSONSchema_frame, uri_iterators) {
   EXPECT_TRUE(uris.contains("#/items/$id"));
   EXPECT_TRUE(uris.contains("#/items/$anchor"));
   EXPECT_TRUE(uris.contains("#/items/type"));
+
+  // References
+
+  // TODO: Get anchors
+  EXPECT_TRUE(references.empty());
 }
 
 TEST(JSONSchema_frame, reference_frame_uri_canonicalize) {

--- a/test/jsonschema/referencingsuite.cc
+++ b/test/jsonschema/referencingsuite.cc
@@ -51,8 +51,9 @@ public:
         new_entries;
     for (const auto &[uri, schema] : this->registry) {
       sourcemeta::jsontoolkit::ReferenceFrame static_frame;
+      sourcemeta::jsontoolkit::ReferenceMap references;
       sourcemeta::jsontoolkit::frame(
-          schema.first, static_frame,
+          schema.first, static_frame, references,
           sourcemeta::jsontoolkit::default_schema_walker,
           sourcemeta::jsontoolkit::official_resolver, this->dialect, uri)
           .wait();


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
