### PR TITLE
Downgrade CMake minimum version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.22)
 project(jsontoolkit VERSION 1.0.0 LANGUAGES CXX
   DESCRIPTION "The swiss-army knife for JSON programming in C++"
   HOMEPAGE_URL "https://jsontoolkit.sourcemeta.com")


### PR DESCRIPTION
This is the one that Ubuntu 22.04 LTS has at the moment.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
