### PR TITLE
Generalize transformer `.at()` into a schema getter

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
@@ -51,10 +51,8 @@ public:
   /// Construct a transformer given a schema
   SchemaTransformer(JSON &schema);
 
-  /// Proxy to sourcemeta::jsontoolkit::JSON::at
-  auto at(const JSON::Array::size_type index) const -> const JSON &;
-  /// Proxy to sourcemeta::jsontoolkit::JSON::at
-  auto at(const JSON::String &key) const -> const JSON &;
+  /// Get the underlying schema
+  auto schema() const -> const JSON &;
   /// Proxy to sourcemeta::jsontoolkit::JSON::into_object
   auto into_object() -> void;
   /// Proxy to sourcemeta::jsontoolkit::JSON::erase

--- a/src/jsonschema/transformer.cc
+++ b/src/jsonschema/transformer.cc
@@ -6,16 +6,9 @@ sourcemeta::jsontoolkit::SchemaTransformer::SchemaTransformer(
     sourcemeta::jsontoolkit::JSON &schema)
     : data{schema} {}
 
-auto sourcemeta::jsontoolkit::SchemaTransformer::at(
-    const sourcemeta::jsontoolkit::JSON::Array::size_type index) const
+auto sourcemeta::jsontoolkit::SchemaTransformer::schema() const
     -> const sourcemeta::jsontoolkit::JSON & {
-  return this->data.at(index);
-}
-
-auto sourcemeta::jsontoolkit::SchemaTransformer::at(
-    const sourcemeta::jsontoolkit::JSON::String &key) const
-    -> const sourcemeta::jsontoolkit::JSON & {
-  return this->data.at(key);
+  return this->data;
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::into_object() -> void {

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -4,6 +4,17 @@
 #include <sourcemeta/jsontoolkit/jsonpointer.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
+TEST(JSONSchema_transformer, schema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]");
+  sourcemeta::jsontoolkit::SchemaTransformer transformer{document};
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]");
+  EXPECT_EQ(transformer.schema(), document);
+  EXPECT_EQ(transformer.schema(), expected);
+  EXPECT_EQ(expected, document);
+}
+
 TEST(JSONSchema_transformer, into_object) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
