### PR TITLE
Optimize `maximum` and `minimum` conditions if there is `type`

### DIFF
--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -964,12 +964,18 @@ auto compiler_draft4_validation_maximum(
     -> SchemaCompilerTemplate {
   assert(schema_context.schema.at(dynamic_context.keyword).is_number());
 
-  // TODO: As an optimization, avoid this condition if the subschema
-  // declares `type` to `number` or `integer` already
-  SchemaCompilerTemplate condition{make<SchemaCompilerAssertionTypeStrictAny>(
-      false, context, schema_context, relative_dynamic_context,
-      std::set<JSON::Type>{JSON::Type::Integer, JSON::Type::Real}, {},
-      SchemaCompilerTargetType::Instance)};
+  SchemaCompilerTemplate condition;
+  const auto is_numeric{
+      schema_context.schema.defines("type") &&
+      (schema_context.schema.at("type").is_string() &&
+       (schema_context.schema.at("type").to_string() == "integer" ||
+        schema_context.schema.at("type").to_string() == "number"))};
+  if (!is_numeric) {
+    condition.push_back(make<SchemaCompilerAssertionTypeStrictAny>(
+        false, context, schema_context, relative_dynamic_context,
+        std::set<JSON::Type>{JSON::Type::Integer, JSON::Type::Real}, {},
+        SchemaCompilerTargetType::Instance));
+  }
 
   // TODO: As an optimization, if `minimum` is set to the same number, do
   // a single equality assertion
@@ -997,12 +1003,18 @@ auto compiler_draft4_validation_minimum(
     -> SchemaCompilerTemplate {
   assert(schema_context.schema.at(dynamic_context.keyword).is_number());
 
-  // TODO: As an optimization, avoid this condition if the subschema
-  // declares `type` to `number` or `integer` already
-  SchemaCompilerTemplate condition{make<SchemaCompilerAssertionTypeStrictAny>(
-      false, context, schema_context, relative_dynamic_context,
-      std::set<JSON::Type>{JSON::Type::Integer, JSON::Type::Real}, {},
-      SchemaCompilerTargetType::Instance)};
+  SchemaCompilerTemplate condition;
+  const auto is_numeric{
+      schema_context.schema.defines("type") &&
+      (schema_context.schema.at("type").is_string() &&
+       (schema_context.schema.at("type").to_string() == "integer" ||
+        schema_context.schema.at("type").to_string() == "number"))};
+  if (!is_numeric) {
+    condition.push_back(make<SchemaCompilerAssertionTypeStrictAny>(
+        false, context, schema_context, relative_dynamic_context,
+        std::set<JSON::Type>{JSON::Type::Integer, JSON::Type::Real}, {},
+        SchemaCompilerTargetType::Instance));
+  }
 
   // TODO: As an optimization, if `maximum` is set to the same number, do
   // a single equality assertion

--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -52,6 +52,8 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2020-12/vocab/applicator", "properties",
                        Members, HTTPS_BASE "2020-12/vocab/validation", "type",
                        "required")
+  WALK(HTTPS_BASE "2020-12/vocab/validation", "maximum", None, "type")
+  WALK(HTTPS_BASE "2020-12/vocab/validation", "minimum", None, "type")
 
   // 2019-09
   WALK(HTTPS_BASE "2019-09/vocab/core", "$defs", Members)
@@ -89,6 +91,8 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2019-09/vocab/applicator", "properties",
                        Members, HTTPS_BASE "2019-09/vocab/validation", "type",
                        "required")
+  WALK(HTTPS_BASE "2019-09/vocab/validation", "maximum", None, "type")
+  WALK(HTTPS_BASE "2019-09/vocab/validation", "minimum", None, "type")
 
 #undef HTTPS_BASE
 
@@ -126,6 +130,8 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   // For the purpose of compiler optimizations
   WALK(HTTP_BASE "draft-07/schema#", "properties", Members, "$ref", "type",
        "required")
+  WALK(HTTP_BASE "draft-07/schema#", "maximum", None, "$ref", "type")
+  WALK(HTTP_BASE "draft-07/schema#", "minimum", None, "$ref", "type")
 
   // $ref also takes precedence over any unknown keyword
   if (vocabularies.contains(HTTP_BASE "draft-07/schema#") &&
@@ -160,6 +166,8 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   // For the purpose of compiler optimizations
   WALK(HTTP_BASE "draft-06/schema#", "properties", Members, "$ref", "type",
        "required")
+  WALK(HTTP_BASE "draft-06/schema#", "maximum", None, "$ref", "type")
+  WALK(HTTP_BASE "draft-06/schema#", "minimum", None, "$ref", "type")
 
   // $ref also takes precedence over any unknown keyword
   if (vocabularies.contains(HTTP_BASE "draft-06/schema#") &&
@@ -186,6 +194,8 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK(HTTP_BASE "draft-04/schema#", "minLength", None, "$ref", "type")
   WALK(HTTP_BASE "draft-04/schema#", "maxItems", None, "$ref", "type")
   WALK(HTTP_BASE "draft-04/schema#", "minItems", None, "$ref", "type")
+  WALK(HTTP_BASE "draft-04/schema#", "maximum", None, "$ref", "type")
+  WALK(HTTP_BASE "draft-04/schema#", "minimum", None, "$ref", "type")
   WALK(HTTP_BASE "draft-04/schema#", "maxProperties", None, "$ref", "type")
   WALK(HTTP_BASE "draft-04/schema#", "minProperties", None, "$ref", "type")
   WALK(HTTP_BASE "draft-04/schema#", "properties", Members, "$ref", "type",

--- a/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
@@ -294,7 +294,8 @@ TEST(JSONSchema_default_walker_2019_09, validation_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  EXPECT_TRUE(result.dependencies.empty());
+  const std::set<std::string> expected{"type"};
+  EXPECT_EQ(result.dependencies, expected);
 }
 
 TEST(JSONSchema_default_walker_2019_09, validation_minimum) {
@@ -302,7 +303,8 @@ TEST(JSONSchema_default_walker_2019_09, validation_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  EXPECT_TRUE(result.dependencies.empty());
+  const std::set<std::string> expected{"type"};
+  EXPECT_EQ(result.dependencies, expected);
 }
 
 TEST(JSONSchema_default_walker_2019_09, validation_exclusiveMaximum) {

--- a/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
@@ -334,7 +334,8 @@ TEST(JSONSchema_default_walker_2020_12, validation_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  EXPECT_TRUE(result.dependencies.empty());
+  const std::set<std::string> expected{"type"};
+  EXPECT_EQ(result.dependencies, expected);
 }
 
 TEST(JSONSchema_default_walker_2020_12, validation_minimum) {
@@ -342,7 +343,8 @@ TEST(JSONSchema_default_walker_2020_12, validation_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  EXPECT_TRUE(result.dependencies.empty());
+  const std::set<std::string> expected{"type"};
+  EXPECT_EQ(result.dependencies, expected);
 }
 
 TEST(JSONSchema_default_walker_2020_12, validation_exclusiveMaximum) {

--- a/test/jsonschema/jsonschema_default_walker_draft4_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft4_test.cc
@@ -149,7 +149,7 @@ TEST(JSONSchema_default_walker_draft4, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  const std::set<std::string> expected{"$ref"};
+  const std::set<std::string> expected{"$ref", "type"};
   EXPECT_EQ(result.dependencies, expected);
 }
 
@@ -157,7 +157,7 @@ TEST(JSONSchema_default_walker_draft4, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  const std::set<std::string> expected{"$ref"};
+  const std::set<std::string> expected{"$ref", "type"};
   EXPECT_EQ(result.dependencies, expected);
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft6_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft6_test.cc
@@ -174,7 +174,7 @@ TEST(JSONSchema_default_walker_draft6, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  const std::set<std::string> expected{"$ref"};
+  const std::set<std::string> expected{"$ref", "type"};
   EXPECT_EQ(result.dependencies, expected);
 }
 
@@ -182,7 +182,7 @@ TEST(JSONSchema_default_walker_draft6, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  const std::set<std::string> expected{"$ref"};
+  const std::set<std::string> expected{"$ref", "type"};
   EXPECT_EQ(result.dependencies, expected);
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft7_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft7_test.cc
@@ -206,7 +206,7 @@ TEST(JSONSchema_default_walker_draft7, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  const std::set<std::string> expected{"$ref"};
+  const std::set<std::string> expected{"$ref", "type"};
   EXPECT_EQ(result.dependencies, expected);
 }
 
@@ -214,7 +214,7 @@ TEST(JSONSchema_default_walker_draft7, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::None);
-  const std::set<std::string> expected{"$ref"};
+  const std::set<std::string> expected{"$ref", "type"};
   EXPECT_EQ(result.dependencies, expected);
 }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
