### PR TITLE
Start generalizing `LoopItemsFromAnnotationIndex` as `LoopItemsUnevaluated`

### DIFF
--- a/src/jsonschema/compile_describe.cc
+++ b/src/jsonschema/compile_describe.cc
@@ -646,13 +646,13 @@ struct DescribeVisitor {
     return unknown();
   }
 
-  auto operator()(const SchemaCompilerLoopItemsFromAnnotationIndex &step) const
+  auto operator()(const SchemaCompilerLoopItemsUnevaluated &step) const
       -> std::string {
     assert(this->keyword == "unevaluatedItems");
     const auto &value{step_value(step)};
     std::ostringstream message;
     message << "The array items not evaluated by the keyword "
-            << escape_string(value)
+            << escape_string(value.index)
             << ", if any, were expected to validate against this subschema";
     return message.str();
   }

--- a/src/jsonschema/compile_evaluate.cc
+++ b/src/jsonschema/compile_evaluate.cc
@@ -1309,18 +1309,15 @@ auto evaluate_step(
     }
 
     CALLBACK_POST("SchemaCompilerLoopItemsUnmarked", loop);
-  } else if (std::holds_alternative<SchemaCompilerLoopItemsFromAnnotationIndex>(
-                 step)) {
-    SOURCEMETA_TRACE_START(trace_id,
-                           "SchemaCompilerLoopItemsFromAnnotationIndex");
-    const auto &loop{
-        std::get<SchemaCompilerLoopItemsFromAnnotationIndex>(step)};
+  } else if (std::holds_alternative<SchemaCompilerLoopItemsUnevaluated>(step)) {
+    SOURCEMETA_TRACE_START(trace_id, "SchemaCompilerLoopItemsUnevaluated");
+    const auto &loop{std::get<SchemaCompilerLoopItemsUnevaluated>(step)};
     context.push(loop);
-    EVALUATE_CONDITION_GUARD("SchemaCompilerLoopItemsFromAnnotationIndex", loop,
+    EVALUATE_CONDITION_GUARD("SchemaCompilerLoopItemsUnevaluated", loop,
                              instance);
     const auto &target{context.resolve_target<JSON>(loop.target, instance)};
-    EVALUATE_IMPLICIT_PRECONDITION("SchemaCompilerLoopItemsFromAnnotationIndex",
-                                   loop, target.is_array());
+    EVALUATE_IMPLICIT_PRECONDITION("SchemaCompilerLoopItemsUnevaluated", loop,
+                                   target.is_array());
     CALLBACK_PRE(loop, context.instance_location());
     const auto &value{context.resolve_value(loop.value, instance)};
     assert(target.is_array());
@@ -1331,7 +1328,7 @@ auto evaluate_step(
     // Determine the proper start based on integer annotations collected for the
     // current instance location by the keyword requested by the user.
     const std::uint64_t start{context.largest_annotation_index(
-        context.instance_location(), {value}, 0)};
+        context.instance_location(), {value.index}, 0)};
 
     // We need this check, as advancing an iterator past its bounds
     // is considered undefined behavior
@@ -1348,14 +1345,14 @@ auto evaluate_step(
         if (!evaluate_step(child, instance, mode, callback, context)) {
           result = false;
           context.pop(loop);
-          CALLBACK_POST("SchemaCompilerLoopItemsFromAnnotationIndex", loop);
+          CALLBACK_POST("SchemaCompilerLoopItemsUnevaluated", loop);
         }
       }
 
       context.pop(loop);
     }
 
-    CALLBACK_POST("SchemaCompilerLoopItemsFromAnnotationIndex", loop);
+    CALLBACK_POST("SchemaCompilerLoopItemsUnevaluated", loop);
   } else if (std::holds_alternative<SchemaCompilerLoopContains>(step)) {
     SOURCEMETA_TRACE_START(trace_id, "SchemaCompilerLoopContains");
     const auto &loop{std::get<SchemaCompilerLoopContains>(step)};

--- a/src/jsonschema/compile_json.cc
+++ b/src/jsonschema/compile_json.cc
@@ -122,6 +122,12 @@ auto value_to_json(const sourcemeta::jsontoolkit::SchemaCompilerStepValue<T>
 
     result.assign("value", std::move(values));
     return result;
+  } else if constexpr (std::is_same_v<
+                           SchemaCompilerValueItemsAnnotationKeywords, T>) {
+    result.assign("type", JSON{"items-annotation-keywords"});
+    JSON values{JSON::make_object()};
+    result.assign("index", JSON{std::get<T>(value).index});
+    return result;
   } else if constexpr (std::is_same_v<SchemaCompilerValueStringType, T>) {
     result.assign("type", JSON{"string-type"});
     switch (std::get<T>(value)) {
@@ -272,8 +278,7 @@ struct StepVisitor {
   HANDLE_STEP("loop", "keys", SchemaCompilerLoopKeys)
   HANDLE_STEP("loop", "items", SchemaCompilerLoopItems)
   HANDLE_STEP("loop", "items-unmarked", SchemaCompilerLoopItemsUnmarked)
-  HANDLE_STEP("loop", "items-from-annotation-index",
-              SchemaCompilerLoopItemsFromAnnotationIndex)
+  HANDLE_STEP("loop", "items-unevaluated", SchemaCompilerLoopItemsUnevaluated)
   HANDLE_STEP("loop", "contains", SchemaCompilerLoopContains)
   HANDLE_STEP("control", "label", SchemaCompilerControlLabel)
   HANDLE_STEP("control", "mark", SchemaCompilerControlMark)

--- a/src/jsonschema/default_compiler_2019_09.h
+++ b/src/jsonschema/default_compiler_2019_09.h
@@ -220,10 +220,10 @@ auto compiler_2019_09_applicator_unevaluateditems(
         false, context, schema_context, relative_dynamic_context, JSON{true},
         {}, SchemaCompilerTargetType::Annotations,
         {"items", "additionalItems", "unevaluatedItems"})};
-    return {make<SchemaCompilerLoopItemsFromAnnotationIndex>(
+    return {make<SchemaCompilerLoopItemsUnevaluated>(
         true, context, schema_context, dynamic_context,
-        SchemaCompilerValueString{"items"}, std::move(children),
-        std::move(condition))};
+        SchemaCompilerValueItemsAnnotationKeywords{"items"},
+        std::move(children), std::move(condition))};
   } else if (schema_context.vocabularies.contains(
                  "https://json-schema.org/draft/2020-12/vocab/applicator")) {
     SchemaCompilerTemplate subcondition{
@@ -241,10 +241,10 @@ auto compiler_2019_09_applicator_unevaluateditems(
         false, context, schema_context, relative_dynamic_context, JSON{true},
         {}, SchemaCompilerTargetType::Annotations,
         {"prefixItems", "items", "contains", "unevaluatedItems"})};
-    return {make<SchemaCompilerLoopItemsFromAnnotationIndex>(
+    return {make<SchemaCompilerLoopItemsUnevaluated>(
         true, context, schema_context, dynamic_context,
-        SchemaCompilerValueString{"prefixItems"}, std::move(subchildren),
-        std::move(condition))};
+        SchemaCompilerValueItemsAnnotationKeywords{"prefixItems"},
+        std::move(subchildren), std::move(condition))};
   } else {
     return {make<SchemaCompilerLoopItemsUnmarked>(
         true, context, schema_context, dynamic_context,

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_compile.h
@@ -104,6 +104,12 @@ using SchemaCompilerValueNamedIndexes =
 enum class SchemaCompilerValueStringType { URI };
 
 /// @ingroup jsonschema
+/// Represents an array loop compiler step annotation keywords
+struct SchemaCompilerValueItemsAnnotationKeywords {
+  const SchemaCompilerValueString index;
+};
+
+/// @ingroup jsonschema
 /// Represents a value in a compiler step
 template <typename T>
 using SchemaCompilerStepValue = std::variant<T, SchemaCompilerTarget>;
@@ -307,9 +313,8 @@ struct SchemaCompilerLoopItems;
 struct SchemaCompilerLoopItemsUnmarked;
 
 /// @ingroup jsonschema
-/// Represents a compiler step that loops over array items, potentially starting
-/// from a given index that was previously collected as an annotation
-struct SchemaCompilerLoopItemsFromAnnotationIndex;
+/// Represents a compiler step that loops over unevaluated array items
+struct SchemaCompilerLoopItemsUnevaluated;
 
 /// @ingroup jsonschema
 /// Represents a compiler step that checks array items match a given criteria
@@ -358,7 +363,7 @@ using SchemaCompilerTemplate = std::vector<std::variant<
     SchemaCompilerLoopPropertiesNoAdjacentAnnotation,
     SchemaCompilerLoopPropertiesNoAnnotation, SchemaCompilerLoopKeys,
     SchemaCompilerLoopItems, SchemaCompilerLoopItemsUnmarked,
-    SchemaCompilerLoopItemsFromAnnotationIndex, SchemaCompilerLoopContains,
+    SchemaCompilerLoopItemsUnevaluated, SchemaCompilerLoopContains,
     SchemaCompilerControlLabel, SchemaCompilerControlMark,
     SchemaCompilerControlJump, SchemaCompilerControlDynamicAnchorJump>>;
 
@@ -461,8 +466,8 @@ DEFINE_STEP_APPLICATOR(Loop, PropertiesNoAnnotation, SchemaCompilerValueStrings)
 DEFINE_STEP_APPLICATOR(Loop, Keys, SchemaCompilerValueNone)
 DEFINE_STEP_APPLICATOR(Loop, Items, SchemaCompilerValueUnsignedInteger)
 DEFINE_STEP_APPLICATOR(Loop, ItemsUnmarked, SchemaCompilerValueStrings)
-DEFINE_STEP_APPLICATOR(Loop, ItemsFromAnnotationIndex,
-                       SchemaCompilerValueString)
+DEFINE_STEP_APPLICATOR(Loop, ItemsUnevaluated,
+                       SchemaCompilerValueItemsAnnotationKeywords)
 DEFINE_STEP_APPLICATOR(Loop, Contains, SchemaCompilerValueRange)
 DEFINE_CONTROL(Label, SchemaCompilerValueUnsignedInteger)
 DEFINE_CONTROL(Mark, SchemaCompilerValueUnsignedInteger)

--- a/test/jsonschema/jsonschema_compile_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_compile_2019_09_test.cc
@@ -2385,10 +2385,10 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_1) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 1);
 
-  EVALUATE_TRACE_PRE(0, LoopItemsFromAnnotationIndex, "/unevaluatedItems",
+  EVALUATE_TRACE_PRE(0, LoopItemsUnevaluated, "/unevaluatedItems",
                      "#/unevaluatedItems", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, LoopItemsFromAnnotationIndex,
-                              "/unevaluatedItems", "#/unevaluatedItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0,
@@ -2413,7 +2413,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_2) {
       sourcemeta::jsontoolkit::parse("[ true, false ]")};
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 4);
-  EVALUATE_TRACE_PRE(0, LoopItemsFromAnnotationIndex, "/unevaluatedItems",
+  EVALUATE_TRACE_PRE(0, LoopItemsUnevaluated, "/unevaluatedItems",
                      "#/unevaluatedItems", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/unevaluatedItems/type",
                      "#/unevaluatedItems/type", "/0");
@@ -2428,8 +2428,8 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_2) {
                                  "", true);
   EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/unevaluatedItems/type",
                               "#/unevaluatedItems/type", "/1");
-  EVALUATE_TRACE_POST_SUCCESS(3, LoopItemsFromAnnotationIndex,
-                              "/unevaluatedItems", "#/unevaluatedItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type boolean");
@@ -2508,15 +2508,15 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_4) {
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/items/0/type", "#/items/0/type",
                      "/0");
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/items", "#/items", "");
-  EVALUATE_TRACE_PRE(3, LoopItemsFromAnnotationIndex, "/unevaluatedItems",
+  EVALUATE_TRACE_PRE(3, LoopItemsUnevaluated, "/unevaluatedItems",
                      "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/items/0/type",
                               "#/items/0/type", "/0");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/items", "#/items", "", 0);
   EVALUATE_TRACE_POST_SUCCESS(2, LogicalWhenType, "/items", "#/items", "");
-  EVALUATE_TRACE_POST_SUCCESS(3, LoopItemsFromAnnotationIndex,
-                              "/unevaluatedItems", "#/unevaluatedItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(3, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
@@ -2598,7 +2598,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_6) {
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/items/0/type", "#/items/0/type",
                      "/0");
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/items", "#/items", "");
-  EVALUATE_TRACE_PRE(3, LoopItemsFromAnnotationIndex, "/unevaluatedItems",
+  EVALUATE_TRACE_PRE(3, LoopItemsUnevaluated, "/unevaluatedItems",
                      "#/unevaluatedItems", "");
   EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/unevaluatedItems/type",
                      "#/unevaluatedItems/type", "/1");
@@ -2613,8 +2613,8 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_6) {
                               "#/unevaluatedItems/type", "/1");
   EVALUATE_TRACE_POST_ANNOTATION(4, "/unevaluatedItems", "#/unevaluatedItems",
                                  "", true);
-  EVALUATE_TRACE_POST_SUCCESS(5, LoopItemsFromAnnotationIndex,
-                              "/unevaluatedItems", "#/unevaluatedItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(5, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
@@ -2665,7 +2665,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_7) {
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/items/0/type",
                      "#/allOf/0/items/0/type", "/0");
   EVALUATE_TRACE_PRE_ANNOTATION(3, "/allOf/0/items", "#/allOf/0/items", "");
-  EVALUATE_TRACE_PRE(4, LoopItemsFromAnnotationIndex, "/unevaluatedItems",
+  EVALUATE_TRACE_PRE(4, LoopItemsUnevaluated, "/unevaluatedItems",
                      "#/unevaluatedItems", "");
   EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/unevaluatedItems/type",
                      "#/unevaluatedItems/type", "/1");
@@ -2682,8 +2682,8 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_7) {
                               "#/unevaluatedItems/type", "/1");
   EVALUATE_TRACE_POST_ANNOTATION(5, "/unevaluatedItems", "#/unevaluatedItems",
                                  "", true);
-  EVALUATE_TRACE_POST_SUCCESS(6, LoopItemsFromAnnotationIndex,
-                              "/unevaluatedItems", "#/unevaluatedItems", "");
+  EVALUATE_TRACE_POST_SUCCESS(6, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
@@ -2737,7 +2737,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_8) {
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/items/0/type",
                      "#/allOf/0/items/0/type", "/0");
   EVALUATE_TRACE_PRE_ANNOTATION(3, "/allOf/0/items", "#/allOf/0/items", "");
-  EVALUATE_TRACE_PRE(4, LoopItemsFromAnnotationIndex, "/unevaluatedItems",
+  EVALUATE_TRACE_PRE(4, LoopItemsUnevaluated, "/unevaluatedItems",
                      "#/unevaluatedItems", "");
   EVALUATE_TRACE_PRE(5, AssertionTypeStrict, "/unevaluatedItems/type",
                      "#/unevaluatedItems/type", "/1");
@@ -2750,8 +2750,8 @@ TEST(JSONSchema_compile_2019_09, unevaluatedItems_8) {
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf", "#/allOf", "");
   EVALUATE_TRACE_POST_FAILURE(4, AssertionTypeStrict, "/unevaluatedItems/type",
                               "#/unevaluatedItems/type", "/1");
-  EVALUATE_TRACE_POST_FAILURE(5, LoopItemsFromAnnotationIndex,
-                              "/unevaluatedItems", "#/unevaluatedItems", "");
+  EVALUATE_TRACE_POST_FAILURE(5, LoopItemsUnevaluated, "/unevaluatedItems",
+                              "#/unevaluatedItems", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
