### PR TITLE
Correctly compile `trace.h` on macOS on GCC

### DIFF
--- a/src/jsonschema/trace.h
+++ b/src/jsonschema/trace.h
@@ -2,7 +2,7 @@
 #define SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_TRACE_H_
 
 // We only perform tracing on debugging builds, at least for now
-#if !defined(NDEBUG) && defined(__APPLE__)
+#if !defined(NDEBUG) && defined(__APPLE__) && defined(__clang__)
 
 #include <os/log.h>
 #include <os/signpost.h>


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
