### PR TITLE
Add performance-friendly `vocabularies()` overloads

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -184,6 +184,15 @@ auto vocabularies(const JSON &schema, const SchemaResolver &resolver,
                   const std::optional<std::string> &default_dialect =
                       std::nullopt) -> std::future<std::map<std::string, bool>>;
 
+/// @ingroup jsonschema
+///
+/// A shortcut to sourcemeta::jsontoolkit::vocabularies based on the base
+/// dialect and dialect URI.
+SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
+auto vocabularies(const SchemaResolver &resolver,
+                  const std::string &base_dialect, const std::string &dialect)
+    -> std::future<std::map<std::string, bool>>;
+
 } // namespace sourcemeta::jsontoolkit
 
 #endif

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -171,9 +171,10 @@ auto sourcemeta::jsontoolkit::frame(
       }
     }
 
-    const auto vocabularies{sourcemeta::jsontoolkit::vocabularies(
-                                subschema, resolver, effective_dialects.front())
-                                .get()};
+    const auto vocabularies{
+        sourcemeta::jsontoolkit::vocabularies(resolver, base_dialect.value(),
+                                              effective_dialects.front())
+            .get()};
 
     // Handle schema anchors
     for (const auto &[name, type] :
@@ -279,9 +280,15 @@ auto sourcemeta::jsontoolkit::frame(
               fragment_string(destination_uri)}});
       }
 
-      const auto vocabularies{
-          sourcemeta::jsontoolkit::vocabularies(subschema, resolver,
+      const std::optional<std::string> schema_base_dialect{
+          sourcemeta::jsontoolkit::base_dialect(subschema, resolver,
                                                 effective_dialects.front())
+              .get()};
+      assert(schema_base_dialect.has_value());
+
+      const auto vocabularies{
+          sourcemeta::jsontoolkit::vocabularies(
+              resolver, schema_base_dialect.value(), effective_dialects.front())
               .get()};
 
       if (vocabularies.contains(


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
