### PR TITLE
Avoid passing a separate `ReferenceFrame` for dynamic frames

### DIFF
--- a/contrib/jsonschema_frame/main.cc
+++ b/contrib/jsonschema_frame/main.cc
@@ -31,24 +31,17 @@ auto frame(std::basic_istream<CharT, Traits> &stream) -> int {
   const sourcemeta::jsontoolkit::JSON schema =
       sourcemeta::jsontoolkit::parse(stream);
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(schema, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(schema, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
   std::cout << "--------------------------------------------------\n";
-  std::cout << "Static frame: " << static_frame.size() << "\n";
+  std::cout << "Static frame: " << frame.size() << "\n";
   std::cout << "--------------------------------------------------\n";
-  print_frame(static_frame);
-
-  std::cout << "--------------------------------------------------\n";
-  std::cout << "Dynamic frame: " << dynamic_frame.size() << "\n";
-  std::cout << "--------------------------------------------------\n";
-  print_frame(dynamic_frame);
+  print_frame(frame);
 
   std::cout << "--------------------------------------------------\n";
   std::cout << "References: " << references.size() << "\n";

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -52,38 +52,37 @@ using ReferenceMap = std::map<Pointer, std::string>;
 ///   }
 /// })JSON");
 ///
-/// sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-/// sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+/// sourcemeta::jsontoolkit::ReferenceFrame frame;
 /// sourcemeta::jsontoolkit::ReferenceMap references;
-/// sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
+/// sourcemeta::jsontoolkit::frame(document, frame,
 /// references,
 ///                                sourcemeta::jsontoolkit::default_schema_walker,
 ///                                sourcemeta::jsontoolkit::official_resolver)
 ///     .wait();
 ///
 /// // IDs
-/// assert(static_frame.defines("https://www.example.com/schema"));
-/// assert(static_frame.defines("https://www.example.com/foo"));
+/// assert(frame.defines("https://www.example.com/schema"));
+/// assert(frame.defines("https://www.example.com/foo"));
 ///
 /// // Anchors
-/// assert(static_frame.defines("https://www.example.com/schema#test"));
+/// assert(frame.defines("https://www.example.com/schema#test"));
 ///
 /// // Root Pointers
-/// assert(static_frame.defines("https://www.example.com/schema#/$id"));
-/// assert(static_frame.defines("https://www.example.com/schema#/$schema"));
-/// assert(static_frame.defines("https://www.example.com/schema#/items"));
-/// assert(static_frame.defines("https://www.example.com/schema#/items/$id"));
-/// assert(static_frame.defines("https://www.example.com/schema#/items/type"));
-/// assert(static_frame.defines("https://www.example.com/schema#/properties"));
-/// assert(static_frame.defines("https://www.example.com/schema#/properties/foo"));
-/// assert(static_frame.defines("https://www.example.com/schema#/properties/foo/$anchor"));
-/// assert(static_frame.defines("https://www.example.com/schema#/properties/foo/type"));
-/// assert(static_frame.defines("https://www.example.com/schema#/properties/bar"));
-/// assert(static_frame.defines("https://www.example.com/schema#/properties/bar/$ref"));
+/// assert(frame.defines("https://www.example.com/schema#/$id"));
+/// assert(frame.defines("https://www.example.com/schema#/$schema"));
+/// assert(frame.defines("https://www.example.com/schema#/items"));
+/// assert(frame.defines("https://www.example.com/schema#/items/$id"));
+/// assert(frame.defines("https://www.example.com/schema#/items/type"));
+/// assert(frame.defines("https://www.example.com/schema#/properties"));
+/// assert(frame.defines("https://www.example.com/schema#/properties/foo"));
+/// assert(frame.defines("https://www.example.com/schema#/properties/foo/$anchor"));
+/// assert(frame.defines("https://www.example.com/schema#/properties/foo/type"));
+/// assert(frame.defines("https://www.example.com/schema#/properties/bar"));
+/// assert(frame.defines("https://www.example.com/schema#/properties/bar/$ref"));
 ///
 /// // Subpointers
-/// assert(static_frame.defines("https://www.example.com/foo#/$id"));
-/// assert(static_frame.defines("https://www.example.com/foo#/type"));
+/// assert(frame.defines("https://www.example.com/foo#/$id"));
+/// assert(frame.defines("https://www.example.com/foo#/type"));
 ///
 /// // References
 /// assert(references.contains({ "properties", "bar", "$ref" }));
@@ -91,8 +90,7 @@ using ReferenceMap = std::map<Pointer, std::string>;
 ///   "https://www.example.com/schema#/properties/foo");
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
-auto frame(const JSON &schema, ReferenceFrame &static_frame,
-           ReferenceFrame &dynamic_frame, ReferenceMap &references,
+auto frame(const JSON &schema, ReferenceFrame &frame, ReferenceMap &references,
            const SchemaWalker &walker, const SchemaResolver &resolver,
            const std::optional<std::string> &default_dialect = std::nullopt,
            const std::optional<std::string> &default_id = std::nullopt)

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -53,8 +53,7 @@ static auto find_every_base(const std::map<sourcemeta::jsontoolkit::Pointer,
 // TODO: Populate the dynamic frame
 auto sourcemeta::jsontoolkit::frame(
     const sourcemeta::jsontoolkit::JSON &schema,
-    sourcemeta::jsontoolkit::ReferenceFrame &static_frame,
-    sourcemeta::jsontoolkit::ReferenceFrame &,
+    sourcemeta::jsontoolkit::ReferenceFrame &frame,
     sourcemeta::jsontoolkit::ReferenceMap &references,
     const sourcemeta::jsontoolkit::SchemaWalker &walker,
     const sourcemeta::jsontoolkit::SchemaResolver &resolver,
@@ -79,9 +78,8 @@ auto sourcemeta::jsontoolkit::frame(
                                        default_id.has_value() &&
                                        root_id.value() != default_id.value()};
   if (has_explicit_different_id) {
-    static_frame.store(default_id.value(), root_id.value(), root_id.value(),
-                       sourcemeta::jsontoolkit::empty_pointer,
-                       root_dialect.value());
+    frame.store(default_id.value(), root_id.value(), root_id.value(),
+                sourcemeta::jsontoolkit::empty_pointer, root_dialect.value());
     base_uris.insert(
         {sourcemeta::jsontoolkit::empty_pointer, {default_id.value()}});
   }
@@ -143,9 +141,9 @@ auto sourcemeta::jsontoolkit::frame(
           const sourcemeta::jsontoolkit::URI base{base_string};
           const sourcemeta::jsontoolkit::URI maybe_relative{id.value()};
           const std::string new_id{maybe_relative.resolve_from(base)};
-          if (!maybe_relative.is_absolute() || !static_frame.defines(new_id)) {
-            static_frame.store(new_id, root_id, new_id, pointer,
-                               effective_dialects.front());
+          if (!maybe_relative.is_absolute() || !frame.defines(new_id)) {
+            frame.store(new_id, root_id, new_id, pointer,
+                        effective_dialects.front());
           }
 
           if (base_uris.contains(pointer)) {
@@ -168,25 +166,25 @@ auto sourcemeta::jsontoolkit::frame(
 
       if (bases.empty()) {
         if (type == sourcemeta::jsontoolkit::AnchorType::Static) {
-          static_frame.store(relative_anchor_uri, root_id, "", pointer,
-                             effective_dialects.front());
+          frame.store(relative_anchor_uri, root_id, "", pointer,
+                      effective_dialects.front());
         }
       } else {
         bool is_first = true;
         for (const auto &base_string : bases) {
           const sourcemeta::jsontoolkit::URI anchor_base{base_string};
           const auto absolute_anchor_uri{anchor_uri.resolve_from(anchor_base)};
-          if (!is_first && static_frame.defines(absolute_anchor_uri)) {
+          if (!is_first && frame.defines(absolute_anchor_uri)) {
             continue;
           }
 
           if (type == sourcemeta::jsontoolkit::AnchorType::Static) {
-            static_frame.store(absolute_anchor_uri, root_id, base_string,
-                               pointer, effective_dialects.front());
+            frame.store(absolute_anchor_uri, root_id, base_string, pointer,
+                        effective_dialects.front());
 
             if (root_id.has_value() && root_id.value() == base_string) {
-              static_frame.store(relative_anchor_uri, root_id, "", pointer,
-                                 effective_dialects.front());
+              frame.store(relative_anchor_uri, root_id, "", pointer,
+                          effective_dialects.front());
             }
           }
 
@@ -208,12 +206,12 @@ auto sourcemeta::jsontoolkit::frame(
       const auto result{base.first.empty()
                             ? relative_pointer_uri.recompose()
                             : relative_pointer_uri.resolve_from({base.first})};
-      if (!static_frame.defines(result)) {
+      if (!frame.defines(result)) {
         const auto nearest_bases{
             find_nearest_bases(base_uris, pointer, base.first)};
         assert(!nearest_bases.empty());
-        static_frame.store(result, root_id, nearest_bases.front(), pointer,
-                           dialects.front());
+        frame.store(result, root_id, nearest_bases.front(), pointer,
+                    dialects.front());
       }
     }
   }

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/items",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/properties",
                        "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/properties/foo",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
@@ -113,73 +97,60 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
+  EXPECT_EQ(frame.size(), 15);
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux",
                        "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo",
                        "https://www.sourcemeta.com/test/qux", "/items");
 
   // Anchors
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test/qux#test",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#test",
                        "https://www.sourcemeta.com/test/qux",
                        "/properties/foo");
-  EXPECT_FRAME_2019_09(static_frame, "#test",
-                       "https://www.sourcemeta.com/test/qux",
+  EXPECT_FRAME_2019_09(frame, "#test", "https://www.sourcemeta.com/test/qux",
                        "/properties/foo");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test/qux#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#/$id",
                        "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                        "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#/items",
                        "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/items/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#/items/$id",
                        "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                        "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/properties",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test/qux#/properties",
                        "https://www.sourcemeta.com/test/qux", "/properties");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/test/qux#/properties/foo",
+      frame, "https://www.sourcemeta.com/test/qux#/properties/foo",
       "https://www.sourcemeta.com/test/qux", "/properties/foo");
   EXPECT_FRAME_2019_09(
-      static_frame,
-      "https://www.sourcemeta.com/test/qux#/properties/foo/$anchor",
+      frame, "https://www.sourcemeta.com/test/qux#/properties/foo/$anchor",
       "https://www.sourcemeta.com/test/qux", "/properties/foo/$anchor");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/test/qux#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/test/qux#/properties/foo/type",
       "https://www.sourcemeta.com/test/qux", "/properties/foo/type");
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/$id",
                        "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/type",
                        "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
@@ -193,48 +164,39 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo",
                        "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/items",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/items/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/items/$id",
                        "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/$id",
                        "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, nested_schemas) {
@@ -262,129 +224,119 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo#test"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz#extra"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/qux"));
+  EXPECT_EQ(frame.size(), 30);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/foo#test"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/bar"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/baz"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/baz#extra"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/qux"));
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#test",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#test",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/bar",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/bar",
                        "https://www.sourcemeta.com/schema", "/properties/bar");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/baz",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/baz",
                        "https://www.sourcemeta.com/schema", "/properties/baz");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/baz#extra",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/baz#extra",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/items");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/qux",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/qux",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/properties",
                        "https://www.sourcemeta.com/schema", "/properties");
 
   // foo
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/properties/foo",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/$id",
       "https://www.sourcemeta.com/schema", "/properties/foo/$id");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/foo/$anchor");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/items",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/items",
       "https://www.sourcemeta.com/schema", "/properties/foo/items");
   EXPECT_FRAME_2019_09(
-      static_frame,
-      "https://www.sourcemeta.com/schema#/properties/foo/items/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/items/$id",
       "https://www.sourcemeta.com/schema", "/properties/foo/items/$id");
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/$anchor",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/foo#/items",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/items",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/items");
-  EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/foo#/items/$id",
-      "https://www.sourcemeta.com/schema", "/properties/foo/items/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/qux#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/foo#/items/$id",
+                       "https://www.sourcemeta.com/schema",
+                       "/properties/foo/items/$id");
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/qux#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/items/$id");
 
   // bar
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/properties/bar",
                        "https://www.sourcemeta.com/schema", "/properties/bar");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/bar/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/bar/$id",
       "https://www.sourcemeta.com/schema", "/properties/bar/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/bar#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/bar#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/bar/$id");
 
   // baz
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/properties/baz",
                        "https://www.sourcemeta.com/schema", "/properties/baz");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/baz/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/baz/$id",
       "https://www.sourcemeta.com/schema", "/properties/baz/$id");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/baz/items",
+      frame, "https://www.sourcemeta.com/schema#/properties/baz/items",
       "https://www.sourcemeta.com/schema", "/properties/baz/items");
   EXPECT_FRAME_2019_09(
-      static_frame,
-      "https://www.sourcemeta.com/schema#/properties/baz/items/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/baz/items/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/baz/items/$anchor");
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/baz#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/baz#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/baz#/items",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/baz#/items",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/items");
-  EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/baz#/items/$anchor",
-      "https://www.sourcemeta.com/schema", "/properties/baz/items/$anchor");
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/baz#/items/$anchor",
+                       "https://www.sourcemeta.com/schema",
+                       "/properties/baz/items/$anchor");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, id_override) {
@@ -395,11 +347,10 @@ TEST(JSONSchema_frame_2019_09, id_override) {
     "items": { "$id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -415,11 +366,10 @@ TEST(JSONSchema_frame_2019_09, static_anchor_override) {
     "items": { "$anchor": "foo" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -433,36 +383,29 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2019-09/schema",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, anchor_top_level) {
@@ -473,42 +416,33 @@ TEST(JSONSchema_frame_2019_09, anchor_top_level) {
     "$anchor": "foo"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(frame.size(), 6);
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$anchor",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$anchor",
                        "https://www.sourcemeta.com/schema", "/$anchor");
 
   // Anchors
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#foo",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#foo",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2019_09(static_frame, "#foo",
-                       "https://www.sourcemeta.com/schema", "");
+  EXPECT_FRAME_2019_09(frame, "#foo", "https://www.sourcemeta.com/schema", "");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
@@ -531,95 +465,88 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "https://json-schema.org/draft/2019-09/schema", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "https://json-schema.org/draft/2019-09/schema",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 39);
+  EXPECT_EQ(frame.size(), 39);
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.example.com",
+  EXPECT_FRAME_2019_09(frame, "https://www.example.com",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_2019_09(frame, "https://www.example.com/test",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.test.com",
+  EXPECT_FRAME_2019_09(frame, "https://www.test.com",
                        "https://www.sourcemeta.com/schema", "/properties/two");
 
   // Anchors
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#foo",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#foo",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.example.com#foo",
+  EXPECT_FRAME_2019_09(frame, "https://www.example.com#foo",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test#bar",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test#bar",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.example.com/test#bar",
+  EXPECT_FRAME_2019_09(frame, "https://www.example.com/test#bar",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.test.com#baz",
+  EXPECT_FRAME_2019_09(frame, "https://www.test.com#baz",
                        "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_2019_09(static_frame, "#foo",
-                       "https://www.sourcemeta.com/schema", "/items");
+  EXPECT_FRAME_2019_09(frame, "#foo", "https://www.sourcemeta.com/schema",
+                       "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/items",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/items/$anchor",
                        "https://www.sourcemeta.com/schema", "/items/$anchor");
-  EXPECT_FRAME_2019_09(static_frame,
-                       "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/schema#/properties",
                        "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/properties/one",
                        "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
       "https://www.sourcemeta.com/schema", "/properties/one/$id");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/one/$anchor");
-  EXPECT_FRAME_2019_09(static_frame,
+  EXPECT_FRAME_2019_09(frame,
                        "https://www.sourcemeta.com/schema#/properties/two",
                        "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
       "https://www.sourcemeta.com/schema", "/properties/two/$id");
   EXPECT_FRAME_2019_09(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/two/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/one/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.sourcemeta.com/test#/$anchor",
+  EXPECT_FRAME_2019_09(frame, "https://www.sourcemeta.com/test#/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/one/$anchor");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.test.com#/$id",
+  EXPECT_FRAME_2019_09(frame, "https://www.test.com#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$id");
-  EXPECT_FRAME_2019_09(static_frame, "https://www.test.com#/$anchor",
+  EXPECT_FRAME_2019_09(frame, "https://www.test.com#/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$anchor");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/items",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/properties",
                        "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/properties/foo",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
@@ -113,72 +97,59 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 15);
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 15);
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux",
                        "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo",
                        "https://www.sourcemeta.com/test/qux", "/items");
 
   // Anchors
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test/qux#test",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#test",
                        "https://www.sourcemeta.com/test/qux",
                        "/properties/foo");
-  EXPECT_FRAME_2020_12(static_frame, "#test",
-                       "https://www.sourcemeta.com/test/qux",
+  EXPECT_FRAME_2020_12(frame, "#test", "https://www.sourcemeta.com/test/qux",
                        "/properties/foo");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test/qux#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#/$id",
                        "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                        "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#/items",
                        "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/items/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#/items/$id",
                        "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                        "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/test/qux#/properties",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test/qux#/properties",
                        "https://www.sourcemeta.com/test/qux", "/properties");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/test/qux#/properties/foo",
+      frame, "https://www.sourcemeta.com/test/qux#/properties/foo",
       "https://www.sourcemeta.com/test/qux", "/properties/foo");
   EXPECT_FRAME_2020_12(
-      static_frame,
-      "https://www.sourcemeta.com/test/qux#/properties/foo/$anchor",
+      frame, "https://www.sourcemeta.com/test/qux#/properties/foo/$anchor",
       "https://www.sourcemeta.com/test/qux", "/properties/foo/$anchor");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/test/qux#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/test/qux#/properties/foo/type",
       "https://www.sourcemeta.com/test/qux", "/properties/foo/type");
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#/$id",
                        "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#/type",
                        "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
@@ -192,44 +163,35 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo",
                        "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/items",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/items/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/items/$id",
                        "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/items/type",
                        "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, nested_schemas) {
@@ -257,129 +219,119 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 30);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo#test"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/baz#extra"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/qux"));
+  EXPECT_EQ(frame.size(), 30);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/foo#test"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/bar"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/baz"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/baz#extra"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/qux"));
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#test",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#test",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/bar",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/bar",
                        "https://www.sourcemeta.com/schema", "/properties/bar");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/baz",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/baz",
                        "https://www.sourcemeta.com/schema", "/properties/baz");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/baz#extra",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/baz#extra",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/items");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/qux",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/qux",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/properties",
                        "https://www.sourcemeta.com/schema", "/properties");
 
   // foo
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/properties/foo",
                        "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/$id",
       "https://www.sourcemeta.com/schema", "/properties/foo/$id");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/foo/$anchor");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/items",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/items",
       "https://www.sourcemeta.com/schema", "/properties/foo/items");
   EXPECT_FRAME_2020_12(
-      static_frame,
-      "https://www.sourcemeta.com/schema#/properties/foo/items/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/items/$id",
       "https://www.sourcemeta.com/schema", "/properties/foo/items/$id");
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#/$anchor",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/foo#/items",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#/items",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/items");
-  EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/foo#/items/$id",
-      "https://www.sourcemeta.com/schema", "/properties/foo/items/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/qux#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/foo#/items/$id",
+                       "https://www.sourcemeta.com/schema",
+                       "/properties/foo/items/$id");
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/qux#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/foo/items/$id");
 
   // bar
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/properties/bar",
                        "https://www.sourcemeta.com/schema", "/properties/bar");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/bar/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/bar/$id",
       "https://www.sourcemeta.com/schema", "/properties/bar/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/bar#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/bar#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/bar/$id");
 
   // baz
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/properties/baz",
                        "https://www.sourcemeta.com/schema", "/properties/baz");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/baz/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/baz/$id",
       "https://www.sourcemeta.com/schema", "/properties/baz/$id");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/baz/items",
+      frame, "https://www.sourcemeta.com/schema#/properties/baz/items",
       "https://www.sourcemeta.com/schema", "/properties/baz/items");
   EXPECT_FRAME_2020_12(
-      static_frame,
-      "https://www.sourcemeta.com/schema#/properties/baz/items/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/baz/items/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/baz/items/$anchor");
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/baz#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/baz#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/baz#/items",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/baz#/items",
                        "https://www.sourcemeta.com/schema",
                        "/properties/baz/items");
-  EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/baz#/items/$anchor",
-      "https://www.sourcemeta.com/schema", "/properties/baz/items/$anchor");
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/baz#/items/$anchor",
+                       "https://www.sourcemeta.com/schema",
+                       "/properties/baz/items/$anchor");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, id_override) {
@@ -390,11 +342,10 @@ TEST(JSONSchema_frame_2020_12, id_override) {
     "items": { "$id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -410,11 +361,10 @@ TEST(JSONSchema_frame_2020_12, static_anchor_override) {
     "items": { "$anchor": "foo" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -428,36 +378,29 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, anchor_top_level) {
@@ -468,42 +411,33 @@ TEST(JSONSchema_frame_2020_12, anchor_top_level) {
     "$anchor": "foo"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 6);
+  EXPECT_EQ(frame.size(), 6);
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$anchor",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$anchor",
                        "https://www.sourcemeta.com/schema", "/$anchor");
 
   // Anchors
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#foo",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#foo",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2020_12(static_frame, "#foo",
-                       "https://www.sourcemeta.com/schema", "");
+  EXPECT_FRAME_2020_12(frame, "#foo", "https://www.sourcemeta.com/schema", "");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
@@ -526,95 +460,88 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "https://json-schema.org/draft/2020-12/schema", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "https://json-schema.org/draft/2020-12/schema",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 39);
+  EXPECT_EQ(frame.size(), 39);
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.example.com",
+  EXPECT_FRAME_2020_12(frame, "https://www.example.com",
                        "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_2020_12(frame, "https://www.example.com/test",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.test.com",
+  EXPECT_FRAME_2020_12(frame, "https://www.test.com",
                        "https://www.sourcemeta.com/schema", "/properties/two");
 
   // Anchors
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.example.com#foo",
+  EXPECT_FRAME_2020_12(frame, "https://www.example.com#foo",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#foo",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#foo",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test#bar",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test#bar",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.example.com/test#bar",
+  EXPECT_FRAME_2020_12(frame, "https://www.example.com/test#bar",
                        "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.test.com#baz",
+  EXPECT_FRAME_2020_12(frame, "https://www.test.com#baz",
                        "https://www.sourcemeta.com/schema", "/properties/two");
-  EXPECT_FRAME_2020_12(static_frame, "#foo",
-                       "https://www.sourcemeta.com/schema", "/items");
+  EXPECT_FRAME_2020_12(frame, "#foo", "https://www.sourcemeta.com/schema",
+                       "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$id",
                        "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/$schema",
                        "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/items",
                        "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/items/$anchor",
                        "https://www.sourcemeta.com/schema", "/items/$anchor");
-  EXPECT_FRAME_2020_12(static_frame,
-                       "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/schema#/properties",
                        "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/properties/one",
                        "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
       "https://www.sourcemeta.com/schema", "/properties/one/$id");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/one/$anchor");
-  EXPECT_FRAME_2020_12(static_frame,
+  EXPECT_FRAME_2020_12(frame,
                        "https://www.sourcemeta.com/schema#/properties/two",
                        "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
       "https://www.sourcemeta.com/schema", "/properties/two/$id");
   EXPECT_FRAME_2020_12(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/$anchor",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/$anchor",
       "https://www.sourcemeta.com/schema", "/properties/two/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/one/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.sourcemeta.com/test#/$anchor",
+  EXPECT_FRAME_2020_12(frame, "https://www.sourcemeta.com/test#/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/one/$anchor");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.test.com#/$id",
+  EXPECT_FRAME_2020_12(frame, "https://www.test.com#/$id",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$id");
-  EXPECT_FRAME_2020_12(static_frame, "https://www.test.com#/$anchor",
+  EXPECT_FRAME_2020_12(frame, "https://www.test.com#/$anchor",
                        "https://www.sourcemeta.com/schema",
                        "/properties/two/$anchor");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -17,35 +17,28 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
@@ -59,48 +52,39 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT0(static_frame,
+  EXPECT_FRAME_DRAFT0(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT0(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
@@ -111,49 +95,39 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
     "items": { "id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/test/qux#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test/qux#/id",
                       "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test/qux#/items/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
@@ -167,48 +141,39 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/items/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft0, id_override) {
@@ -219,11 +184,10 @@ TEST(JSONSchema_frame_draft0, id_override) {
     "items": { "id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -237,37 +201,30 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-00/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
@@ -285,68 +242,61 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-00/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-00/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT0(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT0(static_frame,
+  EXPECT_FRAME_DRAFT0(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT0(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/id",
       "https://www.sourcemeta.com/schema", "/properties/one/id");
-  EXPECT_FRAME_DRAFT0(static_frame,
+  EXPECT_FRAME_DRAFT0(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT0(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/id",
       "https://www.sourcemeta.com/schema", "/properties/two/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.sourcemeta.com/test#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.sourcemeta.com/test#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
-  EXPECT_FRAME_DRAFT0(static_frame, "https://www.test.com#/id",
+  EXPECT_FRAME_DRAFT0(frame, "https://www.test.com#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT1(static_frame,
+  EXPECT_FRAME_DRAFT1(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT1(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
@@ -110,49 +94,39 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
     "items": { "id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/test/qux#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test/qux#/id",
                       "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test/qux#/items/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
@@ -166,48 +140,39 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/items/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft1, id_override) {
@@ -218,11 +183,10 @@ TEST(JSONSchema_frame_draft1, id_override) {
     "items": { "id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -236,37 +200,30 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-01/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
@@ -284,68 +241,61 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-01/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-01/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT1(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT1(static_frame,
+  EXPECT_FRAME_DRAFT1(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT1(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/id",
       "https://www.sourcemeta.com/schema", "/properties/one/id");
-  EXPECT_FRAME_DRAFT1(static_frame,
+  EXPECT_FRAME_DRAFT1(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT1(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/id",
       "https://www.sourcemeta.com/schema", "/properties/two/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.sourcemeta.com/test#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.sourcemeta.com/test#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
-  EXPECT_FRAME_DRAFT1(static_frame, "https://www.test.com#/id",
+  EXPECT_FRAME_DRAFT1(frame, "https://www.test.com#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT2(static_frame,
+  EXPECT_FRAME_DRAFT2(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT2(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
@@ -110,49 +94,39 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
     "items": { "id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/test/qux#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test/qux#/id",
                       "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test/qux#/items/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
@@ -166,48 +140,39 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/items/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft2, id_override) {
@@ -218,11 +183,10 @@ TEST(JSONSchema_frame_draft2, id_override) {
     "items": { "id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -236,37 +200,30 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-02/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
@@ -284,68 +241,61 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-02/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-02/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT2(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT2(static_frame,
+  EXPECT_FRAME_DRAFT2(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT2(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/id",
       "https://www.sourcemeta.com/schema", "/properties/one/id");
-  EXPECT_FRAME_DRAFT2(static_frame,
+  EXPECT_FRAME_DRAFT2(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT2(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/id",
       "https://www.sourcemeta.com/schema", "/properties/two/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.sourcemeta.com/test#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.sourcemeta.com/test#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
-  EXPECT_FRAME_DRAFT2(static_frame, "https://www.test.com#/id",
+  EXPECT_FRAME_DRAFT2(frame, "https://www.test.com#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT3(static_frame,
+  EXPECT_FRAME_DRAFT3(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT3(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
@@ -110,49 +94,39 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
     "items": { "id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/test/qux#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test/qux#/id",
                       "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test/qux#/items/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
@@ -166,48 +140,39 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/items/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft3, id_override) {
@@ -218,11 +183,10 @@ TEST(JSONSchema_frame_draft3, id_override) {
     "items": { "id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -236,37 +200,30 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-03/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
@@ -284,68 +241,61 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-03/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-03/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT3(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT3(static_frame,
+  EXPECT_FRAME_DRAFT3(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT3(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/id",
       "https://www.sourcemeta.com/schema", "/properties/one/id");
-  EXPECT_FRAME_DRAFT3(static_frame,
+  EXPECT_FRAME_DRAFT3(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT3(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/id",
       "https://www.sourcemeta.com/schema", "/properties/two/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.sourcemeta.com/test#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.sourcemeta.com/test#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
-  EXPECT_FRAME_DRAFT3(static_frame, "https://www.test.com#/id",
+  EXPECT_FRAME_DRAFT3(frame, "https://www.test.com#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT4(static_frame,
+  EXPECT_FRAME_DRAFT4(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT4(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
@@ -110,49 +94,39 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
     "items": { "id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/test/qux#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test/qux#/id",
                       "https://www.sourcemeta.com/test/qux", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test/qux#/items/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/test/qux", "/items/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
@@ -166,48 +140,39 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/items/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/foo#/id",
                       "https://www.sourcemeta.com/schema", "/items/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft4, id_override) {
@@ -218,11 +183,10 @@ TEST(JSONSchema_frame_draft4, id_override) {
     "items": { "id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -236,37 +200,30 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-04/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
@@ -284,68 +241,61 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-04/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-04/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/schema#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/id",
                       "https://www.sourcemeta.com/schema", "/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT4(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT4(static_frame,
+  EXPECT_FRAME_DRAFT4(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT4(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/id",
       "https://www.sourcemeta.com/schema", "/properties/one/id");
-  EXPECT_FRAME_DRAFT4(static_frame,
+  EXPECT_FRAME_DRAFT4(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT4(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/id",
       "https://www.sourcemeta.com/schema", "/properties/two/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.sourcemeta.com/test#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.sourcemeta.com/test#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/id");
-  EXPECT_FRAME_DRAFT4(static_frame, "https://www.test.com#/id",
+  EXPECT_FRAME_DRAFT4(frame, "https://www.test.com#/id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT6(static_frame,
+  EXPECT_FRAME_DRAFT6(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT6(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
@@ -110,49 +94,39 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
     "items": { "$id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/test/qux#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test/qux#/$id",
                       "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test/qux#/items/$id",
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
@@ -166,48 +140,39 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/items/$id",
                       "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft6, id_override) {
@@ -218,11 +183,10 @@ TEST(JSONSchema_frame_draft6, id_override) {
     "items": { "$id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -236,37 +200,30 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-06/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
@@ -284,68 +241,61 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-06/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-06/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT6(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT6(static_frame,
+  EXPECT_FRAME_DRAFT6(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT6(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
       "https://www.sourcemeta.com/schema", "/properties/one/$id");
-  EXPECT_FRAME_DRAFT6(static_frame,
+  EXPECT_FRAME_DRAFT6(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT6(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
       "https://www.sourcemeta.com/schema", "/properties/two/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.sourcemeta.com/test#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.sourcemeta.com/test#/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/$id");
-  EXPECT_FRAME_DRAFT6(static_frame, "https://www.test.com#/$id",
+  EXPECT_FRAME_DRAFT6(frame, "https://www.test.com#/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/$id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -17,34 +17,27 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
@@ -58,48 +51,39 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 8);
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 8);
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT7(static_frame,
+  EXPECT_FRAME_DRAFT7(frame,
                       "https://www.sourcemeta.com/schema#/properties/foo",
                       "https://www.sourcemeta.com/schema", "/properties/foo");
   EXPECT_FRAME_DRAFT7(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
+      frame, "https://www.sourcemeta.com/schema#/properties/foo/type",
       "https://www.sourcemeta.com/schema", "/properties/foo/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
@@ -110,49 +94,39 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
     "items": { "$id": "../foo", "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/test/qux",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test/qux",
                       "https://www.sourcemeta.com/test/qux", "");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/test/qux", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/test/qux#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test/qux#/$id",
                       "https://www.sourcemeta.com/test/qux", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/$schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test/qux#/$schema",
                       "https://www.sourcemeta.com/test/qux", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test/qux#/items",
                       "https://www.sourcemeta.com/test/qux", "/items");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test/qux#/items/$id",
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/test/qux#/items/type",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test/qux#/items/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/test/qux", "/items/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/test/qux", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
@@ -166,48 +140,39 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
      }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 9);
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 9);
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/foo",
                       "https://www.sourcemeta.com/schema", "/items");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/items",
                       "https://www.sourcemeta.com/schema", "/items");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/items/$id",
                       "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/items/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/foo#/$id",
                       "https://www.sourcemeta.com/schema", "/items/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/foo#/type",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/foo#/type",
                       "https://www.sourcemeta.com/schema", "/items/type");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft7, id_override) {
@@ -218,11 +183,10 @@ TEST(JSONSchema_frame_draft7, id_override) {
     "items": { "$id": "schema" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
-                   document, static_frame, dynamic_frame, references,
+                   document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
                    sourcemeta::jsontoolkit::official_resolver)
                    .wait(),
@@ -236,36 +200,29 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-07/schema#",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 3);
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 3);
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
@@ -283,68 +240,61 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(
-      document, static_frame, dynamic_frame, references,
-      sourcemeta::jsontoolkit::default_schema_walker,
-      sourcemeta::jsontoolkit::official_resolver,
-      "http://json-schema.org/draft-07/schema#", "https://www.example.com")
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver,
+                                 "http://json-schema.org/draft-07/schema#",
+                                 "https://www.example.com")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 22);
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/schema"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com"));
-  EXPECT_TRUE(static_frame.defines("https://www.example.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.test.com"));
+  EXPECT_EQ(frame.size(), 22);
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/schema"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.example.com"));
+  EXPECT_TRUE(frame.defines("https://www.example.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.test.com"));
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.example.com",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.example.com",
                       "https://www.sourcemeta.com/schema", "");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.example.com/test",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.example.com/test",
                       "https://www.sourcemeta.com/schema", "/properties/one");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.test.com",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.test.com",
                       "https://www.sourcemeta.com/schema", "/properties/two");
 
   // JSON Pointers
 
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/schema#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$id",
                       "https://www.sourcemeta.com/schema", "/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/$schema",
                       "https://www.sourcemeta.com/schema", "/$schema");
-  EXPECT_FRAME_DRAFT7(static_frame,
-                      "https://www.sourcemeta.com/schema#/properties",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/schema#/properties",
                       "https://www.sourcemeta.com/schema", "/properties");
-  EXPECT_FRAME_DRAFT7(static_frame,
+  EXPECT_FRAME_DRAFT7(frame,
                       "https://www.sourcemeta.com/schema#/properties/one",
                       "https://www.sourcemeta.com/schema", "/properties/one");
   EXPECT_FRAME_DRAFT7(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/one/$id",
       "https://www.sourcemeta.com/schema", "/properties/one/$id");
-  EXPECT_FRAME_DRAFT7(static_frame,
+  EXPECT_FRAME_DRAFT7(frame,
                       "https://www.sourcemeta.com/schema#/properties/two",
                       "https://www.sourcemeta.com/schema", "/properties/two");
   EXPECT_FRAME_DRAFT7(
-      static_frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
+      frame, "https://www.sourcemeta.com/schema#/properties/two/$id",
       "https://www.sourcemeta.com/schema", "/properties/two/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.sourcemeta.com/test#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.sourcemeta.com/test#/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/one/$id");
-  EXPECT_FRAME_DRAFT7(static_frame, "https://www.test.com#/$id",
+  EXPECT_FRAME_DRAFT7(frame, "https://www.test.com#/$id",
                       "https://www.sourcemeta.com/schema",
                       "/properties/two/$id");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -27,150 +27,140 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 21);
+  EXPECT_EQ(frame.size(), 21);
 
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/test"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/foo"));
-  EXPECT_TRUE(static_frame.defines("https://www.sourcemeta.com/bar"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/test"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/foo"));
+  EXPECT_TRUE(frame.defines("https://www.sourcemeta.com/bar"));
 
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/test",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test",
                "https://www.sourcemeta.com/test", "",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/foo",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo",
                "https://www.sourcemeta.com/test", "/$defs/foo",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/bar",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/bar",
                "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar",
                "http://json-schema.org/draft-04/schema#");
 
   // Bases
 
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test"),
             "https://www.sourcemeta.com/test");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo"),
             "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/bar"),
             "https://www.sourcemeta.com/bar");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test#/$id"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test#/$id"),
             "https://www.sourcemeta.com/test");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test#/$schema"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test#/$schema"),
             "https://www.sourcemeta.com/test");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test#/$defs"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test#/$defs"),
             "https://www.sourcemeta.com/test");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test#/$defs/foo"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test#/$defs/foo"),
             "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/test#/$defs/foo/id"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test#/$defs/foo/id"),
+            "https://www.sourcemeta.com/foo");
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/test#/$defs/foo/$schema"),
             "https://www.sourcemeta.com/foo");
   EXPECT_EQ(
-      static_frame.base("https://www.sourcemeta.com/test#/$defs/foo/$schema"),
+      frame.base("https://www.sourcemeta.com/test#/$defs/foo/definitions"),
       "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(static_frame.base(
-                "https://www.sourcemeta.com/test#/$defs/foo/definitions"),
-            "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(static_frame.base(
-                "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar"),
-            "https://www.sourcemeta.com/bar");
   EXPECT_EQ(
-      static_frame.base(
+      frame.base("https://www.sourcemeta.com/test#/$defs/foo/definitions/bar"),
+      "https://www.sourcemeta.com/bar");
+  EXPECT_EQ(
+      frame.base(
           "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar/id"),
       "https://www.sourcemeta.com/bar");
   EXPECT_EQ(
-      static_frame.base(
+      frame.base(
           "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar/type"),
       "https://www.sourcemeta.com/bar");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo#/id"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo#/id"),
             "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo#/$schema"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo#/$schema"),
             "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/foo#/definitions"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo#/definitions"),
             "https://www.sourcemeta.com/foo");
-  EXPECT_EQ(
-      static_frame.base("https://www.sourcemeta.com/foo#/definitions/bar"),
-      "https://www.sourcemeta.com/bar");
-  EXPECT_EQ(
-      static_frame.base("https://www.sourcemeta.com/foo#/definitions/bar/id"),
-      "https://www.sourcemeta.com/bar");
-  EXPECT_EQ(
-      static_frame.base("https://www.sourcemeta.com/foo#/definitions/bar/type"),
-      "https://www.sourcemeta.com/bar");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar#/id"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo#/definitions/bar"),
             "https://www.sourcemeta.com/bar");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/bar#/type"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo#/definitions/bar/id"),
+            "https://www.sourcemeta.com/bar");
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/foo#/definitions/bar/type"),
+            "https://www.sourcemeta.com/bar");
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/bar#/id"),
+            "https://www.sourcemeta.com/bar");
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/bar#/type"),
             "https://www.sourcemeta.com/bar");
 
   // JSON Pointers
 
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/test#/$id",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$id",
                "https://www.sourcemeta.com/test", "/$id",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/test#/$schema",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$schema",
                "https://www.sourcemeta.com/test", "/$schema",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/test#/$defs",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$defs",
                "https://www.sourcemeta.com/test", "/$defs",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/test#/$defs/foo",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$defs/foo",
                "https://www.sourcemeta.com/test", "/$defs/foo",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/test#/$defs/foo/id",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$defs/foo/id",
                "https://www.sourcemeta.com/test", "/$defs/foo/id",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame,
-               "https://www.sourcemeta.com/test#/$defs/foo/$schema",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$defs/foo/$schema",
                "https://www.sourcemeta.com/test", "/$defs/foo/$schema",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame,
-               "https://www.sourcemeta.com/test#/$defs/foo/definitions",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/test#/$defs/foo/definitions",
                "https://www.sourcemeta.com/test", "/$defs/foo/definitions",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame,
+  EXPECT_FRAME(frame,
                "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar",
                "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame,
-               "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar/id",
-               "https://www.sourcemeta.com/test",
-               "/$defs/foo/definitions/bar/id",
-               "http://json-schema.org/draft-04/schema#");
   EXPECT_FRAME(
-      static_frame,
-      "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar/type",
-      "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar/type",
-      "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/foo#/id",
-               "https://www.sourcemeta.com/test", "/$defs/foo/id",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/foo#/$schema",
-               "https://www.sourcemeta.com/test", "/$defs/foo/$schema",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/foo#/definitions",
-               "https://www.sourcemeta.com/test", "/$defs/foo/definitions",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/foo#/definitions/bar",
-               "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar",
-               "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(
-      static_frame, "https://www.sourcemeta.com/foo#/definitions/bar/id",
+      frame, "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar/id",
       "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar/id",
       "http://json-schema.org/draft-04/schema#");
   EXPECT_FRAME(
-      static_frame, "https://www.sourcemeta.com/foo#/definitions/bar/type",
+      frame, "https://www.sourcemeta.com/test#/$defs/foo/definitions/bar/type",
       "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar/type",
       "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/bar#/id",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo#/id",
+               "https://www.sourcemeta.com/test", "/$defs/foo/id",
+               "http://json-schema.org/draft-04/schema#");
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo#/$schema",
+               "https://www.sourcemeta.com/test", "/$defs/foo/$schema",
+               "http://json-schema.org/draft-04/schema#");
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo#/definitions",
+               "https://www.sourcemeta.com/test", "/$defs/foo/definitions",
+               "http://json-schema.org/draft-04/schema#");
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo#/definitions/bar",
+               "https://www.sourcemeta.com/test", "/$defs/foo/definitions/bar",
+               "http://json-schema.org/draft-04/schema#");
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo#/definitions/bar/id",
                "https://www.sourcemeta.com/test",
                "/$defs/foo/definitions/bar/id",
                "http://json-schema.org/draft-04/schema#");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/bar#/type",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/foo#/definitions/bar/type",
+               "https://www.sourcemeta.com/test",
+               "/$defs/foo/definitions/bar/type",
+               "http://json-schema.org/draft-04/schema#");
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/bar#/id",
+               "https://www.sourcemeta.com/test",
+               "/$defs/foo/definitions/bar/id",
+               "http://json-schema.org/draft-04/schema#");
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/bar#/type",
                "https://www.sourcemeta.com/test",
                "/$defs/foo/definitions/bar/type",
                "http://json-schema.org/draft-04/schema#");
@@ -178,10 +168,6 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame, no_id) {
@@ -200,52 +186,44 @@ TEST(JSONSchema_frame, no_id) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 11);
+  EXPECT_EQ(frame.size(), 11);
 
-  EXPECT_ANONYMOUS_FRAME(static_frame, "", "",
+  EXPECT_ANONYMOUS_FRAME(frame, "", "",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/$schema", "/$schema",
+  EXPECT_ANONYMOUS_FRAME(frame, "#/$schema", "/$schema",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties", "/properties",
+  EXPECT_ANONYMOUS_FRAME(frame, "#/properties", "/properties",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties/foo", "/properties/foo",
+  EXPECT_ANONYMOUS_FRAME(frame, "#/properties/foo", "/properties/foo",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties/foo/$anchor",
+  EXPECT_ANONYMOUS_FRAME(frame, "#/properties/foo/$anchor",
                          "/properties/foo/$anchor",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#/properties/foo/type",
-                         "/properties/foo/type",
+  EXPECT_ANONYMOUS_FRAME(frame, "#/properties/foo/type", "/properties/foo/type",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "#foo", "/properties/foo",
+  EXPECT_ANONYMOUS_FRAME(frame, "#foo", "/properties/foo",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "https://example.com", "/properties/bar",
+  EXPECT_ANONYMOUS_FRAME(frame, "https://example.com", "/properties/bar",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "https://example.com#bar",
-                         "/properties/bar",
+  EXPECT_ANONYMOUS_FRAME(frame, "https://example.com#bar", "/properties/bar",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "https://example.com#/$id",
+  EXPECT_ANONYMOUS_FRAME(frame, "https://example.com#/$id",
                          "/properties/bar/$id",
                          "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_ANONYMOUS_FRAME(static_frame, "https://example.com#/$anchor",
+  EXPECT_ANONYMOUS_FRAME(frame, "https://example.com#/$anchor",
                          "/properties/bar/$anchor",
                          "https://json-schema.org/draft/2020-12/schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame, no_id_with_default) {
@@ -255,49 +233,43 @@ TEST(JSONSchema_frame, no_id_with_default) {
     "items": { "type": "string" }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
                                  "https://www.sourcemeta.com/schema")
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 4);
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/schema",
+  EXPECT_EQ(frame.size(), 4);
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/schema",
                "https://www.sourcemeta.com/schema", "",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/schema#/$schema",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/schema#/$schema",
                "https://www.sourcemeta.com/schema", "/$schema",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/schema#/items",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/schema#/items",
                "https://www.sourcemeta.com/schema", "/items",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.sourcemeta.com/schema#/items/type",
+  EXPECT_FRAME(frame, "https://www.sourcemeta.com/schema#/items/type",
                "https://www.sourcemeta.com/schema", "/items/type",
                "https://json-schema.org/draft/2020-12/schema");
 
   // Bases
 
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema#/$schema"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/schema#/$schema"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema#/items"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/schema#/items"),
             "https://www.sourcemeta.com/schema");
-  EXPECT_EQ(static_frame.base("https://www.sourcemeta.com/schema#/items/type"),
+  EXPECT_EQ(frame.base("https://www.sourcemeta.com/schema#/items/type"),
             "https://www.sourcemeta.com/schema");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame, anchor_on_absolute_subid) {
@@ -313,91 +285,78 @@ TEST(JSONSchema_frame, anchor_on_absolute_subid) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
-  EXPECT_EQ(static_frame.size(), 12);
-  EXPECT_FRAME(static_frame, "https://www.example.com",
-               "https://www.example.com", "",
+  EXPECT_EQ(frame.size(), 12);
+  EXPECT_FRAME(frame, "https://www.example.com", "https://www.example.com", "",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.org",
-               "https://www.example.com", "/items",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.org#foo",
-               "https://www.example.com", "/items/items",
-               "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_FRAME(frame, "https://www.example.org", "https://www.example.com",
+               "/items", "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_FRAME(frame, "https://www.example.org#foo", "https://www.example.com",
+               "/items/items", "https://json-schema.org/draft/2020-12/schema");
 
   // JSON Pointers
 
-  EXPECT_FRAME(static_frame, "https://www.example.com#/$id",
-               "https://www.example.com", "/$id",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.com#/$schema",
+  EXPECT_FRAME(frame, "https://www.example.com#/$id", "https://www.example.com",
+               "/$id", "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_FRAME(frame, "https://www.example.com#/$schema",
                "https://www.example.com", "/$schema",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.com#/items",
+  EXPECT_FRAME(frame, "https://www.example.com#/items",
                "https://www.example.com", "/items",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.com#/items/$id",
+  EXPECT_FRAME(frame, "https://www.example.com#/items/$id",
                "https://www.example.com", "/items/$id",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.com#/items/items",
+  EXPECT_FRAME(frame, "https://www.example.com#/items/items",
                "https://www.example.com", "/items/items",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.com#/items/items/$anchor",
+  EXPECT_FRAME(frame, "https://www.example.com#/items/items/$anchor",
                "https://www.example.com", "/items/items/$anchor",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.org#/$id",
-               "https://www.example.com", "/items/$id",
-               "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.org#/items",
+  EXPECT_FRAME(frame, "https://www.example.org#/$id", "https://www.example.com",
+               "/items/$id", "https://json-schema.org/draft/2020-12/schema");
+  EXPECT_FRAME(frame, "https://www.example.org#/items",
                "https://www.example.com", "/items/items",
                "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_FRAME(static_frame, "https://www.example.org#/items/$anchor",
+  EXPECT_FRAME(frame, "https://www.example.org#/items/$anchor",
                "https://www.example.com", "/items/items/$anchor",
                "https://json-schema.org/draft/2020-12/schema");
 
   // Bases
 
-  EXPECT_EQ(static_frame.base("https://www.example.com"),
+  EXPECT_EQ(frame.base("https://www.example.com"), "https://www.example.com");
+  EXPECT_EQ(frame.base("https://www.example.com#/$id"),
             "https://www.example.com");
-  EXPECT_EQ(static_frame.base("https://www.example.com#/$id"),
-            "https://www.example.com");
-  EXPECT_EQ(static_frame.base("https://www.example.com#/$schema"),
+  EXPECT_EQ(frame.base("https://www.example.com#/$schema"),
             "https://www.example.com");
 
-  EXPECT_EQ(static_frame.base("https://www.example.org"),
+  EXPECT_EQ(frame.base("https://www.example.org"), "https://www.example.org");
+  EXPECT_EQ(frame.base("https://www.example.org#foo"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.org#foo"),
+  EXPECT_EQ(frame.base("https://www.example.com#/items"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.com#/items"),
+  EXPECT_EQ(frame.base("https://www.example.com#/items/$id"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.com#/items/$id"),
+  EXPECT_EQ(frame.base("https://www.example.com#/items/items"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.com#/items/items"),
+  EXPECT_EQ(frame.base("https://www.example.com#/items/items/$anchor"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.com#/items/items/$anchor"),
+  EXPECT_EQ(frame.base("https://www.example.org#/$id"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.org#/$id"),
+  EXPECT_EQ(frame.base("https://www.example.org#/items"),
             "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.org#/items"),
-            "https://www.example.org");
-  EXPECT_EQ(static_frame.base("https://www.example.org#/items/$anchor"),
+  EXPECT_EQ(frame.base("https://www.example.org#/items/$anchor"),
             "https://www.example.org");
 
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame, uri_iterators) {
@@ -412,21 +371,19 @@ TEST(JSONSchema_frame, uri_iterators) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
   std::set<std::string> uris;
-  for (const auto &uri : static_frame) {
+  for (const auto &uri : frame) {
     uris.insert(uri);
   }
 
-  EXPECT_EQ(static_frame.size(), 12);
+  EXPECT_EQ(frame.size(), 12);
   EXPECT_EQ(uris.size(), 12);
 
   EXPECT_TRUE(uris.contains("https://www.sourcemeta.com/schema"));
@@ -446,10 +403,6 @@ TEST(JSONSchema_frame, uri_iterators) {
   // References
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame, reference_frame_uri_canonicalize) {
@@ -479,20 +432,14 @@ TEST(JSONSchema_frame, no_refs) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
 
   EXPECT_TRUE(references.empty());
-
-  // Dynamic frame
-
-  EXPECT_TRUE(dynamic_frame.empty());
 }
 
 TEST(JSONSchema_frame, refs_with_id) {
@@ -517,11 +464,9 @@ TEST(JSONSchema_frame, refs_with_id) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();
@@ -558,11 +503,9 @@ TEST(JSONSchema_frame, refs_with_no_id) {
     }
   })JSON");
 
-  sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-  sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
-  sourcemeta::jsontoolkit::frame(document, static_frame, dynamic_frame,
-                                 references,
+  sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver)
       .wait();

--- a/test/jsonschema/referencingsuite.cc
+++ b/test/jsonschema/referencingsuite.cc
@@ -50,19 +50,18 @@ public:
     std::map<std::string, std::pair<sourcemeta::jsontoolkit::JSON, std::string>>
         new_entries;
     for (const auto &[uri, schema] : this->registry) {
-      sourcemeta::jsontoolkit::ReferenceFrame static_frame;
-      sourcemeta::jsontoolkit::ReferenceFrame dynamic_frame;
+      sourcemeta::jsontoolkit::ReferenceFrame frame;
       sourcemeta::jsontoolkit::ReferenceMap references;
       sourcemeta::jsontoolkit::frame(
-          schema.first, static_frame, dynamic_frame, references,
+          schema.first, frame, references,
           sourcemeta::jsontoolkit::default_schema_walker,
           sourcemeta::jsontoolkit::official_resolver, this->dialect, uri)
           .wait();
-      for (const auto &entry : static_frame) {
-        new_entries.insert({entry,
-                            {sourcemeta::jsontoolkit::get(
-                                 schema.first, static_frame.pointer(entry)),
-                             static_frame.base(entry)}});
+      for (const auto &entry : frame) {
+        new_entries.insert(
+            {entry,
+             {sourcemeta::jsontoolkit::get(schema.first, frame.pointer(entry)),
+              frame.base(entry)}});
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
