### PR TITLE
Fix "Escape" typo in URI docs

### DIFF
--- a/src/uri/include/sourcemeta/jsontoolkit/uri.h
+++ b/src/uri/include/sourcemeta/jsontoolkit/uri.h
@@ -212,7 +212,7 @@ public:
   /// ```
   auto resolve_from(const URI &base) -> URI &;
 
-  /// Esscape a string as established by RFC 3986 using C++ standard stream. For
+  /// Escape a string as established by RFC 3986 using C++ standard stream. For
   /// example:
   ///
   /// ```cpp


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
