### PR TITLE
refactor(jsonschema/uri): remove useless std::move

### DIFF
--- a/src/evaluator/context.cc
+++ b/src/evaluator/context.cc
@@ -71,7 +71,7 @@ auto EvaluationContext::push(const Pointer &relative_schema_location,
                               relative_instance_location, schema_resource,
                               dynamic);
   assert(!relative_instance_location.empty());
-  this->instances_.emplace_back(std::move(new_instance));
+  this->instances_.emplace_back(new_instance);
 }
 
 auto EvaluationContext::pop(const bool dynamic) -> void {

--- a/src/uri/uri.cc
+++ b/src/uri/uri.cc
@@ -133,7 +133,7 @@ URI::URI(URI &&other)
   this->scheme_ = std::move(other.scheme_);
   this->userinfo_ = std::move(other.userinfo_);
   this->host_ = std::move(other.host_);
-  this->port_ = std::move(other.port_);
+  this->port_ = other.port_;
   this->fragment_ = std::move(other.fragment_);
   this->query_ = std::move(other.query_);
 


### PR DESCRIPTION
According to clang tidy:

```cpp
/Users/tonygo/oss/jsontoolkit/src/evaluator/context.cc:74:33: error: std::move of the variable 'new_instance' of 
the trivially-copyable type 'std::reference_wrapper<const JSON>' has no effect; remove std::move() 
[performance-move-const-arg,-warnings-as-errors]
```