### PR TITLE
refactor(uri): avoid using uriparser internals

### DIFF
--- a/src/uri/uri.cc
+++ b/src/uri/uri.cc
@@ -206,7 +206,7 @@ auto URI::is_relative() const -> bool {
 
 auto URI::is_absolute() const noexcept -> bool {
   // An absolute URI always contains a scheme component,
-  return this->internal->uri.scheme.first != nullptr;
+  return this->scheme_.has_value();
 }
 
 auto URI::is_urn() const -> bool {


### PR DESCRIPTION
One of the next thing is to reduce the coupling we have with `uriparser`. On the end (before replacing the parser) we should be able to put all the coupling in the `parse` method.

This PR is one of this!