### PR TITLE
Remove unused `KRAFT` variable from the `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # Programs
 CMAKE = cmake
 CTEST = ctest
-KRAFT = kraft
 
 # Options
 PRESET = Debug


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
