### PR TITLE
Get rid of the `SchemaCompilerAnnotationPrivate` step

### DIFF
--- a/src/jsonschema/compile_describe.cc
+++ b/src/jsonschema/compile_describe.cc
@@ -50,10 +50,6 @@ struct DescribeVisitor {
   auto operator()(const SchemaCompilerAnnotationPublic &) const -> std::string {
     return "Emit an annotation";
   }
-  auto
-  operator()(const SchemaCompilerAnnotationPrivate &) const -> std::string {
-    return "Emit an internal annotation";
-  }
   auto operator()(const SchemaCompilerLoopProperties &) const -> std::string {
     return "Loop over the properties of the target object";
   }

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -199,7 +199,6 @@ struct StepVisitor {
   HANDLE_STEP("assertion", "string-type", SchemaCompilerAssertionStringType)
   HANDLE_STEP("assertion", "equals-any", SchemaCompilerAssertionEqualsAny)
   HANDLE_STEP("annotation", "public", SchemaCompilerAnnotationPublic)
-  HANDLE_STEP("annotation", "private", SchemaCompilerAnnotationPrivate)
   HANDLE_STEP("logical", "or", SchemaCompilerLogicalOr)
   HANDLE_STEP("logical", "and", SchemaCompilerLogicalAnd)
   HANDLE_STEP("logical", "xor", SchemaCompilerLogicalXor)

--- a/src/jsonschema/default_compiler.cc
+++ b/src/jsonschema/default_compiler.cc
@@ -50,15 +50,6 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
 
   // TODO: Implement the new keywords
 
-  // With public annotations
-  COMPILE(
-      "https://json-schema.org/draft/2019-09/vocab/applicator", "properties",
-      compiler_draft4_applicator_properties<SchemaCompilerAnnotationPublic>);
-  COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator",
-          "patternProperties",
-          compiler_draft4_applicator_patternproperties<
-              SchemaCompilerAnnotationPublic>);
-
   // Same as Draft 7
 
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "if",
@@ -94,6 +85,11 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
           compiler_draft4_applicator_oneof);
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "not",
           compiler_draft4_applicator_not);
+
+  COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator",
+          "properties", compiler_draft4_applicator_properties);
+  COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator",
+          "patternProperties", compiler_draft4_applicator_patternproperties);
 
   COMPILE("https://json-schema.org/draft/2019-09/vocab/validation", "enum",
           compiler_draft4_validation_enum);
@@ -183,12 +179,10 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
           compiler_draft4_validation_maxproperties);
   COMPILE("http://json-schema.org/draft-07/schema#", "minProperties",
           compiler_draft4_validation_minproperties);
-  COMPILE(
-      "http://json-schema.org/draft-07/schema#", "properties",
-      compiler_draft4_applicator_properties<SchemaCompilerAnnotationPrivate>);
+  COMPILE("http://json-schema.org/draft-07/schema#", "properties",
+          compiler_draft4_applicator_properties);
   COMPILE("http://json-schema.org/draft-07/schema#", "patternProperties",
-          compiler_draft4_applicator_patternproperties<
-              SchemaCompilerAnnotationPrivate>);
+          compiler_draft4_applicator_patternproperties);
   COMPILE("http://json-schema.org/draft-07/schema#", "additionalProperties",
           compiler_draft4_applicator_additionalproperties);
   COMPILE("http://json-schema.org/draft-07/schema#", "dependencies",
@@ -266,12 +260,10 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
           compiler_draft4_validation_maxproperties);
   COMPILE("http://json-schema.org/draft-06/schema#", "minProperties",
           compiler_draft4_validation_minproperties);
-  COMPILE(
-      "http://json-schema.org/draft-06/schema#", "properties",
-      compiler_draft4_applicator_properties<SchemaCompilerAnnotationPrivate>);
+  COMPILE("http://json-schema.org/draft-06/schema#", "properties",
+          compiler_draft4_applicator_properties);
   COMPILE("http://json-schema.org/draft-06/schema#", "patternProperties",
-          compiler_draft4_applicator_patternproperties<
-              SchemaCompilerAnnotationPrivate>);
+          compiler_draft4_applicator_patternproperties);
   COMPILE("http://json-schema.org/draft-06/schema#", "additionalProperties",
           compiler_draft4_applicator_additionalproperties);
   COMPILE("http://json-schema.org/draft-06/schema#", "dependencies",
@@ -308,12 +300,10 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
           compiler_draft4_applicator_oneof);
   COMPILE("http://json-schema.org/draft-04/schema#", "not",
           compiler_draft4_applicator_not);
-  COMPILE(
-      "http://json-schema.org/draft-04/schema#", "properties",
-      compiler_draft4_applicator_properties<SchemaCompilerAnnotationPrivate>);
+  COMPILE("http://json-schema.org/draft-04/schema#", "properties",
+          compiler_draft4_applicator_properties);
   COMPILE("http://json-schema.org/draft-04/schema#", "patternProperties",
-          compiler_draft4_applicator_patternproperties<
-              SchemaCompilerAnnotationPrivate>);
+          compiler_draft4_applicator_patternproperties);
   COMPILE("http://json-schema.org/draft-04/schema#", "additionalProperties",
           compiler_draft4_applicator_additionalproperties);
   COMPILE("http://json-schema.org/draft-04/schema#", "items",

--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -267,7 +267,6 @@ auto compiler_draft4_applicator_oneof(
       std::move(disjunctors), SchemaCompilerTemplate{})};
 }
 
-template <typename AnnotationType>
 auto compiler_draft4_applicator_properties(
     const SchemaCompilerContext &context,
     const SchemaCompilerSchemaContext &schema_context,
@@ -285,7 +284,7 @@ auto compiler_draft4_applicator_properties(
                           {key}, {key})};
     // TODO: As an optimization, only emit an annotation if
     // `additionalProperties` is also declared in the same subschema
-    substeps.push_back(make<AnnotationType>(
+    substeps.push_back(make<SchemaCompilerAnnotationPublic>(
         schema_context, relative_dynamic_context, JSON{key}, {},
         SchemaCompilerTargetType::Instance));
     children.push_back(make<SchemaCompilerInternalContainer>(
@@ -303,7 +302,6 @@ auto compiler_draft4_applicator_properties(
       std::move(children), type_condition(schema_context, JSON::Type::Object))};
 }
 
-template <typename AnnotationType>
 auto compiler_draft4_applicator_patternproperties(
     const SchemaCompilerContext &context,
     const SchemaCompilerSchemaContext &schema_context,
@@ -328,7 +326,7 @@ auto compiler_draft4_applicator_patternproperties(
     // The evaluator will make sure the same annotation is not reported twice.
     // For example, if the same property matches more than one subschema in
     // `patternProperties`
-    substeps.push_back(make<AnnotationType>(
+    substeps.push_back(make<SchemaCompilerAnnotationPublic>(
         schema_context, relative_dynamic_context,
         SchemaCompilerTarget{SchemaCompilerTargetType::InstanceBasename,
                              empty_pointer},

--- a/src/jsonschema/default_compiler_draft7.h
+++ b/src/jsonschema/default_compiler_draft7.h
@@ -17,7 +17,7 @@ auto compiler_draft7_applicator_if(
   SchemaCompilerTemplate children{compile(context, schema_context,
                                           relative_dynamic_context,
                                           empty_pointer, empty_pointer)};
-  children.push_back(make<SchemaCompilerAnnotationPrivate>(
+  children.push_back(make<SchemaCompilerAnnotationPublic>(
       schema_context, relative_dynamic_context, JSON{true}, {},
       SchemaCompilerTargetType::Instance));
   return {make<SchemaCompilerLogicalTry>(

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -201,12 +201,8 @@ struct SchemaCompilerAssertionDivisible;
 struct SchemaCompilerAssertionStringType;
 
 /// @ingroup jsonschema
-/// Represents a compiler step that emits a public annotation
+/// Represents a compiler step that emits an annotation
 struct SchemaCompilerAnnotationPublic;
-
-/// @ingroup jsonschema
-/// Represents a compiler step that emits a private annotation
-struct SchemaCompilerAnnotationPrivate;
 
 /// @ingroup jsonschema
 /// Represents a compiler logical step that represents a disjunction
@@ -287,8 +283,7 @@ using SchemaCompilerTemplate = std::vector<std::variant<
     SchemaCompilerAssertionGreater, SchemaCompilerAssertionLess,
     SchemaCompilerAssertionUnique, SchemaCompilerAssertionDivisible,
     SchemaCompilerAssertionStringType, SchemaCompilerAnnotationPublic,
-    SchemaCompilerAnnotationPrivate, SchemaCompilerLogicalOr,
-    SchemaCompilerLogicalAnd, SchemaCompilerLogicalXor,
+    SchemaCompilerLogicalOr, SchemaCompilerLogicalAnd, SchemaCompilerLogicalXor,
     SchemaCompilerLogicalTry, SchemaCompilerLogicalNot,
     SchemaCompilerInternalAnnotation, SchemaCompilerInternalNoAnnotation,
     SchemaCompilerInternalContainer, SchemaCompilerInternalDefinesAll,
@@ -348,7 +343,6 @@ DEFINE_STEP_WITH_VALUE(Assertion, Unique, SchemaCompilerValueNone)
 DEFINE_STEP_WITH_VALUE(Assertion, Divisible, SchemaCompilerValueJSON)
 DEFINE_STEP_WITH_VALUE(Assertion, StringType, SchemaCompilerValueStringType)
 DEFINE_STEP_WITH_VALUE(Annotation, Public, SchemaCompilerValueJSON)
-DEFINE_STEP_WITH_VALUE(Annotation, Private, SchemaCompilerValueJSON)
 DEFINE_STEP_APPLICATOR(Logical, Or, SchemaCompilerValueNone)
 DEFINE_STEP_APPLICATOR(Logical, And, SchemaCompilerValueNone)
 DEFINE_STEP_APPLICATOR(Logical, Xor, SchemaCompilerValueNone)

--- a/test/jsonschema/jsonschema_compile_draft4_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft4_test.cc
@@ -500,8 +500,8 @@ TEST(JSONSchema_compile_draft4, ref_3) {
                      "https://example.com#/type", "/foo");
   EVALUATE_TRACE_PRE(4, LogicalAnd, "/properties/foo/$ref/properties",
                      "https://example.com#/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(5, "/properties",
-                                        "https://example.com#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(5, "/properties",
+                                "https://example.com#/properties", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type",
                               "https://example.com#/type", "");
@@ -513,8 +513,8 @@ TEST(JSONSchema_compile_draft4, ref_3) {
   EVALUATE_TRACE_POST_SUCCESS(3, ControlLabel, "/properties/foo/$ref",
                               "https://example.com#/properties/foo/$ref",
                               "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(
-      4, "/properties", "https://example.com#/properties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(4, "/properties",
+                                 "https://example.com#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(5, LogicalAnd, "/properties",
                               "https://example.com#/properties", "");
 
@@ -527,7 +527,7 @@ TEST(JSONSchema_compile_draft4, ref_3) {
   EVALUATE_TRACE_POST_DESCRIBE(
       3,
       "Mark the current position of the evaluation process for future jumps");
-  EVALUATE_TRACE_POST_DESCRIBE(4, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(4, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       5, "The target is expected to match all of the given assertions");
 }
@@ -573,11 +573,10 @@ TEST(JSONSchema_compile_draft4, ref_4) {
   EVALUATE_TRACE_PRE(7, LogicalAnd,
                      "/properties/foo/$ref/properties/foo/$ref/properties",
                      "https://example.com#/properties", "/foo/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(8, "/properties/foo/$ref/properties",
-                                        "https://example.com#/properties",
-                                        "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(9, "/properties",
-                                        "https://example.com#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(8, "/properties/foo/$ref/properties",
+                                "https://example.com#/properties", "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(9, "/properties",
+                                "https://example.com#/properties", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type",
                               "https://example.com#/type", "");
@@ -593,16 +592,16 @@ TEST(JSONSchema_compile_draft4, ref_4) {
   EVALUATE_TRACE_POST_SUCCESS(
       4, ControlJump, "/properties/foo/$ref/properties/foo/$ref",
       "https://example.com#/properties/foo/$ref", "/foo/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(5, "/properties/foo/$ref/properties",
-                                         "https://example.com#/properties",
-                                         "/foo", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(5, "/properties/foo/$ref/properties",
+                                 "https://example.com#/properties", "/foo",
+                                 "foo");
   EVALUATE_TRACE_POST_SUCCESS(6, LogicalAnd, "/properties/foo/$ref/properties",
                               "https://example.com#/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(7, ControlLabel, "/properties/foo/$ref",
                               "https://example.com#/properties/foo/$ref",
                               "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(
-      8, "/properties", "https://example.com#/properties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(8, "/properties",
+                                 "https://example.com#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(9, LogicalAnd, "/properties",
                               "https://example.com#/properties", "");
 
@@ -616,13 +615,13 @@ TEST(JSONSchema_compile_draft4, ref_4) {
       3, "The target is expected to match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(
       4, "Jump to another point of the evaluation process");
-  EVALUATE_TRACE_POST_DESCRIBE(5, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(5, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       6, "The target is expected to match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(
       7,
       "Mark the current position of the evaluation process for future jumps");
-  EVALUATE_TRACE_POST_DESCRIBE(8, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(8, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       9, "The target is expected to match all of the given assertions");
 }
@@ -732,7 +731,7 @@ TEST(JSONSchema_compile_draft4, ref_6) {
                      "#/type", "/foo");
   EVALUATE_TRACE_PRE(4, LogicalAnd, "/properties/foo/$ref/properties",
                      "#/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(5, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(5, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
@@ -741,8 +740,7 @@ TEST(JSONSchema_compile_draft4, ref_6) {
                               "#/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(3, ControlLabel, "/properties/foo/$ref",
                               "#/properties/foo/$ref", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(4, "/properties", "#/properties", "",
-                                         "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(4, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(5, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -754,7 +752,7 @@ TEST(JSONSchema_compile_draft4, ref_6) {
   EVALUATE_TRACE_POST_DESCRIBE(
       3,
       "Mark the current position of the evaluation process for future jumps");
-  EVALUATE_TRACE_POST_DESCRIBE(4, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(4, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       5, "The target is expected to match all of the given assertions");
 }
@@ -811,21 +809,20 @@ TEST(JSONSchema_compile_draft4, properties_1) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
                      "#/properties/bar/type", "/bar");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
                               "#/properties/bar/type", "/bar");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/properties", "#/properties", "",
-                                         "bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "bar");
   EVALUATE_TRACE_POST_FAILURE(2, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_FAILURE(3, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target document is expected to be of the given type");
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -855,27 +852,25 @@ TEST(JSONSchema_compile_draft4, properties_2) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
                      "#/properties/bar/type", "/bar");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(4, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
                               "#/properties/bar/type", "/bar");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/properties", "#/properties", "",
-                                         "bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "bar");
   EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(3, "/properties", "#/properties", "",
-                                         "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(3, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(3, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       4, "The target is expected to match all of the given assertions");
 }
@@ -936,28 +931,26 @@ TEST(JSONSchema_compile_draft4, properties_4) {
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict,
                      "/properties/foo/properties/bar/type",
                      "#/properties/foo/properties/bar/type", "/foo/bar");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(3, "/properties/foo/properties",
-                                        "#/properties/foo/properties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(4, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/properties/foo/properties",
+                                "#/properties/foo/properties", "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_SUCCESS(
       0, AssertionTypeStrict, "/properties/foo/properties/bar/type",
       "#/properties/foo/properties/bar/type", "/foo/bar");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/properties/foo/properties",
-                                         "#/properties/foo/properties", "/foo",
-                                         "bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties/foo/properties",
+                                 "#/properties/foo/properties", "/foo", "bar");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties/foo/properties",
                               "#/properties/foo/properties", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(3, "/properties", "#/properties", "",
-                                         "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
-  EVALUATE_TRACE_POST_DESCRIBE(3, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(3, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       4, "The target is expected to match all of the given assertions");
 }
@@ -1086,15 +1079,15 @@ TEST(JSONSchema_compile_draft4, patternProperties_3) {
 
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/patternProperties", "#/patternProperties",
                      "");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(1, "/patternProperties",
-                                        "#/patternProperties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(1, "/patternProperties", "#/patternProperties",
+                                "");
 
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(0, "/patternProperties",
-                                         "#/patternProperties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(0, "/patternProperties", "#/patternProperties",
+                                 "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/patternProperties",
                               "#/patternProperties", "");
 
-  EVALUATE_TRACE_POST_DESCRIBE(0, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(0, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       1, "The target is expected to match all of the given assertions");
 }
@@ -1123,21 +1116,21 @@ TEST(JSONSchema_compile_draft4, patternProperties_4) {
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/patternProperties/^f/type",
                      // Note that the caret needs to be URI escaped
                      "#/patternProperties/%5Ef/type", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/patternProperties",
-                                        "#/patternProperties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/patternProperties", "#/patternProperties",
+                                "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
                               "/patternProperties/^f/type",
                               // Note that the caret needs to be URI escaped
                               "#/patternProperties/%5Ef/type", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/patternProperties",
-                                         "#/patternProperties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/patternProperties", "#/patternProperties",
+                                 "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/patternProperties",
                               "#/patternProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
 }
@@ -1205,8 +1198,8 @@ TEST(JSONSchema_compile_draft4, patternProperties_6) {
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/patternProperties/^f/type",
                      // Note that the caret needs to be URI escaped
                      "#/patternProperties/%5Ef/type", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/patternProperties",
-                                        "#/patternProperties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/patternProperties", "#/patternProperties",
+                                "");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/patternProperties/o$/type",
                      "#/patternProperties/o$/type", "/foo");
 
@@ -1214,8 +1207,8 @@ TEST(JSONSchema_compile_draft4, patternProperties_6) {
                               "/patternProperties/^f/type",
                               // Note that the caret needs to be URI escaped
                               "#/patternProperties/%5Ef/type", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/patternProperties",
-                                         "#/patternProperties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/patternProperties", "#/patternProperties",
+                                 "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict,
                               "/patternProperties/o$/type",
                               "#/patternProperties/o$/type", "/foo");
@@ -1224,7 +1217,7 @@ TEST(JSONSchema_compile_draft4, patternProperties_6) {
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target document is expected to be of the given type");
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -1261,32 +1254,32 @@ TEST(JSONSchema_compile_draft4, patternProperties_7) {
   EVALUATE_TRACE_PRE(
       2, AssertionTypeStrict, "/patternProperties/^f/patternProperties/^b/type",
       "#/patternProperties/%5Ef/patternProperties/%5Eb/type", "/foo/bar");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(
-      3, "/patternProperties/^f/patternProperties",
-      "#/patternProperties/%5Ef/patternProperties", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(4, "/patternProperties",
-                                        "#/patternProperties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/patternProperties/^f/patternProperties",
+                                "#/patternProperties/%5Ef/patternProperties",
+                                "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/patternProperties", "#/patternProperties",
+                                "");
 
   EVALUATE_TRACE_POST_SUCCESS(
       0, AssertionTypeStrict, "/patternProperties/^f/patternProperties/^b/type",
       "#/patternProperties/%5Ef/patternProperties/%5Eb/type", "/foo/bar");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(
-      1, "/patternProperties/^f/patternProperties",
-      "#/patternProperties/%5Ef/patternProperties", "/foo", "bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/patternProperties/^f/patternProperties",
+                                 "#/patternProperties/%5Ef/patternProperties",
+                                 "/foo", "bar");
   EVALUATE_TRACE_POST_SUCCESS(
       2, LogicalAnd, "/patternProperties/^f/patternProperties",
       "#/patternProperties/%5Ef/patternProperties", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(3, "/patternProperties",
-                                         "#/patternProperties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/patternProperties", "#/patternProperties",
+                                 "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/patternProperties",
                               "#/patternProperties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
-  EVALUATE_TRACE_POST_DESCRIBE(3, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(3, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       4, "The target is expected to match all of the given assertions");
 }
@@ -1361,7 +1354,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_2) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(3, LoopProperties, "/additionalProperties",
                      "#/additionalProperties", "");
   EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/additionalProperties/type",
@@ -1369,8 +1362,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_2) {
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/properties", "#/properties", "",
-                                         "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict,
                               "/additionalProperties/type",
@@ -1380,7 +1372,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_2) {
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -1469,13 +1461,13 @@ TEST(JSONSchema_compile_draft4, additionalProperties_4) {
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/patternProperties/^bar$/type",
                      // Note that the caret needs to be URI escaped
                      "#/patternProperties/%5Ebar$/type", "/bar");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/patternProperties",
-                                        "#/patternProperties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/patternProperties", "#/patternProperties",
+                                "");
 
   EVALUATE_TRACE_PRE(3, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(5, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(5, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_PRE(6, LoopProperties, "/additionalProperties",
                      "#/additionalProperties", "");
@@ -1487,16 +1479,15 @@ TEST(JSONSchema_compile_draft4, additionalProperties_4) {
                               "/patternProperties/^bar$/type",
                               // Note that the caret needs to be URI escaped
                               "#/patternProperties/%5Ebar$/type", "/bar");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/patternProperties",
-                                         "#/patternProperties", "", "bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/patternProperties", "#/patternProperties",
+                                 "", "bar");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/patternProperties",
                               "#/patternProperties", "");
 
   // `properties`
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(4, "/properties", "#/properties", "",
-                                         "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(4, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(5, LogicalAnd, "/properties", "#/properties", "");
 
   // `additionalProperties`
@@ -1508,12 +1499,12 @@ TEST(JSONSchema_compile_draft4, additionalProperties_4) {
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(
       3, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(4, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(4, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       5, "The target is expected to match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -1612,8 +1603,7 @@ TEST(JSONSchema_compile_draft4, not_3) {
   EVALUATE_TRACE_PRE(1, LogicalAnd, "/not/properties", "#/not/properties", "");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/not/properties/foo/type",
                      "#/not/properties/foo/type", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(3, "/not/properties",
-                                        "#/not/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(3, "/not/properties", "#/not/properties", "");
   EVALUATE_TRACE_PRE(4, LoopProperties, "/not/additionalProperties",
                      "#/not/additionalProperties", "");
   EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/not/additionalProperties/type",
@@ -1622,8 +1612,8 @@ TEST(JSONSchema_compile_draft4, not_3) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
                               "/not/properties/foo/type",
                               "#/not/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/not/properties",
-                                         "#/not/properties", "", "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/not/properties", "#/not/properties", "",
+                                 "foo");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/not/properties",
                               "#/not/properties", "");
   EVALUATE_TRACE_POST_FAILURE(3, AssertionTypeStrict,
@@ -1635,7 +1625,7 @@ TEST(JSONSchema_compile_draft4, not_3) {
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target document is expected to be of the given type");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(

--- a/test/jsonschema/jsonschema_compile_draft6_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft6_test.cc
@@ -416,17 +416,16 @@ TEST(JSONSchema_compile_draft6, property_names_4) {
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, LoopKeys, "/properties/foo/propertyNames",
                      "#/properties/foo/propertyNames", "/foo");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, LoopKeys, "/properties/foo/propertyNames",
                               "#/properties/foo/propertyNames", "/foo");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/properties", "#/properties", "",
-                                         "foo");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "Loop over the property keys of the target object");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target is expected to match all of the given assertions");
 }

--- a/test/jsonschema/jsonschema_compile_draft7_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft7_test.cc
@@ -38,15 +38,15 @@ TEST(JSONSchema_compile_draft7, if_1) {
 
   EVALUATE_TRACE_PRE(0, LogicalTry, "/if", "#/if", "");
   EVALUATE_TRACE_PRE(1, AssertionEqual, "/if/const", "#/if/const", "");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/if", "#/if", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/if", "#/if", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionEqual, "/if/const", "#/if/const", "");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/if", "#/if", "", true);
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/if", "#/if", "", true);
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalTry, "/if", "#/if", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target is expected to be equal to the given value");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target might match all of the given assertions");
 }
@@ -112,13 +112,13 @@ TEST(JSONSchema_compile_draft7, then_2) {
 
   EVALUATE_TRACE_PRE(0, LogicalTry, "/if", "#/if", "");
   EVALUATE_TRACE_PRE(1, AssertionEqual, "/if/const", "#/if/const", "");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/if", "#/if", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/if", "#/if", "");
   EVALUATE_TRACE_PRE(3, LogicalAnd, "/then", "#/then", "");
   EVALUATE_TRACE_PRE(4, AssertionDivisible, "/then/multipleOf",
                      "#/then/multipleOf", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionEqual, "/if/const", "#/if/const", "");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/if", "#/if", "", true);
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/if", "#/if", "", true);
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalTry, "/if", "#/if", "");
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionDivisible, "/then/multipleOf",
                               "#/then/multipleOf", "");
@@ -126,7 +126,7 @@ TEST(JSONSchema_compile_draft7, then_2) {
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target is expected to be equal to the given value");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target might match all of the given assertions");
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -197,15 +197,15 @@ TEST(JSONSchema_compile_draft7, else_2) {
 
   EVALUATE_TRACE_PRE(0, LogicalTry, "/if", "#/if", "");
   EVALUATE_TRACE_PRE(1, AssertionEqual, "/if/const", "#/if/const", "");
-  EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(2, "/if", "#/if", "");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/if", "#/if", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionEqual, "/if/const", "#/if/const", "");
-  EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(1, "/if", "#/if", "", true);
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/if", "#/if", "", true);
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalTry, "/if", "#/if", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       0, "The target is expected to be equal to the given value");
-  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an internal annotation");
+  EVALUATE_TRACE_POST_DESCRIBE(1, "Emit an annotation");
   EVALUATE_TRACE_POST_DESCRIBE(
       2, "The target might match all of the given assertions");
 }

--- a/test/jsonschema/jsonschema_compile_json_test.cc
+++ b/test/jsonschema/jsonschema_compile_json_test.cc
@@ -722,42 +722,6 @@ TEST(JSONSchema_compile_json, public_annotation_without_condition) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONSchema_compile_json, private_annotation_without_condition) {
-  using namespace sourcemeta::jsontoolkit;
-
-  const SchemaCompilerTemplate steps{SchemaCompilerAnnotationPrivate{
-      {SchemaCompilerTargetType::Instance, {"foo"}},
-      Pointer{"test"},
-      Pointer{},
-      "#/test",
-      JSON{5},
-      {}}};
-
-  const JSON result{to_json(steps)};
-  const JSON expected{parse(R"EOF([
-    {
-      "category": "annotation",
-      "type": "private",
-      "relativeSchemaLocation": "/test",
-      "relativeInstanceLocation": "",
-      "absoluteKeywordLocation": "#/test",
-      "target": {
-        "category": "target",
-        "location": "/foo",
-        "type": "instance"
-      },
-      "value": {
-        "category": "value",
-        "type": "json",
-        "value": 5
-      },
-      "condition": []
-    }
-  ])EOF")};
-
-  EXPECT_EQ(result, expected);
-}
-
 TEST(JSONSchema_compile_json, public_annotation_with_condition) {
   using namespace sourcemeta::jsontoolkit;
 
@@ -782,69 +746,6 @@ TEST(JSONSchema_compile_json, public_annotation_with_condition) {
     {
       "category": "annotation",
       "type": "public",
-      "relativeSchemaLocation": "/test",
-      "relativeInstanceLocation": "",
-      "absoluteKeywordLocation": "#/test",
-      "target": {
-        "category": "target",
-        "location": "/foo",
-        "type": "instance"
-      },
-      "value": {
-        "category": "value",
-        "type": "json",
-        "value": 5
-      },
-      "condition": [
-        {
-          "category": "assertion",
-          "type": "type-strict",
-          "relativeSchemaLocation": "",
-          "relativeInstanceLocation": "",
-          "absoluteKeywordLocation": "#",
-          "target": {
-            "category": "target",
-            "location": "",
-            "type": "instance"
-          },
-          "value": {
-            "category": "value",
-            "type": "type",
-            "value": "object"
-          },
-          "condition": []
-        }
-      ]
-    }
-  ])EOF")};
-
-  EXPECT_EQ(result, expected);
-}
-
-TEST(JSONSchema_compile_json, private_annotation_with_condition) {
-  using namespace sourcemeta::jsontoolkit;
-
-  const SchemaCompilerTemplate condition{SchemaCompilerAssertionTypeStrict{
-      {SchemaCompilerTargetType::Instance, {}},
-      Pointer{},
-      Pointer{},
-      "#",
-      SchemaCompilerValueType{JSON::Type::Object},
-      {}}};
-
-  const SchemaCompilerTemplate steps{SchemaCompilerAnnotationPrivate{
-      {SchemaCompilerTargetType::Instance, {"foo"}},
-      Pointer{"test"},
-      Pointer{},
-      "#/test",
-      JSON{5},
-      condition}};
-
-  const JSON result{to_json(steps)};
-  const JSON expected{parse(R"EOF([
-    {
-      "category": "annotation",
-      "type": "private",
       "relativeSchemaLocation": "/test",
       "relativeInstanceLocation": "",
       "absoluteKeywordLocation": "#/test",

--- a/test/jsonschema/jsonschema_compile_template_draft4_test.cc
+++ b/test/jsonschema/jsonschema_compile_template_draft4_test.cc
@@ -109,7 +109,7 @@ TEST(JSONSchema_compile_template_draft4, properties_single) {
             },
             {
               "category": "annotation",
-              "type": "private",
+              "type": "public",
               "condition": [],
               "relativeSchemaLocation": "",
               "relativeInstanceLocation": "",
@@ -240,7 +240,7 @@ TEST(JSONSchema_compile_template_draft4, properties_multi) {
             },
             {
               "category": "annotation",
-              "type": "private",
+              "type": "public",
               "condition": [],
               "relativeSchemaLocation": "",
               "relativeInstanceLocation": "",
@@ -311,7 +311,7 @@ TEST(JSONSchema_compile_template_draft4, properties_multi) {
             },
             {
               "category": "annotation",
-              "type": "private",
+              "type": "public",
               "condition": [],
               "relativeSchemaLocation": "",
               "relativeInstanceLocation": "",

--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -248,18 +248,17 @@
                       instance_location);                                      \
   EXPECT_TRUE(std::get<4>(trace_post.at(index)).is_null());
 
-#define EVALUATE_TRACE_PRE_ANNOTATION_PRIVATE(                                 \
-    index, evaluate_path, keyword_location, instance_location)                 \
-  EVALUATE_TRACE_PRE(index, AnnotationPrivate, evaluate_path,                  \
-                     keyword_location, instance_location);                     \
+#define EVALUATE_TRACE_PRE_ANNOTATION(index, evaluate_path, keyword_location,  \
+                                      instance_location)                       \
+  EVALUATE_TRACE_PRE(index, AnnotationPublic, evaluate_path, keyword_location, \
+                     instance_location);                                       \
   EXPECT_TRUE(std::get<4>(trace_pre.at(index)).is_null());
 
-#define EVALUATE_TRACE_POST_ANNOTATION_PRIVATE(                                \
-    index, evaluate_path, keyword_location, instance_location,                 \
-    expected_annotation)                                                       \
+#define EVALUATE_TRACE_POST_ANNOTATION(index, evaluate_path, keyword_location, \
+                                       instance_location, expected_annotation) \
   EXPECT_TRUE(index < trace_post.size());                                      \
   EXPECT_TRUE(std::get<0>(trace_post.at(index)));                              \
-  EVALUATE_TRACE_POST(index, AnnotationPrivate, evaluate_path,                 \
+  EVALUATE_TRACE_POST(index, AnnotationPublic, evaluate_path,                  \
                       keyword_location, instance_location);                    \
   EXPECT_EQ(std::get<4>(trace_post.at(index)),                                 \
             sourcemeta::jsontoolkit::JSON(expected_annotation));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
