### PR TITLE
Rename `NoAnnotation` to `NoAdjacentAnnotation` in the compiler

### DIFF
--- a/src/jsonschema/compile_describe.cc
+++ b/src/jsonschema/compile_describe.cc
@@ -31,9 +31,10 @@ struct DescribeVisitor {
   operator()(const SchemaCompilerInternalAnnotation &) const -> std::string {
     return "The target was annotated with the given value";
   }
-  auto
-  operator()(const SchemaCompilerInternalNoAnnotation &) const -> std::string {
-    return "The target was not annotated with the given value";
+  auto operator()(const SchemaCompilerInternalNoAdjacentAnnotation &) const
+      -> std::string {
+    return "The target was not annotated with the given value at the same "
+           "schema location";
   }
   auto
   operator()(const SchemaCompilerInternalDefinesAll &) const -> std::string {

--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -529,8 +529,10 @@ auto evaluate_step(
     // We treat this step as transparent to the consumer
     context.pop();
     return result;
-  } else if (std::holds_alternative<SchemaCompilerInternalNoAnnotation>(step)) {
-    const auto &assertion{std::get<SchemaCompilerInternalNoAnnotation>(step)};
+  } else if (std::holds_alternative<SchemaCompilerInternalNoAdjacentAnnotation>(
+                 step)) {
+    const auto &assertion{
+        std::get<SchemaCompilerInternalNoAdjacentAnnotation>(step)};
     context.push(assertion);
     EVALUATE_CONDITION_GUARD(assertion.condition, instance);
     const auto &value{context.resolve_value(assertion.value, instance)};

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -217,7 +217,8 @@ struct StepVisitor {
   HANDLE_STEP("logical", "try", SchemaCompilerLogicalTry)
   HANDLE_STEP("logical", "not", SchemaCompilerLogicalNot)
   HANDLE_STEP("internal", "annotation", SchemaCompilerInternalAnnotation)
-  HANDLE_STEP("internal", "no-annotation", SchemaCompilerInternalNoAnnotation)
+  HANDLE_STEP("internal", "no-adjacent-annotation",
+              SchemaCompilerInternalNoAdjacentAnnotation)
   HANDLE_STEP("internal", "container", SchemaCompilerInternalContainer)
   HANDLE_STEP("internal", "defines-all", SchemaCompilerInternalDefinesAll)
   HANDLE_STEP("loop", "properties", SchemaCompilerLoopProperties)

--- a/src/jsonschema/default_compiler_2019_09.h
+++ b/src/jsonschema/default_compiler_2019_09.h
@@ -132,14 +132,14 @@ auto compiler_2019_09_applicator_additionalproperties(
   // was NOT collected as an annotation on either "properties" or
   // "patternProperties"
   SchemaCompilerTemplate conjunctions{
-      make<SchemaCompilerInternalNoAnnotation>(
+      make<SchemaCompilerInternalNoAdjacentAnnotation>(
           schema_context, relative_dynamic_context,
           SchemaCompilerTarget{SchemaCompilerTargetType::InstanceBasename,
                                empty_pointer},
           {}, SchemaCompilerTargetType::ParentAdjacentAnnotations,
           Pointer{"properties"}),
 
-      make<SchemaCompilerInternalNoAnnotation>(
+      make<SchemaCompilerInternalNoAdjacentAnnotation>(
           schema_context, relative_dynamic_context,
           SchemaCompilerTarget{SchemaCompilerTargetType::InstanceBasename,
                                empty_pointer},

--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -373,7 +373,7 @@ auto compiler_draft4_applicator_additionalproperties(
 
       // TODO: As an optimization, avoid this condition if the subschema does
       // not declare `properties`
-      make<SchemaCompilerInternalNoAnnotation>(
+      make<SchemaCompilerInternalNoAdjacentAnnotation>(
           schema_context, relative_dynamic_context,
           SchemaCompilerTarget{SchemaCompilerTargetType::InstanceBasename,
                                empty_pointer},
@@ -382,7 +382,7 @@ auto compiler_draft4_applicator_additionalproperties(
 
       // TODO: As an optimization, avoid this condition if the subschema does
       // not declare `patternProperties`
-      make<SchemaCompilerInternalNoAnnotation>(
+      make<SchemaCompilerInternalNoAdjacentAnnotation>(
           schema_context, relative_dynamic_context,
           SchemaCompilerTarget{SchemaCompilerTargetType::InstanceBasename,
                                empty_pointer},

--- a/src/jsonschema/default_compiler_draft7.h
+++ b/src/jsonschema/default_compiler_draft7.h
@@ -63,9 +63,10 @@ auto compiler_draft7_applicator_else(
   SchemaCompilerTemplate children{compile(context, schema_context,
                                           relative_dynamic_context,
                                           empty_pointer, empty_pointer)};
-  SchemaCompilerTemplate condition{make<SchemaCompilerInternalNoAnnotation>(
-      schema_context, relative_dynamic_context, JSON{true}, {},
-      SchemaCompilerTargetType::AdjacentAnnotations, Pointer{"if"})};
+  SchemaCompilerTemplate condition{
+      make<SchemaCompilerInternalNoAdjacentAnnotation>(
+          schema_context, relative_dynamic_context, JSON{true}, {},
+          SchemaCompilerTargetType::AdjacentAnnotations, Pointer{"if"})};
   return {make<SchemaCompilerLogicalAnd>(
       schema_context, dynamic_context, SchemaCompilerValueNone{},
       std::move(children), std::move(condition))};

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -243,8 +243,8 @@ struct SchemaCompilerInternalAnnotation;
 
 /// @ingroup jsonschema
 /// Represents a hidden compiler assertion step that checks a certain
-/// annotation was not produced
-struct SchemaCompilerInternalNoAnnotation;
+/// annotation was not produced at an adjacent location
+struct SchemaCompilerInternalNoAdjacentAnnotation;
 
 /// @ingroup jsonschema
 /// Represents a hidden conjunction compiler step
@@ -297,10 +297,10 @@ using SchemaCompilerTemplate = std::vector<std::variant<
     SchemaCompilerAnnotationPublic, SchemaCompilerLogicalOr,
     SchemaCompilerLogicalAnd, SchemaCompilerLogicalXor,
     SchemaCompilerLogicalTry, SchemaCompilerLogicalNot,
-    SchemaCompilerInternalAnnotation, SchemaCompilerInternalNoAnnotation,
-    SchemaCompilerInternalContainer, SchemaCompilerInternalDefinesAll,
-    SchemaCompilerLoopProperties, SchemaCompilerLoopKeys,
-    SchemaCompilerLoopItems, SchemaCompilerLoopContains,
+    SchemaCompilerInternalAnnotation,
+    SchemaCompilerInternalNoAdjacentAnnotation, SchemaCompilerInternalContainer,
+    SchemaCompilerInternalDefinesAll, SchemaCompilerLoopProperties,
+    SchemaCompilerLoopKeys, SchemaCompilerLoopItems, SchemaCompilerLoopContains,
     SchemaCompilerControlLabel, SchemaCompilerControlJump>>;
 
 #if !defined(DOXYGEN)
@@ -362,7 +362,7 @@ DEFINE_STEP_APPLICATOR(Logical, Xor, SchemaCompilerValueNone)
 DEFINE_STEP_APPLICATOR(Logical, Try, SchemaCompilerValueNone)
 DEFINE_STEP_APPLICATOR(Logical, Not, SchemaCompilerValueNone)
 DEFINE_STEP_WITH_VALUE(Internal, Annotation, SchemaCompilerValueJSON)
-DEFINE_STEP_WITH_VALUE(Internal, NoAnnotation, SchemaCompilerValueJSON)
+DEFINE_STEP_WITH_VALUE(Internal, NoAdjacentAnnotation, SchemaCompilerValueJSON)
 DEFINE_STEP_APPLICATOR(Internal, Container, SchemaCompilerValueNone)
 DEFINE_STEP_WITH_VALUE(Internal, DefinesAll, SchemaCompilerValueStrings)
 DEFINE_STEP_APPLICATOR(Loop, Properties, SchemaCompilerValueBoolean)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
