### PR TITLE
Avoid `BENCHMARK_MAIN` as we are already linking to `benchmark::benchmark_main`

### DIFF
--- a/benchmark/jsonschema/compiler_basic.cc
+++ b/benchmark/jsonschema/compiler_basic.cc
@@ -23,5 +23,3 @@ static void Compiler_Basic(benchmark::State &state) {
 }
 
 BENCHMARK(Compiler_Basic);
-
-BENCHMARK_MAIN();


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
