### PR TITLE
Fix walker to make `unevaluatedItems` depend on `contains` on 2020-12

### DIFF
--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -47,7 +47,7 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
                        "patternProperties", "additionalProperties")
   WALK_MAYBE_DEPENDENT(
       HTTPS_BASE "2020-12/vocab/unevaluated", "unevaluatedItems", Value,
-      HTTPS_BASE "2020-12/vocab/applicator", "prefixItems", "items")
+      HTTPS_BASE "2020-12/vocab/applicator", "prefixItems", "items", "contains")
 
   // 2019-09
   WALK(HTTPS_BASE "2019-09/vocab/core", "$defs", Members)

--- a/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
@@ -266,7 +266,7 @@ TEST(JSONSchema_default_walker_2020_12,
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("unevaluatedItems", vocabularies)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
-  const std::set<std::string> expected{"prefixItems", "items"};
+  const std::set<std::string> expected{"prefixItems", "items", "contains"};
   EXPECT_EQ(result.dependencies, expected);
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
