### PR TITLE
Make `unevaluatedItems` in 2020-12 point to 2019-09

### DIFF
--- a/src/jsonschema/default_compiler.cc
+++ b/src/jsonschema/default_compiler.cc
@@ -73,9 +73,6 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
   COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator", "contains",
           compiler_2020_12_applicator_contains);
 
-  COMPILE("https://json-schema.org/draft/2020-12/vocab/unevaluated",
-          "unevaluatedItems", compiler_2020_12_unevaluated_unevaluateditems);
-
   // Same as 2019-09
 
   COMPILE("https://json-schema.org/draft/2020-12/vocab/validation",
@@ -91,6 +88,8 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
   COMPILE("https://json-schema.org/draft/2020-12/vocab/unevaluated",
           "unevaluatedProperties",
           compiler_2019_09_applicator_unevaluatedproperties);
+  COMPILE("https://json-schema.org/draft/2020-12/vocab/unevaluated",
+          "unevaluatedItems", compiler_2019_09_applicator_unevaluateditems);
 
   // Same as Draft 7
 

--- a/src/jsonschema/default_compiler_2020_12.h
+++ b/src/jsonschema/default_compiler_2020_12.h
@@ -49,12 +49,5 @@ auto compiler_2020_12_core_dynamicref(
   return {};
 }
 
-auto compiler_2020_12_unevaluated_unevaluateditems(
-    const SchemaCompilerContext &, const SchemaCompilerSchemaContext &,
-    const SchemaCompilerDynamicContext &) -> SchemaCompilerTemplate {
-  // TODO: Implement
-  return {};
-}
-
 } // namespace internal
 #endif


### PR DESCRIPTION
We'll address minor differences in there to avoid unnecessary code
duplication.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
