### PR TITLE
Make string `.size()` report logical size and introduce `.byte_size()`

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -987,7 +987,25 @@ public:
     } else if (this->is_array()) {
       return std::get<Array>(this->data).data.size();
     } else {
-      return std::get<String>(this->data).size();
+      // We want to count the number of logical characters,
+      // not the number of bytes
+      const auto &string_data{std::get<String>(this->data)};
+      std::size_t result{0};
+
+      // TODO: Loop on string characters instead
+      for (std::size_t cursor{0}; cursor < string_data.size(); cursor++) {
+        // In UTF-8, continuation bytes (i.e. not the first) are
+        // encoded as `10xxxxxx`, so this means we are at the start
+        // of a code-point
+        // See https://en.wikipedia.org/wiki/UTF-8#Encoding
+        if ((string_data[cursor] & 0b11000000) != 0b10000000) {
+          result += 1;
+        }
+      }
+
+      // Otherwise we messed up
+      assert(result <= string_data.size());
+      return result;
     }
   }
 

--- a/test/json/json_parse_test.cc
+++ b/test/json/json_parse_test.cc
@@ -1217,6 +1217,7 @@ TEST(JSON_parse, string_unicode_length) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 1);
+  EXPECT_EQ(document.byte_size(), 2);
 }
 
 TEST(JSON_parse, string_unicode_code_point_equality) {

--- a/test/json/json_parse_test.cc
+++ b/test/json/json_parse_test.cc
@@ -1211,6 +1211,14 @@ TEST(JSON_parse, string_unicode_code_points) {
   EXPECT_EQ(document.to_string(), "\u002F");
 }
 
+TEST(JSON_parse, string_unicode_length) {
+  std::istringstream input{"\"\\uD83D\\uDCA9\""};
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(input);
+  EXPECT_TRUE(document.is_string());
+  EXPECT_EQ(document.size(), 1);
+}
+
 TEST(JSON_parse, string_unicode_code_point_equality) {
   std::istringstream input_1{"\"\\u002F\""};
   std::istringstream input_2{"\"\\u002f\""};

--- a/test/jsonschema/officialsuite.cc
+++ b/test/jsonschema/officialsuite.cc
@@ -138,8 +138,7 @@ int main(int argc, char **argv) {
   register_tests("draft4", "JSONSchemaOfficialSuite_Draft4",
                  "http://json-schema.org/draft-04/schema#",
                  // TODO: Enable all tests
-                 {"refRemote", "maxLength", "multipleOf", "ref", "definitions",
-                  "minLength"});
+                 {"refRemote", "multipleOf", "ref", "definitions"});
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
