### PR TITLE
Add a `Pointer::pop_back` overload to pop many tokens

### DIFF
--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
@@ -196,6 +196,25 @@ public:
     this->data.pop_back();
   }
 
+  /// Remove a number of tokens from the back of a JSON Pointer. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/jsontoolkit/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  /// pointer.pop_back(2);
+  /// assert(pointer.size() == 1);
+  /// assert(pointer.at(0).is_property());
+  /// assert(pointer.at(0).to_property() == "foo");
+  /// ```
+  auto pop_back(const size_type count) -> void {
+    assert(this->size() >= count);
+    for (std::size_t index = 0; index < count; index++) {
+      this->data.pop_back();
+    }
+  }
+
   /// Concatenate a JSON Pointer with another JSON Pointer, getting a new
   /// pointer as a result. For example:
   ///

--- a/test/jsonpointer/jsonpointer_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_pointer_test.cc
@@ -139,3 +139,23 @@ TEST(JSONPointer_pointer, ordering_less_than) {
   EXPECT_TRUE(pointer_3 < pointer_1);
   EXPECT_TRUE(pointer_3 < pointer_2);
 }
+
+TEST(JSONPointer_pointer, pop_back_zero_empty) {
+  sourcemeta::jsontoolkit::Pointer pointer{};
+  pointer.pop_back(0);
+  EXPECT_EQ(pointer.size(), 0);
+}
+
+TEST(JSONPointer_pointer, pop_back_many_subset) {
+  sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  pointer.pop_back(2);
+  EXPECT_EQ(pointer.size(), 1);
+  EXPECT_TRUE(pointer.at(0).is_property());
+  EXPECT_EQ(pointer.at(0).to_property(), "foo");
+}
+
+TEST(JSONPointer_pointer, pop_back_many_all) {
+  sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  pointer.pop_back(3);
+  EXPECT_EQ(pointer.size(), 0);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
