### PR TITLE
Make sure empty fragment references are framed correctly

### DIFF
--- a/test/uri/uri_canonicalize_test.cc
+++ b/test/uri/uri_canonicalize_test.cc
@@ -99,3 +99,9 @@ TEST(URI_canonicalize, example_15) {
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/unreserved/~foo");
 }
+
+TEST(URI_canonicalize, empty_fragment) {
+  sourcemeta::jsontoolkit::URI uri{"#"};
+  uri.canonicalize();
+  EXPECT_EQ(uri.recompose(), "");
+}

--- a/test/uri/uri_recompose_test.cc
+++ b/test/uri/uri_recompose_test.cc
@@ -30,3 +30,8 @@ TEST(URI_recompose, no_scheme) {
   const sourcemeta::jsontoolkit::URI uri{"example.com/foo"};
   EXPECT_EQ(uri.recompose(), "example.com/foo");
 }
+
+TEST(URI_recompose, empty_fragment) {
+  const sourcemeta::jsontoolkit::URI uri{"#"};
+  EXPECT_EQ(uri.recompose(), "#");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
