### PR TITLE
Fix describe statement for `SchemaCompilerAssertionEqual`

### DIFF
--- a/src/jsonschema/compile_describe.cc
+++ b/src/jsonschema/compile_describe.cc
@@ -98,7 +98,7 @@ struct DescribeVisitor {
   }
 
   auto operator()(const SchemaCompilerAssertionEqual &) const -> std::string {
-    return "The target size is expected to be equal to the given number";
+    return "The target is expected to be equal to the given value";
   }
   auto operator()(const SchemaCompilerAssertionGreaterEqual &) const {
     return "The target number is expected to be greater than or equal to the "

--- a/test/jsonschema/jsonschema_compile_draft4_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft4_test.cc
@@ -2107,7 +2107,7 @@ TEST(JSONSchema_compile_draft4, enum_3) {
   EVALUATE_TRACE_SUCCESS(0, AssertionEqual, "/enum", "#/enum", "");
 
   EVALUATE_TRACE_DESCRIBE(
-      0, "The target size is expected to be equal to the given number");
+      0, "The target is expected to be equal to the given value");
 }
 
 TEST(JSONSchema_compile_draft4, uniqueItems_1) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
