### PR TITLE
Rename `SchemaExplainer` instances to `SchemaExplanation`

### DIFF
--- a/src/jsonschema/explain.cc
+++ b/src/jsonschema/explain.cc
@@ -60,8 +60,8 @@ explain_constant_from_value(const sourcemeta::jsontoolkit::JSON &schema,
     description = schema.at("description").to_string();
   }
 
-  return sourcemeta::jsontoolkit::SchemaExplainerConstant{value, title,
-                                                          description};
+  return sourcemeta::jsontoolkit::SchemaExplanationConstant{value, title,
+                                                            description};
 }
 
 static auto translate_format(const std::string &type) -> std::string {
@@ -107,7 +107,7 @@ static auto translate_format(const std::string &type) -> std::string {
 static auto explain_string(const sourcemeta::jsontoolkit::JSON &schema,
                            const std::map<std::string, bool> &vocabularies)
     -> std::optional<sourcemeta::jsontoolkit::SchemaExplanation> {
-  sourcemeta::jsontoolkit::SchemaExplainerScalar explanation;
+  sourcemeta::jsontoolkit::SchemaExplanationScalar explanation;
   explanation.type = "String";
 
   if (vocabularies.contains("http://json-schema.org/draft-07/schema#")) {

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_explain.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_explain.h
@@ -20,7 +20,7 @@ namespace sourcemeta::jsontoolkit {
 
 /// @ingroup jsonschema
 /// The explanation result of a constant value
-struct SchemaExplainerConstant {
+struct SchemaExplanationConstant {
   JSON value;
   std::optional<std::string> title;
   std::optional<std::string> description;
@@ -28,7 +28,7 @@ struct SchemaExplainerConstant {
 
 /// @ingroup jsonschema
 /// The explanation result of a scalar value (non container and non enumeration)
-struct SchemaExplainerScalar {
+struct SchemaExplanationScalar {
   std::string type;
   std::map<std::string, std::string> constraints;
   std::optional<std::string> title;
@@ -39,7 +39,7 @@ struct SchemaExplainerScalar {
 /// @ingroup jsonschema
 /// The explanation result of a schema
 using SchemaExplanation =
-    std::variant<SchemaExplainerConstant, SchemaExplainerScalar>;
+    std::variant<SchemaExplanationConstant, SchemaExplanationScalar>;
 
 /// @ingroup jsonschema
 ///
@@ -63,7 +63,7 @@ using SchemaExplanation =
 ///
 /// assert(result.has_value());
 /// assert(std::holds_alternative<
-///   sourcemeta::jsontoolkit::SchemaExplainerScalar>(result.value()));
+///   sourcemeta::jsontoolkit::SchemaExplanationScalar>(result.value()));
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto explain(const JSON &schema, const SchemaResolver &resolver,

--- a/test/jsonschema/jsonschema_explain_string_test.cc
+++ b/test/jsonschema/jsonschema_explain_string_test.cc
@@ -22,7 +22,7 @@ TEST(JSONSchema_explain_string, draft7_type) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -39,7 +39,7 @@ TEST(JSONSchema_explain_string, draft7_type_id) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -56,7 +56,7 @@ TEST(JSONSchema_explain_string, draft7_type_comment) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -73,7 +73,7 @@ TEST(JSONSchema_explain_string, draft7_type_title) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -91,7 +91,7 @@ TEST(JSONSchema_explain_string, draft7_type_description) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -109,7 +109,7 @@ TEST(JSONSchema_explain_string, draft7_type_pattern) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -128,7 +128,7 @@ TEST(JSONSchema_explain_string, draft7_type_format) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String (IP Address v4)");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -145,7 +145,7 @@ TEST(JSONSchema_explain_string, draft7_type_examples) {
     "examples": [ "foo", "bar", "baz" ]
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -182,7 +182,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -201,7 +201,7 @@ TEST(JSONSchema_explain_string, draft7_type_maxlength) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -221,7 +221,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_maxlength_different) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -241,7 +241,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_maxlength_equal) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -261,7 +261,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_maxlength_equal_1) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -280,7 +280,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_1) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -299,7 +299,7 @@ TEST(JSONSchema_explain_string, draft7_type_maxlength_1) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -319,7 +319,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_0_maxlength) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_EQ(explanation.constraints.size(), 1);
@@ -338,7 +338,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_0) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerScalar);
+  EXPLAIN(schema, SchemaExplanationScalar);
 
   EXPECT_EQ(explanation.type, "String");
   EXPECT_TRUE(explanation.constraints.empty());
@@ -355,7 +355,7 @@ TEST(JSONSchema_explain_string, draft7_type_maxlength_0) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerConstant);
+  EXPLAIN(schema, SchemaExplanationConstant);
 
   EXPECT_TRUE(explanation.value.is_string());
   EXPECT_EQ(explanation.value.to_string(), "");
@@ -372,7 +372,7 @@ TEST(JSONSchema_explain_string, draft7_type_minlength_0_maxlength_0) {
     "type": "string"
   })JSON")};
 
-  EXPLAIN(schema, SchemaExplainerConstant);
+  EXPLAIN(schema, SchemaExplanationConstant);
 
   EXPECT_TRUE(explanation.value.is_string());
   EXPECT_EQ(explanation.value.to_string(), "");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
