### PR TITLE
Lint `unevaluated*` keywords when set to their logical defaults

### DIFF
--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -23,6 +23,8 @@ noa_library(NAMESPACE sourcemeta PROJECT jsontoolkit NAME jsonschema
     rules/min_contains_without_contains.h
     rules/single_type_array.h
     rules/then_without_if.h
+    rules/unevaluated_items_default.h
+    rules/unevaluated_properties_default.h
 
     "${CMAKE_CURRENT_BINARY_DIR}/official_resolver.cc")
 

--- a/src/jsonschema/rules/unevaluated_items_default.h
+++ b/src/jsonschema/rules/unevaluated_items_default.h
@@ -1,0 +1,26 @@
+class UnevaluatedItemsDefault final : public SchemaTransformRule {
+public:
+  UnevaluatedItemsDefault()
+      : SchemaTransformRule{
+            "unevaluated_items_default",
+            "Setting the `unevaluatedItems` keyword to the true schema "
+            "does not add any further constraint"} {};
+
+  [[nodiscard]] auto condition(const JSON &schema, const std::string &,
+                               const std::set<std::string> &vocabularies,
+                               const Pointer &) const -> bool override {
+    return contains_any(
+               vocabularies,
+               {"https://json-schema.org/draft/2020-12/vocab/unevaluated",
+                "https://json-schema.org/draft/2019-09/vocab/applicator"}),
+           schema.is_object() && schema.defines("unevaluatedItems") &&
+               ((schema.at("unevaluatedItems").is_boolean() &&
+                 schema.at("unevaluatedItems").to_boolean()) ||
+                (schema.at("unevaluatedItems").is_object() &&
+                 schema.at("unevaluatedItems").empty()));
+  }
+
+  auto transform(SchemaTransformer &transformer) const -> void override {
+    transformer.erase("unevaluatedItems");
+  }
+};

--- a/src/jsonschema/rules/unevaluated_properties_default.h
+++ b/src/jsonschema/rules/unevaluated_properties_default.h
@@ -1,0 +1,26 @@
+class UnevaluatedPropertiesDefault final : public SchemaTransformRule {
+public:
+  UnevaluatedPropertiesDefault()
+      : SchemaTransformRule{
+            "unevaluated_properties_default",
+            "Setting the `unevaluatedProperties` keyword to the true schema "
+            "does not add any further constraint"} {};
+
+  [[nodiscard]] auto condition(const JSON &schema, const std::string &,
+                               const std::set<std::string> &vocabularies,
+                               const Pointer &) const -> bool override {
+    return contains_any(
+               vocabularies,
+               {"https://json-schema.org/draft/2020-12/vocab/unevaluated",
+                "https://json-schema.org/draft/2019-09/vocab/applicator"}),
+           schema.is_object() && schema.defines("unevaluatedProperties") &&
+               ((schema.at("unevaluatedProperties").is_boolean() &&
+                 schema.at("unevaluatedProperties").to_boolean()) ||
+                (schema.at("unevaluatedProperties").is_object() &&
+                 schema.at("unevaluatedProperties").empty()));
+  }
+
+  auto transform(SchemaTransformer &transformer) const -> void override {
+    transformer.erase("unevaluatedProperties");
+  }
+};

--- a/src/jsonschema/transform_bundle.cc
+++ b/src/jsonschema/transform_bundle.cc
@@ -29,6 +29,8 @@ auto contains_any(const T &container, const T &values) -> bool {
 #include "rules/max_contains_without_contains.h"
 #include "rules/min_contains_without_contains.h"
 #include "rules/then_without_if.h"
+#include "rules/unevaluated_items_default.h"
+#include "rules/unevaluated_properties_default.h"
 } // namespace sourcemeta::jsontoolkit
 
 auto sourcemeta::jsontoolkit::SchemaTransformBundle::add(
@@ -52,6 +54,8 @@ auto sourcemeta::jsontoolkit::SchemaTransformBundle::add(
       this->template add<MaxContainsWithoutContains>();
       this->template add<MinContainsWithoutContains>();
       this->template add<ThenWithoutIf>();
+      this->template add<UnevaluatedItemsDefault>();
+      this->template add<UnevaluatedPropertiesDefault>();
       break;
     default:
       // We should never get here

--- a/test/jsonschema/jsonschema_lint_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_lint_2019_09_test.cc
@@ -262,3 +262,107 @@ TEST(JSONSchema_lint_2019_09, else_without_if_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_lint_2019_09, unevaluated_properties_default_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedProperties": true
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, unevaluated_properties_default_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedProperties": {}
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, unevaluated_properties_default_3) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedProperties": { "type": "string" }
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedProperties": { "type": "string" }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, unevaluated_items_default_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedItems": true
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, unevaluated_items_default_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedItems": {}
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2019_09, unevaluated_items_default_3) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedItems": { "type": "string" }
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "unevaluatedItems": { "type": "string" }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_lint_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_lint_2020_12_test.cc
@@ -262,3 +262,107 @@ TEST(JSONSchema_lint_2020_12, else_without_if_2) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_lint_2020_12, unevaluated_properties_default_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedProperties": true
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, unevaluated_properties_default_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedProperties": {}
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, unevaluated_properties_default_3) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedProperties": { "type": "string" }
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedProperties": { "type": "string" }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, unevaluated_items_default_1) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedItems": true
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, unevaluated_items_default_2) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedItems": {}
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_lint_2020_12, unevaluated_items_default_3) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedItems": { "type": "string" }
+  })JSON");
+
+  LINT_AND_FIX(document);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "unevaluatedItems": { "type": "string" }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
