### PR TITLE
Extract `ReferenceType` to its own header

### DIFF
--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -4,7 +4,8 @@ include(./official_resolver.cmake)
 
 noa_library(NAMESPACE sourcemeta PROJECT jsontoolkit NAME jsonschema
   FOLDER "JSON Toolkit/JSON Schema"
-  PRIVATE_HEADERS anchor.h resolver.h walker.h reference.h reference_frame.h error.h
+  PRIVATE_HEADERS anchor.h resolver.h walker.h reference.h
+    reference_frame.h reference_type.h error.h
     transformer.h transform_rule.h transform_bundle.h
   SOURCES jsonschema.cc default_walker.cc reference.cc reference_frame.cc anchor.cc walker.cc
     transformer.cc transform_rule.cc transform_bundle.cc

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -9,6 +9,7 @@
 
 #include <sourcemeta/jsontoolkit/jsonpointer.h>
 #include <sourcemeta/jsontoolkit/jsonschema_reference_frame.h>
+#include <sourcemeta/jsontoolkit/jsonschema_reference_type.h>
 #include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
 #include <sourcemeta/jsontoolkit/jsonschema_walker.h>
 
@@ -20,10 +21,6 @@
 #include <utility>  // std::pair
 
 namespace sourcemeta::jsontoolkit {
-
-/// @ingroup jsonschema
-/// The reference type
-enum class ReferenceType { Static, Dynamic };
 
 // TODO: Encapsulate this behind a class to make sure we
 // can keep a stable API even if changing the underlying map.

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference_type.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference_type.h
@@ -1,0 +1,12 @@
+#ifndef SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_REFERENCE_TYPE_H_
+#define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_REFERENCE_TYPE_H_
+
+namespace sourcemeta::jsontoolkit {
+
+/// @ingroup jsonschema
+/// The reference type
+enum class ReferenceType { Static, Dynamic };
+
+} // namespace sourcemeta::jsontoolkit
+
+#endif


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
