### PR TITLE
Rename `SchemaCompilerValue` to `SchemaCompilerStepValue`

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -124,9 +124,9 @@ public:
   }
 
   template <typename T>
-  auto
-  resolve_value(const sourcemeta::jsontoolkit::SchemaCompilerValue<T> &value,
-                const JSON &instance) -> T {
+  auto resolve_value(
+      const sourcemeta::jsontoolkit::SchemaCompilerStepValue<T> &value,
+      const JSON &instance) -> T {
     using namespace sourcemeta::jsontoolkit;
     // We only define target resolution for JSON documents, at least for now
     if constexpr (std::is_same_v<SchemaCompilerValueJSON, T>) {

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -35,8 +35,8 @@ auto target_to_json(const sourcemeta::jsontoolkit::SchemaCompilerTarget &target)
 }
 
 template <typename T>
-auto value_to_json(const sourcemeta::jsontoolkit::SchemaCompilerValue<T> &value)
-    -> sourcemeta::jsontoolkit::JSON {
+auto value_to_json(const sourcemeta::jsontoolkit::SchemaCompilerStepValue<T>
+                       &value) -> sourcemeta::jsontoolkit::JSON {
   using namespace sourcemeta::jsontoolkit;
   if (std::holds_alternative<SchemaCompilerTarget>(value)) {
     return target_to_json(std::get<SchemaCompilerTarget>(value));

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -86,7 +86,7 @@ enum class SchemaCompilerValueStringType { URI };
 /// @ingroup jsonschema
 /// Represents a value in a compiler step
 template <typename T>
-using SchemaCompilerValue = std::variant<T, SchemaCompilerTarget>;
+using SchemaCompilerStepValue = std::variant<T, SchemaCompilerTarget>;
 
 /// @ingroup jsonschema
 /// Represents a compiler assertion step that always fails
@@ -235,7 +235,7 @@ using SchemaCompilerTemplate = std::vector<std::variant<
     const Pointer relative_schema_location;                                    \
     const Pointer relative_instance_location;                                  \
     const std::string keyword_location;                                        \
-    const SchemaCompilerValue<type> value;                                     \
+    const SchemaCompilerStepValue<type> value;                                 \
     const SchemaCompilerTemplate condition;                                    \
   };
 
@@ -245,7 +245,7 @@ using SchemaCompilerTemplate = std::vector<std::variant<
     const Pointer relative_schema_location;                                    \
     const Pointer relative_instance_location;                                  \
     const std::string keyword_location;                                        \
-    const SchemaCompilerValue<type> value;                                     \
+    const SchemaCompilerStepValue<type> value;                                 \
     const SchemaCompilerTemplate children;                                     \
     const SchemaCompilerTemplate condition;                                    \
   };


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
