### PR TITLE
Simplify `ReferenceMap` to only consider static references

### DIFF
--- a/contrib/jsonschema_frame/main.cc
+++ b/contrib/jsonschema_frame/main.cc
@@ -53,12 +53,10 @@ auto frame(std::basic_istream<CharT, Traits> &stream) -> int {
   std::cout << "--------------------------------------------------\n";
   std::cout << "References: " << references.size() << "\n";
   std::cout << "--------------------------------------------------\n";
-  for (const auto &[pointer, reference] : references) {
-    if (reference.first == sourcemeta::jsontoolkit::ReferenceType::Static) {
-      std::cout << "(STATIC) ";
-      sourcemeta::jsontoolkit::stringify(pointer, std::cout);
-      std::cout << "\n         --> " << reference.second << "\n";
-    }
+  for (const auto &[pointer, destination] : references) {
+    std::cout << "(STATIC) ";
+    sourcemeta::jsontoolkit::stringify(pointer, std::cout);
+    std::cout << "\n         --> " << destination << "\n";
   }
 
   return EXIT_SUCCESS;

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -21,13 +21,9 @@
 namespace sourcemeta::jsontoolkit {
 
 /// @ingroup jsonschema
-/// The reference type
-enum class ReferenceType { Static, Dynamic };
-
-/// @ingroup jsonschema
-/// A JSON Schema reference map is a mapping of a JSON Pointer of a subschema to
-/// a reference type and destination reference URI.
-using ReferenceMap = std::map<Pointer, std::pair<ReferenceType, std::string>>;
+/// A JSON Schema reference map is a mapping of a JSON Pointer
+/// of a subschema to a destination static reference URI.
+using ReferenceMap = std::map<Pointer, std::string>;
 
 // TODO: Support $dynamicRef
 // TODO: Support $recursiveAnchor
@@ -89,25 +85,9 @@ using ReferenceMap = std::map<Pointer, std::pair<ReferenceType, std::string>>;
 /// assert(static_frame.defines("https://www.example.com/foo#/$id"));
 /// assert(static_frame.defines("https://www.example.com/foo#/type"));
 ///
-/// // Anonymous pointers
-/// assert(static_frame.defines(""));
-/// assert(static_frame.defines("#/$id"));
-/// assert(static_frame.defines("#/$schema"));
-/// assert(static_frame.defines("#/items"));
-/// assert(static_frame.defines("#/items/$id"));
-/// assert(static_frame.defines("#/items/type"));
-/// assert(static_frame.defines("#/properties"));
-/// assert(static_frame.defines("#/properties/foo"));
-/// assert(static_frame.defines("#/properties/foo/$anchor"));
-/// assert(static_frame.defines("#/properties/foo/type"));
-/// assert(static_frame.defines("#/properties/bar"));
-/// assert(static_frame.defines("#/properties/bar/$ref"));
-///
 /// // References
 /// assert(references.contains({ "properties", "bar", "$ref" }));
-/// assert(references.at({ "properties", "bar", "$ref" }).first ==
-///   sourcemeta::jsontoolkit::ReferenceType::Static);
-/// assert(references.at({ "properties", "bar", "$ref" }).second ==
+/// assert(references.at({ "properties", "bar", "$ref" }) ==
 ///   "https://www.example.com/schema#/properties/foo");
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -236,11 +236,10 @@ auto sourcemeta::jsontoolkit::frame(
       assert(subschema.at("$ref").is_string());
       const sourcemeta::jsontoolkit::URI ref{subschema.at("$ref").to_string()};
       const auto nearest_bases{find_nearest_bases(base_uris, pointer, id)};
-      references.insert(
-          {pointer.concat({"$ref"}),
-           {ReferenceType::Static,
-            nearest_bases.empty() ? ref.recompose()
-                                  : ref.resolve_from(nearest_bases.front())}});
+      references.insert({pointer.concat({"$ref"}),
+                         nearest_bases.empty()
+                             ? ref.recompose()
+                             : ref.resolve_from(nearest_bases.front())});
     }
   }
 

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -527,14 +527,14 @@ TEST(JSONSchema_frame, refs_with_id) {
       .wait();
 
   EXPECT_EQ(references.size(), 4);
-  EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref",
-                          "https://www.sourcemeta.com/schema#");
-  EXPECT_STATIC_REFERENCE(references, "/properties/bar/$ref",
-                          "https://www.sourcemeta.com/schema#/properties/baz");
-  EXPECT_STATIC_REFERENCE(references, "/properties/qux/$ref",
-                          "https://www.sourcemeta.com/test#");
-  EXPECT_STATIC_REFERENCE(references, "/properties/anchor/$ref",
-                          "https://www.sourcemeta.com/schema#baz");
+  EXPECT_REFERENCE(references, "/properties/foo/$ref",
+                   "https://www.sourcemeta.com/schema#");
+  EXPECT_REFERENCE(references, "/properties/bar/$ref",
+                   "https://www.sourcemeta.com/schema#/properties/baz");
+  EXPECT_REFERENCE(references, "/properties/qux/$ref",
+                   "https://www.sourcemeta.com/test#");
+  EXPECT_REFERENCE(references, "/properties/anchor/$ref",
+                   "https://www.sourcemeta.com/schema#baz");
 }
 
 TEST(JSONSchema_frame, refs_with_no_id) {
@@ -568,10 +568,9 @@ TEST(JSONSchema_frame, refs_with_no_id) {
       .wait();
 
   EXPECT_EQ(references.size(), 4);
-  EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref", "#");
-  EXPECT_STATIC_REFERENCE(references, "/properties/bar/$ref",
-                          "#/properties/baz");
-  EXPECT_STATIC_REFERENCE(references, "/properties/qux/$ref",
-                          "https://www.example.com#");
-  EXPECT_STATIC_REFERENCE(references, "/properties/anchor/$ref", "#baz");
+  EXPECT_REFERENCE(references, "/properties/foo/$ref", "#");
+  EXPECT_REFERENCE(references, "/properties/bar/$ref", "#/properties/baz");
+  EXPECT_REFERENCE(references, "/properties/qux/$ref",
+                   "https://www.example.com#");
+  EXPECT_REFERENCE(references, "/properties/anchor/$ref", "#baz");
 }

--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -1,36 +1,27 @@
 #ifndef SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_TEST_UTILS_H_
 #define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_TEST_UTILS_H_
 
+#define TO_POINTER(pointer_string)                                             \
+  sourcemeta::jsontoolkit::to_pointer(                                         \
+      sourcemeta::jsontoolkit::JSON((pointer_string)))
+
 #define EXPECT_FRAME(frame, reference, root_id, expected_pointer,              \
                      expected_dialect)                                         \
   EXPECT_TRUE((frame).defines((reference)));                                   \
   EXPECT_TRUE((frame).root((reference)).has_value());                          \
   EXPECT_EQ((frame).root((reference)).value(), (root_id));                     \
-  EXPECT_EQ((frame).pointer((reference)),                                      \
-            sourcemeta::jsontoolkit::to_pointer(                               \
-                sourcemeta::jsontoolkit::JSON((expected_pointer))));           \
+  EXPECT_EQ((frame).pointer((reference)), TO_POINTER(expected_pointer));       \
   EXPECT_EQ((frame).dialect((reference)), (expected_dialect));
 
 #define EXPECT_ANONYMOUS_FRAME(frame, reference, expected_pointer,             \
                                expected_dialect)                               \
   EXPECT_TRUE((frame).defines((reference)));                                   \
   EXPECT_FALSE((frame).root((reference)).has_value());                         \
-  EXPECT_EQ((frame).pointer((reference)),                                      \
-            sourcemeta::jsontoolkit::to_pointer(                               \
-                sourcemeta::jsontoolkit::JSON((expected_pointer))));           \
+  EXPECT_EQ((frame).pointer((reference)), TO_POINTER(expected_pointer));       \
   EXPECT_EQ((frame).dialect((reference)), (expected_dialect));
 
-#define EXPECT_REFERENCE(references, expected_pointer, expected_type,          \
-                         expected_uri)                                         \
-  EXPECT_TRUE((references).contains((expected_pointer)));                      \
-  EXPECT_EQ((references).at((expected_pointer)).first,                         \
-            sourcemeta::jsontoolkit::ReferenceType::expected_type);            \
-  EXPECT_EQ((references).at((expected_pointer)).second, (expected_uri));
-
-#define EXPECT_STATIC_REFERENCE(references, expected_pointer, expected_uri)    \
-  EXPECT_REFERENCE(references,                                                 \
-                   sourcemeta::jsontoolkit::to_pointer(                        \
-                       sourcemeta::jsontoolkit::JSON((expected_pointer))),     \
-                   Static, expected_uri);
+#define EXPECT_REFERENCE(references, expected_pointer, expected_uri)           \
+  EXPECT_TRUE((references).contains(TO_POINTER(expected_pointer)));            \
+  EXPECT_EQ((references).at(TO_POINTER(expected_pointer)), (expected_uri));
 
 #endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
