### PR TITLE
Create a single Google Benchmark executable

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,10 +1,34 @@
-if(JSONTOOLKIT_JSON AND JSONTOOLKIT_JSONSCHEMA)
-  add_subdirectory(jsonschema)
+set(BENCHMARK_SOURCES)
 
-  # TODO: find a way to put this outside this if statement
-  # by adding a dependency to existing targets
+if(JSONTOOLKIT_JSONSCHEMA)
+  list(APPEND BENCHMARK_SOURCES jsonschema_compiler.cc)
+  list(APPEND BENCHMARK_SOURCES jsonschema_validator.cc)
+endif()
+
+if(BENCHMARK_SOURCES)
+  add_executable(sourcemeta_jsontoolkit_benchmark ${BENCHMARK_SOURCES})
+  noa_add_default_options(PRIVATE sourcemeta_jsontoolkit_benchmark)
+  target_link_libraries(sourcemeta_jsontoolkit_benchmark 
+    PRIVATE benchmark::benchmark)
+  target_link_libraries(sourcemeta_jsontoolkit_benchmark 
+    PRIVATE benchmark::benchmark_main)
+
+  if(JSONTOOLKIT_JSON)
+    target_link_libraries(sourcemeta_jsontoolkit_benchmark 
+      PRIVATE sourcemeta::jsontoolkit::json)
+  endif()
+  if(JSONTOOLKIT_JSONSCHEMA)
+    target_link_libraries(sourcemeta_jsontoolkit_benchmark 
+      PRIVATE sourcemeta::jsontoolkit::jsonschema)
+  endif()
+
   add_custom_target(benchmark_all
-      COMMAND sourcemeta_jsontoolkit_benchmark_jsonschema
-      DEPENDS sourcemeta_jsontoolkit_benchmark_jsonschema
-      COMMENT "Running benchmark...")
+    COMMAND sourcemeta_jsontoolkit_benchmark
+    DEPENDS sourcemeta_jsontoolkit_benchmark
+    COMMENT "Running benchmark...")
+else()
+  add_custom_target(benchmark_all
+    VERBATIM
+    COMMAND "${CMAKE_COMMAND}" -E echo "Nothing to benchmark"
+    COMMAND "${CMAKE_COMMAND}" -E false)
 endif()

--- a/benchmark/jsonschema/CMakeLists.txt
+++ b/benchmark/jsonschema/CMakeLists.txt
@@ -1,7 +1,0 @@
-add_executable(sourcemeta_jsontoolkit_benchmark_jsonschema compiler_basic.cc validator.cc)
-noa_add_default_options(PRIVATE sourcemeta_jsontoolkit_benchmark_jsonschema)
-
-target_link_libraries(sourcemeta_jsontoolkit_benchmark_jsonschema PRIVATE benchmark::benchmark)
-target_link_libraries(sourcemeta_jsontoolkit_benchmark_jsonschema PRIVATE benchmark::benchmark_main)
-target_link_libraries(sourcemeta_jsontoolkit_benchmark_jsonschema PRIVATE sourcemeta::jsontoolkit::json)
-target_link_libraries(sourcemeta_jsontoolkit_benchmark_jsonschema PRIVATE sourcemeta::jsontoolkit::jsonschema)

--- a/benchmark/jsonschema_compiler.cc
+++ b/benchmark/jsonschema_compiler.cc
@@ -3,7 +3,7 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-static void Compiler_Basic(benchmark::State &state) {
+static void JSONSchema_Compile_Basic(benchmark::State &state) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -22,4 +22,4 @@ static void Compiler_Basic(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Compiler_Basic);
+BENCHMARK(JSONSchema_Compile_Basic);

--- a/benchmark/jsonschema_validator.cc
+++ b/benchmark/jsonschema_validator.cc
@@ -3,7 +3,8 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-static void Draft4_Meta_1_No_Callback(benchmark::State &state) {
+static void
+JSONSchema_Validate_Draft4_Meta_1_No_Callback(benchmark::State &state) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -26,4 +27,4 @@ static void Draft4_Meta_1_No_Callback(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Draft4_Meta_1_No_Callback);
+BENCHMARK(JSONSchema_Validate_Draft4_Meta_1_No_Callback);


### PR DESCRIPTION
This will make it more practical to adopt
https://github.com/benchmark-action/github-action-benchmark. We can
still focus on specific subcomponents by either omitting the ones we
don't want at the CMake options level, or with `--benchmark_filter`.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
