### PR TITLE
Fix `SchemaCompilerLogicalTry` break on exhaustive mode

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -458,8 +458,7 @@ auto evaluate_step(
     EVALUATE_CONDITION_GUARD(logical.condition, instance);
     result = true;
     for (const auto &child : logical.children) {
-      if (!evaluate_step(child, instance, mode, callback, context) &&
-          mode == SchemaCompilerEvaluationMode::Fast) {
+      if (!evaluate_step(child, instance, mode, callback, context)) {
         break;
       }
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
