### PR TITLE
Better handle `$id`/`id` with sibling `$ref` in `identify()`

### DIFF
--- a/src/jsonschema/jsonschema.cc
+++ b/src/jsonschema/jsonschema.cc
@@ -135,6 +135,23 @@ auto sourcemeta::jsontoolkit::identify(
     throw sourcemeta::jsontoolkit::SchemaError(error.str());
   }
 
+  // In older drafts, the presence of `$ref` would override any sibling
+  // keywords. Note that `$ref` was first introduced in Draft 3, so we
+  // don't check for base dialects lower than that.
+  // See
+  // https://json-schema.org/draft-07/draft-handrews-json-schema-01#rfc.section.8.3
+  if (schema.defines("$ref") &&
+      (base_dialect == "http://json-schema.org/draft-07/schema#" ||
+       base_dialect == "http://json-schema.org/draft-07/hyper-schema#" ||
+       base_dialect == "http://json-schema.org/draft-06/schema#" ||
+       base_dialect == "http://json-schema.org/draft-06/hyper-schema#" ||
+       base_dialect == "http://json-schema.org/draft-04/schema#" ||
+       base_dialect == "http://json-schema.org/draft-04/hyper-schema#" ||
+       base_dialect == "http://json-schema.org/draft-03/schema#" ||
+       base_dialect == "http://json-schema.org/draft-03/hyper-schema#")) {
+    return std::nullopt;
+  }
+
   return identifier.to_string();
 }
 

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -66,10 +66,7 @@ ref_overrides_adjacent_keywords(const std::string &base_dialect) -> bool {
          base_dialect == "http://json-schema.org/draft-04/schema#" ||
          base_dialect == "http://json-schema.org/draft-04/hyper-schema#" ||
          base_dialect == "http://json-schema.org/draft-03/schema#" ||
-         base_dialect == "http://json-schema.org/draft-03/hyper-schema#" ||
-         base_dialect == "http://json-schema.org/draft-02/hyper-schema#" ||
-         base_dialect == "http://json-schema.org/draft-01/hyper-schema#" ||
-         base_dialect == "http://json-schema.org/draft-00/hyper-schema#";
+         base_dialect == "http://json-schema.org/draft-03/hyper-schema#";
 }
 
 static auto supports_id_anchors(const std::string &base_dialect) -> bool {

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -1780,3 +1780,67 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_on_relative_id) {
       references, "/$schema", "https://json-schema.org/draft/2019-09/schema",
       "https://json-schema.org/draft/2019-09/schema", std::nullopt);
 }
+
+TEST(JSONSchema_frame_2019_09, ref_with_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#/$defs/string",
+    "$defs": {
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 7);
+
+  EXPECT_FRAME_STATIC_2019_09_RESOURCE(frame,
+                                       "https://www.sourcemeta.com/schema",
+                                       "https://www.sourcemeta.com/schema", "",
+                                       "https://www.sourcemeta.com/schema", "");
+
+  // JSON Pointers
+
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$id",
+      "https://www.sourcemeta.com/schema", "/$id",
+      "https://www.sourcemeta.com/schema", "/$id");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$defs",
+      "https://www.sourcemeta.com/schema", "/$defs",
+      "https://www.sourcemeta.com/schema", "/$defs");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$defs/string",
+      "https://www.sourcemeta.com/schema", "/$defs/string",
+      "https://www.sourcemeta.com/schema", "/$defs/string");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$defs/string/type",
+      "https://www.sourcemeta.com/schema", "/$defs/string/type",
+      "https://www.sourcemeta.com/schema", "/$defs/string/type");
+
+  // References
+
+  EXPECT_EQ(references.size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "https://json-schema.org/draft/2019-09/schema",
+      "https://json-schema.org/draft/2019-09/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(references, "/$ref",
+                          "https://www.sourcemeta.com/schema#/$defs/string",
+                          "https://www.sourcemeta.com/schema", "/$defs/string");
+}

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -1327,3 +1327,67 @@ TEST(JSONSchema_frame_2020_12, location_independent_identifier_anonymous) {
                    .wait(),
                sourcemeta::jsontoolkit::SchemaError);
 }
+
+TEST(JSONSchema_frame_2020_12, ref_with_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/string",
+    "$defs": {
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 7);
+
+  EXPECT_FRAME_STATIC_2020_12_RESOURCE(frame,
+                                       "https://www.sourcemeta.com/schema",
+                                       "https://www.sourcemeta.com/schema", "",
+                                       "https://www.sourcemeta.com/schema", "");
+
+  // JSON Pointers
+
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$id",
+      "https://www.sourcemeta.com/schema", "/$id",
+      "https://www.sourcemeta.com/schema", "/$id");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$defs",
+      "https://www.sourcemeta.com/schema", "/$defs",
+      "https://www.sourcemeta.com/schema", "/$defs");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$defs/string",
+      "https://www.sourcemeta.com/schema", "/$defs/string",
+      "https://www.sourcemeta.com/schema", "/$defs/string");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$defs/string/type",
+      "https://www.sourcemeta.com/schema", "/$defs/string/type",
+      "https://www.sourcemeta.com/schema", "/$defs/string/type");
+
+  // References
+
+  EXPECT_EQ(references.size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "https://json-schema.org/draft/2020-12/schema",
+      "https://json-schema.org/draft/2020-12/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(references, "/$ref",
+                          "https://www.sourcemeta.com/schema#/$defs/string",
+                          "https://www.sourcemeta.com/schema", "/$defs/string");
+}

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -490,3 +490,43 @@ TEST(JSONSchema_frame_draft3, ref_metaschema) {
       references, "/$ref", "http://json-schema.org/draft-03/schema",
       "http://json-schema.org/draft-03/schema", std::nullopt);
 }
+
+TEST(JSONSchema_frame_draft3, ref_with_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "$ref": "#/definitions/string"
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 4);
+
+  // JSON Pointers
+
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "", "", "http://json-schema.org/draft-03/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/id", "/id", "http://json-schema.org/draft-03/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema",
+      "http://json-schema.org/draft-03/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-03/schema#");
+
+  // References
+
+  EXPECT_EQ(references.size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "http://json-schema.org/draft-03/schema",
+      "http://json-schema.org/draft-03/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(references, "/$ref", "#/definitions/string",
+                          std::nullopt, "/definitions/string");
+}

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -555,3 +555,55 @@ TEST(JSONSchema_frame_draft4, location_independent_identifier_anonymous) {
   EXPECT_STATIC_REFERENCE(references, "/definitions/bar/$ref", "#foo",
                           std::nullopt, "foo");
 }
+
+TEST(JSONSchema_frame_draft4, ref_with_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/string",
+    "definitions": {
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 7);
+
+  // JSON Pointers
+
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "", "", "http://json-schema.org/draft-04/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/id", "/id", "http://json-schema.org/draft-04/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema",
+      "http://json-schema.org/draft-04/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-04/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions", "/definitions",
+      "http://json-schema.org/draft-04/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string", "/definitions/string",
+      "http://json-schema.org/draft-04/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string/type", "/definitions/string/type",
+      "http://json-schema.org/draft-04/schema#");
+
+  // References
+
+  EXPECT_EQ(references.size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "http://json-schema.org/draft-04/schema",
+      "http://json-schema.org/draft-04/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(references, "/$ref", "#/definitions/string",
+                          std::nullopt, "/definitions/string");
+}

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -555,3 +555,55 @@ TEST(JSONSchema_frame_draft6, location_independent_identifier_anonymous) {
   EXPECT_STATIC_REFERENCE(references, "/definitions/bar/$ref", "#foo",
                           std::nullopt, "foo");
 }
+
+TEST(JSONSchema_frame_draft6, ref_with_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/string",
+    "definitions": {
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 7);
+
+  // JSON Pointers
+
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "", "", "http://json-schema.org/draft-06/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$id", "/$id", "http://json-schema.org/draft-06/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema",
+      "http://json-schema.org/draft-06/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-06/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions", "/definitions",
+      "http://json-schema.org/draft-06/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string", "/definitions/string",
+      "http://json-schema.org/draft-06/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string/type", "/definitions/string/type",
+      "http://json-schema.org/draft-06/schema#");
+
+  // References
+
+  EXPECT_EQ(references.size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "http://json-schema.org/draft-06/schema",
+      "http://json-schema.org/draft-06/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(references, "/$ref", "#/definitions/string",
+                          std::nullopt, "/definitions/string");
+}

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -555,3 +555,55 @@ TEST(JSONSchema_frame_draft7, location_independent_identifier_anonymous) {
   EXPECT_STATIC_REFERENCE(references, "/definitions/bar/$ref", "#foo",
                           std::nullopt, "foo");
 }
+
+TEST(JSONSchema_frame_draft7, ref_with_id) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/string",
+    "definitions": {
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 7);
+
+  // JSON Pointers
+
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "", "", "http://json-schema.org/draft-07/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$id", "/$id", "http://json-schema.org/draft-07/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema",
+      "http://json-schema.org/draft-07/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-07/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions", "/definitions",
+      "http://json-schema.org/draft-07/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string", "/definitions/string",
+      "http://json-schema.org/draft-07/schema#");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string/type", "/definitions/string/type",
+      "http://json-schema.org/draft-07/schema#");
+
+  // References
+
+  EXPECT_EQ(references.size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "http://json-schema.org/draft-07/schema",
+      "http://json-schema.org/draft-07/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(references, "/$ref", "#/definitions/string",
+                          std::nullopt, "/definitions/string");
+}

--- a/test/jsonschema/jsonschema_identify_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_identify_2019_09_test.cc
@@ -162,6 +162,19 @@ TEST(JSONSchema_identify_2019_09, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_2019_09, sibling_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
 TEST(JSONSchema_identify_2019_09, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_identify_2020_12_test.cc
@@ -162,6 +162,19 @@ TEST(JSONSchema_identify_2020_12, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_2020_12, sibling_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
 TEST(JSONSchema_identify_2020_12, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft0_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft0_test.cc
@@ -162,6 +162,19 @@ TEST(JSONSchema_identify_draft0, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft0, sibling_unknown_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-00/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
 TEST(JSONSchema_identify_draft0, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft1_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft1_test.cc
@@ -162,6 +162,19 @@ TEST(JSONSchema_identify_draft1, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft1, sibling_unknown_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-01/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
 TEST(JSONSchema_identify_draft1, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft2_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft2_test.cc
@@ -162,6 +162,19 @@ TEST(JSONSchema_identify_draft2, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft2, sibling_unknown_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-02/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+}
+
 TEST(JSONSchema_identify_draft2, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft3_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft3_test.cc
@@ -162,6 +162,18 @@ TEST(JSONSchema_identify_draft3, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft3, sibling_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
 TEST(JSONSchema_identify_draft3, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft4_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft4_test.cc
@@ -162,6 +162,18 @@ TEST(JSONSchema_identify_draft4, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft4, sibling_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
 TEST(JSONSchema_identify_draft4, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft6_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft6_test.cc
@@ -162,6 +162,18 @@ TEST(JSONSchema_identify_draft6, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft6, sibling_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
 TEST(JSONSchema_identify_draft6, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({

--- a/test/jsonschema/jsonschema_identify_draft7_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft7_test.cc
@@ -162,6 +162,18 @@ TEST(JSONSchema_identify_draft7, anonymize_with_base_dialect_no_id) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(JSONSchema_identify_draft7, sibling_ref) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-schema",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#"
+  })JSON");
+  std::optional<std::string> id{
+      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+  EXPECT_FALSE(id.has_value());
+}
+
 TEST(JSONSchema_identify_draft7, reidentify_replace) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
