### PR TITLE
Fix JSON Pointer double quotes and backslashes on URI fragment encodings

### DIFF
--- a/src/jsonpointer/stringify.h
+++ b/src/jsonpointer/stringify.h
@@ -64,17 +64,23 @@ auto stringify(const GenericPointer<CharT, Traits, Allocator> &pointer,
           // (%x5C), and control (%x00-1F) characters MUST be escaped. See
           // https://www.rfc-editor.org/rfc/rfc6901#section-5
           case internal::token_pointer_quote<CharT>:
-            write_character<CharT, Traits, Allocator>(
-                stream, internal::token_pointer_reverse_solidus<CharT>,
-                perform_uri_escaping);
+            if (!perform_uri_escaping) {
+              write_character<CharT, Traits, Allocator>(
+                  stream, internal::token_pointer_reverse_solidus<CharT>,
+                  perform_uri_escaping);
+            }
+
             write_character<CharT, Traits, Allocator>(
                 stream, internal::token_pointer_quote<CharT>,
                 perform_uri_escaping);
             break;
           case internal::token_pointer_reverse_solidus<CharT>:
-            write_character<CharT, Traits, Allocator>(
-                stream, internal::token_pointer_reverse_solidus<CharT>,
-                perform_uri_escaping);
+            if (!perform_uri_escaping) {
+              write_character<CharT, Traits, Allocator>(
+                  stream, internal::token_pointer_reverse_solidus<CharT>,
+                  perform_uri_escaping);
+            }
+
             write_character<CharT, Traits, Allocator>(
                 stream, internal::token_pointer_reverse_solidus<CharT>,
                 perform_uri_escaping);

--- a/test/jsonpointer/jsonpointer_to_uri_test.cc
+++ b/test/jsonpointer/jsonpointer_to_uri_test.cc
@@ -55,7 +55,14 @@ TEST(JSONPointer_to_uri, escape_uri_quote) {
   const sourcemeta::jsontoolkit::Pointer pointer{"foo", "quote\"field"};
   const sourcemeta::jsontoolkit::URI fragment{
       sourcemeta::jsontoolkit::to_uri(pointer)};
-  EXPECT_EQ(fragment.recompose(), "#/foo/quote%5C%22field");
+  EXPECT_EQ(fragment.recompose(), "#/foo/quote%22field");
+}
+
+TEST(JSONPointer_to_uri, escape_uri_backslash) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar\\baz"};
+  const sourcemeta::jsontoolkit::URI fragment{
+      sourcemeta::jsontoolkit::to_uri(pointer)};
+  EXPECT_EQ(fragment.recompose(), "#/foo/bar%5Cbaz");
 }
 
 TEST(JSONPointer_to_uri, escape_uri_dollar_sign) {

--- a/test/jsonschema/officialsuite.cc
+++ b/test/jsonschema/officialsuite.cc
@@ -177,9 +177,7 @@ int main(int argc, char **argv) {
   // Draft4
   // TODO: Enable optional tests too
   register_tests("draft4", "JSONSchemaOfficialSuite_Draft4",
-                 "http://json-schema.org/draft-04/schema#",
-                 // TODO: Enable all tests
-                 {"ref"});
+                 "http://json-schema.org/draft-04/schema#", {});
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
