### PR TITLE
Don't let JSON be configured with different character types

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json.h
@@ -15,7 +15,7 @@
 #include <istream>    // std::basic_istream
 #include <memory>     // std::allocator
 #include <ostream>    // std::basic_ostream
-#include <string>     // std::char_traits, std::basic_string
+#include <string>     // std::basic_string
 
 /// @defgroup json JSON
 /// @brief A full-blown ECMA-404 implementation with read, write, and iterators
@@ -30,7 +30,7 @@
 namespace sourcemeta::jsontoolkit {
 
 /// @ingroup json
-using JSON = GenericValue<char, std::char_traits<char>, std::allocator>;
+using JSON = GenericValue<std::allocator>;
 
 /// @ingroup json
 /// Create a JSON document from a C++ standard input stream. For example, a JSON

--- a/src/json/json.cc
+++ b/src/json/json.cc
@@ -11,29 +11,25 @@ namespace sourcemeta::jsontoolkit {
 
 auto parse(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
            std::uint64_t &line, std::uint64_t &column) -> JSON {
-  return parse<JSON::Char, JSON::CharTraits, std::allocator>(stream, line,
-                                                             column);
+  return parse<std::allocator>(stream, line, column);
 }
 
 auto parse(const std::basic_string<JSON::Char, JSON::CharTraits> &input,
            std::uint64_t &line, std::uint64_t &column) -> JSON {
-  return parse<JSON::Char, JSON::CharTraits, std::allocator>(input, line,
-                                                             column);
+  return parse<std::allocator>(input, line, column);
 }
 
 auto parse(std::basic_istream<JSON::Char, JSON::CharTraits> &stream) -> JSON {
   std::uint64_t line{1};
   std::uint64_t column{0};
-  return parse<JSON::Char, JSON::CharTraits, std::allocator>(stream, line,
-                                                             column);
+  return parse<std::allocator>(stream, line, column);
 }
 
 auto parse(const std::basic_string<JSON::Char, JSON::CharTraits> &input)
     -> JSON {
   std::uint64_t line{1};
   std::uint64_t column{0};
-  return parse<JSON::Char, JSON::CharTraits, std::allocator>(input, line,
-                                                             column);
+  return parse<std::allocator>(input, line, column);
 }
 
 auto from_file(const std::filesystem::path &path) -> JSON {
@@ -45,13 +41,13 @@ auto from_file(const std::filesystem::path &path) -> JSON {
 auto stringify(const JSON &document,
                std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
-  stringify<JSON::Char, JSON::CharTraits, std::allocator>(document, stream);
+  stringify<std::allocator>(document, stream);
 }
 
 auto prettify(const JSON &document,
               std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {
-  prettify<JSON::Char, JSON::CharTraits, std::allocator>(document, stream);
+  prettify<std::allocator>(document, stream);
 }
 
 auto operator<<(std::basic_ostream<JSON::Char, JSON::CharTraits> &stream,

--- a/src/json/parser.h
+++ b/src/json/parser.h
@@ -19,62 +19,71 @@
 
 namespace sourcemeta::jsontoolkit::internal {
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-inline auto parse_null(const std::uint64_t line, const std::uint64_t column,
-                       std::basic_istream<CharT, Traits> &stream)
-    -> GenericValue<CharT, Traits, Allocator> {
+template <template <typename T> typename Allocator>
+inline auto parse_null(
+    const std::uint64_t line, const std::uint64_t column,
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream)
+    -> GenericValue<Allocator> {
   auto new_column{column};
   for (const auto character :
-       internal::constant_null<CharT, Traits>.substr(1)) {
+       internal::constant_null<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.substr(1)) {
     new_column += 1;
     if (stream.get() != character) {
       throw ParseError(line, new_column);
     }
   }
 
-  return GenericValue<CharT, Traits, Allocator>{nullptr};
+  return GenericValue<Allocator>{nullptr};
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-inline auto parse_boolean_true(const std::uint64_t line, std::uint64_t &column,
-                               std::basic_istream<CharT, Traits> &stream)
-    -> GenericValue<CharT, Traits, Allocator> {
+template <template <typename T> typename Allocator>
+inline auto parse_boolean_true(
+    const std::uint64_t line, std::uint64_t &column,
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream)
+    -> GenericValue<Allocator> {
   for (const auto character :
-       internal::constant_true<CharT, Traits>.substr(1)) {
+       internal::constant_true<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.substr(1)) {
     column += 1;
     if (stream.get() != character) {
       throw ParseError(line, column);
     }
   }
 
-  return GenericValue<CharT, Traits, Allocator>{true};
+  return GenericValue<Allocator>{true};
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-inline auto parse_boolean_false(const std::uint64_t line, std::uint64_t &column,
-                                std::basic_istream<CharT, Traits> &stream)
-    -> GenericValue<CharT, Traits, Allocator> {
+template <template <typename T> typename Allocator>
+inline auto parse_boolean_false(
+    const std::uint64_t line, std::uint64_t &column,
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream)
+    -> GenericValue<Allocator> {
   for (const auto character :
-       internal::constant_false<CharT, Traits>.substr(1)) {
+       internal::constant_false<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.substr(1)) {
     column += 1;
     if (stream.get() != character) {
       throw ParseError(line, column);
     }
   }
 
-  return GenericValue<CharT, Traits, Allocator>{false};
+  return GenericValue<Allocator>{false};
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_string_unicode(
     const std::uint64_t line, std::uint64_t &column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result) -> void {
-  std::basic_string<CharT, Traits, Allocator<CharT>> code_point;
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> void {
+  std::basic_string<typename GenericValue<Allocator>::Char,
+                    typename GenericValue<Allocator>::CharTraits,
+                    Allocator<typename GenericValue<Allocator>::Char>>
+      code_point;
   code_point.resize(4);
   std::size_t code_point_size{0};
 
@@ -91,7 +100,8 @@ auto parse_string_unicode(
   // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
   while (code_point_size < 4) {
     column += 1;
-    code_point[code_point_size] = static_cast<CharT>(stream.get());
+    code_point[code_point_size] =
+        static_cast<typename GenericValue<Allocator>::Char>(stream.get());
     if (std::isxdigit(code_point[code_point_size])) {
       code_point_size += 1;
     } else {
@@ -103,39 +113,51 @@ auto parse_string_unicode(
   // According to ECMA 404, \u can be followed by "any"
   // sequence of 4 hexadecimal digits.
   constexpr auto unicode_base{16};
-  result.put(static_cast<CharT>(std::stoul(code_point, nullptr, unicode_base)));
+  result.put(static_cast<typename GenericValue<Allocator>::Char>(
+      std::stoul(code_point, nullptr, unicode_base)));
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_string_escape(
     const std::uint64_t line, std::uint64_t &column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result) -> void {
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> void {
   column += 1;
   switch (stream.get()) {
-    case internal::token_string_quote<CharT>:
-      result.put(internal::token_string_quote<CharT>);
+    case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
+      result.put(
+          internal::token_string_quote<typename GenericValue<Allocator>::Char>);
       return;
-    case internal::token_string_escape<CharT>:
-      result.put(internal::token_string_escape<CharT>);
+    case internal::token_string_escape<typename GenericValue<Allocator>::Char>:
+      result.put(internal::token_string_escape<
+                 typename GenericValue<Allocator>::Char>);
       return;
-    case internal::token_string_solidus<CharT>:
-      result.put(internal::token_string_solidus<CharT>);
+    case internal::token_string_solidus<typename GenericValue<Allocator>::Char>:
+      result.put(internal::token_string_solidus<
+                 typename GenericValue<Allocator>::Char>);
       return;
-    case internal::token_string_escape_backspace<CharT>:
+    case internal::token_string_escape_backspace<
+        typename GenericValue<Allocator>::Char>:
       result.put('\b');
       return;
-    case internal::token_string_escape_form_feed<CharT>:
+    case internal::token_string_escape_form_feed<
+        typename GenericValue<Allocator>::Char>:
       result.put('\f');
       return;
-    case internal::token_string_escape_line_feed<CharT>:
+    case internal::token_string_escape_line_feed<
+        typename GenericValue<Allocator>::Char>:
       result.put('\n');
       return;
-    case internal::token_string_escape_carriage_return<CharT>:
+    case internal::token_string_escape_carriage_return<
+        typename GenericValue<Allocator>::Char>:
       result.put('\r');
       return;
-    case internal::token_string_escape_tabulation<CharT>:
+    case internal::token_string_escape_tabulation<
+        typename GenericValue<Allocator>::Char>:
       result.put('\t');
       return;
 
@@ -150,7 +172,8 @@ auto parse_string_escape(
     // or lowercase (U+0061 through U+0066).
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_string_escape_unicode<CharT>:
+    case internal::token_string_escape_unicode<
+        typename GenericValue<Allocator>::Char>:
       parse_string_unicode(line, column, stream, result);
       return;
 
@@ -159,22 +182,28 @@ auto parse_string_escape(
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto parse_string(const std::uint64_t line, std::uint64_t &column,
-                  std::basic_istream<CharT, Traits> &stream) ->
-    typename GenericValue<CharT, Traits, Allocator>::String {
-  std::basic_ostringstream<CharT, Traits, Allocator<CharT>> result;
+template <template <typename T> typename Allocator>
+auto parse_string(
+    const std::uint64_t line, std::uint64_t &column,
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream) ->
+    typename GenericValue<Allocator>::String {
+  std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                           typename GenericValue<Allocator>::CharTraits,
+                           Allocator<typename GenericValue<Allocator>::Char>>
+      result;
   while (!stream.eof()) {
     column += 1;
-    const CharT character{static_cast<CharT>(stream.get())};
+    const typename GenericValue<Allocator>::Char character{
+        static_cast<typename GenericValue<Allocator>::Char>(stream.get())};
     switch (character) {
       // A string is a sequence of Unicode code points wrapped with quotation
       // marks (U+0022). See
       // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-      case internal::token_string_quote<CharT>:
+      case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
         return result.str();
-      case internal::token_string_escape<CharT>:
+      case internal::token_string_escape<
+          typename GenericValue<Allocator>::Char>:
         parse_string_escape(line, column, stream, result);
         break;
       // These are always disallowed
@@ -210,7 +239,8 @@ auto parse_string(const std::uint64_t line, std::uint64_t &column,
       case '\u001D':
       case '\u001E':
       case '\u001F':
-      case static_cast<CharT>(Traits::eof()):
+      case static_cast<typename GenericValue<Allocator>::Char>(
+          GenericValue<Allocator>::CharTraits::eof()):
         throw ParseError(line, column);
       default:
         result.put(character);
@@ -243,27 +273,30 @@ auto parse_number_real(const std::uint64_t line, const std::uint64_t column,
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_exponent_rest(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> double {
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> double {
   while (!stream.eof()) {
-    const CharT character{static_cast<CharT>(stream.peek())};
+    const typename GenericValue<Allocator>::Char character{
+        static_cast<typename GenericValue<Allocator>::Char>(stream.peek())};
     switch (character) {
-      case internal::token_number_zero<CharT>:
-      case internal::token_number_one<CharT>:
-      case internal::token_number_two<CharT>:
-      case internal::token_number_three<CharT>:
-      case internal::token_number_four<CharT>:
-      case internal::token_number_five<CharT>:
-      case internal::token_number_six<CharT>:
-      case internal::token_number_seven<CharT>:
-      case internal::token_number_eight<CharT>:
-      case internal::token_number_nine<CharT>:
+      case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
         result.put(character);
         stream.ignore(1);
         column += 1;
@@ -276,27 +309,30 @@ auto parse_number_exponent_rest(
   throw ParseError(line, column);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_exponent(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> double {
-  const CharT character{static_cast<CharT>(stream.get())};
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> double {
+  const typename GenericValue<Allocator>::Char character{
+      static_cast<typename GenericValue<Allocator>::Char>(stream.get())};
   column += 1;
   switch (character) {
-    case internal::token_number_zero<CharT>:
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
       result.put(character);
       return parse_number_exponent_rest(line, column, original_column, stream,
                                         result);
@@ -305,37 +341,40 @@ auto parse_number_exponent(
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_exponent_first(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> double {
-  const CharT character{static_cast<CharT>(stream.get())};
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> double {
+  const typename GenericValue<Allocator>::Char character{
+      static_cast<typename GenericValue<Allocator>::Char>(stream.get())};
   column += 1;
   switch (character) {
-    case internal::token_number_plus<CharT>:
+    case internal::token_number_plus<typename GenericValue<Allocator>::Char>:
       // Exponents are positive by default,
       // so no need to write the plus sign.
       return parse_number_exponent(line, column, original_column, stream,
                                    result);
-    case internal::token_number_minus<CharT>:
+    case internal::token_number_minus<typename GenericValue<Allocator>::Char>:
       result.put(character);
       return parse_number_exponent(line, column, original_column, stream,
                                    result);
 
-    case internal::token_number_zero<CharT>:
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
       result.put(character);
       return parse_number_exponent_rest(line, column, original_column, stream,
                                         result);
@@ -344,38 +383,43 @@ auto parse_number_exponent_first(
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_fractional(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> double {
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> double {
   while (!stream.eof()) {
-    const CharT character{static_cast<CharT>(stream.peek())};
+    const typename GenericValue<Allocator>::Char character{
+        static_cast<typename GenericValue<Allocator>::Char>(stream.peek())};
     switch (character) {
       // [A number] may have an exponent, prefixed by e (U+0065) or E (U+0045)
       // See
       // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-      case internal::token_number_exponent_uppercase<CharT>:
-      case internal::token_number_exponent_lowercase<CharT>:
+      case internal::token_number_exponent_uppercase<
+          typename GenericValue<Allocator>::Char>:
+      case internal::token_number_exponent_lowercase<
+          typename GenericValue<Allocator>::Char>:
         result.put(character);
         stream.ignore(1);
         column += 1;
         return parse_number_exponent_first(line, column, original_column,
                                            stream, result);
 
-      case internal::token_number_zero<CharT>:
-      case internal::token_number_one<CharT>:
-      case internal::token_number_two<CharT>:
-      case internal::token_number_three<CharT>:
-      case internal::token_number_four<CharT>:
-      case internal::token_number_five<CharT>:
-      case internal::token_number_six<CharT>:
-      case internal::token_number_seven<CharT>:
-      case internal::token_number_eight<CharT>:
-      case internal::token_number_nine<CharT>:
+      case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
         result.put(character);
         stream.ignore(1);
         column += 1;
@@ -388,33 +432,38 @@ auto parse_number_fractional(
   throw ParseError(line, column);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_fractional_first(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> double {
-  const CharT character{static_cast<CharT>(stream.peek())};
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> double {
+  const typename GenericValue<Allocator>::Char character{
+      static_cast<typename GenericValue<Allocator>::Char>(stream.peek())};
   switch (character) {
     // [A number] may have a fractional part prefixed by a decimal point
     // (U+002E). See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_number_decimal_point<CharT>:
-    case static_cast<CharT>(Traits::eof()):
+    case internal::token_number_decimal_point<
+        typename GenericValue<Allocator>::Char>:
+    case static_cast<typename GenericValue<Allocator>::Char>(
+        GenericValue<Allocator>::CharTraits::eof()):
       column += 1;
       throw ParseError(line, column);
-    case internal::token_number_zero<CharT>:
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
       result.put(character);
       stream.ignore(1);
       column += 1;
@@ -425,95 +474,104 @@ auto parse_number_fractional_first(
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_maybe_fractional(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> GenericValue<CharT, Traits, Allocator> {
-  const CharT character{static_cast<CharT>(stream.peek())};
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> GenericValue<Allocator> {
+  const typename GenericValue<Allocator>::Char character{
+      static_cast<typename GenericValue<Allocator>::Char>(stream.peek())};
   switch (character) {
     // [A number] may have a fractional part prefixed by a decimal point
     // (U+002E). See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_number_decimal_point<CharT>:
+    case internal::token_number_decimal_point<
+        typename GenericValue<Allocator>::Char>:
       result.put(character);
       stream.ignore(1);
       column += 1;
-      return GenericValue<CharT, Traits, Allocator>{
-          parse_number_fractional_first(line, column, original_column, stream,
-                                        result)};
-    case internal::token_number_exponent_uppercase<CharT>:
-    case internal::token_number_exponent_lowercase<CharT>:
-      result.put(character);
-      stream.ignore(1);
-      column += 1;
-      return GenericValue<CharT, Traits, Allocator>{parse_number_exponent_first(
+      return GenericValue<Allocator>{parse_number_fractional_first(
           line, column, original_column, stream, result)};
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
+    case internal::token_number_exponent_uppercase<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_number_exponent_lowercase<
+        typename GenericValue<Allocator>::Char>:
+      result.put(character);
+      stream.ignore(1);
+      column += 1;
+      return GenericValue<Allocator>{parse_number_exponent_first(
+          line, column, original_column, stream, result)};
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
       column += 1;
       throw ParseError(line, column);
     default:
-      return GenericValue<CharT, Traits, Allocator>{
+      return GenericValue<Allocator>{
           parse_number_integer(line, original_column, result.str())};
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_any_rest(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> GenericValue<CharT, Traits, Allocator> {
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> GenericValue<Allocator> {
   while (!stream.eof()) {
-    const CharT character{static_cast<CharT>(stream.peek())};
+    const typename GenericValue<Allocator>::Char character{
+        static_cast<typename GenericValue<Allocator>::Char>(stream.peek())};
     switch (character) {
       // [A number] may have a fractional part prefixed by a decimal point
       // (U+002E). See
       // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-      case internal::token_number_decimal_point<CharT>:
+      case internal::token_number_decimal_point<
+          typename GenericValue<Allocator>::Char>:
         result.put(character);
         stream.ignore(1);
         column += 1;
-        return GenericValue<CharT, Traits, Allocator>{
-            parse_number_fractional_first(line, column, original_column, stream,
-                                          result)};
-      case internal::token_number_exponent_uppercase<CharT>:
-      case internal::token_number_exponent_lowercase<CharT>:
+        return GenericValue<Allocator>{parse_number_fractional_first(
+            line, column, original_column, stream, result)};
+      case internal::token_number_exponent_uppercase<
+          typename GenericValue<Allocator>::Char>:
+      case internal::token_number_exponent_lowercase<
+          typename GenericValue<Allocator>::Char>:
         result.put(character);
         stream.ignore(1);
         column += 1;
-        return GenericValue<CharT, Traits, Allocator>{
-            parse_number_exponent_first(line, column, original_column, stream,
-                                        result)};
-      case internal::token_number_zero<CharT>:
-      case internal::token_number_one<CharT>:
-      case internal::token_number_two<CharT>:
-      case internal::token_number_three<CharT>:
-      case internal::token_number_four<CharT>:
-      case internal::token_number_five<CharT>:
-      case internal::token_number_six<CharT>:
-      case internal::token_number_seven<CharT>:
-      case internal::token_number_eight<CharT>:
-      case internal::token_number_nine<CharT>:
+        return GenericValue<Allocator>{parse_number_exponent_first(
+            line, column, original_column, stream, result)};
+      case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+      case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
         result.put(character);
         stream.ignore(1);
         column += 1;
         break;
       default:
-        return GenericValue<CharT, Traits, Allocator>{
+        return GenericValue<Allocator>{
             parse_number_integer(line, original_column, result.str())};
     }
   }
@@ -521,33 +579,36 @@ auto parse_number_any_rest(
   throw ParseError(line, column);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto parse_number_any_negative_first(
     const std::uint64_t line, std::uint64_t &column,
     const std::uint64_t original_column,
-    std::basic_istream<CharT, Traits> &stream,
-    std::basic_ostringstream<CharT, Traits, Allocator<CharT>> &result)
-    -> GenericValue<CharT, Traits, Allocator> {
-  const CharT character{static_cast<CharT>(stream.get())};
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                             typename GenericValue<Allocator>::CharTraits,
+                             Allocator<typename GenericValue<Allocator>::Char>>
+        &result) -> GenericValue<Allocator> {
+  const typename GenericValue<Allocator>::Char character{
+      static_cast<typename GenericValue<Allocator>::Char>(stream.get())};
   column += 1;
   switch (character) {
     // A number is a sequence of decimal digits with no superfluous leading
     // zero. See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_number_zero<CharT>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
       result.put(character);
       return parse_number_maybe_fractional(line, column, original_column,
                                            stream, result);
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
       result.put(character);
       return parse_number_any_rest(line, column, original_column, stream,
                                    result);
@@ -556,22 +617,27 @@ auto parse_number_any_negative_first(
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto parse_number(const std::uint64_t line, std::uint64_t &column,
-                  std::basic_istream<CharT, Traits> &stream,
-                  const CharT first) -> GenericValue<CharT, Traits, Allocator> {
-  std::basic_ostringstream<CharT, Traits, Allocator<CharT>> result;
+template <template <typename T> typename Allocator>
+auto parse_number(
+    const std::uint64_t line, std::uint64_t &column,
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    const typename GenericValue<Allocator>::Char first)
+    -> GenericValue<Allocator> {
+  std::basic_ostringstream<typename GenericValue<Allocator>::Char,
+                           typename GenericValue<Allocator>::CharTraits,
+                           Allocator<typename GenericValue<Allocator>::Char>>
+      result;
   result.put(first);
 
   // A number is a sequence of decimal digits with no superfluous leading zero.
   // It may have a preceding minus sign (U+002D). See
   // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
   switch (first) {
-    case internal::token_number_minus<CharT>:
+    case internal::token_number_minus<typename GenericValue<Allocator>::Char>:
       return parse_number_any_negative_first(line, column, column, stream,
                                              result);
-    case internal::token_number_zero<CharT>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
       return parse_number_maybe_fractional(line, column, column, stream,
                                            result);
     // Any other digit
@@ -586,18 +652,19 @@ auto parse_number(const std::uint64_t line, std::uint64_t &column,
 // NOLINTBEGIN(cppcoreguidelines-avoid-goto)
 
 namespace sourcemeta::jsontoolkit {
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto parse(std::basic_istream<CharT, Traits> &stream, std::uint64_t &line,
-           std::uint64_t &column) -> GenericValue<CharT, Traits, Allocator> {
+template <template <typename T> typename Allocator>
+auto parse(
+    std::basic_istream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    std::uint64_t &line, std::uint64_t &column) -> GenericValue<Allocator> {
   // Globals
-  using Result = GenericValue<CharT, Traits, Allocator>;
+  using Result = GenericValue<Allocator>;
   enum class Container { Array, Object };
   std::stack<Container> levels;
   std::stack<std::reference_wrapper<Result>> frames;
   std::optional<Result> result;
   typename Result::String key{""};
-  CharT character;
+  typename GenericValue<Allocator>::Char character;
 
   /*
    * Parse any JSON document
@@ -605,57 +672,56 @@ auto parse(std::basic_istream<CharT, Traits> &stream, std::uint64_t &line,
 
 do_parse:
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
 
   // A JSON value can be an object, array, number, string, true, false, or null.
   // See
   // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
   switch (character) {
-    case internal::constant_true<CharT, Traits>.front():
-      return internal::parse_boolean_true<CharT, Traits, Allocator>(
-          line, column, stream);
-    case internal::constant_false<CharT, Traits>.front():
-      return internal::parse_boolean_false<CharT, Traits, Allocator>(
-          line, column, stream);
-    case internal::constant_null<CharT, Traits>.front():
-      return internal::parse_null<CharT, Traits, Allocator>(line, column,
-                                                            stream);
+    case internal::constant_true<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
+      return internal::parse_boolean_true<Allocator>(line, column, stream);
+    case internal::constant_false<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
+      return internal::parse_boolean_false<Allocator>(line, column, stream);
+    case internal::constant_null<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
+      return internal::parse_null<Allocator>(line, column, stream);
 
     // A string is a sequence of Unicode code points wrapped with quotation
     // marks (U+0022). See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_string_quote<CharT>:
-      return Result{internal::parse_string<CharT, Traits, Allocator>(
-          line, column, stream)};
-    case internal::token_array_begin<CharT>:
+    case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
+      return Result{internal::parse_string<Allocator>(line, column, stream)};
+    case internal::token_array_begin<typename GenericValue<Allocator>::Char>:
       goto do_parse_array;
-    case internal::token_object_begin<CharT>:
+    case internal::token_object_begin<typename GenericValue<Allocator>::Char>:
       goto do_parse_object;
 
-    case internal::token_number_minus<CharT>:
-    case internal::token_number_zero<CharT>:
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
-      return internal::parse_number<CharT, Traits, Allocator>(
-          line, column, stream, character);
+    case internal::token_number_minus<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
+      return internal::parse_number<Allocator>(line, column, stream, character);
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse;
     default:
       throw ParseError(line, column);
@@ -695,10 +761,10 @@ do_parse_array:
 do_parse_array_item:
   assert(levels.top() == Container::Array);
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
   switch (character) {
     // Positional
-    case internal::token_array_end<CharT>:
+    case internal::token_array_end<typename GenericValue<Allocator>::Char>:
       if (frames.top().get().empty()) {
         goto do_parse_container_end;
       } else {
@@ -706,60 +772,60 @@ do_parse_array_item:
       }
 
     // Values
-    case internal::token_array_begin<CharT>:
+    case internal::token_array_begin<typename GenericValue<Allocator>::Char>:
       goto do_parse_array;
-    case internal::token_object_begin<CharT>:
+    case internal::token_object_begin<typename GenericValue<Allocator>::Char>:
       goto do_parse_object;
-    case internal::constant_true<CharT, Traits>.front():
+    case internal::constant_true<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
       frames.top().get().push_back(
-          internal::parse_boolean_true<CharT, Traits, Allocator>(line, column,
-                                                                 stream));
+          internal::parse_boolean_true<Allocator>(line, column, stream));
       goto do_parse_array_item_separator;
-    case internal::constant_false<CharT, Traits>.front():
+    case internal::constant_false<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
       frames.top().get().push_back(
-          internal::parse_boolean_false<CharT, Traits, Allocator>(line, column,
-                                                                  stream));
+          internal::parse_boolean_false<Allocator>(line, column, stream));
       goto do_parse_array_item_separator;
-    case internal::constant_null<CharT, Traits>.front():
+    case internal::constant_null<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
       frames.top().get().push_back(
-          internal::parse_null<CharT, Traits, Allocator>(line, column, stream));
+          internal::parse_null<Allocator>(line, column, stream));
       goto do_parse_array_item_separator;
 
     // A string is a sequence of Unicode code points wrapped with quotation
     // marks (U+0022). See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_string_quote<CharT>:
+    case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
       frames.top().get().push_back(
-          Result{internal::parse_string<CharT, Traits, Allocator>(line, column,
-                                                                  stream)});
+          Result{internal::parse_string<Allocator>(line, column, stream)});
       goto do_parse_array_item_separator;
 
-    case internal::token_number_minus<CharT>:
-    case internal::token_number_zero<CharT>:
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
+    case internal::token_number_minus<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
       frames.top().get().push_back(
-          internal::parse_number<CharT, Traits, Allocator>(line, column, stream,
-                                                           character));
+          internal::parse_number<Allocator>(line, column, stream, character));
       goto do_parse_array_item_separator;
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse_array_item;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_array_item;
     default:
       goto error;
@@ -768,24 +834,29 @@ do_parse_array_item:
 do_parse_array_item_separator:
   assert(levels.top() == Container::Array);
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
   switch (character) {
     // Positional
-    case internal::token_array_delimiter<CharT>:
+    case internal::token_array_delimiter<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_array_item;
-    case internal::token_array_end<CharT>:
+    case internal::token_array_end<typename GenericValue<Allocator>::Char>:
       goto do_parse_container_end;
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse_array_item_separator;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_array_item_separator;
     default:
       goto error;
@@ -828,9 +899,9 @@ do_parse_object:
 do_parse_object_property_key:
   assert(levels.top() == Container::Object);
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
   switch (character) {
-    case internal::token_object_end<CharT>:
+    case internal::token_object_end<typename GenericValue<Allocator>::Char>:
       if (frames.top().get().empty()) {
         goto do_parse_container_end;
       } else {
@@ -840,21 +911,24 @@ do_parse_object_property_key:
     // A string is a sequence of Unicode code points wrapped with quotation
     // marks (U+0022). See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_string_quote<CharT>:
-      key = internal::parse_string<CharT, Traits, Allocator>(line, column,
-                                                             stream);
+    case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
+      key = internal::parse_string<Allocator>(line, column, stream);
       goto do_parse_object_property_separator;
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse_object_property_key;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_object_property_key;
     default:
       goto error;
@@ -863,21 +937,26 @@ do_parse_object_property_key:
 do_parse_object_property_separator:
   assert(levels.top() == Container::Object);
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
   switch (character) {
-    case internal::token_object_key_delimiter<CharT>:
+    case internal::token_object_key_delimiter<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_object_property_value;
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse_object_property_separator;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_object_property_separator;
     default:
       goto error;
@@ -886,64 +965,63 @@ do_parse_object_property_separator:
 do_parse_object_property_value:
   assert(levels.top() == Container::Object);
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
   switch (character) {
     // Values
-    case internal::token_array_begin<CharT>:
+    case internal::token_array_begin<typename GenericValue<Allocator>::Char>:
       goto do_parse_array;
-    case internal::token_object_begin<CharT>:
+    case internal::token_object_begin<typename GenericValue<Allocator>::Char>:
       goto do_parse_object;
-    case internal::constant_true<CharT, Traits>.front():
+    case internal::constant_true<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
       frames.top().get().assign(
-          key, internal::parse_boolean_true<CharT, Traits, Allocator>(
-                   line, column, stream));
+          key, internal::parse_boolean_true<Allocator>(line, column, stream));
       goto do_parse_object_property_end;
-    case internal::constant_false<CharT, Traits>.front():
+    case internal::constant_false<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
       frames.top().get().assign(
-          key, internal::parse_boolean_false<CharT, Traits, Allocator>(
-                   line, column, stream));
+          key, internal::parse_boolean_false<Allocator>(line, column, stream));
       goto do_parse_object_property_end;
-    case internal::constant_null<CharT, Traits>.front():
+    case internal::constant_null<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.front():
       frames.top().get().assign(
-          key,
-          internal::parse_null<CharT, Traits, Allocator>(line, column, stream));
+          key, internal::parse_null<Allocator>(line, column, stream));
       goto do_parse_object_property_end;
 
     // A string is a sequence of Unicode code points wrapped with quotation
     // marks (U+0022). See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_string_quote<CharT>:
+    case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
       frames.top().get().assign(
-          key, Result{internal::parse_string<CharT, Traits, Allocator>(
-                   line, column, stream)});
+          key, Result{internal::parse_string<Allocator>(line, column, stream)});
       goto do_parse_object_property_end;
 
-    case internal::token_number_minus<CharT>:
-    case internal::token_number_zero<CharT>:
-    case internal::token_number_one<CharT>:
-    case internal::token_number_two<CharT>:
-    case internal::token_number_three<CharT>:
-    case internal::token_number_four<CharT>:
-    case internal::token_number_five<CharT>:
-    case internal::token_number_six<CharT>:
-    case internal::token_number_seven<CharT>:
-    case internal::token_number_eight<CharT>:
-    case internal::token_number_nine<CharT>:
-      frames.top().get().assign(
-          key, internal::parse_number<CharT, Traits, Allocator>(
-                   line, column, stream, character));
+    case internal::token_number_minus<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_zero<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_one<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_two<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_three<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_four<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_five<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_six<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_seven<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_eight<typename GenericValue<Allocator>::Char>:
+    case internal::token_number_nine<typename GenericValue<Allocator>::Char>:
+      frames.top().get().assign(key, internal::parse_number<Allocator>(
+                                         line, column, stream, character));
       goto do_parse_object_property_end;
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse_object_property_value;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_object_property_value;
     default:
       goto error;
@@ -952,23 +1030,28 @@ do_parse_object_property_value:
 do_parse_object_property_end:
   assert(levels.top() == Container::Object);
   column += 1;
-  character = static_cast<CharT>(stream.get());
+  character = static_cast<typename GenericValue<Allocator>::Char>(stream.get());
   switch (character) {
-    case internal::token_object_delimiter<CharT>:
+    case internal::token_object_delimiter<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_object_property_key;
-    case internal::token_object_end<CharT>:
+    case internal::token_object_end<typename GenericValue<Allocator>::Char>:
       goto do_parse_container_end;
 
     // Insignificant whitespace is allowed before or after any token.
     // See
     // https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf
-    case internal::token_whitespace_line_feed<CharT>:
+    case internal::token_whitespace_line_feed<
+        typename GenericValue<Allocator>::Char>:
       column = 0;
       line += 1;
       goto do_parse_object_property_end;
-    case internal::token_whitespace_tabulation<CharT>:
-    case internal::token_whitespace_carriage_return<CharT>:
-    case internal::token_whitespace_space<CharT>:
+    case internal::token_whitespace_tabulation<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_carriage_return<
+        typename GenericValue<Allocator>::Char>:
+    case internal::token_whitespace_space<
+        typename GenericValue<Allocator>::Char>:
       goto do_parse_object_property_end;
     default:
       goto error;
@@ -1008,12 +1091,17 @@ do_parse_container_end:
 
 // NOLINTEND(cppcoreguidelines-avoid-goto)
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto parse(const std::basic_string<CharT, Traits> &input, std::uint64_t &line,
-           std::uint64_t &column) -> GenericValue<CharT, Traits, Allocator> {
-  std::basic_istringstream<CharT, Traits, Allocator<CharT>> stream{input};
-  return parse<CharT, Traits, Allocator>(stream, line, column);
+template <template <typename T> typename Allocator>
+auto parse(const std::basic_string<typename GenericValue<Allocator>::Char,
+                                   typename GenericValue<Allocator>::CharTraits>
+               &input,
+           std::uint64_t &line,
+           std::uint64_t &column) -> GenericValue<Allocator> {
+  std::basic_istringstream<typename GenericValue<Allocator>::Char,
+                           typename GenericValue<Allocator>::CharTraits,
+                           Allocator<typename GenericValue<Allocator>::Char>>
+      stream{input};
+  return parse<Allocator>(stream, line, column);
 }
 
 } // namespace sourcemeta::jsontoolkit

--- a/src/json/stringify.h
+++ b/src/json/stringify.h
@@ -23,42 +23,47 @@ auto indent(std::basic_ostream<CharT, Traits> &stream,
 
 namespace sourcemeta::jsontoolkit {
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto stringify(const std::nullptr_t,
-               std::basic_ostream<CharT, Traits> &stream) -> void {
-  stream.write(internal::constant_null<CharT, Traits>.data(),
-               internal::constant_null<CharT, Traits>.size());
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
+  stream.write(internal::constant_null<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.data(),
+               internal::constant_null<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.size());
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto stringify(const bool value,
-               std::basic_ostream<CharT, Traits> &stream) -> void {
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
   if (value) {
-    stream.write(internal::constant_true<CharT, Traits>.data(),
-                 internal::constant_true<CharT, Traits>.size());
+    stream.write(internal::constant_true<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.data(),
+                 internal::constant_true<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.size());
   } else {
-    stream.write(internal::constant_false<CharT, Traits>.data(),
-                 internal::constant_false<CharT, Traits>.size());
+    stream.write(internal::constant_false<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.data(),
+                 internal::constant_false<typename GenericValue<Allocator>::Char, typename GenericValue<Allocator>::CharTraits>.size());
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto stringify(const std::int64_t value,
-               std::basic_ostream<CharT, Traits> &stream) -> void {
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
   const auto string{std::to_string(value)};
-  stream.write(
-      string.c_str(),
-      static_cast<typename std::basic_ostream<CharT, Traits>::int_type>(
-          string.size()));
+  stream.write(string.c_str(),
+               static_cast<typename std::basic_ostream<
+                   typename GenericValue<Allocator>::Char,
+                   typename GenericValue<Allocator>::CharTraits>::int_type>(
+                   string.size()));
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto stringify(const double value,
-               std::basic_ostream<CharT, Traits> &stream) -> void {
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
   if (value == static_cast<double>(0.0)) {
     stream.write("0.0", 3);
   } else {
@@ -67,22 +72,26 @@ auto stringify(const double value,
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto stringify(const GenericValue<CharT, Traits, Allocator> &document,
-               std::basic_ostream<CharT, Traits> &stream) -> void;
+template <template <typename T> typename Allocator>
+auto stringify(const GenericValue<Allocator> &document,
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void;
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto stringify(
-    const typename GenericValue<CharT, Traits, Allocator>::String &document,
-    std::basic_ostream<CharT, Traits> &stream) -> void {
-  stream.put(internal::token_string_quote<CharT>);
+template <template <typename T> typename Allocator>
+auto stringify(const typename GenericValue<Allocator>::String &document,
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
+  stream.put(
+      internal::token_string_quote<typename GenericValue<Allocator>::Char>);
   for (const auto character : document) {
     switch (character) {
-      case internal::token_string_escape<CharT>:
-      case internal::token_string_quote<CharT>:
-        stream.put(internal::token_string_escape<CharT>);
+      case internal::token_string_escape<
+          typename GenericValue<Allocator>::Char>:
+      case internal::token_string_quote<typename GenericValue<Allocator>::Char>:
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
         stream.put(character);
         break;
 
@@ -91,8 +100,10 @@ auto stringify(
 
       // Null
       case '\u0000':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -100,8 +111,10 @@ auto stringify(
         break;
       // Start of heading
       case '\u0001':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -109,8 +122,10 @@ auto stringify(
         break;
       // Start of text
       case '\u0002':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -118,8 +133,10 @@ auto stringify(
         break;
       // End of text
       case '\u0003':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -127,8 +144,10 @@ auto stringify(
         break;
       // End of transmission
       case '\u0004':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -136,8 +155,10 @@ auto stringify(
         break;
       // Enquiry
       case '\u0005':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -145,8 +166,10 @@ auto stringify(
         break;
       // Acknowledge
       case '\u0006':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -154,8 +177,10 @@ auto stringify(
         break;
       // Bell
       case '\u0007':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -163,23 +188,31 @@ auto stringify(
         break;
       // Backspace
       case '\b':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_backspace<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_backspace<
+                   typename GenericValue<Allocator>::Char>);
         break;
       // Horizontal tab
       case '\t':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_tabulation<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_tabulation<
+                   typename GenericValue<Allocator>::Char>);
         break;
       // Line feed
       case '\n':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_line_feed<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_line_feed<
+                   typename GenericValue<Allocator>::Char>);
         break;
       // Vertical tab
       case '\u000B':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -187,18 +220,24 @@ auto stringify(
         break;
       // Form feed
       case '\f':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_form_feed<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_form_feed<
+                   typename GenericValue<Allocator>::Char>);
         break;
       // Carriage return
       case '\r':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_carriage_return<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_carriage_return<
+                   typename GenericValue<Allocator>::Char>);
         break;
       // Shift out
       case '\u000E':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -206,8 +245,10 @@ auto stringify(
         break;
       // Shift in
       case '\u000F':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('0');
@@ -215,8 +256,10 @@ auto stringify(
         break;
       // Data link escape
       case '\u0010':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -224,8 +267,10 @@ auto stringify(
         break;
       // Device control 1
       case '\u0011':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -233,8 +278,10 @@ auto stringify(
         break;
       // Device control 2
       case '\u0012':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -242,8 +289,10 @@ auto stringify(
         break;
       // Device control 3
       case '\u0013':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -251,8 +300,10 @@ auto stringify(
         break;
       // Device control 4
       case '\u0014':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -260,8 +311,10 @@ auto stringify(
         break;
       // Negative acknowledge
       case '\u0015':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -269,8 +322,10 @@ auto stringify(
         break;
       // Synchronous idle
       case '\u0016':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -278,8 +333,10 @@ auto stringify(
         break;
       // End of transmission block
       case '\u0017':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -287,8 +344,10 @@ auto stringify(
         break;
       // Cancel
       case '\u0018':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -296,8 +355,10 @@ auto stringify(
         break;
       // End of medium
       case '\u0019':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -305,8 +366,10 @@ auto stringify(
         break;
       // Substitute
       case '\u001A':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -314,8 +377,10 @@ auto stringify(
         break;
       // Escape
       case '\u001B':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -323,8 +388,10 @@ auto stringify(
         break;
       // File separator
       case '\u001C':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -332,8 +399,10 @@ auto stringify(
         break;
       // Group separator
       case '\u001D':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -341,8 +410,10 @@ auto stringify(
         break;
       // Record separator
       case '\u001E':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -350,8 +421,10 @@ auto stringify(
         break;
       // Unit separator
       case '\u001F':
-        stream.put(internal::token_string_escape<CharT>);
-        stream.put(internal::token_string_escape_unicode<CharT>);
+        stream.put(internal::token_string_escape<
+                   typename GenericValue<Allocator>::Char>);
+        stream.put(internal::token_string_escape_unicode<
+                   typename GenericValue<Allocator>::Char>);
         stream.put('0');
         stream.put('0');
         stream.put('1');
@@ -362,67 +435,79 @@ auto stringify(
     }
   }
 
-  stream.put(internal::token_string_quote<CharT>);
+  stream.put(
+      internal::token_string_quote<typename GenericValue<Allocator>::Char>);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto stringify(
-    const typename GenericValue<CharT, Traits, Allocator>::Array &document,
-    std::basic_ostream<CharT, Traits> &stream) -> void {
-  stream.put(internal::token_array_begin<CharT>);
+template <template <typename T> typename Allocator>
+auto stringify(const typename GenericValue<Allocator>::Array &document,
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
+  stream.put(
+      internal::token_array_begin<typename GenericValue<Allocator>::Char>);
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
-    stringify<CharT, Traits, Allocator>(*iterator, stream);
+    stringify<Allocator>(*iterator, stream);
     if (std::next(iterator) != end) {
-      stream.put(internal::token_array_delimiter<CharT>);
+      stream.put(internal::token_array_delimiter<
+                 typename GenericValue<Allocator>::Char>);
     }
   }
 
-  stream.put(internal::token_array_end<CharT>);
+  stream.put(internal::token_array_end<typename GenericValue<Allocator>::Char>);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto stringify(
-    const typename GenericValue<CharT, Traits, Allocator>::Object &document,
-    std::basic_ostream<CharT, Traits> &stream) -> void {
-  stream.put(internal::token_object_begin<CharT>);
+template <template <typename T> typename Allocator>
+auto stringify(const typename GenericValue<Allocator>::Object &document,
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
+  stream.put(
+      internal::token_object_begin<typename GenericValue<Allocator>::Char>);
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
-    stringify<CharT, Traits, Allocator>(iterator->first, stream);
-    stream.put(internal::token_object_key_delimiter<CharT>);
-    stringify<CharT, Traits, Allocator>(iterator->second, stream);
+    stringify<Allocator>(iterator->first, stream);
+    stream.put(internal::token_object_key_delimiter<
+               typename GenericValue<Allocator>::Char>);
+    stringify<Allocator>(iterator->second, stream);
     if (std::next(iterator) != end) {
-      stream.put(internal::token_object_delimiter<CharT>);
+      stream.put(internal::token_object_delimiter<
+                 typename GenericValue<Allocator>::Char>);
     }
   }
 
-  stream.put(internal::token_object_end<CharT>);
+  stream.put(
+      internal::token_object_end<typename GenericValue<Allocator>::Char>);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto prettify(
-    const typename GenericValue<CharT, Traits, Allocator>::Object &document,
-    std::basic_ostream<CharT, Traits> &stream, const std::size_t) -> void;
+    const typename GenericValue<Allocator>::Object &document,
+    std::basic_ostream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    const std::size_t) -> void;
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto prettify(
-    const typename GenericValue<CharT, Traits, Allocator>::Array &document,
-    std::basic_ostream<CharT, Traits> &stream,
+    const typename GenericValue<Allocator>::Array &document,
+    std::basic_ostream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
     const std::size_t indentation) -> void {
-  stream.put(internal::token_array_begin<CharT>);
+  stream.put(
+      internal::token_array_begin<typename GenericValue<Allocator>::Char>);
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
-    stream.put(internal::token_whitespace_line_feed<CharT>);
+    stream.put(internal::token_whitespace_line_feed<
+               typename GenericValue<Allocator>::Char>);
     internal::indent(stream, indentation + 1);
-    prettify<CharT, Traits, Allocator>(*iterator, stream, indentation + 1);
+    prettify<Allocator>(*iterator, stream, indentation + 1);
     if (std::next(iterator) == end) {
-      stream.put(internal::token_whitespace_line_feed<CharT>);
+      stream.put(internal::token_whitespace_line_feed<
+                 typename GenericValue<Allocator>::Char>);
     } else {
-      stream.put(internal::token_array_delimiter<CharT>);
+      stream.put(internal::token_array_delimiter<
+                 typename GenericValue<Allocator>::Char>);
     }
   }
 
@@ -430,29 +515,34 @@ auto prettify(
     internal::indent(stream, indentation);
   }
 
-  stream.put(internal::token_array_end<CharT>);
+  stream.put(internal::token_array_end<typename GenericValue<Allocator>::Char>);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
+template <template <typename T> typename Allocator>
 auto prettify(
-    const typename GenericValue<CharT, Traits, Allocator>::Object &document,
-    std::basic_ostream<CharT, Traits> &stream,
+    const typename GenericValue<Allocator>::Object &document,
+    std::basic_ostream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
     const std::size_t indentation) -> void {
-  stream.put(internal::token_object_begin<CharT>);
+  stream.put(
+      internal::token_object_begin<typename GenericValue<Allocator>::Char>);
   const auto end{std::cend(document)};
   for (auto iterator = std::cbegin(document); iterator != end; ++iterator) {
-    stream.put(internal::token_whitespace_line_feed<CharT>);
+    stream.put(internal::token_whitespace_line_feed<
+               typename GenericValue<Allocator>::Char>);
     internal::indent(stream, indentation + 1);
-    stringify<CharT, Traits, Allocator>(iterator->first, stream);
-    stream.put(internal::token_object_key_delimiter<CharT>);
-    stream.put(internal::token_whitespace_space<CharT>);
-    prettify<CharT, Traits, Allocator>(iterator->second, stream,
-                                       indentation + 1);
+    stringify<Allocator>(iterator->first, stream);
+    stream.put(internal::token_object_key_delimiter<
+               typename GenericValue<Allocator>::Char>);
+    stream.put(internal::token_whitespace_space<
+               typename GenericValue<Allocator>::Char>);
+    prettify<Allocator>(iterator->second, stream, indentation + 1);
     if (std::next(iterator) == end) {
-      stream.put(internal::token_whitespace_line_feed<CharT>);
+      stream.put(internal::token_whitespace_line_feed<
+                 typename GenericValue<Allocator>::Char>);
     } else {
-      stream.put(internal::token_object_delimiter<CharT>);
+      stream.put(internal::token_object_delimiter<
+                 typename GenericValue<Allocator>::Char>);
     }
   }
 
@@ -460,66 +550,67 @@ auto prettify(
     internal::indent(stream, indentation);
   }
 
-  stream.put(internal::token_object_end<CharT>);
+  stream.put(
+      internal::token_object_end<typename GenericValue<Allocator>::Char>);
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto stringify(const GenericValue<CharT, Traits, Allocator> &document,
-               std::basic_ostream<CharT, Traits> &stream) -> void {
+template <template <typename T> typename Allocator>
+auto stringify(const GenericValue<Allocator> &document,
+               std::basic_ostream<typename GenericValue<Allocator>::Char,
+                                  typename GenericValue<Allocator>::CharTraits>
+                   &stream) -> void {
   switch (document.type()) {
-    case GenericValue<CharT, Traits, Allocator>::Type::Null:
-      stringify<CharT, Traits, Allocator>(nullptr, stream);
+    case GenericValue<Allocator>::Type::Null:
+      stringify<Allocator>(nullptr, stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Boolean:
-      stringify<CharT, Traits, Allocator>(document.to_boolean(), stream);
+    case GenericValue<Allocator>::Type::Boolean:
+      stringify<Allocator>(document.to_boolean(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Integer:
-      stringify<CharT, Traits, Allocator>(document.to_integer(), stream);
+    case GenericValue<Allocator>::Type::Integer:
+      stringify<Allocator>(document.to_integer(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Real:
-      stringify<CharT, Traits, Allocator>(document.to_real(), stream);
+    case GenericValue<Allocator>::Type::Real:
+      stringify<Allocator>(document.to_real(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::String:
-      stringify<CharT, Traits, Allocator>(document.to_string(), stream);
+    case GenericValue<Allocator>::Type::String:
+      stringify<Allocator>(document.to_string(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Array:
-      stringify<CharT, Traits, Allocator>(document.as_array(), stream);
+    case GenericValue<Allocator>::Type::Array:
+      stringify<Allocator>(document.as_array(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Object:
-      stringify<CharT, Traits, Allocator>(document.as_object(), stream);
+    case GenericValue<Allocator>::Type::Object:
+      stringify<Allocator>(document.as_object(), stream);
       break;
   }
 }
 
-template <typename CharT, typename Traits,
-          template <typename T> typename Allocator>
-auto prettify(const GenericValue<CharT, Traits, Allocator> &document,
-              std::basic_ostream<CharT, Traits> &stream,
-              const std::size_t indentation = 0) -> void {
+template <template <typename T> typename Allocator>
+auto prettify(
+    const GenericValue<Allocator> &document,
+    std::basic_ostream<typename GenericValue<Allocator>::Char,
+                       typename GenericValue<Allocator>::CharTraits> &stream,
+    const std::size_t indentation = 0) -> void {
   switch (document.type()) {
-    case GenericValue<CharT, Traits, Allocator>::Type::Null:
-      stringify<CharT, Traits, Allocator>(nullptr, stream);
+    case GenericValue<Allocator>::Type::Null:
+      stringify<Allocator>(nullptr, stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Boolean:
-      stringify<CharT, Traits, Allocator>(document.to_boolean(), stream);
+    case GenericValue<Allocator>::Type::Boolean:
+      stringify<Allocator>(document.to_boolean(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Integer:
-      stringify<CharT, Traits, Allocator>(document.to_integer(), stream);
+    case GenericValue<Allocator>::Type::Integer:
+      stringify<Allocator>(document.to_integer(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Real:
-      stringify<CharT, Traits, Allocator>(document.to_real(), stream);
+    case GenericValue<Allocator>::Type::Real:
+      stringify<Allocator>(document.to_real(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::String:
-      stringify<CharT, Traits, Allocator>(document.to_string(), stream);
+    case GenericValue<Allocator>::Type::String:
+      stringify<Allocator>(document.to_string(), stream);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Array:
-      prettify<CharT, Traits, Allocator>(document.as_array(), stream,
-                                         indentation);
+    case GenericValue<Allocator>::Type::Array:
+      prettify<Allocator>(document.as_array(), stream, indentation);
       break;
-    case GenericValue<CharT, Traits, Allocator>::Type::Object:
-      prettify<CharT, Traits, Allocator>(document.as_object(), stream,
-                                         indentation);
+    case GenericValue<Allocator>::Type::Object:
+      prettify<Allocator>(document.as_object(), stream, indentation);
       break;
   }
 }

--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer.h
@@ -28,6 +28,8 @@
 /// #include <sourcemeta/jsontoolkit/jsonpointer.h>
 /// ```
 
+// TODO: Remove character and character traits template arguments from pointers
+
 namespace sourcemeta::jsontoolkit {
 
 /// @ingroup jsonpointer

--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_token.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_token.h
@@ -14,7 +14,7 @@ template <typename CharT, typename Traits,
           template <typename T> typename Allocator>
 class GenericToken {
 public:
-  using Value = GenericValue<CharT, Traits, Allocator>;
+  using Value = GenericValue<Allocator>;
   using Property = typename Value::String;
   using Index = typename Value::Array::size_type;
 
@@ -199,11 +199,11 @@ public:
   /// assert(json_index.is_integer());
   /// assert(json_property.is_string());
   /// ```
-  [[nodiscard]] auto to_json() const -> GenericValue<CharT, Traits, Allocator> {
+  [[nodiscard]] auto to_json() const -> GenericValue<Allocator> {
     if (this->is_property()) {
-      return GenericValue<CharT, Traits, Allocator>{this->to_property()};
+      return GenericValue<Allocator>{this->to_property()};
     } else {
-      return GenericValue<CharT, Traits, Allocator>{this->to_index()};
+      return GenericValue<Allocator>{this->to_index()};
     }
   }
 

--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_walker.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_walker.h
@@ -18,7 +18,7 @@ private:
       typename std::vector<GenericPointer<CharT, Traits, Allocator>>;
 
 public:
-  GenericPointerWalker(const GenericValue<CharT, Traits, Allocator> &document) {
+  GenericPointerWalker(const GenericValue<Allocator> &document) {
     this->walk(document, {});
   }
 
@@ -29,7 +29,7 @@ public:
   auto cend() const -> const_iterator { return this->pointers.cend(); };
 
 private:
-  auto walk(const GenericValue<CharT, Traits, Allocator> &document,
+  auto walk(const GenericValue<Allocator> &document,
             const GenericPointer<CharT, Traits, Allocator> &pointer) -> void {
     this->pointers.push_back(pointer);
     if (document.is_array()) {


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsontoolkit/issues/684
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
