### PR TITLE
Remove unnecessary `SchemaBasename` compiler target type

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -102,8 +102,6 @@ auto target_value(const sourcemeta::jsontoolkit::SchemaCompilerTarget &target,
       return get(instance, context.instance_location(target));
     case SchemaCompilerTargetType::InstanceBasename:
       return context.value(context.instance_location(target).back().to_json());
-    case SchemaCompilerTargetType::SchemaBasename:
-      return context.value(context.evaluate_path().back().to_json());
     default:
       // We should never get here
       assert(false);

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -28,11 +28,6 @@ auto target_to_json(const sourcemeta::jsontoolkit::SchemaCompilerTarget &target)
       result.assign("type", JSON{"instance-parent"});
       result.assign("location", JSON{to_string(target.second)});
       return result;
-    case SchemaCompilerTargetType::SchemaBasename:
-      result.assign("category", JSON{"target"});
-      result.assign("type", JSON{"schema-basename"});
-      result.assign("location", JSON{to_string(target.second)});
-      return result;
     default:
       // We should never get here
       assert(false);

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -36,10 +36,7 @@ enum class SchemaCompilerTargetType {
   InstanceBasename,
 
   /// The penultimate path (i.e. property or index) of the instance location
-  InstanceParent,
-
-  /// The last path (i.e. property or index) of the evaluation path
-  SchemaBasename
+  InstanceParent
 };
 
 /// @ingroup jsonschema


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
