### PR TITLE
Fix `URI::path()` example

### DIFF
--- a/src/uri/include/sourcemeta/jsontoolkit/uri.h
+++ b/src/uri/include/sourcemeta/jsontoolkit/uri.h
@@ -127,7 +127,8 @@ public:
   /// #include <cassert>
   ///
   /// const sourcemeta::jsontoolkit::URI
-  /// uri{"https://www.sourcemeta.com/foo/bar"}; assert(uri.path().has_value());
+  /// uri{"https://www.sourcemeta.com/foo/bar"};
+  /// assert(uri.path().has_value());
   /// assert(uri.path().value() == "/foo/bar");
   /// ```
   [[nodiscard]] auto path() const -> std::optional<std::string>;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
