### PR TITLE
Fix `LoopContains` compiler step with min/max bounds

### DIFF
--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -727,6 +727,7 @@ auto evaluate_step(
     CALLBACK_PRE(context.instance_location());
     const auto &value{context.resolve_value(loop.value, instance)};
     const auto minimum{value.first};
+    assert(minimum > 0);
     const auto &maximum{value.second};
     assert(!maximum.has_value() || maximum.value() >= minimum);
     const auto &target{context.resolve_target<JSON>(loop.target, instance)};
@@ -755,7 +756,7 @@ auto evaluate_step(
           break;
         }
 
-        if (match_count > minimum) {
+        if (match_count >= minimum) {
           result = true;
 
           // Exceeding the lower bound when there is no upper bound

--- a/src/jsonschema/default_compiler_draft6.h
+++ b/src/jsonschema/default_compiler_draft6.h
@@ -190,7 +190,7 @@ auto compiler_draft6_applicator_contains(
     -> SchemaCompilerTemplate {
   return {make<SchemaCompilerLoopContains>(
       schema_context, dynamic_context,
-      SchemaCompilerValueRange{0, std::nullopt},
+      SchemaCompilerValueRange{1, std::nullopt},
       compile(context, schema_context, relative_dynamic_context, empty_pointer,
               empty_pointer),
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
