### PR TITLE
Stop using GoogleTest's `SUCCEED` given latest MSVC errors

### DIFF
--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -7,6 +7,7 @@ function(sourcemeta_jsontoolkit_add_compile_options target)
       /W4
       /WL
       /MP
+      /MT
       /sdl)
   else()
     target_compile_options("${target}" PRIVATE

--- a/cmake/FindGoogleTest.cmake
+++ b/cmake/FindGoogleTest.cmake
@@ -1,4 +1,6 @@
 if(NOT GoogleTest_FOUND)
+  # See https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   set(BUILD_GMOCK OFF CACHE BOOL "disable googlemock")
   set(INSTALL_GTEST OFF CACHE BOOL "disable installation")
   add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/googletest")

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -11,7 +11,6 @@
   } catch (const sourcemeta::jsontoolkit::ParseError &error) {                 \
     EXPECT_EQ(error.line(), expected_line);                                    \
     EXPECT_EQ(error.column(), expected_column);                                \
-    SUCCEED();                                                                 \
   } catch (const std::exception &) {                                           \
     FAIL() << "The parse function was expected to throw a parse error";        \
   }

--- a/test/json/jsontestsuite.cc
+++ b/test/json/jsontestsuite.cc
@@ -41,7 +41,11 @@ public:
           sourcemeta::jsontoolkit::parse(stream);
         }
       } catch (const sourcemeta::jsontoolkit::ParseError &) {
+        // As SUCCEED() is broken on MSVC
+        // See https://github.com/google/googletest/issues/4556
+#if !defined(_MSC_VER)
         SUCCEED();
+#endif
       } catch (const std::exception &) {
         FAIL() << "The parse function threw an unexpected error";
       }

--- a/test/jsonl/jsonl_parse_error_test.cc
+++ b/test/jsonl/jsonl_parse_error_test.cc
@@ -15,7 +15,6 @@
   } catch (const sourcemeta::jsontoolkit::ParseError &error) {                 \
     EXPECT_EQ(error.line(), expected_line);                                    \
     EXPECT_EQ(error.column(), expected_column);                                \
-    SUCCEED();                                                                 \
   } catch (const std::exception &) {                                           \
     FAIL() << "The JSONL parser was expected to throw a parse error";          \
   }

--- a/test/jsonpointer/jsonpointer_parse_error_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_error_test.cc
@@ -13,7 +13,7 @@
     sourcemeta::jsontoolkit::parse(stream.str());                              \
     FAIL() << "The parse function was expected to throw";                      \
   } catch (const sourcemeta::jsontoolkit::ParseError &) {                      \
-    SUCCEED();                                                                 \
+    EXPECT_TRUE(true);                                                         \
   } catch (const std::exception &) {                                           \
     FAIL() << "The parse operation threw an unexpected error";                 \
   }
@@ -24,7 +24,6 @@
     FAIL() << "The to_pointer function was expected to throw";                 \
   } catch (const sourcemeta::jsontoolkit::PointerParseError &error) {          \
     EXPECT_EQ(error.column(), expected_column);                                \
-    SUCCEED();                                                                 \
   } catch (const std::exception &) {                                           \
     FAIL() << "The to_pointer function threw an unexpected error";             \
   }


### PR DESCRIPTION
See: https://github.com/google/googletest/issues/4556
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
