### PR TITLE
Generalize transformer `.replace()` to take pointers

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
@@ -53,18 +53,27 @@ public:
 
   /// Get the underlying schema
   auto schema() const -> const JSON &;
-  /// Replace a schema with another value
-  auto replace(const JSON &value) -> void;
-  /// Replace a schema with another value
-  auto replace(JSON &&value) -> void;
+  /// Trace the operations applied to the schema
+  auto traces() const -> const std::vector<SchemaTransformerOperation> &;
+
+  /// Replace a subschema with another value
+  auto replace(const Pointer &path, const JSON &value) -> void;
+  /// Replace a subschema with another value
+  auto replace(const Pointer &path, JSON &&value) -> void;
+
   /// Proxy to sourcemeta::jsontoolkit::JSON::erase
   auto erase(const JSON::String &key) -> void;
   /// Proxy to sourcemeta::jsontoolkit::JSON::assign
   auto assign(const JSON::String &key, const JSON &value) -> void;
   /// Proxy to sourcemeta::jsontoolkit::JSON::assign
   auto assign(const JSON::String &key, JSON &&value) -> void;
-  /// Trace the operations applied to the schema
-  auto traces() const -> const std::vector<SchemaTransformerOperation> &;
+
+  // For convenience
+
+  /// Replace a schema with another value
+  auto replace(const JSON &value) -> void;
+  /// Replace a schema with another value
+  auto replace(JSON &&value) -> void;
 
 private:
   JSON &data;

--- a/src/jsonschema/transformer.cc
+++ b/src/jsonschema/transformer.cc
@@ -12,17 +12,29 @@ auto sourcemeta::jsontoolkit::SchemaTransformer::schema() const
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
+    const sourcemeta::jsontoolkit::Pointer &path,
     const sourcemeta::jsontoolkit::JSON &value) -> void {
-  this->data = value;
-  this->operations.push_back(SchemaTransformerOperationReplace{
-      sourcemeta::jsontoolkit::empty_pointer});
+  // TODO: Check that the path exists with an assert
+  sourcemeta::jsontoolkit::set(this->data, path, value);
+  this->operations.push_back(SchemaTransformerOperationReplace{path});
+}
+
+auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
+    const sourcemeta::jsontoolkit::Pointer &path,
+    sourcemeta::jsontoolkit::JSON &&value) -> void {
+  // TODO: Check that the path exists with an assert
+  sourcemeta::jsontoolkit::set(this->data, path, std::move(value));
+  this->operations.push_back(SchemaTransformerOperationReplace{path});
+}
+
+auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
+    const sourcemeta::jsontoolkit::JSON &value) -> void {
+  this->replace(sourcemeta::jsontoolkit::empty_pointer, value);
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
     sourcemeta::jsontoolkit::JSON &&value) -> void {
-  this->data = std::move(value);
-  this->operations.push_back(SchemaTransformerOperationReplace{
-      sourcemeta::jsontoolkit::empty_pointer});
+  this->replace(sourcemeta::jsontoolkit::empty_pointer, std::move(value));
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::erase(

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -35,6 +35,26 @@ TEST(JSONSchema_transformer, replace_with_empty_object) {
                   .pointer.empty());
 }
 
+TEST(JSONSchema_transformer, replace_subschema_with_empty_object) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("[ 1, 2, 3 ]");
+  sourcemeta::jsontoolkit::SchemaTransformer transformer{document};
+  transformer.replace({1}, sourcemeta::jsontoolkit::JSON::make_object());
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse("[ 1, {}, 3 ]");
+  const auto &traces{transformer.traces()};
+
+  EXPECT_EQ(document, expected);
+  EXPECT_EQ(traces.size(), 1);
+
+  using namespace sourcemeta::jsontoolkit;
+  EXPECT_TRUE(
+      std::holds_alternative<SchemaTransformerOperationReplace>(traces.at(0)));
+  EXPECT_EQ(std::get<SchemaTransformerOperationReplace>(traces.at(0)).pointer,
+            sourcemeta::jsontoolkit::Pointer({1}));
+}
+
 TEST(JSONSchema_transformer, assign) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{ \"foo\": 1 }");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
