### PR TITLE
Mask `FindGoogleTest.cmake` by default

### DIFF
--- a/vendorpull.mask
+++ b/vendorpull.mask
@@ -24,6 +24,7 @@ vendor/googletest
 vendor/googletest.mask
 vendor/referencing-suite
 vendor/referencing-suite.mask
+cmake/FindGoogleTest.cmake
 .editorconfig
 .ackrc
 .gitattributes


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
