### PR TITLE
Better describe cases of unsatisfiable `minContains`/`maxContains`

### DIFF
--- a/src/jsonschema/compile_describe.cc
+++ b/src/jsonschema/compile_describe.cc
@@ -753,6 +753,10 @@ struct DescribeVisitor {
   }
 
   auto operator()(const SchemaCompilerAssertionFail &) const -> std::string {
+    if (this->keyword == "contains") {
+      return "The constraints declared for this keyword are not satisfiable";
+    }
+
     return "Abort evaluation on failure";
   }
 

--- a/test/jsonschema/jsonschema_compile_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_compile_2019_09_test.cc
@@ -1068,7 +1068,9 @@ TEST(JSONSchema_compile_2019_09, contains_12) {
   EVALUATE_TRACE_PRE(0, AssertionFail, "/contains", "#/contains", "");
   EVALUATE_TRACE_POST_FAILURE(0, AssertionFail, "/contains", "#/contains", "");
 
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 0, "Abort evaluation on failure");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 0,
+      "The constraints declared for this keyword are not satisfiable");
 }
 
 TEST(JSONSchema_compile_2019_09, title) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
