### PR TITLE
Support every comparison operator in the JSON class

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_array.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_array.h
@@ -9,17 +9,37 @@ namespace sourcemeta::jsontoolkit {
 /// @ingroup json
 template <typename Value, typename Allocator> class GenericArray {
 public:
+  // Constructors
   using Container = std::vector<Value, Allocator>;
   GenericArray() : data{} {}
   GenericArray(std::initializer_list<Value> values) : data{values} {}
+
+  // Operators
+  // We cannot default given that this class references
+  // a JSON "value" as an incomplete type
   auto operator<(const GenericArray<Value, Allocator> &other) const noexcept
       -> bool {
     return this->data < other.data;
   }
-  /// Compare array instances
+  auto operator<=(const GenericArray<Value, Allocator> &other) const noexcept
+      -> bool {
+    return this->data <= other.data;
+  }
+  auto operator>(const GenericArray<Value, Allocator> &other) const noexcept
+      -> bool {
+    return this->data > other.data;
+  }
+  auto operator>=(const GenericArray<Value, Allocator> &other) const noexcept
+      -> bool {
+    return this->data >= other.data;
+  }
   auto operator==(const GenericArray<Value, Allocator> &other) const noexcept
       -> bool {
     return this->data == other.data;
+  }
+  auto operator!=(const GenericArray<Value, Allocator> &other) const noexcept
+      -> bool {
+    return this->data != other.data;
   }
 
   // Member types

--- a/src/json/include/sourcemeta/jsontoolkit/json_object.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_object.h
@@ -11,18 +11,38 @@ namespace sourcemeta::jsontoolkit {
 template <typename Key, typename Value, typename Allocator>
 class GenericObject {
 public:
-  // Constructors & operators
+  // Constructors
   using Container = std::map<Key, Value, std::less<Key>, Allocator>;
   GenericObject() : data{} {}
   GenericObject(std::initializer_list<typename Container::value_type> values)
       : data{values} {}
+
+  // Operators
+  // We cannot default given that this class references
+  // a JSON "value" as an incomplete type
   auto operator<(const GenericObject<Key, Value, Allocator> &other)
       const noexcept -> bool {
     return this->data < other.data;
   }
+  auto operator<=(const GenericObject<Key, Value, Allocator> &other)
+      const noexcept -> bool {
+    return this->data <= other.data;
+  }
+  auto operator>(const GenericObject<Key, Value, Allocator> &other)
+      const noexcept -> bool {
+    return this->data > other.data;
+  }
+  auto operator>=(const GenericObject<Key, Value, Allocator> &other)
+      const noexcept -> bool {
+    return this->data >= other.data;
+  }
   auto operator==(const GenericObject<Key, Value, Allocator> &other)
       const noexcept -> bool {
     return this->data == other.data;
+  }
+  auto operator!=(const GenericObject<Key, Value, Allocator> &other)
+      const noexcept -> bool {
+    return this->data != other.data;
   }
 
   // Member types

--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -258,8 +258,6 @@ public:
    * Operators
    */
 
-  /// Overload to support ordering of JSON documents. Typically for sorting
-  /// reasons.
   auto operator<(const GenericValue<CharT, Traits, Allocator> &other)
       const noexcept -> bool {
     if (this->type() == Type::Integer && other.type() == Type::Real) {
@@ -292,16 +290,30 @@ public:
     }
   }
 
-  /// Overload to support deep equality of JSON documents.
-  auto operator==(const GenericValue<CharT, Traits, Allocator> &other)
+  auto operator<=(const GenericValue<CharT, Traits, Allocator> &other)
       const noexcept -> bool {
-    return this->data == other.data;
+    return *this < other || *this == other;
   }
+
+  auto operator>(const GenericValue<CharT, Traits, Allocator> &other)
+      const noexcept -> bool {
+    return !(*this < other);
+  }
+
+  auto operator>=(const GenericValue<CharT, Traits, Allocator> &other)
+      const noexcept -> bool {
+    return *this > other || *this == other;
+  }
+
+  auto operator==(const GenericValue<CharT, Traits, Allocator> &) const noexcept
+      -> bool = default;
+  auto operator!=(const GenericValue<CharT, Traits, Allocator> &) const noexcept
+      -> bool = default;
 
   // TODO: Support passing integer and real literals too.
   /// This overload adds a numeric JSON instance to another numeric JSON
   /// instance. For example, a numeric JSON instance 3.2 can be added to a
-  /// numeric JSON instance 5 as follows::
+  /// numeric JSON instance 5 as follows:
   ///
   /// ```cpp
   /// #include <sourcemeta/jsontoolkit/json.h>

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -225,6 +225,33 @@ TEST(JSON_value, compare_object_object_different) {
   EXPECT_TRUE(right < left);
 }
 
+TEST(JSON_value, compare_int_operator_less_than_or_equal_int) {
+  const sourcemeta::jsontoolkit::JSON left{3};
+  const sourcemeta::jsontoolkit::JSON right{4};
+  EXPECT_TRUE(left <= right);
+  EXPECT_FALSE(right <= left);
+}
+
+TEST(JSON_value, compare_int_operator_greater_than_int) {
+  const sourcemeta::jsontoolkit::JSON left{5};
+  const sourcemeta::jsontoolkit::JSON right{4};
+  EXPECT_TRUE(left > right);
+  EXPECT_FALSE(right > left);
+}
+
+TEST(JSON_value, compare_int_operator_greater_than_or_equal_int) {
+  const sourcemeta::jsontoolkit::JSON left{5};
+  const sourcemeta::jsontoolkit::JSON right{4};
+  EXPECT_TRUE(left >= right);
+  EXPECT_FALSE(right >= left);
+}
+
+TEST(JSON_value, compare_int_operator_not_equal_int) {
+  const sourcemeta::jsontoolkit::JSON left{5};
+  const sourcemeta::jsontoolkit::JSON right{4};
+  EXPECT_TRUE(left != right);
+}
+
 TEST(JSON_value, set_null) {
   sourcemeta::jsontoolkit::JSON document{true};
   EXPECT_FALSE(document.is_null());


### PR DESCRIPTION
Sadly we needed to be super explicit. We cannot default given we often
deal with incomplete types, and the spaceship operator won't work the
same across objects and arrays.

See: https://github.com/sourcemeta/jsontoolkit/issues/509
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
