### PR TITLE
Implement a `SchemaCompilerAssertionSizeLess` step

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -232,8 +232,17 @@ auto evaluate_step(
     const auto &value{context.resolve_value(assertion.value, instance)};
     const auto &target{
         context.resolve_target<JSON>(assertion.target, instance)};
-    assert(target.is_array());
+    assert(target.is_array() || target.is_object() || target.is_string());
     result = target.size() > value;
+  } else if (std::holds_alternative<SchemaCompilerAssertionSizeLess>(step)) {
+    const auto &assertion{std::get<SchemaCompilerAssertionSizeLess>(step)};
+    context.push(assertion);
+    EVALUATE_CONDITION_GUARD(assertion.condition, instance);
+    const auto &value{context.resolve_value(assertion.value, instance)};
+    const auto &target{
+        context.resolve_target<JSON>(assertion.target, instance)};
+    assert(target.is_array() || target.is_object() || target.is_string());
+    result = target.size() < value;
   } else if (std::holds_alternative<SchemaCompilerAssertionEqual>(step)) {
     const auto &assertion{std::get<SchemaCompilerAssertionEqual>(step)};
     context.push(assertion);

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -239,6 +239,15 @@ struct StepVisitor {
         assertion.value, assertion.condition);
   }
 
+  auto operator()(const sourcemeta::jsontoolkit::SchemaCompilerAssertionSizeLess
+                      &assertion) const -> sourcemeta::jsontoolkit::JSON {
+    return step_with_value_to_json("assertion", "size-less", assertion.target,
+                                   assertion.relative_schema_location,
+                                   assertion.relative_instance_location,
+                                   assertion.keyword_location, assertion.value,
+                                   assertion.condition);
+  }
+
   auto operator()(const sourcemeta::jsontoolkit::SchemaCompilerAssertionEqual
                       &assertion) const -> sourcemeta::jsontoolkit::JSON {
     return step_with_value_to_json("assertion", "equal", assertion.target,

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -111,6 +111,12 @@ struct SchemaCompilerAssertionNotContains;
 struct SchemaCompilerAssertionSizeGreater;
 
 /// @ingroup jsonschema
+/// Represents a compiler assertion step that checks a given array, object, or
+/// string has less than a certain number of items, properties, or characters,
+/// respectively
+struct SchemaCompilerAssertionSizeLess;
+
+/// @ingroup jsonschema
 /// Represents a compiler assertion step that checks the instance equals a given
 /// JSON document
 struct SchemaCompilerAssertionEqual;
@@ -168,9 +174,10 @@ using SchemaCompilerTemplate = std::vector<std::variant<
     SchemaCompilerAssertionFail, SchemaCompilerAssertionDefines,
     SchemaCompilerAssertionType, SchemaCompilerAssertionRegex,
     SchemaCompilerAssertionNotContains, SchemaCompilerAssertionSizeGreater,
-    SchemaCompilerAssertionEqual, SchemaCompilerAssertionUnique,
-    SchemaCompilerAnnotationPublic, SchemaCompilerAnnotationPrivate,
-    SchemaCompilerLogicalOr, SchemaCompilerLogicalAnd, SchemaCompilerLogicalXor,
+    SchemaCompilerAssertionSizeLess, SchemaCompilerAssertionEqual,
+    SchemaCompilerAssertionUnique, SchemaCompilerAnnotationPublic,
+    SchemaCompilerAnnotationPrivate, SchemaCompilerLogicalOr,
+    SchemaCompilerLogicalAnd, SchemaCompilerLogicalXor,
     SchemaCompilerLogicalNot, SchemaCompilerLoopProperties,
     SchemaCompilerLoopItems, SchemaCompilerControlLabel,
     SchemaCompilerControlJump>>;
@@ -213,6 +220,7 @@ DEFINE_STEP_WITH_VALUE(Assertion, Regex, SchemaCompilerValueRegex)
 DEFINE_STEP_WITH_VALUE(Assertion, NotContains, SchemaCompilerValueJSON)
 DEFINE_STEP_WITH_VALUE(Assertion, SizeGreater,
                        SchemaCompilerValueUnsignedInteger)
+DEFINE_STEP_WITH_VALUE(Assertion, SizeLess, SchemaCompilerValueUnsignedInteger)
 DEFINE_STEP_WITH_VALUE(Assertion, Equal, SchemaCompilerValueJSON)
 DEFINE_STEP_WITH_VALUE(Assertion, Unique, SchemaCompilerValueNone)
 DEFINE_STEP_WITH_VALUE(Annotation, Public, SchemaCompilerValueJSON)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
