### PR TITLE
Generalize transformer `into_object()` as `replace()`

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
@@ -53,8 +53,10 @@ public:
 
   /// Get the underlying schema
   auto schema() const -> const JSON &;
-  /// Proxy to sourcemeta::jsontoolkit::JSON::into_object
-  auto into_object() -> void;
+  /// Replace a schema with another value
+  auto replace(const JSON &value) -> void;
+  /// Replace a schema with another value
+  auto replace(JSON &&value) -> void;
   /// Proxy to sourcemeta::jsontoolkit::JSON::erase
   auto erase(const JSON::String &key) -> void;
   /// Proxy to sourcemeta::jsontoolkit::JSON::assign

--- a/src/jsonschema/transformer.cc
+++ b/src/jsonschema/transformer.cc
@@ -11,8 +11,16 @@ auto sourcemeta::jsontoolkit::SchemaTransformer::schema() const
   return this->data;
 }
 
-auto sourcemeta::jsontoolkit::SchemaTransformer::into_object() -> void {
-  this->data.into_object();
+auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
+    const sourcemeta::jsontoolkit::JSON &value) -> void {
+  this->data = value;
+  this->operations.push_back(SchemaTransformerOperationReplace{
+      sourcemeta::jsontoolkit::empty_pointer});
+}
+
+auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
+    sourcemeta::jsontoolkit::JSON &&value) -> void {
+  this->data = std::move(value);
   this->operations.push_back(SchemaTransformerOperationReplace{
       sourcemeta::jsontoolkit::empty_pointer});
 }

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -15,11 +15,11 @@ TEST(JSONSchema_transformer, schema) {
   EXPECT_EQ(expected, document);
 }
 
-TEST(JSONSchema_transformer, into_object) {
+TEST(JSONSchema_transformer, replace_with_empty_object) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]");
   sourcemeta::jsontoolkit::SchemaTransformer transformer{document};
-  transformer.into_object();
+  transformer.replace(sourcemeta::jsontoolkit::JSON::make_object());
 
   const sourcemeta::jsontoolkit::JSON expected =
       sourcemeta::jsontoolkit::parse("{}");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
