### PR TITLE
Lint that `maxContains` and `minContains` are redundant without `contains`

### DIFF
--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -12,12 +12,16 @@ noa_library(NAMESPACE sourcemeta PROJECT jsontoolkit NAME jsonschema
     compile_helpers.h default_compiler.cc
     default_compiler_draft6.h
     default_compiler_draft4.h
+
     rules/const_with_type.h
-    rules/enum_to_const.h
-    rules/enum_with_type.h
-    rules/single_type_array.h
     rules/content_media_type_without_encoding.h
     rules/content_schema_without_media_type.h
+    rules/enum_to_const.h
+    rules/enum_with_type.h
+    rules/max_contains_without_contains.h
+    rules/min_contains_without_contains.h
+    rules/single_type_array.h
+
     "${CMAKE_CURRENT_BINARY_DIR}/official_resolver.cc")
 
 if(JSONTOOLKIT_INSTALL)

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transform_bundle.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_transform_bundle.h
@@ -113,7 +113,10 @@ public:
     AntiPattern,
 
     /// Rules that simplify the given schema
-    Simplify
+    Simplify,
+
+    /// Rules that remove schema redundancies
+    Redundant
   };
 
   /// Add a set of built-in rules given a category

--- a/src/jsonschema/rules/max_contains_without_contains.h
+++ b/src/jsonschema/rules/max_contains_without_contains.h
@@ -1,0 +1,23 @@
+class MaxContainsWithoutContains final : public SchemaTransformRule {
+public:
+  MaxContainsWithoutContains()
+      : SchemaTransformRule{"max_contains_without_contains",
+                            "The `maxContains` keyword is meaningless "
+                            "without the presence of the `contains` keyword"} {
+        };
+
+  [[nodiscard]] auto condition(const JSON &schema, const std::string &,
+                               const std::set<std::string> &vocabularies,
+                               const Pointer &) const -> bool override {
+    return contains_any(
+               vocabularies,
+               {"https://json-schema.org/draft/2020-12/vocab/validation",
+                "https://json-schema.org/draft/2019-09/vocab/validation"}),
+           schema.is_object() && schema.defines("maxContains") &&
+               !schema.defines("contains");
+  }
+
+  auto transform(SchemaTransformer &transformer) const -> void override {
+    transformer.erase("maxContains");
+  }
+};

--- a/src/jsonschema/rules/min_contains_without_contains.h
+++ b/src/jsonschema/rules/min_contains_without_contains.h
@@ -1,0 +1,23 @@
+class MinContainsWithoutContains final : public SchemaTransformRule {
+public:
+  MinContainsWithoutContains()
+      : SchemaTransformRule{"min_contains_without_contains",
+                            "The `minContains` keyword is meaningless "
+                            "without the presence of the `contains` keyword"} {
+        };
+
+  [[nodiscard]] auto condition(const JSON &schema, const std::string &,
+                               const std::set<std::string> &vocabularies,
+                               const Pointer &) const -> bool override {
+    return contains_any(
+               vocabularies,
+               {"https://json-schema.org/draft/2020-12/vocab/validation",
+                "https://json-schema.org/draft/2019-09/vocab/validation"}),
+           schema.is_object() && schema.defines("minContains") &&
+               !schema.defines("contains");
+  }
+
+  auto transform(SchemaTransformer &transformer) const -> void override {
+    transformer.erase("minContains");
+  }
+};

--- a/src/jsonschema/transform_bundle.cc
+++ b/src/jsonschema/transform_bundle.cc
@@ -16,12 +16,17 @@ auto contains_any(const T &container, const T &values) -> bool {
 }
 
 // Modernize
+#include "rules/enum_to_const.h"
+// AntiPattern
 #include "rules/const_with_type.h"
+#include "rules/enum_with_type.h"
+// Simplify
+#include "rules/single_type_array.h"
+// Redundant
 #include "rules/content_media_type_without_encoding.h"
 #include "rules/content_schema_without_media_type.h"
-#include "rules/enum_to_const.h"
-#include "rules/enum_with_type.h"
-#include "rules/single_type_array.h"
+#include "rules/max_contains_without_contains.h"
+#include "rules/min_contains_without_contains.h"
 } // namespace sourcemeta::jsontoolkit
 
 auto sourcemeta::jsontoolkit::SchemaTransformBundle::add(
@@ -37,8 +42,12 @@ auto sourcemeta::jsontoolkit::SchemaTransformBundle::add(
       break;
     case sourcemeta::jsontoolkit::SchemaTransformBundle::Category::Simplify:
       this->template add<SingleTypeArray>();
+      break;
+    case sourcemeta::jsontoolkit::SchemaTransformBundle::Category::Redundant:
       this->template add<ContentMediaTypeWithoutEncoding>();
       this->template add<ContentSchemaWithoutMediaType>();
+      this->template add<MaxContainsWithoutContains>();
+      this->template add<MinContainsWithoutContains>();
       break;
     default:
       // We should never get here

--- a/test/jsonschema/jsonschema_lint_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_lint_2019_09_test.cc
@@ -114,3 +114,77 @@ TEST(JSONSchema_lint_2019_09, content_schema_without_media_type_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_lint_2019_09, max_contains_without_contains_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "maxContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, max_contains_without_contains_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": true,
+    "maxContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": true,
+    "maxContains": 1
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, min_contains_without_contains_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "minContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, min_contains_without_contains_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": true,
+    "minContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "contains": true,
+    "minContains": 1
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_lint_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_lint_2020_12_test.cc
@@ -114,3 +114,77 @@ TEST(JSONSchema_lint_2020_12, content_schema_without_media_type_1) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_lint_2020_12, max_contains_without_contains_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "maxContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, max_contains_without_contains_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": true,
+    "maxContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": true,
+    "maxContains": 1
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, min_contains_without_contains_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "minContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, min_contains_without_contains_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": true,
+    "minContains": 1
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "contains": true,
+    "minContains": 1
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -235,6 +235,8 @@
       sourcemeta::jsontoolkit::SchemaTransformBundle::Category::AntiPattern);  \
   bundle.add(                                                                  \
       sourcemeta::jsontoolkit::SchemaTransformBundle::Category::Simplify);     \
+  bundle.add(                                                                  \
+      sourcemeta::jsontoolkit::SchemaTransformBundle::Category::Redundant);    \
   bundle.apply(document, sourcemeta::jsontoolkit::default_schema_walker,       \
                sourcemeta::jsontoolkit::official_resolver);
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
