### PR TITLE
Fix `JSON::is_integer_real()` to not crash on non-numeric instances

### DIFF
--- a/src/json/json_value.cc
+++ b/src/json/json_value.cc
@@ -175,15 +175,16 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
 }
 
 [[nodiscard]] auto JSON::is_integer_real() const noexcept -> bool {
-  assert(this->is_number());
   if (this->is_integer()) {
     return false;
+  } else if (this->is_real()) {
+    const auto value{this->to_real()};
+    Real integral;
+    return !std::isinf(value) && !std::isnan(value) &&
+           std::modf(value, &integral) == 0.0;
+  } else {
+    return false;
   }
-
-  const auto value{this->to_real()};
-  Real integral;
-  return !std::isinf(value) && !std::isnan(value) &&
-         std::modf(value, &integral) == 0.0;
 }
 
 [[nodiscard]] auto JSON::is_number() const noexcept -> bool {

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -397,6 +397,11 @@ TEST(JSON_number, is_integer_real_integer_real) {
   EXPECT_TRUE(document.is_integer_real());
 }
 
+TEST(JSON_number, is_integer_real_non_number) {
+  const sourcemeta::jsontoolkit::JSON document{true};
+  EXPECT_FALSE(document.is_integer_real());
+}
+
 TEST(JSON_number, as_integer_integer) {
   const sourcemeta::jsontoolkit::JSON document{5};
   EXPECT_EQ(document.as_integer(), 5);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
