### PR TITLE
Let `SchemaCompilerValueRange` be configured to run exhaustively

### DIFF
--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -115,9 +115,11 @@ auto value_to_json(const sourcemeta::jsontoolkit::SchemaCompilerStepValue<T>
     result.assign("type", JSON{"range"});
     JSON values{JSON::make_array()};
     const auto &range{std::get<T>(value)};
-    values.push_back(JSON{range.first});
-    values.push_back(range.second.has_value() ? JSON{range.second.value()}
-                                              : JSON{nullptr});
+    values.push_back(JSON{std::get<0>(range)});
+    values.push_back(std::get<1>(range).has_value()
+                         ? JSON{std::get<1>(range).value()}
+                         : JSON{nullptr});
+    values.push_back(JSON{std::get<2>(range)});
     result.assign("value", std::move(values));
     return result;
   } else if constexpr (std::is_same_v<SchemaCompilerValueStringType, T>) {

--- a/src/jsonschema/default_compiler_2019_09.h
+++ b/src/jsonschema/default_compiler_2019_09.h
@@ -140,7 +140,13 @@ auto compiler_2019_09_applicator_contains_conditional_annotate(
 
   return {make<SchemaCompilerLoopContains>(
       context, schema_context, dynamic_context,
-      SchemaCompilerValueRange{minimum, maximum}, std::move(children),
+      SchemaCompilerValueRange{
+          minimum, maximum,
+          // TODO: We only need to be exhaustive here if `unevaluatedItems` is
+          // in use on the schema. Can we pre-determine that and speed things up
+          // if not?
+          annotate},
+      std::move(children),
       {make<SchemaCompilerAssertionTypeStrict>(
           context, schema_context, relative_dynamic_context, JSON::Type::Array,
           {}, SchemaCompilerTargetType::Instance)})};

--- a/src/jsonschema/default_compiler_draft6.h
+++ b/src/jsonschema/default_compiler_draft6.h
@@ -190,7 +190,7 @@ auto compiler_draft6_applicator_contains(
     -> SchemaCompilerTemplate {
   return {make<SchemaCompilerLoopContains>(
       context, schema_context, dynamic_context,
-      SchemaCompilerValueRange{1, std::nullopt},
+      SchemaCompilerValueRange{1, std::nullopt, false},
       compile(context, schema_context, relative_dynamic_context, empty_pointer,
               empty_pointer),
 

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -17,6 +17,7 @@
 #include <regex>      // std::regex
 #include <set>        // std::set
 #include <string>     // std::string
+#include <tuple>      // std::tuple
 #include <utility>    // std::move, std::pair
 #include <variant>    // std::variant
 #include <vector>     // std::vector
@@ -94,9 +95,11 @@ using SchemaCompilerValueRegex = std::pair<std::regex, std::string>;
 using SchemaCompilerValueUnsignedInteger = std::size_t;
 
 /// @ingroup jsonschema
-/// Represents a compiler step range value
+/// Represents a compiler step range value. The boolean option
+/// modifies whether the range is considered exhaustively or
+/// if the evaluator is allowed to break early
 using SchemaCompilerValueRange =
-    std::pair<std::size_t, std::optional<std::size_t>>;
+    std::tuple<std::size_t, std::optional<std::size_t>, bool>;
 
 /// @ingroup jsonschema
 /// Represents a compiler step boolean value


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
