### PR TITLE
Fix JSON docs that reference `parse_json`

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -705,7 +705,7 @@ public:
   /// assert(my_array.at(1).to_integer() == 2);
   ///
   /// const sourcemeta::jsontoolkit::JSON my_object =
-  ///   sourcemeta::jsontoolkit::parse_json("{ \"1\": "foo" }");
+  ///   sourcemeta::jsontoolkit::parse("{ \"1\": "foo" }");
   /// assert(my_array.at(1).to_string() == "foo");
   /// ```
   [[nodiscard]] auto
@@ -736,7 +736,7 @@ public:
   /// assert(my_array.at(1).to_integer() == 2);
   ///
   /// sourcemeta::jsontoolkit::JSON my_object =
-  ///   sourcemeta::jsontoolkit::parse_json("{ \"1\": "foo" }");
+  ///   sourcemeta::jsontoolkit::parse("{ \"1\": "foo" }");
   /// assert(my_array.at(1).to_string() == "foo");
   /// ```
   [[nodiscard]] auto
@@ -998,7 +998,7 @@ public:
   /// #include <cassert>
   ///
   /// const sourcemeta::jsontoolkit::JSON document =
-  ///   sourcemeta::jsontoolkit::parse_json("{ \"0\": 1 }");
+  ///   sourcemeta::jsontoolkit::parse("{ \"0\": 1 }");
   /// assert(document.defines(0));
   /// assert(!document.defines(1));
   /// ```


### PR DESCRIPTION
The right function name is now `parse`. There used to be a `parse_json`
one before.

See: https://github.com/sourcemeta/jsontoolkit/discussions/561
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
