### PR TITLE
Add an overload for `anchors()` that directly take vocabularies

### DIFF
--- a/src/jsonschema/anchor.cc
+++ b/src/jsonschema/anchor.cc
@@ -12,6 +12,13 @@ auto anchors(const JSON &schema, const SchemaResolver &resolver,
       sourcemeta::jsontoolkit::vocabularies(schema, resolver, default_dialect)
           .get()};
   std::promise<std::map<std::string, AnchorType>> promise;
+  promise.set_value(anchors(schema, vocabularies));
+  return promise.get_future();
+}
+
+auto anchors(const JSON &schema,
+             const std::map<std::string, bool> &vocabularies)
+    -> std::map<std::string, AnchorType> {
   std::map<std::string, AnchorType> result;
 
   // 2020-12
@@ -47,8 +54,7 @@ auto anchors(const JSON &schema, const SchemaResolver &resolver,
     }
   }
 
-  promise.set_value(std::move(result));
-  return promise.get_future();
+  return result;
 }
 
 } // namespace sourcemeta::jsontoolkit

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_anchor.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_anchor.h
@@ -51,6 +51,15 @@ auto anchors(const JSON &schema, const SchemaResolver &resolver,
              const std::optional<std::string> &default_dialect = std::nullopt)
     -> std::future<std::map<std::string, AnchorType>>;
 
+/// @ingroup jsonschema
+///
+/// This function is a shortcut to sourcemeta::jsontoolkit::anchors if you have
+/// already computed the vocabularies that the given schema makes use of.
+SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
+auto anchors(const JSON &schema,
+             const std::map<std::string, bool> &vocabularies)
+    -> std::map<std::string, AnchorType>;
+
 } // namespace sourcemeta::jsontoolkit
 
 #endif

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -166,11 +166,13 @@ auto sourcemeta::jsontoolkit::frame(
       }
     }
 
+    const auto vocabularies{sourcemeta::jsontoolkit::vocabularies(
+                                subschema, resolver, effective_dialects.front())
+                                .get()};
+
     // Handle schema anchors
     for (const auto &[name, type] :
-         sourcemeta::jsontoolkit::anchors(subschema, resolver,
-                                          effective_dialects.front())
-             .get()) {
+         sourcemeta::jsontoolkit::anchors(subschema, vocabularies)) {
       const auto anchor_uri{sourcemeta::jsontoolkit::URI::from_fragment(name)};
       const auto bases{find_nearest_bases(base_uris, pointer, id)};
       const auto relative_anchor_uri{anchor_uri.recompose()};

--- a/test/jsonschema/jsonschema_anchor_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2019_09_test.cc
@@ -66,3 +66,21 @@ TEST(JSONSchema_anchor_2019_09, nested_static_with_default_dialect) {
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
 }
+
+TEST(JSONSchema_anchor_2019_09, vocabularies_shortcut) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$anchor": "foo"
+  })JSON");
+
+  const std::map<std::string, bool> vocabularies{
+      sourcemeta::jsontoolkit::vocabularies(
+          document, sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
+  EXPECT_EQ(anchors.size(), 1);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
+}

--- a/test/jsonschema/jsonschema_anchor_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2020_12_test.cc
@@ -102,3 +102,24 @@ TEST(JSONSchema_anchor_2020_12, nested_static_with_default_dialect) {
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
 }
+
+TEST(JSONSchema_anchor_2020_12, vocabularies_shortcut) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$anchor": "foo",
+    "$dynamicAnchor": "bar"
+  })JSON");
+
+  const std::map<std::string, bool> vocabularies{
+      sourcemeta::jsontoolkit::vocabularies(
+          document, sourcemeta::jsontoolkit::official_resolver)
+          .get()};
+
+  const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
+  EXPECT_EQ(anchors.size(), 2);
+  EXPECT_TRUE(anchors.contains("foo"));
+  EXPECT_TRUE(anchors.contains("bar"));
+  EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
+  EXPECT_EQ(anchors.at("bar"), sourcemeta::jsontoolkit::AnchorType::Dynamic);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
