### PR TITLE
Don't record plain reference frames on schemas with ids

### DIFF
--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -43,8 +43,10 @@ static auto find_every_base(const std::map<sourcemeta::jsontoolkit::Pointer,
     }
   }
 
-  // The empty base is always a base
-  result.push_back({"", sourcemeta::jsontoolkit::empty_pointer});
+  if (result.empty()) {
+    result.push_back({"", sourcemeta::jsontoolkit::empty_pointer});
+  }
+
   return result;
 }
 

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2019_09(static_frame,
                        "https://www.sourcemeta.com/schema#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_2019_09(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "#/items",
-                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame, "#/items/type",
-                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo",
-                       "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/type",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/type");
 
   // References
 
@@ -147,7 +122,7 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 25);
+  EXPECT_EQ(static_frame.size(), 15);
 
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test/qux",
                        "https://www.sourcemeta.com/test/qux", "");
@@ -198,30 +173,6 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/type",
                        "https://www.sourcemeta.com/test/qux", "/items/type");
 
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "#/items",
-                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_2019_09(static_frame, "#/items/$id",
-                       "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/items/type",
-                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/test/qux", "/properties");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo",
-                       "https://www.sourcemeta.com/test/qux",
-                       "/properties/foo");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/$anchor",
-                       "https://www.sourcemeta.com/test/qux",
-                       "/properties/foo/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/type",
-                       "https://www.sourcemeta.com/test/qux",
-                       "/properties/foo/type");
-
   // References
 
   EXPECT_TRUE(references.empty());
@@ -251,7 +202,7 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo",
@@ -275,19 +226,6 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/$id",
                        "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/type",
-                       "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "#/items",
-                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame, "#/items/$id",
-                       "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -333,7 +271,7 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 45);
+  EXPECT_EQ(static_frame.size(), 30);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo#test"));
@@ -440,45 +378,6 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
       static_frame, "https://www.sourcemeta.com/baz#/items/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/baz/items/$anchor");
 
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo",
-                       "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/items",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/items");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/foo/items/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/items/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/bar",
-                       "https://www.sourcemeta.com/schema", "/properties/bar");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/bar/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/bar/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/baz",
-                       "https://www.sourcemeta.com/schema", "/properties/baz");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/baz/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/baz/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/baz/items",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/baz/items");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/baz/items/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/baz/items/$anchor");
-
   // References
 
   EXPECT_TRUE(references.empty());
@@ -545,7 +444,7 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
@@ -555,13 +454,6 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2019_09(static_frame,
                        "https://www.sourcemeta.com/schema#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -590,7 +482,7 @@ TEST(JSONSchema_frame_2019_09, anchor_top_level) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 10);
+  EXPECT_EQ(static_frame.size(), 6);
 
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
@@ -601,17 +493,6 @@ TEST(JSONSchema_frame_2019_09, anchor_top_level) {
                        "https://www.sourcemeta.com/schema", "/$schema");
   EXPECT_FRAME_2019_09(static_frame,
                        "https://www.sourcemeta.com/schema#/$anchor",
-                       "https://www.sourcemeta.com/schema", "/$anchor");
-
-  // JSON Pointers
-
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "#/$anchor",
                        "https://www.sourcemeta.com/schema", "/$anchor");
 
   // Anchors
@@ -660,7 +541,7 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
       "https://json-schema.org/draft/2019-09/schema", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 51);
+  EXPECT_EQ(static_frame.size(), 39);
 
   EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
@@ -731,35 +612,6 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$id");
   EXPECT_FRAME_2019_09(static_frame, "https://www.test.com#/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/two/$anchor");
-
-  EXPECT_FRAME_2019_09(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2019_09(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "#/items",
-                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame, "#/items/$anchor",
-                       "https://www.sourcemeta.com/schema", "/items/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/one",
-                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/one/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/one/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/one/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/one/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/two",
-                       "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/two/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/two/$id");
-  EXPECT_FRAME_2019_09(static_frame, "#/properties/two/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$anchor");
 

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2020_12(static_frame,
                        "https://www.sourcemeta.com/schema#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_2020_12(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "#/items",
-                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame, "#/items/type",
-                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo",
-                       "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/type",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/type");
 
   // References
 
@@ -147,7 +122,7 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 25);
+  EXPECT_EQ(static_frame.size(), 15);
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test/qux",
                        "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo",
@@ -197,30 +172,6 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#/type",
                        "https://www.sourcemeta.com/test/qux", "/items/type");
 
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "#/items",
-                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_2020_12(static_frame, "#/items/$id",
-                       "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/items/type",
-                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/test/qux", "/properties");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo",
-                       "https://www.sourcemeta.com/test/qux",
-                       "/properties/foo");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/$anchor",
-                       "https://www.sourcemeta.com/test/qux",
-                       "/properties/foo/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/type",
-                       "https://www.sourcemeta.com/test/qux",
-                       "/properties/foo/type");
-
   // References
 
   EXPECT_TRUE(references.empty());
@@ -250,7 +201,7 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo",
@@ -270,19 +221,6 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
                        "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_2020_12(static_frame,
                        "https://www.sourcemeta.com/schema#/items/type",
-                       "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "#/items",
-                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame, "#/items/$id",
-                       "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -328,7 +266,7 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 45);
+  EXPECT_EQ(static_frame.size(), 30);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo#test"));
@@ -435,45 +373,6 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
       static_frame, "https://www.sourcemeta.com/baz#/items/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/baz/items/$anchor");
 
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo",
-                       "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/items",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/items");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/foo/items/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/foo/items/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/bar",
-                       "https://www.sourcemeta.com/schema", "/properties/bar");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/bar/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/bar/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/baz",
-                       "https://www.sourcemeta.com/schema", "/properties/baz");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/baz/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/baz/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/baz/items",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/baz/items");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/baz/items/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/baz/items/$anchor");
-
   // References
 
   EXPECT_TRUE(references.empty());
@@ -540,7 +439,7 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
@@ -550,13 +449,6 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
                        "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_2020_12(static_frame,
                        "https://www.sourcemeta.com/schema#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -585,7 +477,7 @@ TEST(JSONSchema_frame_2020_12, anchor_top_level) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 10);
+  EXPECT_EQ(static_frame.size(), 6);
 
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
@@ -596,17 +488,6 @@ TEST(JSONSchema_frame_2020_12, anchor_top_level) {
                        "https://www.sourcemeta.com/schema", "/$schema");
   EXPECT_FRAME_2020_12(static_frame,
                        "https://www.sourcemeta.com/schema#/$anchor",
-                       "https://www.sourcemeta.com/schema", "/$anchor");
-
-  // JSON Pointers
-
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "#/$anchor",
                        "https://www.sourcemeta.com/schema", "/$anchor");
 
   // Anchors
@@ -655,7 +536,7 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
       "https://json-schema.org/draft/2020-12/schema", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 51);
+  EXPECT_EQ(static_frame.size(), 39);
 
   EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
@@ -726,35 +607,6 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$id");
   EXPECT_FRAME_2020_12(static_frame, "https://www.test.com#/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/two/$anchor");
-
-  EXPECT_FRAME_2020_12(static_frame, "", "https://www.sourcemeta.com/schema",
-                       "");
-  EXPECT_FRAME_2020_12(static_frame, "#/$id",
-                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/$schema",
-                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "#/items",
-                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame, "#/items/$anchor",
-                       "https://www.sourcemeta.com/schema", "/items/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties",
-                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/one",
-                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/one/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/one/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/one/$anchor",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/one/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/two",
-                       "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/two/$id",
-                       "https://www.sourcemeta.com/schema",
-                       "/properties/two/$id");
-  EXPECT_FRAME_2020_12(static_frame, "#/properties/two/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$anchor");
 

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -37,13 +37,6 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT0(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT0(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -75,7 +68,7 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -100,24 +93,6 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT0(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT0(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -145,7 +120,7 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo",
@@ -170,19 +145,6 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT0(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/id",
-                      "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -214,7 +176,7 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo",
@@ -238,19 +200,6 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT0(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -299,7 +248,7 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -310,13 +259,6 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT0(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT0(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -353,7 +295,7 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
       "http://json-schema.org/draft-00/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -397,25 +339,6 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
   EXPECT_FRAME_DRAFT0(static_frame, "https://www.test.com#/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/id");
-
-  EXPECT_FRAME_DRAFT0(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties/one/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT0(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT1(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT1(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT1(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT1(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -144,7 +119,7 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo",
@@ -169,19 +144,6 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT1(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/id",
-                      "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -213,7 +175,7 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo",
@@ -237,19 +199,6 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT1(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -298,7 +247,7 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -309,13 +258,6 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT1(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT1(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -352,7 +294,7 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
       "http://json-schema.org/draft-01/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -396,25 +338,6 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
   EXPECT_FRAME_DRAFT1(static_frame, "https://www.test.com#/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/id");
-
-  EXPECT_FRAME_DRAFT1(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties/one/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT1(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT2(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT2(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT2(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT2(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -144,7 +119,7 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo",
@@ -169,19 +144,6 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT2(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/id",
-                      "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -213,7 +175,7 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo",
@@ -237,19 +199,6 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT2(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -298,7 +247,7 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -309,13 +258,6 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT2(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT2(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -352,7 +294,7 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
       "http://json-schema.org/draft-02/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -396,25 +338,6 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
   EXPECT_FRAME_DRAFT2(static_frame, "https://www.test.com#/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/id");
-
-  EXPECT_FRAME_DRAFT2(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties/one/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT2(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT3(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT3(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT3(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT3(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -144,7 +119,7 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo",
@@ -169,19 +144,6 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT3(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/id",
-                      "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -213,7 +175,7 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo",
@@ -237,19 +199,6 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT3(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -298,7 +247,7 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -309,13 +258,6 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT3(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT3(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -352,7 +294,7 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
       "http://json-schema.org/draft-03/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -396,25 +338,6 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
   EXPECT_FRAME_DRAFT3(static_frame, "https://www.test.com#/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/id");
-
-  EXPECT_FRAME_DRAFT3(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties/one/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT3(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT4(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT4(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT4(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT4(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -144,7 +119,7 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo",
@@ -169,19 +144,6 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT4(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/id",
-                      "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -213,7 +175,7 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo",
@@ -237,19 +199,6 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT4(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items/id",
-                      "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -298,7 +247,7 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -309,13 +258,6 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/id");
   EXPECT_FRAME_DRAFT4(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT4(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -352,7 +294,7 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
       "http://json-schema.org/draft-04/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -396,25 +338,6 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
   EXPECT_FRAME_DRAFT4(static_frame, "https://www.test.com#/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/id");
-
-  EXPECT_FRAME_DRAFT4(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/id", "https://www.sourcemeta.com/schema",
-                      "/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties/one/id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT4(static_frame, "#/properties/two/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT6(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT6(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT6(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT6(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -144,7 +119,7 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo",
@@ -169,19 +144,6 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT6(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items/$id",
-                      "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -213,7 +175,7 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo",
@@ -237,19 +199,6 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT6(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items/$id",
-                      "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -298,7 +247,7 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
@@ -309,13 +258,6 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT6(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT6(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -352,7 +294,7 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
       "http://json-schema.org/draft-06/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -396,25 +338,6 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/$id");
   EXPECT_FRAME_DRAFT6(static_frame, "https://www.test.com#/$id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/$id");
-
-  EXPECT_FRAME_DRAFT6(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties/one/$id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT6(static_frame, "#/properties/two/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/$id");
 

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -26,7 +26,7 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -36,13 +36,6 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT7(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT7(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -74,7 +67,7 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 16);
+  EXPECT_EQ(static_frame.size(), 8);
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -99,24 +92,6 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
   EXPECT_FRAME_DRAFT7(
       static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
-
-  EXPECT_FRAME_DRAFT7(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties/foo",
-                      "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties/foo/type",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/foo/type");
 
   // References
 
@@ -144,7 +119,7 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo",
@@ -169,19 +144,6 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/test/qux", "/items/type");
-
-  EXPECT_FRAME_DRAFT7(static_frame, "", "https://www.sourcemeta.com/test/qux",
-                      "");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items",
-                      "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items/$id",
-                      "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
@@ -213,7 +175,7 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(static_frame.size(), 9);
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo",
@@ -237,19 +199,6 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/schema", "/items/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/type",
-                      "https://www.sourcemeta.com/schema", "/items/type");
-
-  EXPECT_FRAME_DRAFT7(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items",
-                      "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items/$id",
-                      "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
@@ -298,7 +247,7 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(static_frame.size(), 3);
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
@@ -308,13 +257,6 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
                       "https://www.sourcemeta.com/schema", "/$id");
   EXPECT_FRAME_DRAFT7(static_frame,
                       "https://www.sourcemeta.com/schema#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-
-  EXPECT_FRAME_DRAFT7(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
@@ -351,7 +293,7 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
       "http://json-schema.org/draft-07/schema#", "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
+  EXPECT_EQ(static_frame.size(), 22);
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.example.com"));
@@ -395,25 +337,6 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/$id");
   EXPECT_FRAME_DRAFT7(static_frame, "https://www.test.com#/$id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/two/$id");
-
-  EXPECT_FRAME_DRAFT7(static_frame, "", "https://www.sourcemeta.com/schema",
-                      "");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$id",
-                      "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/$schema",
-                      "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties",
-                      "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties/one",
-                      "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties/one/$id",
-                      "https://www.sourcemeta.com/schema",
-                      "/properties/one/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties/two",
-                      "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_DRAFT7(static_frame, "#/properties/two/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/$id");
 

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -36,7 +36,7 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 32);
+  EXPECT_EQ(static_frame.size(), 21);
 
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
   EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
@@ -175,37 +175,6 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
                "/$defs/foo/definitions/bar/type",
                "http://json-schema.org/draft-04/schema#");
 
-  EXPECT_FRAME(static_frame, "", "https://www.sourcemeta.com/test", "",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$id", "https://www.sourcemeta.com/test", "/$id",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$schema", "https://www.sourcemeta.com/test",
-               "/$schema", "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$defs", "https://www.sourcemeta.com/test",
-               "/$defs", "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$defs/foo", "https://www.sourcemeta.com/test",
-               "/$defs/foo", "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "#/$defs/foo/id",
-               "https://www.sourcemeta.com/test", "/$defs/foo/id",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "#/$defs/foo/$schema",
-               "https://www.sourcemeta.com/test", "/$defs/foo/$schema",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "#/$defs/foo/definitions",
-               "https://www.sourcemeta.com/test", "/$defs/foo/definitions",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "#/$defs/foo/definitions/bar",
-               "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "#/$defs/foo/definitions/bar/id",
-               "https://www.sourcemeta.com/test",
-               "/$defs/foo/definitions/bar/id",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "#/$defs/foo/definitions/bar/type",
-               "https://www.sourcemeta.com/test",
-               "/$defs/foo/definitions/bar/type",
-               "http://json-schema.org/draft-04/schema#");
-
   // References
 
   EXPECT_TRUE(references.empty());
@@ -240,7 +209,7 @@ TEST(JSONSchema_frame, no_id) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 14);
+  EXPECT_EQ(static_frame.size(), 11);
 
   EXPECT_ANONYMOUS_FRAME(static_frame, "", "",
                          "https://json-schema.org/draft/2020-12/schema");
@@ -257,14 +226,6 @@ TEST(JSONSchema_frame, no_id) {
                          "/properties/foo/type",
                          "https://json-schema.org/draft/2020-12/schema");
   EXPECT_ANONYMOUS_FRAME(static_frame, "#foo", "/properties/foo",
-                         "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties/bar", "/properties/bar",
-                         "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties/bar/$id",
-                         "/properties/bar/$id",
-                         "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties/bar/$anchor",
-                         "/properties/bar/$anchor",
                          "https://json-schema.org/draft/2020-12/schema");
   EXPECT_ANONYMOUS_FRAME(static_frame, "https://example.com", "/properties/bar",
                          "https://json-schema.org/draft/2020-12/schema");
@@ -305,7 +266,7 @@ TEST(JSONSchema_frame, no_id_with_default) {
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
+  EXPECT_EQ(static_frame.size(), 4);
   EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/schema",
                "https://www.sourcemeta.com/schema", "",
                "https://json-schema.org/draft/2020-12/schema");
@@ -316,18 +277,6 @@ TEST(JSONSchema_frame, no_id_with_default) {
                "https://www.sourcemeta.com/schema", "/items",
                "https://json-schema.org/draft/2020-12/schema");
   EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/schema#/items/type",
-               "https://www.sourcemeta.com/schema", "/items/type",
-               "https://json-schema.org/draft/2020-12/schema");
-
-  // Empty base
-
-  EXPECT_FRAME(static_frame, "", "https://www.sourcemeta.com/schema", "",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$schema", "https://www.sourcemeta.com/schema",
-               "/$schema", "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/items", "https://www.sourcemeta.com/schema",
-               "/items", "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/items/type",
                "https://www.sourcemeta.com/schema", "/items/type",
                "https://json-schema.org/draft/2020-12/schema");
 
@@ -373,7 +322,7 @@ TEST(JSONSchema_frame, anchor_on_absolute_subid) {
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 19);
+  EXPECT_EQ(static_frame.size(), 12);
   EXPECT_FRAME(static_frame, "https://www.example.com",
                "https://www.example.com", "",
                "https://json-schema.org/draft/2020-12/schema");
@@ -412,22 +361,6 @@ TEST(JSONSchema_frame, anchor_on_absolute_subid) {
                "https://json-schema.org/draft/2020-12/schema");
   EXPECT_FRAME(static_frame, "https://www.example.org#/items/$anchor",
                "https://www.example.com", "/items/items/$anchor",
-               "https://json-schema.org/draft/2020-12/schema");
-
-  EXPECT_FRAME(static_frame, "", "https://www.example.com", "",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$id", "https://www.example.com", "/$id",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/$schema", "https://www.example.com", "/$schema",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/items", "https://www.example.com", "/items",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/items/$id", "https://www.example.com",
-               "/items/$id", "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/items/items", "https://www.example.com",
-               "/items/items", "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "#/items/items/$anchor", "https://www.example.com",
-               "/items/items/$anchor",
                "https://json-schema.org/draft/2020-12/schema");
 
   // Bases
@@ -493,8 +426,8 @@ TEST(JSONSchema_frame, uri_iterators) {
     uris.insert(uri);
   }
 
-  EXPECT_EQ(static_frame.size(), 19);
-  EXPECT_EQ(uris.size(), 19);
+  EXPECT_EQ(static_frame.size(), 12);
+  EXPECT_EQ(uris.size(), 12);
 
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/schema"));
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/test"));
@@ -509,14 +442,6 @@ TEST(JSONSchema_frame, uri_iterators) {
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/test#/$id"));
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/test#/$anchor"));
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/test#/type"));
-
-  EXPECT_TRUE(uris.contains(""));
-  EXPECT_TRUE(uris.contains("#/$id"));
-  EXPECT_TRUE(uris.contains("#/$schema"));
-  EXPECT_TRUE(uris.contains("#/items"));
-  EXPECT_TRUE(uris.contains("#/items/$id"));
-  EXPECT_TRUE(uris.contains("#/items/$anchor"));
-  EXPECT_TRUE(uris.contains("#/items/type"));
 
   // References
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
