### PR TITLE
Add a `AdjacentAnnotations` target type for the schema compiler

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -106,12 +106,14 @@ public:
 
     // An optimization for efficiently accessing annotations
     if constexpr (std::is_same_v<Annotations, T>) {
-      assert(target.first ==
-             SchemaCompilerTargetType::ParentAdjacentAnnotations);
       const auto schema_location{
           this->evaluate_path().initial().concat(target.second)};
-      return this->annotations(this->instance_location().initial(),
-                               schema_location);
+      if (target.first == SchemaCompilerTargetType::ParentAdjacentAnnotations) {
+        return this->annotations(this->instance_location().initial(),
+                                 schema_location);
+      } else {
+        return this->annotations(this->instance_location(), schema_location);
+      }
     } else {
       static_assert(std::is_same_v<JSON, T>);
       switch (target.first) {

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -24,6 +24,9 @@ auto target_to_json(const sourcemeta::jsontoolkit::SchemaCompilerTarget &target)
     case SchemaCompilerTargetType::InstanceParent:
       result.assign("type", JSON{"instance-parent"});
       return result;
+    case SchemaCompilerTargetType::AdjacentAnnotations:
+      result.assign("type", JSON{"adjacent-annotations"});
+      return result;
     case SchemaCompilerTargetType::ParentAdjacentAnnotations:
       result.assign("type", JSON{"parent-adjacent-annotations"});
       return result;

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -39,6 +39,10 @@ enum class SchemaCompilerTargetType {
   /// The penultimate path (i.e. property or index) of the instance location
   InstanceParent,
 
+  /// The annotations produced at the same base evaluation path for the
+  /// current instance location
+  AdjacentAnnotations,
+
   /// The annotations produced at the same base evaluation path for the parent
   /// of the current instance location
   ParentAdjacentAnnotations


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
