### PR TITLE
Fix JSON `>` operator to not accidentally behave as `>=`

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -297,7 +297,7 @@ public:
 
   auto operator>(const GenericValue<CharT, Traits, Allocator> &other)
       const noexcept -> bool {
-    return !(*this < other);
+    return !(*this < other) && *this != other;
   }
 
   auto operator>=(const GenericValue<CharT, Traits, Allocator> &other)

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -239,6 +239,12 @@ TEST(JSON_value, compare_int_operator_greater_than_int) {
   EXPECT_FALSE(right > left);
 }
 
+TEST(JSON_value, compare_int_operator_greater_than_int_equal) {
+  const sourcemeta::jsontoolkit::JSON left{5};
+  const sourcemeta::jsontoolkit::JSON right{5};
+  EXPECT_FALSE(left > right);
+}
+
 TEST(JSON_value, compare_int_operator_greater_than_or_equal_int) {
   const sourcemeta::jsontoolkit::JSON left{5};
   const sourcemeta::jsontoolkit::JSON right{4};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
