### PR TITLE
Generalize transformer `.assign()` to take base pointers

### DIFF
--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transformer.h
@@ -60,13 +60,15 @@ public:
   auto replace(const Pointer &path, const JSON &value) -> void;
   /// Replace a subschema with another value
   auto replace(const Pointer &path, JSON &&value) -> void;
+  /// Assign an object property
+  auto assign(const Pointer &path, const JSON::String &key, const JSON &value)
+      -> void;
+  /// Assign an object property
+  auto assign(const Pointer &path, const JSON::String &key, JSON &&value)
+      -> void;
 
   /// Proxy to sourcemeta::jsontoolkit::JSON::erase
   auto erase(const JSON::String &key) -> void;
-  /// Proxy to sourcemeta::jsontoolkit::JSON::assign
-  auto assign(const JSON::String &key, const JSON &value) -> void;
-  /// Proxy to sourcemeta::jsontoolkit::JSON::assign
-  auto assign(const JSON::String &key, JSON &&value) -> void;
 
   // For convenience
 
@@ -74,6 +76,10 @@ public:
   auto replace(const JSON &value) -> void;
   /// Replace a schema with another value
   auto replace(JSON &&value) -> void;
+  /// Assign an object property
+  auto assign(const JSON::String &key, const JSON &value) -> void;
+  /// Assign an object property
+  auto assign(const JSON::String &key, JSON &&value) -> void;
 
 private:
   JSON &data;

--- a/src/jsonschema/transformer.cc
+++ b/src/jsonschema/transformer.cc
@@ -39,22 +39,42 @@ auto sourcemeta::jsontoolkit::SchemaTransformer::replace(
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::erase(
     const sourcemeta::jsontoolkit::JSON::String &key) -> void {
+  // TODO: Check that the path exists with an assert
   this->data.erase(key);
   this->operations.push_back(SchemaTransformerOperationErase{{key}});
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::assign(
+    const sourcemeta::jsontoolkit::Pointer &path,
     const sourcemeta::jsontoolkit::JSON::String &key,
     const sourcemeta::jsontoolkit::JSON &value) -> void {
-  this->data.assign(key, value);
-  this->operations.push_back(SchemaTransformerOperationAssign{{key}});
+  const auto destination{path.concat({key})};
+  // TODO: Check that the path DOES NOT exist with an assert
+  sourcemeta::jsontoolkit::get(this->data, path).assign(key, value);
+  this->operations.push_back(
+      SchemaTransformerOperationAssign{path.concat({key})});
+}
+
+auto sourcemeta::jsontoolkit::SchemaTransformer::assign(
+    const sourcemeta::jsontoolkit::Pointer &path,
+    const sourcemeta::jsontoolkit::JSON::String &key,
+    sourcemeta::jsontoolkit::JSON &&value) -> void {
+  // TODO: Check that the path DOES NOT exist with an assert
+  sourcemeta::jsontoolkit::get(this->data, path).assign(key, std::move(value));
+  this->operations.push_back(
+      SchemaTransformerOperationAssign{path.concat({key})});
+}
+
+auto sourcemeta::jsontoolkit::SchemaTransformer::assign(
+    const sourcemeta::jsontoolkit::JSON::String &key,
+    const sourcemeta::jsontoolkit::JSON &value) -> void {
+  this->assign(sourcemeta::jsontoolkit::empty_pointer, key, value);
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::assign(
     const sourcemeta::jsontoolkit::JSON::String &key,
     sourcemeta::jsontoolkit::JSON &&value) -> void {
-  this->data.assign(key, std::move(value));
-  this->operations.push_back(SchemaTransformerOperationAssign{{key}});
+  this->assign(sourcemeta::jsontoolkit::empty_pointer, key, std::move(value));
 }
 
 auto sourcemeta::jsontoolkit::SchemaTransformer::traces() const

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -75,6 +75,26 @@ TEST(JSONSchema_transformer, assign) {
             sourcemeta::jsontoolkit::Pointer{"bar"});
 }
 
+TEST(JSONSchema_transformer, assign_subobject) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": {} }");
+  sourcemeta::jsontoolkit::SchemaTransformer transformer{document};
+  transformer.assign({"bar"}, "baz", sourcemeta::jsontoolkit::JSON{2});
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": { \"baz\": 2 } }");
+  const auto &traces{transformer.traces()};
+
+  EXPECT_EQ(document, expected);
+  EXPECT_EQ(traces.size(), 1);
+
+  using namespace sourcemeta::jsontoolkit;
+  EXPECT_TRUE(
+      std::holds_alternative<SchemaTransformerOperationAssign>(traces.at(0)));
+  EXPECT_EQ(std::get<SchemaTransformerOperationAssign>(traces.at(0)).pointer,
+            sourcemeta::jsontoolkit::Pointer({"bar", "baz"}));
+}
+
 TEST(JSONSchema_transformer, erase) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{ \"foo\": 1, \"bar\": 2 }");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
