### PR TITLE
Prefer unrolling `properties` for a small amount of optional subschemas

### DIFF
--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -360,8 +360,14 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
   // or whether most of the properties are optional. Each shines
   // in the corresponding case.
 
-  // This strategy only makes sense if most of the properties are "optional"
-  if (is_required <= (size / 2)) {
+  const auto prefer_loop_over_instance{
+      // This strategy only makes sense if most of the properties are "optional"
+      is_required <= (size / 2) &&
+      // If `properties` only defines a relatively small amount of properties,
+      // then its probably still faster to unroll
+      schema_context.schema.at(dynamic_context.keyword).size() > 3};
+
+  if (prefer_loop_over_instance) {
     SchemaCompilerValueNamedIndexes indexes;
     SchemaCompilerTemplate children;
     std::size_t cursor = 0;

--- a/test/jsonschema/jsonschema_compile_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_compile_2019_09_test.cc
@@ -23,75 +23,37 @@ TEST(JSONSchema_compile_2019_09, properties_1) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"bar\": 2, \"foo\": \"xxx\" }")};
 
-  if (FIRST_PROPERTY_IS(instance, "foo")) {
-    EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 5);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 5);
 
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
-    EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(3, AssertionType, "/properties/bar/type",
-                       "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_PRE_ANNOTATION(4, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE_ANNOTATION(4, "/properties", "#/properties", "");
 
-    EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
-    EVALUATE_TRACE_POST_SUCCESS(2, AssertionType, "/properties/bar/type",
-                                "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_ANNOTATION(3, "/properties", "#/properties", "", "bar");
-    EVALUATE_TRACE_POST_SUCCESS(4, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/properties/bar/type",
+                              "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "bar");
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_ANNOTATION(3, "/properties", "#/properties", "", "foo");
+  EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/properties", "#/properties", "");
 
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                                 "The value was expected to be of type string");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The object property \"foo\" successfully "
-                                 "validated against its property subschema");
-    EVALUATE_TRACE_POST_DESCRIBE(
-        instance, 2, "The value was expected to be of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
-                                 "The object property \"bar\" successfully "
-                                 "validated against its property subschema");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
-                                 "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
-  } else {
-    EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 5);
-
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
-    EVALUATE_TRACE_PRE(1, AssertionType, "/properties/bar/type",
-                       "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_PRE_ANNOTATION(4, "/properties", "#/properties", "");
-
-    EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/properties/bar/type",
-                                "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "bar");
-    EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_ANNOTATION(3, "/properties", "#/properties", "", "foo");
-    EVALUATE_TRACE_POST_SUCCESS(4, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
-
-    EVALUATE_TRACE_POST_DESCRIBE(
-        instance, 0, "The value was expected to be of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The object property \"bar\" successfully "
-                                 "validated against its property subschema");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                                 "The value was expected to be of type string");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
-                                 "The object property \"foo\" successfully "
-                                 "validated against its property subschema");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
-                                 "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
-  }
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The object property \"bar\" successfully "
+                               "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The object property \"foo\" successfully "
+                               "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
+                               "The object value was expected to validate "
+                               "against the defined properties subschemas");
 }
 
 TEST(JSONSchema_compile_2019_09, properties_1_exhaustive) {
@@ -115,56 +77,33 @@ TEST(JSONSchema_compile_2019_09, properties_1_exhaustive) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"bar\": 2, \"foo\": 1 }")};
 
-  if (FIRST_PROPERTY_IS(instance, "foo")) {
-    EVALUATE_WITH_TRACE_EXHAUSTIVE_FAILURE(compiled_schema, instance, 2);
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_FAILURE(compiled_schema, instance, 4);
 
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
-    EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, AssertionType, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
 
-    EVALUATE_TRACE_POST_FAILURE(0, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_FAILURE(1, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/properties/bar/type",
+                              "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "bar");
+  EVALUATE_TRACE_POST_FAILURE(2, AssertionTypeStrict, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_FAILURE(3, LogicalAnd, "/properties", "#/properties", "");
 
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                                 "The value was expected to be of type string "
-                                 "but it was of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
-  } else {
-    EVALUATE_WITH_TRACE_EXHAUSTIVE_FAILURE(compiled_schema, instance, 4);
-
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
-    EVALUATE_TRACE_PRE(1, AssertionType, "/properties/bar/type",
-                       "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
-
-    EVALUATE_TRACE_POST_SUCCESS(0, AssertionType, "/properties/bar/type",
-                                "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "bar");
-    EVALUATE_TRACE_POST_FAILURE(2, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_FAILURE(3, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
-
-    EVALUATE_TRACE_POST_DESCRIBE(
-        instance, 0, "The value was expected to be of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The object property \"bar\" successfully "
-                                 "validated against its property subschema");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                                 "The value was expected to be of type string "
-                                 "but it was of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
-                                 "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
-  }
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The object property \"bar\" successfully "
+                               "validated against its property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(
+      instance, 2,
+      "The value was expected to be of type string but it was of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The object value was expected to validate "
+                               "against the defined properties subschemas");
 }
 
 TEST(JSONSchema_compile_2019_09, dependentRequired_1) {
@@ -660,7 +599,7 @@ TEST(JSONSchema_compile_2019_09, additionalProperties_2_fast) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 6);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
@@ -674,8 +613,7 @@ TEST(JSONSchema_compile_2019_09, additionalProperties_2_fast) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionType, "/additionalProperties/type",
                               "#/additionalProperties/type", "/bar");
   EVALUATE_TRACE_POST_ANNOTATION(4, "/additionalProperties",
@@ -727,7 +665,7 @@ TEST(JSONSchema_compile_2019_09, additionalProperties_2_exhaustive) {
 
   EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS(compiled_schema, instance, 6);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
@@ -741,8 +679,7 @@ TEST(JSONSchema_compile_2019_09, additionalProperties_2_exhaustive) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionType, "/additionalProperties/type",
                               "#/additionalProperties/type", "/bar");
   EVALUATE_TRACE_POST_ANNOTATION(4, "/additionalProperties",
@@ -875,7 +812,7 @@ TEST(JSONSchema_compile_2019_09, additionalProperties_4) {
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/patternProperties", "#/patternProperties",
                                 "");
 
-  EVALUATE_TRACE_PRE(3, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE_ANNOTATION(5, "/properties", "#/properties", "");
@@ -900,8 +837,7 @@ TEST(JSONSchema_compile_2019_09, additionalProperties_4) {
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(4, "/properties", "#/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(5, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(5, LogicalAnd, "/properties", "#/properties", "");
 
   // `additionalProperties`
   EVALUATE_TRACE_POST_SUCCESS(6, AssertionTypeStrict,
@@ -2381,7 +2317,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_1) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 6);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
@@ -2395,8 +2331,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_1) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict,
                               "/unevaluatedProperties/type",
                               "#/unevaluatedProperties/type", "/bar");
@@ -2451,7 +2386,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_2) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 7);
 
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/allOf", "#/allOf", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/allOf/0/properties",
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/allOf/0/properties",
                      "#/allOf/0/properties", "");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/properties/foo/type",
                      "#/allOf/0/properties/foo/type", "/foo");
@@ -2469,7 +2404,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_2) {
                               "#/allOf/0/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/allOf/0/properties",
                                  "#/allOf/0/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/allOf/0/properties",
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/allOf/0/properties",
                               "#/allOf/0/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf", "#/allOf", "");
   EVALUATE_TRACE_POST_SUCCESS(4, AssertionTypeStrict,
@@ -2529,7 +2464,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_3) {
   EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 6);
 
   EVALUATE_TRACE_PRE(0, LogicalAnd, "/allOf", "#/allOf", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/allOf/0/properties",
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/allOf/0/properties",
                      "#/allOf/0/properties", "");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/allOf/0/properties/foo/type",
                      "#/allOf/0/properties/foo/type", "/foo");
@@ -2545,7 +2480,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_3) {
                               "#/allOf/0/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/allOf/0/properties",
                                  "#/allOf/0/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/allOf/0/properties",
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/allOf/0/properties",
                               "#/allOf/0/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/allOf", "#/allOf", "");
   EVALUATE_TRACE_POST_FAILURE(4, AssertionTypeStrict,
@@ -2595,7 +2530,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_4) {
 
   EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 5);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE_ANNOTATION(2, "/properties", "#/properties", "");
@@ -2607,8 +2542,7 @@ TEST(JSONSchema_compile_2019_09, unevaluatedProperties_4) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_POST_ANNOTATION(1, "/properties", "#/properties", "", "foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_FAILURE(3, AssertionFail, "/unevaluatedProperties",
                               "#/unevaluatedProperties", "/bar");
   EVALUATE_TRACE_POST_FAILURE(4, LoopPropertiesNoAnnotation,

--- a/test/jsonschema/jsonschema_compile_draft4_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft4_test.cc
@@ -509,13 +509,13 @@ TEST(JSONSchema_compile_draft4, ref_3) {
 
   EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type",
                      "https://example.com#/type", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/properties",
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties",
                      "https://example.com#/properties", "");
   EVALUATE_TRACE_PRE(2, ControlLabel, "/properties/foo/$ref",
                      "https://example.com#/properties/foo/$ref", "/foo");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/$ref/type",
                      "https://example.com#/type", "/foo");
-  EVALUATE_TRACE_PRE(4, LoopPropertiesMatch, "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_PRE(4, LogicalAnd, "/properties/foo/$ref/properties",
                      "https://example.com#/properties", "/foo");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type",
@@ -523,13 +523,12 @@ TEST(JSONSchema_compile_draft4, ref_3) {
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
                               "/properties/foo/$ref/type",
                               "https://example.com#/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch,
-                              "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties/foo/$ref/properties",
                               "https://example.com#/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(3, ControlLabel, "/properties/foo/$ref",
                               "https://example.com#/properties/foo/$ref",
                               "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(4, LoopPropertiesMatch, "/properties",
+  EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/properties",
                               "https://example.com#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
@@ -572,20 +571,20 @@ TEST(JSONSchema_compile_draft4, ref_4) {
 
   EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type",
                      "https://example.com#/type", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/properties",
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties",
                      "https://example.com#/properties", "");
   EVALUATE_TRACE_PRE(2, ControlLabel, "/properties/foo/$ref",
                      "https://example.com#/properties/foo/$ref", "/foo");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/$ref/type",
                      "https://example.com#/type", "/foo");
-  EVALUATE_TRACE_PRE(4, LoopPropertiesMatch, "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_PRE(4, LogicalAnd, "/properties/foo/$ref/properties",
                      "https://example.com#/properties", "/foo");
   EVALUATE_TRACE_PRE(5, ControlJump, "/properties/foo/$ref/properties/foo/$ref",
                      "https://example.com#/properties/foo/$ref", "/foo/foo");
   EVALUATE_TRACE_PRE(6, AssertionTypeStrict,
                      "/properties/foo/$ref/properties/foo/$ref/type",
                      "https://example.com#/type", "/foo/foo");
-  EVALUATE_TRACE_PRE(7, LoopPropertiesMatch,
+  EVALUATE_TRACE_PRE(7, LogicalAnd,
                      "/properties/foo/$ref/properties/foo/$ref/properties",
                      "https://example.com#/properties", "/foo/foo");
 
@@ -598,19 +597,17 @@ TEST(JSONSchema_compile_draft4, ref_4) {
                               "/properties/foo/$ref/properties/foo/$ref/type",
                               "https://example.com#/type", "/foo/foo");
   EVALUATE_TRACE_POST_SUCCESS(
-      3, LoopPropertiesMatch,
-      "/properties/foo/$ref/properties/foo/$ref/properties",
+      3, LogicalAnd, "/properties/foo/$ref/properties/foo/$ref/properties",
       "https://example.com#/properties", "/foo/foo");
   EVALUATE_TRACE_POST_SUCCESS(
       4, ControlJump, "/properties/foo/$ref/properties/foo/$ref",
       "https://example.com#/properties/foo/$ref", "/foo/foo");
-  EVALUATE_TRACE_POST_SUCCESS(5, LoopPropertiesMatch,
-                              "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_POST_SUCCESS(5, LogicalAnd, "/properties/foo/$ref/properties",
                               "https://example.com#/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(6, ControlLabel, "/properties/foo/$ref",
                               "https://example.com#/properties/foo/$ref",
                               "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(7, LoopPropertiesMatch, "/properties",
+  EVALUATE_TRACE_POST_SUCCESS(7, LogicalAnd, "/properties",
                               "https://example.com#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
@@ -661,13 +658,13 @@ TEST(JSONSchema_compile_draft4, ref_5) {
 
   EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type",
                      "https://example.com#/type", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/properties",
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties",
                      "https://example.com#/properties", "");
   EVALUATE_TRACE_PRE(2, ControlLabel, "/properties/foo/$ref",
                      "https://example.com#/properties/foo/$ref", "/foo");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/$ref/type",
                      "https://example.com#/type", "/foo");
-  EVALUATE_TRACE_PRE(4, LoopPropertiesMatch, "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_PRE(4, LogicalAnd, "/properties/foo/$ref/properties",
                      "https://example.com#/properties", "/foo");
   EVALUATE_TRACE_PRE(5, ControlJump, "/properties/foo/$ref/properties/foo/$ref",
                      "https://example.com#/properties/foo/$ref", "/foo/foo");
@@ -686,13 +683,12 @@ TEST(JSONSchema_compile_draft4, ref_5) {
   EVALUATE_TRACE_POST_FAILURE(
       3, ControlJump, "/properties/foo/$ref/properties/foo/$ref",
       "https://example.com#/properties/foo/$ref", "/foo/foo");
-  EVALUATE_TRACE_POST_FAILURE(4, LoopPropertiesMatch,
-                              "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_POST_FAILURE(4, LogicalAnd, "/properties/foo/$ref/properties",
                               "https://example.com#/properties", "/foo");
   EVALUATE_TRACE_POST_FAILURE(5, ControlLabel, "/properties/foo/$ref",
                               "https://example.com#/properties/foo/$ref",
                               "/foo");
-  EVALUATE_TRACE_POST_FAILURE(6, LoopPropertiesMatch, "/properties",
+  EVALUATE_TRACE_POST_FAILURE(6, LogicalAnd, "/properties",
                               "https://example.com#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
@@ -739,24 +735,22 @@ TEST(JSONSchema_compile_draft4, ref_6) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 5);
 
   EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type", "#/type", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(2, ControlLabel, "/properties/foo/$ref",
                      "#/properties/foo/$ref", "/foo");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/$ref/type",
                      "#/type", "/foo");
-  EVALUATE_TRACE_PRE(4, LoopPropertiesMatch, "/properties/foo/$ref/properties",
+  EVALUATE_TRACE_PRE(4, LogicalAnd, "/properties/foo/$ref/properties",
                      "#/properties", "/foo");
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
   EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
                               "/properties/foo/$ref/type", "#/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch,
-                              "/properties/foo/$ref/properties", "#/properties",
-                              "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties/foo/$ref/properties",
+                              "#/properties", "/foo");
   EVALUATE_TRACE_POST_SUCCESS(3, ControlLabel, "/properties/foo/$ref",
                               "#/properties/foo/$ref", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(4, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type object");
@@ -1059,27 +1053,25 @@ TEST(JSONSchema_compile_draft4, properties_1) {
   if (FIRST_PROPERTY_IS(instance, "foo")) {
     EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 2);
 
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
+    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
     EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                        "#/properties/foo/type", "/foo");
 
     EVALUATE_TRACE_POST_FAILURE(0, AssertionTypeStrict, "/properties/foo/type",
                                 "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_FAILURE(1, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+    EVALUATE_TRACE_POST_FAILURE(1, LogicalAnd, "/properties", "#/properties",
+                                "");
 
     EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                  "The value was expected to be of type string "
                                  "but it was of type integer");
     EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                  "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
+                                 "against the defined properties subschemas");
   } else {
     EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 3);
 
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
+    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
     EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
                        "#/properties/bar/type", "/bar");
     EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
@@ -1089,8 +1081,8 @@ TEST(JSONSchema_compile_draft4, properties_1) {
                                 "#/properties/bar/type", "/bar");
     EVALUATE_TRACE_POST_FAILURE(1, AssertionTypeStrict, "/properties/foo/type",
                                 "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_FAILURE(2, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+    EVALUATE_TRACE_POST_FAILURE(2, LogicalAnd, "/properties", "#/properties",
+                                "");
 
     EVALUATE_TRACE_POST_DESCRIBE(
         instance, 0, "The value was expected to be of type integer");
@@ -1099,7 +1091,7 @@ TEST(JSONSchema_compile_draft4, properties_1) {
                                  "but it was of type integer");
     EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                  "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
+                                 "against the defined properties subschemas");
   }
 }
 
@@ -1124,8 +1116,7 @@ TEST(JSONSchema_compile_draft4, properties_2) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 3);
 
   if (FIRST_PROPERTY_IS(instance, "foo")) {
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
+    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
     EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                        "#/properties/foo/type", "/foo");
     EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/bar/type",
@@ -1135,8 +1126,8 @@ TEST(JSONSchema_compile_draft4, properties_2) {
                                 "#/properties/foo/type", "/foo");
     EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/bar/type",
                                 "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+    EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties",
+                                "");
 
     EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                  "The value was expected to be of type string");
@@ -1146,8 +1137,7 @@ TEST(JSONSchema_compile_draft4, properties_2) {
                                  "The object value was expected to validate "
                                  "against the 2 defined properties subschemas");
   } else {
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
+    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
     EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
                        "#/properties/bar/type", "/bar");
     EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
@@ -1157,8 +1147,8 @@ TEST(JSONSchema_compile_draft4, properties_2) {
                                 "#/properties/bar/type", "/bar");
     EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/foo/type",
                                 "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+    EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties",
+                                "");
 
     EVALUATE_TRACE_POST_DESCRIBE(
         instance, 0, "The value was expected to be of type integer");
@@ -1166,7 +1156,7 @@ TEST(JSONSchema_compile_draft4, properties_2) {
                                  "The value was expected to be of type string");
     EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
                                  "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
+                                 "against the defined properties subschemas");
   }
 }
 
@@ -1189,12 +1179,11 @@ TEST(JSONSchema_compile_draft4, properties_3) {
       sourcemeta::jsontoolkit::parse("{ \"baz\": [] }")};
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 1);
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
-  EVALUATE_TRACE_POST_SUCCESS(0, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The object value was expected to validate "
-                               "against the 2 defined properties subschemas");
+                               "against the defined properties subschemas");
 }
 
 TEST(JSONSchema_compile_draft4, properties_4) {
@@ -1222,8 +1211,8 @@ TEST(JSONSchema_compile_draft4, properties_4) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 3);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/properties/foo/properties",
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties/foo/properties",
                      "#/properties/foo/properties", "/foo");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict,
                      "/properties/foo/properties/bar/type",
@@ -1232,11 +1221,9 @@ TEST(JSONSchema_compile_draft4, properties_4) {
   EVALUATE_TRACE_POST_SUCCESS(
       0, AssertionTypeStrict, "/properties/foo/properties/bar/type",
       "#/properties/foo/properties/bar/type", "/foo/bar");
-  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesMatch,
-                              "/properties/foo/properties",
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/properties/foo/properties",
                               "#/properties/foo/properties", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(2, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
@@ -1729,7 +1716,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_2) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 4);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE(2, LoopPropertiesExcept, "/additionalProperties",
@@ -1739,8 +1726,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_2) {
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict,
                               "/additionalProperties/type",
                               "#/additionalProperties/type", "/bar");
@@ -1785,8 +1771,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_3) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 4);
 
   if (FIRST_PROPERTY_IS(instance, "foo")) {
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
+    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
     EVALUATE_TRACE_PRE(1, LoopPropertiesExcept, "/additionalProperties",
                        "#/additionalProperties", "");
     EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/additionalProperties/type",
@@ -1794,8 +1779,8 @@ TEST(JSONSchema_compile_draft4, additionalProperties_3) {
     EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/additionalProperties/type",
                        "#/additionalProperties/type", "/bar");
 
-    EVALUATE_TRACE_POST_SUCCESS(0, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+    EVALUATE_TRACE_POST_SUCCESS(0, LogicalAnd, "/properties", "#/properties",
+                                "");
     EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
                                 "/additionalProperties/type",
                                 "#/additionalProperties/type", "/foo");
@@ -1819,8 +1804,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_3) {
                                  "adjacent object keywords were "
                                  "expected to validate against this subschema");
   } else {
-    EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties",
-                       "");
+    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
     EVALUATE_TRACE_PRE(1, LoopPropertiesExcept, "/additionalProperties",
                        "#/additionalProperties", "");
     EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/additionalProperties/type",
@@ -1828,8 +1812,8 @@ TEST(JSONSchema_compile_draft4, additionalProperties_3) {
     EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/additionalProperties/type",
                        "#/additionalProperties/type", "/foo");
 
-    EVALUATE_TRACE_POST_SUCCESS(0, LoopPropertiesMatch, "/properties",
-                                "#/properties", "");
+    EVALUATE_TRACE_POST_SUCCESS(0, LogicalAnd, "/properties", "#/properties",
+                                "");
     EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict,
                                 "/additionalProperties/type",
                                 "#/additionalProperties/type", "/bar");
@@ -1884,7 +1868,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_4) {
                      // Note that the caret needs to be URI escaped
                      "#/patternProperties/%5Ebar$/type", "/bar");
 
-  EVALUATE_TRACE_PRE(2, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(2, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
 
@@ -1904,8 +1888,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_4) {
   // `properties`
   EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(3, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/properties", "#/properties", "");
 
   // `additionalProperties`
   EVALUATE_TRACE_POST_SUCCESS(4, AssertionTypeStrict,
@@ -1955,7 +1938,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_5) {
 
   EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 4);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE(2, LoopPropertiesExcept, "/additionalProperties",
@@ -1965,8 +1948,7 @@ TEST(JSONSchema_compile_draft4, additionalProperties_5) {
 
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_POST_FAILURE(2, AssertionFail, "/additionalProperties",
                               "#/additionalProperties", "/bar");
   EVALUATE_TRACE_POST_FAILURE(3, LoopPropertiesExcept, "/additionalProperties",
@@ -2075,8 +2057,7 @@ TEST(JSONSchema_compile_draft4, not_3) {
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 5);
 
   EVALUATE_TRACE_PRE(0, LogicalNot, "/not", "#/not", "");
-  EVALUATE_TRACE_PRE(1, LoopPropertiesMatch, "/not/properties",
-                     "#/not/properties", "");
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/not/properties", "#/not/properties", "");
   EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/not/properties/foo/type",
                      "#/not/properties/foo/type", "/foo");
   EVALUATE_TRACE_PRE(3, LoopPropertiesExcept, "/not/additionalProperties",
@@ -2087,7 +2068,7 @@ TEST(JSONSchema_compile_draft4, not_3) {
   EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict,
                               "/not/properties/foo/type",
                               "#/not/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesMatch, "/not/properties",
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/not/properties",
                               "#/not/properties", "");
   EVALUATE_TRACE_POST_FAILURE(2, AssertionTypeStrict,
                               "/not/additionalProperties/type",

--- a/test/jsonschema/jsonschema_compile_draft4_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft4_test.cc
@@ -1050,49 +1050,28 @@ TEST(JSONSchema_compile_draft4, properties_1) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"bar\": 2, \"foo\": 1 }")};
 
-  if (FIRST_PROPERTY_IS(instance, "foo")) {
-    EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 2);
+  EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 3);
 
-    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
 
-    EVALUATE_TRACE_POST_FAILURE(0, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_FAILURE(1, LogicalAnd, "/properties", "#/properties",
-                                "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
+                              "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_POST_FAILURE(1, AssertionTypeStrict, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_FAILURE(2, LogicalAnd, "/properties", "#/properties", "");
 
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                                 "The value was expected to be of type string "
-                                 "but it was of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The object value was expected to validate "
-                                 "against the defined properties subschemas");
-  } else {
-    EVALUATE_WITH_TRACE_FAST_FAILURE(compiled_schema, instance, 3);
-
-    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
-                       "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
-
-    EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
-                                "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_FAILURE(1, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_FAILURE(2, LogicalAnd, "/properties", "#/properties",
-                                "");
-
-    EVALUATE_TRACE_POST_DESCRIBE(
-        instance, 0, "The value was expected to be of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The value was expected to be of type string "
-                                 "but it was of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                                 "The object value was expected to validate "
-                                 "against the defined properties subschemas");
-  }
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string "
+                               "but it was of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The object value was expected to validate "
+                               "against the defined properties subschemas");
 }
 
 TEST(JSONSchema_compile_draft4, properties_2) {
@@ -1115,49 +1094,25 @@ TEST(JSONSchema_compile_draft4, properties_2) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 3);
 
-  if (FIRST_PROPERTY_IS(instance, "foo")) {
-    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/bar/type",
-                       "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
 
-    EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/bar/type",
-                                "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties",
-                                "");
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
+                              "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
 
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
-                                 "The value was expected to be of type string");
-    EVALUATE_TRACE_POST_DESCRIBE(
-        instance, 1, "The value was expected to be of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                                 "The object value was expected to validate "
-                                 "against the 2 defined properties subschemas");
-  } else {
-    EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
-    EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
-                       "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
-                       "#/properties/foo/type", "/foo");
-
-    EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
-                                "#/properties/bar/type", "/bar");
-    EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/foo/type",
-                                "#/properties/foo/type", "/foo");
-    EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties",
-                                "");
-
-    EVALUATE_TRACE_POST_DESCRIBE(
-        instance, 0, "The value was expected to be of type integer");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                                 "The value was expected to be of type string");
-    EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                                 "The object value was expected to validate "
-                                 "against the defined properties subschemas");
-  }
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The object value was expected to validate "
+                               "against the defined properties subschemas");
 }
 
 TEST(JSONSchema_compile_draft4, properties_3) {

--- a/test/jsonschema/jsonschema_compile_draft6_test.cc
+++ b/test/jsonschema/jsonschema_compile_draft6_test.cc
@@ -501,14 +501,13 @@ TEST(JSONSchema_compile_draft6, propertyNames_4) {
 
   EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 2);
 
-  EVALUATE_TRACE_PRE(0, LoopPropertiesMatch, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
   EVALUATE_TRACE_PRE(1, LoopKeys, "/properties/foo/propertyNames",
                      "#/properties/foo/propertyNames", "/foo");
 
   EVALUATE_TRACE_POST_SUCCESS(0, LoopKeys, "/properties/foo/propertyNames",
                               "#/properties/foo/propertyNames", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(1, LoopPropertiesMatch, "/properties",
-                              "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(
       instance, 0,


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
