### PR TITLE
Extend `ReferenceMap` to split URI by its potential fragment

### DIFF
--- a/contrib/jsonschema_frame/main.cc
+++ b/contrib/jsonschema_frame/main.cc
@@ -54,7 +54,17 @@ auto frame(std::basic_istream<CharT, Traits> &stream) -> int {
     }
 
     sourcemeta::jsontoolkit::stringify(pointer.first, std::cout);
-    std::cout << "\n         --> " << destination << "\n";
+    std::cout << "\n         --> " << std::get<0>(destination) << "\n";
+
+    if (std::get<1>(destination).has_value()) {
+      std::cout << "\n         --> (without fragment) "
+                << std::get<1>(destination).value() << "\n";
+    }
+
+    if (std::get<2>(destination).has_value()) {
+      std::cout << "\n         --> (fragment) "
+                << std::get<2>(destination).value() << "\n";
+    }
   }
 
   return EXIT_SUCCESS;

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -16,6 +16,7 @@
 #include <map>      // std::map
 #include <optional> // std::optional
 #include <string>   // std::string
+#include <tuple>    // std::tuple
 #include <utility>  // std::pair
 
 namespace sourcemeta::jsontoolkit {
@@ -24,13 +25,20 @@ namespace sourcemeta::jsontoolkit {
 /// The reference type
 enum class ReferenceType { Static, Dynamic };
 
+// TODO: Encapsulate this behind a class to make sure we
+// can keep a stable API even if changing the underlying map.
 /// @ingroup jsonschema
 /// A JSON Schema reference map is a mapping of a JSON Pointer
 /// of a subschema to a destination static reference URI.
+/// For convenient, the value consists of the URI on its entirety,
+/// but also broken down by its potential fragment component.
 /// The reference type is part of the key as it is possible to
 /// have a static and a dynamic reference to the same location
 /// on the same schema object.
-using ReferenceMap = std::map<std::pair<Pointer, ReferenceType>, std::string>;
+using ReferenceMap =
+    std::map<std::pair<Pointer, ReferenceType>,
+             std::tuple<std::string, std::optional<std::string>,
+                        std::optional<std::string>>>;
 
 // TODO: Support $recursiveAnchor
 // TODO: Support $recursiveRef

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -577,13 +577,18 @@ TEST(JSONSchema_frame_2020_12, dynamic_refs_with_id) {
 
   EXPECT_EQ(references.size(), 4);
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/foo/$dynamicRef",
-                           "https://www.sourcemeta.com/schema#");
+                           "https://www.sourcemeta.com/schema#",
+                           "https://www.sourcemeta.com/schema", "");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/bar/$dynamicRef",
-                           "https://www.sourcemeta.com/schema#/properties/baz");
+                           "https://www.sourcemeta.com/schema#/properties/baz",
+                           "https://www.sourcemeta.com/schema",
+                           "/properties/baz");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/qux/$dynamicRef",
-                           "https://www.sourcemeta.com/test#");
+                           "https://www.sourcemeta.com/test#",
+                           "https://www.sourcemeta.com/test", "");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/anchor/$dynamicRef",
-                           "https://www.sourcemeta.com/schema#baz");
+                           "https://www.sourcemeta.com/schema#baz",
+                           "https://www.sourcemeta.com/schema", "baz");
 }
 
 TEST(JSONSchema_frame_2020_12, dynamic_refs_with_no_id) {
@@ -615,13 +620,15 @@ TEST(JSONSchema_frame_2020_12, dynamic_refs_with_no_id) {
       .wait();
 
   EXPECT_EQ(references.size(), 4);
-  EXPECT_DYNAMIC_REFERENCE(references, "/properties/foo/$dynamicRef", "#");
+  EXPECT_DYNAMIC_REFERENCE(references, "/properties/foo/$dynamicRef", "#",
+                           std::nullopt, "");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/bar/$dynamicRef",
-                           "#/properties/baz");
+                           "#/properties/baz", std::nullopt, "/properties/baz");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/qux/$dynamicRef",
-                           "https://www.example.com#");
-  EXPECT_DYNAMIC_REFERENCE(references, "/properties/anchor/$dynamicRef",
-                           "#baz");
+                           "https://www.example.com#",
+                           "https://www.example.com", "");
+  EXPECT_DYNAMIC_REFERENCE(references, "/properties/anchor/$dynamicRef", "#baz",
+                           std::nullopt, "baz");
 }
 
 TEST(JSONSchema_frame_2020_12, different_dynamic_and_refs_in_same_object) {
@@ -649,9 +656,12 @@ TEST(JSONSchema_frame_2020_12, different_dynamic_and_refs_in_same_object) {
 
   EXPECT_EQ(references.size(), 2);
   EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref",
-                          "https://www.sourcemeta.com/schema#/properties/bar");
+                          "https://www.sourcemeta.com/schema#/properties/bar",
+                          "https://www.sourcemeta.com/schema",
+                          "/properties/bar");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/foo/$dynamicRef",
-                           "https://www.sourcemeta.com/schema#");
+                           "https://www.sourcemeta.com/schema#",
+                           "https://www.sourcemeta.com/schema", "");
 }
 
 TEST(JSONSchema_frame_2020_12, same_dynamic_and_refs_in_same_object) {
@@ -679,7 +689,11 @@ TEST(JSONSchema_frame_2020_12, same_dynamic_and_refs_in_same_object) {
 
   EXPECT_EQ(references.size(), 2);
   EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref",
-                          "https://www.sourcemeta.com/schema#/properties/bar");
+                          "https://www.sourcemeta.com/schema#/properties/bar",
+                          "https://www.sourcemeta.com/schema",
+                          "/properties/bar");
   EXPECT_DYNAMIC_REFERENCE(references, "/properties/foo/$dynamicRef",
-                           "https://www.sourcemeta.com/schema#/properties/bar");
+                           "https://www.sourcemeta.com/schema#/properties/bar",
+                           "https://www.sourcemeta.com/schema",
+                           "/properties/bar");
 }

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -473,13 +473,18 @@ TEST(JSONSchema_frame, refs_with_id) {
 
   EXPECT_EQ(references.size(), 4);
   EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref",
-                          "https://www.sourcemeta.com/schema#");
+                          "https://www.sourcemeta.com/schema#",
+                          "https://www.sourcemeta.com/schema", "");
   EXPECT_STATIC_REFERENCE(references, "/properties/bar/$ref",
-                          "https://www.sourcemeta.com/schema#/properties/baz");
+                          "https://www.sourcemeta.com/schema#/properties/baz",
+                          "https://www.sourcemeta.com/schema",
+                          "/properties/baz");
   EXPECT_STATIC_REFERENCE(references, "/properties/qux/$ref",
-                          "https://www.sourcemeta.com/test#");
+                          "https://www.sourcemeta.com/test#",
+                          "https://www.sourcemeta.com/test", "");
   EXPECT_STATIC_REFERENCE(references, "/properties/anchor/$ref",
-                          "https://www.sourcemeta.com/schema#baz");
+                          "https://www.sourcemeta.com/schema#baz",
+                          "https://www.sourcemeta.com/schema", "baz");
 }
 
 TEST(JSONSchema_frame, refs_with_no_id) {
@@ -511,10 +516,13 @@ TEST(JSONSchema_frame, refs_with_no_id) {
       .wait();
 
   EXPECT_EQ(references.size(), 4);
-  EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref", "#");
+  EXPECT_STATIC_REFERENCE(references, "/properties/foo/$ref", "#", std::nullopt,
+                          "");
   EXPECT_STATIC_REFERENCE(references, "/properties/bar/$ref",
-                          "#/properties/baz");
+                          "#/properties/baz", std::nullopt, "/properties/baz");
   EXPECT_STATIC_REFERENCE(references, "/properties/qux/$ref",
-                          "https://www.example.com#");
-  EXPECT_STATIC_REFERENCE(references, "/properties/anchor/$ref", "#baz");
+                          "https://www.example.com#", "https://www.example.com",
+                          "");
+  EXPECT_STATIC_REFERENCE(references, "/properties/anchor/$ref", "#baz",
+                          std::nullopt, "baz");
 }

--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -21,19 +21,32 @@
   EXPECT_EQ((frame).dialect((reference)), (expected_dialect));
 
 #define EXPECT_REFERENCE(references, expected_type, expected_pointer,          \
-                         expected_uri)                                         \
+                         expected_uri, expected_base, expected_fragment)       \
   EXPECT_TRUE(                                                                 \
       (references).contains({TO_POINTER(expected_pointer), expected_type}));   \
-  EXPECT_EQ((references).at({TO_POINTER(expected_pointer), expected_type}),    \
-            (expected_uri));
+  EXPECT_EQ(                                                                   \
+      std::get<0>(                                                             \
+          (references).at({TO_POINTER(expected_pointer), expected_type})),     \
+      (expected_uri));                                                         \
+  EXPECT_EQ(                                                                   \
+      std::get<1>(                                                             \
+          (references).at({TO_POINTER(expected_pointer), expected_type})),     \
+      (expected_base));                                                        \
+  EXPECT_EQ(                                                                   \
+      std::get<2>(                                                             \
+          (references).at({TO_POINTER(expected_pointer), expected_type})),     \
+      (expected_fragment));
 
-#define EXPECT_STATIC_REFERENCE(references, expected_pointer, expected_uri)    \
+#define EXPECT_STATIC_REFERENCE(references, expected_pointer, expected_uri,    \
+                                expected_base, expected_fragment)              \
   EXPECT_REFERENCE(references, sourcemeta::jsontoolkit::ReferenceType::Static, \
-                   expected_pointer, expected_uri)
+                   expected_pointer, expected_uri, expected_base,              \
+                   expected_fragment)
 
-#define EXPECT_DYNAMIC_REFERENCE(references, expected_pointer, expected_uri)   \
-  EXPECT_REFERENCE(references,                                                 \
-                   sourcemeta::jsontoolkit::ReferenceType::Dynamic,            \
-                   expected_pointer, expected_uri)
+#define EXPECT_DYNAMIC_REFERENCE(references, expected_pointer, expected_uri,   \
+                                 expected_base, expected_fragment)             \
+  EXPECT_REFERENCE(                                                            \
+      references, sourcemeta::jsontoolkit::ReferenceType::Dynamic,             \
+      expected_pointer, expected_uri, expected_base, expected_fragment)
 
 #endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
