### PR TITLE
Fix crash when using a nested `propertyNames` in Draft 6 and 7

### DIFF
--- a/src/jsonschema/default_compiler_draft6.h
+++ b/src/jsonschema/default_compiler_draft6.h
@@ -161,7 +161,7 @@ auto compiler_draft6_applicator_contains(const SchemaCompilerContext &context)
       // TODO: As an optimization, avoid this condition if the subschema
       // declares `type` to `array` already
       {make<SchemaCompilerAssertionTypeStrict>(
-          context, JSON::Type::Array, {},
+          applicate(context), JSON::Type::Array, {},
           SchemaCompilerTargetType::Instance)})};
 }
 
@@ -175,7 +175,7 @@ auto compiler_draft6_validation_propertynames(
       // TODO: As an optimization, avoid this condition if the subschema
       // declares `type` to `object` already
       {make<SchemaCompilerAssertionTypeStrict>(
-          context, JSON::Type::Object, {},
+          applicate(context), JSON::Type::Object, {},
           SchemaCompilerTargetType::Instance)})};
 }
 

--- a/test/jsonschema/jsonschema_compile_draft6_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft6_test.cc
@@ -340,3 +340,39 @@ TEST(JSONSchema_compile_draft6, propertyNames_3) {
   EVALUATE_TRACE_DESCRIBE(2,
                           "Loop over the property keys of the target object");
 }
+
+TEST(JSONSchema_compile_draft6, property_names_4) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": {
+        "propertyNames": {}
+      }
+    }
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::jsontoolkit::compile(
+      schema, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::default_schema_compiler)};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "foo": {}
+  })JSON")};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 3);
+
+  EVALUATE_TRACE_SUCCESS(0, LoopKeys, "/properties/foo/propertyNames",
+                         "#/properties/foo/propertyNames", "/foo");
+  EVALUATE_TRACE_ANNOTATION_PRIVATE(1, "/properties", "#/properties", "",
+                                    "foo");
+  EVALUATE_TRACE_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
+
+  EVALUATE_TRACE_DESCRIBE(0,
+                          "Loop over the property keys of the target object");
+  EVALUATE_TRACE_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_DESCRIBE(
+      2, "The target is expected to match all of the given assertions");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
