### PR TITLE
Fix `items` not producing correct positional annotations in 2019-09

### DIFF
--- a/src/jsonschema/default_compiler_2019_09.h
+++ b/src/jsonschema/default_compiler_2019_09.h
@@ -234,8 +234,18 @@ auto compiler_2019_09_applicator_items(
     // The first entry
     if (cursor == items_size) {
       subchildren.push_back(make<SchemaCompilerAnnotationPublic>(
-          schema_context, relative_dynamic_context, JSON{true}, {},
+          schema_context, relative_dynamic_context, JSON{true},
+          {make<SchemaCompilerAssertionSizeEqual>(
+              schema_context, relative_dynamic_context, cursor, {},
+              SchemaCompilerTargetType::Instance)},
           SchemaCompilerTargetType::Instance));
+      subchildren.push_back(make<SchemaCompilerAnnotationPublic>(
+          schema_context, relative_dynamic_context, JSON{cursor - 1},
+          {make<SchemaCompilerAssertionSizeGreater>(
+              schema_context, relative_dynamic_context, cursor, {},
+              SchemaCompilerTargetType::Instance)},
+          SchemaCompilerTargetType::Instance));
+
       children.push_back(make<SchemaCompilerInternalContainer>(
           schema_context, relative_dynamic_context, SchemaCompilerValueNone{},
           std::move(subchildren),

--- a/test/jsonschema/jsonschema_compile_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_compile_2019_09_test.cc
@@ -1467,7 +1467,7 @@ TEST(JSONSchema_compile_2019_09, items_7) {
                               "#/items/0/type", "/0");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/items/1/type",
                               "#/items/1/type", "/1");
-  EVALUATE_TRACE_POST_ANNOTATION_PUBLIC(2, "/items", "#/items", "", true);
+  EVALUATE_TRACE_POST_ANNOTATION_PUBLIC(2, "/items", "#/items", "", 1);
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/items", "#/items", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
@@ -1695,7 +1695,7 @@ TEST(JSONSchema_compile_2019_09, additionalItems_4) {
                               "#/items/0/type", "/0");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/items/1/type",
                               "#/items/1/type", "/1");
-  EVALUATE_TRACE_POST_ANNOTATION_PUBLIC(2, "/items", "#/items", "", true);
+  EVALUATE_TRACE_POST_ANNOTATION_PUBLIC(2, "/items", "#/items", "", 1);
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/items", "#/items", "");
   EVALUATE_TRACE_POST_SUCCESS(4, AssertionTypeStrict, "/additionalItems/type",
                               "#/additionalItems/type", "/2");
@@ -1754,7 +1754,7 @@ TEST(JSONSchema_compile_2019_09, additionalItems_5) {
                               "#/items/0/type", "/0");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionType, "/items/1/type",
                               "#/items/1/type", "/1");
-  EVALUATE_TRACE_POST_ANNOTATION_PUBLIC(2, "/items", "#/items", "", true);
+  EVALUATE_TRACE_POST_ANNOTATION_PUBLIC(2, "/items", "#/items", "", 1);
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/items", "#/items", "");
   EVALUATE_TRACE_POST_FAILURE(4, AssertionTypeStrict, "/additionalItems/type",
                               "#/additionalItems/type", "/2");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
