### PR TITLE
Never continue on `SchemaCompilerInternalContainer` on failure

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -509,9 +509,7 @@ auto evaluate_step(
     for (const auto &child : container.children) {
       if (!evaluate_step(child, instance, mode, callback, context)) {
         result = false;
-        if (mode == SchemaCompilerEvaluationMode::Fast) {
-          break;
-        }
+        break;
       }
     }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
