### PR TITLE
Simplify `ReferenceFrame::defines` to not canonicalize

### DIFF
--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -232,16 +232,20 @@ auto sourcemeta::jsontoolkit::frame(
     assert(dialects.size() == 1);
 
     for (const auto &base : find_every_base(base_uris, pointer)) {
-      const auto relative_pointer_uri{
+      // TODO: Simplify this URI mess
+      auto relative_pointer_uri{
           sourcemeta::jsontoolkit::to_uri(pointer.resolve_from(base.second))};
       const auto result{base.first.empty()
                             ? relative_pointer_uri.recompose()
                             : relative_pointer_uri.resolve_from({base.first})};
-      if (!frame.defines(ReferenceType::Static, result)) {
+      const auto canonical_result{
+          sourcemeta::jsontoolkit::URI{result}.canonicalize().recompose()};
+
+      if (!frame.defines(ReferenceType::Static, canonical_result)) {
         const auto nearest_bases{
             find_nearest_bases(base_uris, pointer, base.first)};
         assert(!nearest_bases.empty());
-        frame.store(ReferenceType::Static, result, root_id,
+        frame.store(ReferenceType::Static, canonical_result, root_id,
                     nearest_bases.front(), pointer, dialects.front());
       }
     }

--- a/src/jsonschema/reference_frame.cc
+++ b/src/jsonschema/reference_frame.cc
@@ -7,10 +7,7 @@
 
 auto sourcemeta::jsontoolkit::ReferenceFrame::defines(
     const ReferenceType type, const std::string &uri) const -> bool {
-  // TODO: Canonicalize BEFORE checking on the reference frame
-  const auto canonical{
-      sourcemeta::jsontoolkit::URI{uri}.canonicalize().recompose()};
-  return this->data.contains({type, canonical});
+  return this->data.contains({type, uri});
 }
 
 auto sourcemeta::jsontoolkit::ReferenceFrame::size() const -> std::size_t {

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -461,10 +461,9 @@ TEST(JSONSchema_frame, reference_frame_uri_canonicalize) {
   EXPECT_EQ(frame.size(), 1);
   EXPECT_TRUE(frame.defines(sourcemeta::jsontoolkit::ReferenceType::Static,
                             "https://example.com"));
-  // This is canonicalized
-  EXPECT_TRUE(frame.defines(sourcemeta::jsontoolkit::ReferenceType::Static,
-                            "https://example.com#"));
   // These must not be canonicalized
+  EXPECT_FALSE(frame.defines(sourcemeta::jsontoolkit::ReferenceType::Static,
+                             "https://example.com#"));
   EXPECT_TRUE(frame
                   .root(sourcemeta::jsontoolkit::ReferenceType::Static,
                         "https://example.com")


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
