### PR TITLE
Add `absoluteKeywordLocation` to compiler steps

### DIFF
--- a/src/jsonschema/compile.cc
+++ b/src/jsonschema/compile.cc
@@ -18,10 +18,8 @@ auto compile_subschema(
     if (context.schema.to_boolean()) {
       return {};
     } else {
-      return {SchemaCompilerAssertionFail{context.instance_location,
-                                          context.evaluation_path,
-                                          SchemaCompilerValueNone{},
-                                          {}}};
+      return {make<SchemaCompilerAssertionFail>(context,
+                                                SchemaCompilerValueNone{}, {})};
     }
   }
 

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -27,7 +27,7 @@ auto assertion_to_json(
     const std::string_view type,
     const sourcemeta::jsontoolkit::SchemaCompilerTarget &target,
     const sourcemeta::jsontoolkit::Pointer &evaluation_path,
-    sourcemeta::jsontoolkit::JSON &&value,
+    const std::string &keyword_location, sourcemeta::jsontoolkit::JSON &&value,
     const sourcemeta::jsontoolkit::SchemaCompilerTemplate &condition)
     -> sourcemeta::jsontoolkit::JSON {
   using namespace sourcemeta::jsontoolkit;
@@ -36,7 +36,8 @@ auto assertion_to_json(
   result.assign("category", JSON{"assertion"});
   result.assign("type", JSON{type});
   result.assign("target", std::visit(visitor, target));
-  result.assign("schemaLocation", JSON{to_string(evaluation_path)});
+  result.assign("keywordLocation", JSON{to_string(evaluation_path)});
+  result.assign("absoluteKeywordLocation", JSON{keyword_location});
   result.assign("value", std::move(value));
   result.assign("condition", JSON::make_array());
   for (const auto &substep : condition) {
@@ -49,6 +50,7 @@ auto assertion_to_json(
 auto logical_to_json(
     const std::string_view type,
     const sourcemeta::jsontoolkit::Pointer &evaluation_path,
+    const std::string &keyword_location,
     const sourcemeta::jsontoolkit::SchemaCompilerTemplate &children,
     const sourcemeta::jsontoolkit::SchemaCompilerTemplate &condition)
     -> sourcemeta::jsontoolkit::JSON {
@@ -56,7 +58,8 @@ auto logical_to_json(
   JSON result{JSON::make_object()};
   result.assign("category", JSON{"logical"});
   result.assign("type", JSON{type});
-  result.assign("schemaLocation", JSON{to_string(evaluation_path)});
+  result.assign("keywordLocation", JSON{to_string(evaluation_path)});
+  result.assign("absoluteKeywordLocation", JSON{keyword_location});
   result.assign("condition", JSON::make_array());
   result.assign("children", JSON::make_array());
 
@@ -98,9 +101,9 @@ struct StepVisitor {
                       &assertion) const -> sourcemeta::jsontoolkit::JSON {
     using namespace sourcemeta::jsontoolkit;
     assert(std::holds_alternative<SchemaCompilerValueNone>(assertion.value));
-    return assertion_to_json("fail", assertion.target,
-                             assertion.evaluation_path, JSON{nullptr},
-                             assertion.condition);
+    return assertion_to_json(
+        "fail", assertion.target, assertion.evaluation_path,
+        assertion.keyword_location, JSON{nullptr}, assertion.condition);
   }
 
   auto operator()(const sourcemeta::jsontoolkit::SchemaCompilerAssertionDefines
@@ -109,6 +112,7 @@ struct StepVisitor {
     assert(std::holds_alternative<SchemaCompilerValueString>(assertion.value));
     return assertion_to_json(
         "defines", assertion.target, assertion.evaluation_path,
+        assertion.keyword_location,
         value_string(std::get<SchemaCompilerValueString>(assertion.value)),
         assertion.condition);
   }
@@ -119,19 +123,22 @@ struct StepVisitor {
     assert(std::holds_alternative<SchemaCompilerValueType>(assertion.value));
     return assertion_to_json(
         "type", assertion.target, assertion.evaluation_path,
+        assertion.keyword_location,
         value_type(std::get<SchemaCompilerValueType>(assertion.value)),
         assertion.condition);
   }
 
   auto operator()(const sourcemeta::jsontoolkit::SchemaCompilerLogicalOr
                       &logical) const -> sourcemeta::jsontoolkit::JSON {
-    return logical_to_json("or", logical.evaluation_path, logical.children,
+    return logical_to_json("or", logical.evaluation_path,
+                           logical.keyword_location, logical.children,
                            logical.condition);
   }
 
   auto operator()(const sourcemeta::jsontoolkit::SchemaCompilerLogicalAnd
                       &logical) const -> sourcemeta::jsontoolkit::JSON {
-    return logical_to_json("and", logical.evaluation_path, logical.children,
+    return logical_to_json("and", logical.evaluation_path,
+                           logical.keyword_location, logical.children,
                            logical.condition);
   }
 };

--- a/test/jsonschema/jsonschema_compile_evaluate_test.cc
+++ b/test/jsonschema/jsonschema_compile_evaluate_test.cc
@@ -12,6 +12,7 @@ TEST(JSONSchema_compile_evaluate, fast_step_defines_true_no_condition) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"foo"},
                                      {}}};
 
@@ -25,6 +26,7 @@ TEST(JSONSchema_compile_evaluate, fast_step_defines_false_no_condition) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"bar"},
                                      {}}};
 
@@ -39,11 +41,12 @@ TEST(JSONSchema_compile_evaluate, fast_step_defines_true_with_condition) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"foo"},
                                      {}}};
 
   const SchemaCompilerTemplate steps{SchemaCompilerAssertionDefines{
-      SchemaCompilerTargetInstance{}, Pointer{},
+      SchemaCompilerTargetInstance{}, Pointer{}, "#",
       SchemaCompilerValueString{"bar"}, condition}};
 
   const JSON instance{parse("{ \"foo\": 1, \"bar\": 2 }")};
@@ -57,11 +60,12 @@ TEST(JSONSchema_compile_evaluate, fast_step_defines_false_with_condition) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"xxx"},
                                      {}}};
 
   const SchemaCompilerTemplate steps{SchemaCompilerAssertionDefines{
-      SchemaCompilerTargetInstance{}, Pointer{},
+      SchemaCompilerTargetInstance{}, Pointer{}, "#",
       SchemaCompilerValueString{"baz"}, condition}};
 
   const JSON instance{parse("{ \"foo\": 1, \"bar\": 2 }")};
@@ -76,6 +80,7 @@ TEST(JSONSchema_compile_evaluate, fast_step_fail_no_condition) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionFail{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueNone{},
                                   {}}};
 
@@ -90,12 +95,13 @@ TEST(JSONSchema_compile_evaluate, fast_step_fail_with_condition_true) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"foo"},
                                      {}}};
 
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionFail{SchemaCompilerTargetInstance{}, Pointer{},
-                                  SchemaCompilerValueNone{}, condition}};
+                                  "#", SchemaCompilerValueNone{}, condition}};
 
   const JSON instance{parse("{ \"foo\": 1, \"bar\": 2 }")};
   const auto result{evaluate(steps, instance)};
@@ -108,12 +114,13 @@ TEST(JSONSchema_compile_evaluate, fast_step_fail_with_condition_false) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"xxx"},
                                      {}}};
 
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionFail{SchemaCompilerTargetInstance{}, Pointer{},
-                                  SchemaCompilerValueNone{}, condition}};
+                                  "#", SchemaCompilerValueNone{}, condition}};
 
   const JSON instance{parse("{ \"foo\": 1, \"bar\": 2 }")};
   const auto result{evaluate(steps, instance)};
@@ -125,6 +132,7 @@ TEST(JSONSchema_compile_evaluate, fast_step_type_true_no_condition) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Object},
                                   {}}};
 
@@ -138,6 +146,7 @@ TEST(JSONSchema_compile_evaluate, fast_step_type_false_no_condition) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
 
@@ -149,7 +158,7 @@ TEST(JSONSchema_compile_evaluate, fast_step_type_false_no_condition) {
 TEST(JSONSchema_compile_evaluate, fast_step_or_empty_no_condition) {
   using namespace sourcemeta::jsontoolkit;
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {}, {}}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {}, {}}};
 
   const JSON instance{parse("{ \"foo\": 1 }")};
   const auto result{evaluate(steps, instance)};
@@ -162,15 +171,17 @@ TEST(JSONSchema_compile_evaluate, fast_step_or_no_condition_true) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}},
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Object},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {}, children}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {}, children}};
 
   const JSON instance{parse("{ \"foo\": 1 }")};
   const auto result{evaluate(steps, instance)};
@@ -183,15 +194,17 @@ TEST(JSONSchema_compile_evaluate, fast_step_or_no_condition_false) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}},
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Array},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {}, children}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {}, children}};
 
   const JSON instance{parse("{ \"foo\": 1 }")};
   const auto result{evaluate(steps, instance)};
@@ -205,18 +218,20 @@ TEST(JSONSchema_compile_evaluate,
   const auto assertion_1{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
   const auto assertion_2{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Object},
                                   {}}};
 
   const SchemaCompilerTemplate children{assertion_1, assertion_2};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {assertion_1}, children}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {assertion_1}, children}};
 
   std::vector<std::pair<bool, SchemaCompilerTemplate::value_type>> trace;
   const JSON instance{"foo bar"};
@@ -246,18 +261,20 @@ TEST(JSONSchema_compile_evaluate,
   const auto assertion_1{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
   const auto assertion_2{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Object},
                                   {}}};
 
   const SchemaCompilerTemplate children{assertion_1, assertion_2};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {assertion_1}, children}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {assertion_1}, children}};
 
   std::vector<std::pair<bool, SchemaCompilerTemplate::value_type>> trace;
   const JSON instance{"foo bar"};
@@ -287,7 +304,7 @@ TEST(JSONSchema_compile_evaluate,
 TEST(JSONSchema_compile_evaluate, fast_step_and_empty_no_condition) {
   using namespace sourcemeta::jsontoolkit;
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, {}, {}}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", {}, {}}};
 
   const JSON instance{parse("{ \"foo\": 1 }")};
   const auto result{evaluate(steps, instance)};
@@ -300,11 +317,12 @@ TEST(JSONSchema_compile_evaluate, fast_step_and_no_condition_true) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Object},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, {}, children}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", {}, children}};
 
   const JSON instance{parse("{ \"foo\": 1 }")};
   const auto result{evaluate(steps, instance)};
@@ -317,15 +335,17 @@ TEST(JSONSchema_compile_evaluate, fast_step_and_no_condition_false) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}},
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Array},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, {}, children}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", {}, children}};
 
   const JSON instance{parse("{ \"foo\": 1 }")};
   const auto result{evaluate(steps, instance)};

--- a/test/jsonschema/jsonschema_compile_json_test.cc
+++ b/test/jsonschema/jsonschema_compile_json_test.cc
@@ -8,6 +8,7 @@ TEST(JSONSchema_compile_json, defines_basic_root) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"foo"},
                                      {}}};
 
@@ -16,7 +17,8 @@ TEST(JSONSchema_compile_json, defines_basic_root) {
     {
       "category": "assertion",
       "type": "defines",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "target": {
         "category": "target",
         "location": "",
@@ -39,6 +41,7 @@ TEST(JSONSchema_compile_json, defines_basic_nested) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{"xxx"},
                                      Pointer{"foo", "bar"},
+                                     "#/foo/bar",
                                      SchemaCompilerValueString{"foo"},
                                      {}}};
 
@@ -47,7 +50,8 @@ TEST(JSONSchema_compile_json, defines_basic_nested) {
     {
       "category": "assertion",
       "type": "defines",
-      "schemaLocation": "/foo/bar",
+      "keywordLocation": "/foo/bar",
+      "absoluteKeywordLocation": "#/foo/bar",
       "target": {
         "category": "target",
         "location": "/xxx",
@@ -71,11 +75,12 @@ TEST(JSONSchema_compile_json, defines_with_condition) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionDefines{SchemaCompilerTargetInstance{},
                                      Pointer{},
+                                     "#",
                                      SchemaCompilerValueString{"xxx"},
                                      {}}};
 
   const SchemaCompilerTemplate steps{SchemaCompilerAssertionDefines{
-      SchemaCompilerTargetInstance{}, Pointer{},
+      SchemaCompilerTargetInstance{}, Pointer{}, "#",
       SchemaCompilerValueString{"baz"}, condition}};
 
   const JSON result{to_json(steps)};
@@ -83,7 +88,8 @@ TEST(JSONSchema_compile_json, defines_with_condition) {
     {
       "category": "assertion",
       "type": "defines",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "target": {
         "category": "target",
         "location": "",
@@ -98,7 +104,8 @@ TEST(JSONSchema_compile_json, defines_with_condition) {
         {
           "category": "assertion",
           "condition": [],
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -123,6 +130,7 @@ TEST(JSONSchema_compile_json, fail_basic_root) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionFail{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueNone{},
                                   {}}};
 
@@ -131,7 +139,8 @@ TEST(JSONSchema_compile_json, fail_basic_root) {
     {
       "category": "assertion",
       "type": "fail",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "target": {
         "category": "target",
         "location": "",
@@ -150,6 +159,7 @@ TEST(JSONSchema_compile_json, type_basic_root) {
   const SchemaCompilerTemplate steps{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
 
@@ -158,7 +168,8 @@ TEST(JSONSchema_compile_json, type_basic_root) {
     {
       "category": "assertion",
       "type": "type",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "target": {
         "category": "target",
         "location": "",
@@ -179,14 +190,15 @@ TEST(JSONSchema_compile_json, type_basic_root) {
 TEST(JSONSchema_compile_json, or_empty) {
   using namespace sourcemeta::jsontoolkit;
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {}, {}}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {}, {}}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "or",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [],
       "condition": []
     }
@@ -201,23 +213,26 @@ TEST(JSONSchema_compile_json, or_single_child) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {}, children}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {}, children}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "or",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -244,27 +259,31 @@ TEST(JSONSchema_compile_json, or_multiple_children) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}},
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Array},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, {}, children}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", {}, children}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "or",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -280,7 +299,8 @@ TEST(JSONSchema_compile_json, or_multiple_children) {
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -307,24 +327,27 @@ TEST(JSONSchema_compile_json, or_empty_single_condition) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalOr{Pointer{}, condition, {}}};
+      SchemaCompilerLogicalOr{Pointer{}, "#", condition, {}}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "or",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [],
       "condition": [
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -347,14 +370,15 @@ TEST(JSONSchema_compile_json, or_empty_single_condition) {
 TEST(JSONSchema_compile_json, and_empty) {
   using namespace sourcemeta::jsontoolkit;
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, {}, {}}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", {}, {}}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "and",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [],
       "condition": []
     }
@@ -369,23 +393,26 @@ TEST(JSONSchema_compile_json, and_single_child) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, {}, children}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", {}, children}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "and",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -412,27 +439,31 @@ TEST(JSONSchema_compile_json, and_multiple_children) {
   const SchemaCompilerTemplate children{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}},
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::Array},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, {}, children}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", {}, children}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "and",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -448,7 +479,8 @@ TEST(JSONSchema_compile_json, and_multiple_children) {
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",
@@ -475,24 +507,27 @@ TEST(JSONSchema_compile_json, and_empty_single_condition) {
   const SchemaCompilerTemplate condition{
       SchemaCompilerAssertionType{SchemaCompilerTargetInstance{},
                                   Pointer{},
+                                  "#",
                                   SchemaCompilerValueType{JSON::Type::String},
                                   {}}};
 
   const SchemaCompilerTemplate steps{
-      SchemaCompilerLogicalAnd{Pointer{}, condition, {}}};
+      SchemaCompilerLogicalAnd{Pointer{}, "#", condition, {}}};
 
   const JSON result{to_json(steps)};
   const JSON expected{parse(R"EOF([
     {
       "category": "logical",
       "type": "and",
-      "schemaLocation": "",
+      "keywordLocation": "",
+      "absoluteKeywordLocation": "#",
       "children": [],
       "condition": [
         {
           "category": "assertion",
           "type": "type",
-          "schemaLocation": "",
+          "keywordLocation": "",
+          "absoluteKeywordLocation": "#",
           "target": {
             "category": "target",
             "location": "",

--- a/test/jsonschema/jsonschema_compile_template_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_compile_template_2020_12_test.cc
@@ -23,7 +23,8 @@ TEST(JSONSchema_compile_template_2020_12, basic_type_string) {
     {
       "category": "assertion",
       "type": "type",
-      "schemaLocation": "/type",
+      "keywordLocation": "/type",
+      "absoluteKeywordLocation": "#/type",
       "target": {
         "category": "target",
         "location": "",

--- a/test/jsonschema/jsonschema_compile_template_draft4_test.cc
+++ b/test/jsonschema/jsonschema_compile_template_draft4_test.cc
@@ -23,14 +23,16 @@ TEST(JSONSchema_compile_template_draft4, allof_type) {
     {
       "category": "logical",
       "type": "and",
-      "schemaLocation": "/allOf",
+      "keywordLocation": "/allOf",
+      "absoluteKeywordLocation": "#/allOf",
       "condition": [],
       "children": [
         {
           "category": "assertion",
           "type": "type",
           "condition": [],
-          "schemaLocation": "/allOf/0/type",
+          "keywordLocation": "/allOf/0/type",
+          "absoluteKeywordLocation": "#/allOf/0/type",
           "target": {
             "category": "target",
             "location": "",
@@ -46,13 +48,15 @@ TEST(JSONSchema_compile_template_draft4, allof_type) {
           "category": "logical",
           "type": "or",
           "condition": [],
-          "schemaLocation": "/allOf/1/type",
+          "keywordLocation": "/allOf/1/type",
+          "absoluteKeywordLocation": "#/allOf/1/type",
           "children": [
             {
               "category": "assertion",
               "type": "type",
               "condition": [],
-              "schemaLocation": "/allOf/1/type",
+              "keywordLocation": "/allOf/1/type",
+              "absoluteKeywordLocation": "#/allOf/1/type",
               "target": {
                 "category": "target",
                 "location": "",
@@ -67,7 +71,8 @@ TEST(JSONSchema_compile_template_draft4, allof_type) {
             {
               "category": "assertion",
               "condition": [],
-              "schemaLocation": "/allOf/1/type",
+              "keywordLocation": "/allOf/1/type",
+              "absoluteKeywordLocation": "#/allOf/1/type",
               "target": {
                 "category": "target",
                 "location": "",
@@ -81,6 +86,57 @@ TEST(JSONSchema_compile_template_draft4, allof_type) {
               }
             }
           ]
+        }
+      ]
+    }
+  ])EOF")};
+
+  EXPECT_EQ(compiled_schema_json, expected);
+}
+
+TEST(JSONSchema_compile_template_draft4, allof_type_with_id) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.example.com",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+      { "id": "nested", "type": "integer" }
+    ]
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::jsontoolkit::compile(
+      schema, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::default_schema_compiler)};
+
+  const sourcemeta::jsontoolkit::JSON compiled_schema_json{
+      sourcemeta::jsontoolkit::to_json(compiled_schema)};
+
+  const sourcemeta::jsontoolkit::JSON expected{
+      sourcemeta::jsontoolkit::parse(R"EOF([
+    {
+      "category": "logical",
+      "type": "and",
+      "keywordLocation": "/allOf",
+      "absoluteKeywordLocation": "https://www.example.com#/allOf",
+      "condition": [],
+      "children": [
+        {
+          "category": "assertion",
+          "type": "type",
+          "condition": [],
+          "keywordLocation": "/allOf/0/type",
+          "absoluteKeywordLocation": "https://www.example.com/nested#/type",
+          "target": {
+            "category": "target",
+            "location": "",
+            "type": "instance"
+          },
+          "value": {
+            "category": "value",
+            "type": "type",
+            "value": "integer"
+          }
         }
       ]
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
