### PR TITLE
Rename the `Basename` compiler target type to `InstanceBasename`

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -90,7 +90,7 @@ auto target_value(const sourcemeta::jsontoolkit::SchemaCompilerTarget &target,
   switch (target.first) {
     case SchemaCompilerTargetType::Instance:
       return get(instance, location);
-    case SchemaCompilerTargetType::Basename:
+    case SchemaCompilerTargetType::InstanceBasename:
       return context.value(location.back().to_json());
     default:
       // We should never get here

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -18,9 +18,9 @@ auto target_to_json(const sourcemeta::jsontoolkit::SchemaCompilerTarget &target)
       result.assign("type", JSON{"instance"});
       result.assign("location", JSON{to_string(target.second)});
       return result;
-    case SchemaCompilerTargetType::Basename:
+    case SchemaCompilerTargetType::InstanceBasename:
       result.assign("category", JSON{"target"});
-      result.assign("type", JSON{"basename"});
+      result.assign("type", JSON{"instance-basename"});
       result.assign("location", JSON{to_string(target.second)});
       return result;
     default:

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -33,7 +33,7 @@ enum class SchemaCompilerTargetType {
   Instance,
 
   /// The last path (i.e. property or index) of the instance location
-  Basename
+  InstanceBasename
 };
 
 /// @ingroup jsonschema

--- a/test/jsonschema/jsonschema_compile_evaluate_test.cc
+++ b/test/jsonschema/jsonschema_compile_evaluate_test.cc
@@ -596,11 +596,11 @@ TEST(JSONSchema_compile_evaluate, fast_regex_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONSchema_compile_evaluate, fast_loop_regex_basename_empty) {
+TEST(JSONSchema_compile_evaluate, fast_loop_regex_instance_basename_empty) {
   using namespace sourcemeta::jsontoolkit;
 
   const SchemaCompilerTemplate children{SchemaCompilerAssertionRegex{
-      {SchemaCompilerTargetType::Basename, {}},
+      {SchemaCompilerTargetType::InstanceBasename, {}},
       Pointer{"loop", "regex"},
       Pointer{},
       "#/loop/regex",
@@ -620,11 +620,12 @@ TEST(JSONSchema_compile_evaluate, fast_loop_regex_basename_empty) {
   EXPECT_TRUE(result);
 }
 
-TEST(JSONSchema_compile_evaluate, fast_loop_regex_basename_multi_true) {
+TEST(JSONSchema_compile_evaluate,
+     fast_loop_regex_instance_basename_multi_true) {
   using namespace sourcemeta::jsontoolkit;
 
   const SchemaCompilerTemplate children{SchemaCompilerAssertionRegex{
-      {SchemaCompilerTargetType::Basename, {}},
+      {SchemaCompilerTargetType::InstanceBasename, {}},
       Pointer{"loop", "regex"},
       Pointer{},
       "#/loop/regex",
@@ -644,11 +645,12 @@ TEST(JSONSchema_compile_evaluate, fast_loop_regex_basename_multi_true) {
   EXPECT_TRUE(result);
 }
 
-TEST(JSONSchema_compile_evaluate, fast_loop_regex_basename_multi_false) {
+TEST(JSONSchema_compile_evaluate,
+     fast_loop_regex_instance_basename_multi_false) {
   using namespace sourcemeta::jsontoolkit;
 
   const SchemaCompilerTemplate children{SchemaCompilerAssertionRegex{
-      {SchemaCompilerTargetType::Basename, {}},
+      {SchemaCompilerTargetType::InstanceBasename, {}},
       Pointer{"loop", "regex"},
       Pointer{},
       "#/loop/regex",

--- a/test/jsonschema/jsonschema_compile_json_test.cc
+++ b/test/jsonschema/jsonschema_compile_json_test.cc
@@ -985,7 +985,7 @@ TEST(JSONSchema_compile_json, regex_basic) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONSchema_compile_json, loop_properties_annotation_property) {
+TEST(JSONSchema_compile_json, loop_properties_annotation_instance_property) {
   using namespace sourcemeta::jsontoolkit;
 
   const SchemaCompilerTemplate children{SchemaCompilerAnnotationPublic{
@@ -993,7 +993,7 @@ TEST(JSONSchema_compile_json, loop_properties_annotation_property) {
       Pointer{},
       Pointer{},
       "#",
-      SchemaCompilerTarget{SchemaCompilerTargetType::Basename, {}},
+      SchemaCompilerTarget{SchemaCompilerTargetType::InstanceBasename, {}},
       {}}};
 
   const SchemaCompilerTemplate steps{
@@ -1031,7 +1031,7 @@ TEST(JSONSchema_compile_json, loop_properties_annotation_property) {
           },
           "value": {
             "category": "target",
-            "type": "basename",
+            "type": "instance-basename",
             "location": ""
           },
           "condition": []


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
