### PR TITLE
Fix typo on `EVALUATE_WITH_TRACE_EXHAUSTIVE_FAILURE` test macro

### DIFF
--- a/test/jsonschema/jsonschema_test_utils.h
+++ b/test/jsonschema/jsonschema_test_utils.h
@@ -204,7 +204,7 @@
   EVALUATE_WITH_TRACE(Exhaustive, schema_template, instance, count)            \
   EXPECT_TRUE(result);
 
-#define EVALUATE_WITH_TRACE_EXHAUSITVE_FAILURE(schema_template, instance,      \
+#define EVALUATE_WITH_TRACE_EXHAUSTIVE_FAILURE(schema_template, instance,      \
                                                count)                          \
   EVALUATE_WITH_TRACE(Exhaustive, schema_template, instance, count)            \
   EXPECT_FALSE(result);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
