### PR TITLE
Support reusing the `EvaluationContext` across evaluation runs

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -3,7 +3,7 @@ set(BENCHMARK_SOURCES)
 if(JSONTOOLKIT_JSON)
   list(APPEND BENCHMARK_SOURCES json.cc)
 endif()
-if(JSONTOOLKIT_JSONSCHEMA)
+if(JSONTOOLKIT_EVALUATOR AND JSONTOOLKIT_JSONSCHEMA)
   list(APPEND BENCHMARK_SOURCES jsonschema_validator.cc)
 endif()
 
@@ -19,7 +19,9 @@ if(BENCHMARK_SOURCES)
     target_link_libraries(sourcemeta_jsontoolkit_benchmark
       PRIVATE sourcemeta::jsontoolkit::json)
   endif()
-  if(JSONTOOLKIT_JSONSCHEMA)
+  if(JSONTOOLKIT_EVALUATOR AND JSONTOOLKIT_JSONSCHEMA)
+    target_link_libraries(sourcemeta_jsontoolkit_benchmark
+      PRIVATE sourcemeta::jsontoolkit::evaluator)
     target_link_libraries(sourcemeta_jsontoolkit_benchmark
       PRIVATE sourcemeta::jsontoolkit::jsonschema)
   endif()

--- a/benchmark/validator_helper.cc
+++ b/benchmark/validator_helper.cc
@@ -1,3 +1,4 @@
+#include <sourcemeta/jsontoolkit/evaluator.h>
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonl.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
@@ -54,10 +55,12 @@ auto main(int argc, char **argv) noexcept -> int {
   std::cerr << "Number of instances: " << instances.size() << "\n";
 
   // Validate and measure
+  sourcemeta::jsontoolkit::EvaluationContext context;
   const auto timestamp_start{std::chrono::high_resolution_clock::now()};
   for (const auto &instance : instances) {
+    context.prepare(instance);
     const auto result{
-        sourcemeta::jsontoolkit::evaluate(schema_template, instance)};
+        sourcemeta::jsontoolkit::evaluate(schema_template, context)};
     if (!result) {
       return EXIT_FAILURE;
     }

--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -6,7 +6,17 @@
 namespace sourcemeta::jsontoolkit {
 
 auto EvaluationContext::prepare(const JSON &instance) -> void {
+  // Do a full reset for the next run
+  assert(this->evaluate_path_.empty());
+  assert(this->instance_location_.empty());
+  assert(this->frame_sizes.empty());
+  assert(this->resources_.empty());
+  this->instances_.clear();
   this->instances_.emplace_back(instance);
+  this->annotation_blacklist.clear();
+  this->annotations_.clear();
+  this->labels.clear();
+  this->property_as_instance = false;
 }
 
 auto EvaluationContext::push_without_traverse(

--- a/src/evaluator/include/sourcemeta/jsontoolkit/evaluator.h
+++ b/src/evaluator/include/sourcemeta/jsontoolkit/evaluator.h
@@ -55,8 +55,6 @@ using SchemaCompilerEvaluationCallback =
                        const SchemaCompilerTemplate::value_type &,
                        const WeakPointer &, const WeakPointer &, const JSON &)>;
 
-// TODO: Support standard output formats too
-
 /// @ingroup evaluator
 ///
 /// This function evaluates a schema compiler template in validation mode,
@@ -142,6 +140,41 @@ auto SOURCEMETA_JSONTOOLKIT_EVALUATOR_EXPORT
 evaluate(const SchemaCompilerTemplate &steps, const JSON &instance,
          const SchemaCompilerEvaluationMode mode,
          const SchemaCompilerEvaluationCallback &callback) -> bool;
+
+/// @ingroup evaluator
+///
+/// This function evaluates a schema compiler template from an evaluation
+/// context, returning a boolean without error information. The evaluation
+/// context can be re-used among evaluations (as long as its always loaded with
+/// the new instance first) for performance reasons. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/jsontoolkit/json.h>
+/// #include <sourcemeta/jsontoolkit/jsonschema.h>
+/// #include <sourcemeta/jsontoolkit/evaluator.h>
+/// #include <cassert>
+///
+/// const sourcemeta::jsontoolkit::JSON schema =
+///     sourcemeta::jsontoolkit::parse(R"JSON({
+///   "$schema": "https://json-schema.org/draft/2020-12/schema",
+///   "type": "string"
+/// })JSON");
+///
+/// const auto schema_template{sourcemeta::jsontoolkit::compile(
+///     schema, sourcemeta::jsontoolkit::default_schema_walker,
+///     sourcemeta::jsontoolkit::official_resolver,
+///     sourcemeta::jsontoolkit::default_schema_compiler)};
+///
+/// const sourcemeta::jsontoolkit::JSON instance{"foo bar"};
+/// sourcemeta::jsontoolkit::EvaluationContext context;
+/// context.prepare(instance);
+///
+/// const auto result{sourcemeta::jsontoolkit::evaluate(
+///   schema_template, context)};
+/// assert(result);
+/// ```
+auto SOURCEMETA_JSONTOOLKIT_EVALUATOR_EXPORT evaluate(
+    const SchemaCompilerTemplate &steps, EvaluationContext &context) -> bool;
 
 } // namespace sourcemeta::jsontoolkit
 

--- a/test/evaluator/evaluator_test.cc
+++ b/test/evaluator/evaluator_test.cc
@@ -77,3 +77,34 @@ TEST(JSONSchema_evaluator, boolean_false) {
       instance, 0,
       "No instance is expected to succeed against the false schema");
 }
+
+TEST(JSONSchema_evaluator, reusable_context) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "string"
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::jsontoolkit::compile(
+      schema, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::default_schema_compiler)};
+
+  sourcemeta::jsontoolkit::EvaluationContext context;
+
+  const sourcemeta::jsontoolkit::JSON instance_1{"foo bar"};
+  context.prepare(instance_1);
+  EXPECT_TRUE(sourcemeta::jsontoolkit::evaluate(compiled_schema, context));
+
+  const sourcemeta::jsontoolkit::JSON instance_2{"baz"};
+  context.prepare(instance_2);
+  EXPECT_TRUE(sourcemeta::jsontoolkit::evaluate(compiled_schema, context));
+
+  const sourcemeta::jsontoolkit::JSON instance_3{4};
+  context.prepare(instance_3);
+  EXPECT_FALSE(sourcemeta::jsontoolkit::evaluate(compiled_schema, context));
+
+  const sourcemeta::jsontoolkit::JSON instance_4{"qux"};
+  context.prepare(instance_4);
+  EXPECT_TRUE(sourcemeta::jsontoolkit::evaluate(compiled_schema, context));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
