### PR TITLE
Workaround JSON class member initializer lists inconsistencies in MSVC

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -183,13 +183,13 @@ public:
   explicit GenericValue(std::initializer_list<GenericValue> values)
       : data{std::in_place_type<Array>, values} {
 // For some reason, if we construct a GenericValue by passing a single
-// GenericValue as argument, GCC (and only GCC from what we can tell) will
+// GenericValue as argument, GCC and MSVC, in some circumstances will
 // prefer this initializer list constructor over the default copy constructor,
 // effectively creating an array of a single element. We couldn't find a nicer
-// way to force GCC to pick the correct constructor. This is a hacky (and
+// way to force them to pick the correct constructor. This is a hacky (and
 // potentially inefficient?) way to "fix it up" to get consistent behavior
 // across compilers.
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(_MSC_VER)
     if (values.size() == 1) {
       this->data = values.begin()->data;
     }

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <sourcemeta/jsontoolkit/json.h>
 #include <type_traits>
+#include <utility>
 
 TEST(JSON_value, general_traits) {
   EXPECT_FALSE(
@@ -355,4 +356,25 @@ TEST(JSON_value, to_ostream) {
 #else
   EXPECT_EQ(stream.str(), "[\n  1,\n  2,\n  3,\n  4\n]");
 #endif
+}
+
+class ClassMemberInitializerList {
+public:
+  ClassMemberInitializerList(sourcemeta::jsontoolkit::JSON document)
+      : data{std::move(document)} {}
+  auto get() const -> const sourcemeta::jsontoolkit::JSON & {
+    return this->data;
+  }
+
+private:
+  const sourcemeta::jsontoolkit::JSON data;
+};
+
+TEST(JSON_value, class_member_initializer_list) {
+  const sourcemeta::jsontoolkit::JSON document{5};
+  EXPECT_TRUE(document.is_integer());
+  const ClassMemberInitializerList container{document};
+  EXPECT_TRUE(container.get().is_integer());
+  EXPECT_EQ(container.get().to_integer(), 5);
+  EXPECT_EQ(container.get(), document);
 }

--- a/test/jsonschema/officialsuite.cc
+++ b/test/jsonschema/officialsuite.cc
@@ -24,9 +24,7 @@ public:
       sourcemeta::jsontoolkit::SchemaCompilerTemplate test_schema,
       sourcemeta::jsontoolkit::JSON test_instance)
       : valid{test_valid}, mode{test_mode}, schema{std::move(test_schema)},
-
-        // TODO: Why cannot we use {} initializers here without confusing MSVC?
-        instance(std::move(test_instance)) {}
+        instance{std::move(test_instance)} {}
 
   auto TestBody() -> void override {
     const auto result{sourcemeta::jsontoolkit::evaluate(

--- a/test/jsonschema/referencingsuite.cc
+++ b/test/jsonschema/referencingsuite.cc
@@ -32,7 +32,7 @@ public:
                            std::string default_dialect)
       // Ubuntu's ClangFormat gets a bit lost on this one
       // clang-format off
-    : suite(std::move(test_suite)), test(std::move(test_document)),
+    : suite{std::move(test_suite)}, test{std::move(test_document)},
       dialect{std::move(default_dialect)} {}
   // clang-format on
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
