### PR TITLE
Don't assume the instance is an object when unrolling `properties`

### DIFF
--- a/src/jsonpointer/jsonpointer.cc
+++ b/src/jsonpointer/jsonpointer.cc
@@ -66,14 +66,21 @@ auto try_traverse(const sourcemeta::jsontoolkit::JSON &document,
     const auto &instance{current.get()};
     if (token.is_property()) {
       const auto &property{token.to_property()};
+      if (!instance.is_object()) {
+        return std::nullopt;
+      }
+
       auto json_value{instance.try_at(property)};
       if (json_value.has_value()) {
         current = std::move(json_value.value());
-
       } else {
         return std::nullopt;
       }
     } else {
+      if (!instance.is_array() && !instance.is_object()) {
+        return std::nullopt;
+      }
+
       const auto index{token.to_index()};
       if (index < instance.size()) {
         current = instance.at(index);

--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -359,7 +359,7 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
   }
 
   const auto size{schema_context.schema.at(dynamic_context.keyword).size()};
-  const auto imports_required_keyword =
+  const auto imports_validation_vocabulary =
       schema_context.vocabularies.contains(
           "http://json-schema.org/draft-04/schema#") ||
       schema_context.vocabularies.contains(
@@ -371,7 +371,8 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
       schema_context.vocabularies.contains(
           "https://json-schema.org/draft/2020-12/vocab/validation");
   std::set<std::string> required;
-  if (imports_required_keyword && schema_context.schema.defines("required") &&
+  if (imports_validation_vocabulary &&
+      schema_context.schema.defines("required") &&
       schema_context.schema.at("required").is_array()) {
     for (const auto &property :
          schema_context.schema.at("required").as_array()) {
@@ -448,8 +449,15 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
           true, context, schema_context, relative_dynamic_context, JSON{name}));
     }
 
+    const auto assume_object{imports_validation_vocabulary &&
+                             schema_context.schema.defines("type") &&
+                             schema_context.schema.at("type").is_string() &&
+                             schema_context.schema.at("type").to_string() ==
+                                 "object"};
+
     // We can avoid this "defines" condition if the property is a required one
-    if (imports_required_keyword && schema_context.schema.defines("required") &&
+    if (imports_validation_vocabulary && assume_object &&
+        schema_context.schema.defines("required") &&
         schema_context.schema.at("required").is_array() &&
         schema_context.schema.at("required").contains(JSON{name})) {
       // We can avoid the container too and just inline these steps

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -1120,6 +1120,7 @@ TEST(JSONSchema_evaluator_draft4, properties_5) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
     "required": [ "foo", "bar" ],
     "properties": {
       "foo": { "type": "string" },
@@ -1135,33 +1136,68 @@ TEST(JSONSchema_evaluator_draft4, properties_5) {
   const sourcemeta::jsontoolkit::JSON instance{
       sourcemeta::jsontoolkit::parse("{ \"foo\": \"xxx\", \"bar\": 2 }")};
 
-  EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 4);
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 5);
 
-  EVALUATE_TRACE_PRE(0, AssertionDefinesAll, "/required", "#/required", "");
-  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties", "#/properties", "");
-  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/bar/type",
+  EVALUATE_TRACE_PRE(0, AssertionTypeStrict, "/type", "#/type", "");
+  EVALUATE_TRACE_PRE(1, AssertionDefinesAll, "/required", "#/required", "");
+  EVALUATE_TRACE_PRE(2, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/bar/type",
                      "#/properties/bar/type", "/bar");
-  EVALUATE_TRACE_PRE(3, AssertionTypeStrict, "/properties/foo/type",
+  EVALUATE_TRACE_PRE(4, AssertionTypeStrict, "/properties/foo/type",
                      "#/properties/foo/type", "/foo");
 
-  EVALUATE_TRACE_POST_SUCCESS(0, AssertionDefinesAll, "/required", "#/required",
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/type", "#/type", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionDefinesAll, "/required", "#/required",
                               "");
-  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/bar/type",
+  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/properties/bar/type",
                               "#/properties/bar/type", "/bar");
-  EVALUATE_TRACE_POST_SUCCESS(2, AssertionTypeStrict, "/properties/foo/type",
+  EVALUATE_TRACE_POST_SUCCESS(3, AssertionTypeStrict, "/properties/foo/type",
                               "#/properties/foo/type", "/foo");
-  EVALUATE_TRACE_POST_SUCCESS(3, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(4, LogicalAnd, "/properties", "#/properties", "");
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type object");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
                                "The object value was expected to define "
                                "properties \"foo\", and \"bar\"");
-  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
-                               "The value was expected to be of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
-                               "The value was expected to be of type string");
+                               "The value was expected to be of type integer");
   EVALUATE_TRACE_POST_DESCRIBE(instance, 3,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 4,
                                "The object value was expected to validate "
                                "against the defined properties subschemas");
+}
+
+TEST(JSONSchema_evaluator_draft4, properties_6) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "image": {
+        "required": [ "file" ],
+        "properties": {
+          "file": { "type": "string" }
+        }
+      }
+    }
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::jsontoolkit::compile(
+      schema, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::default_schema_compiler)};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"image\": \"foo\" }")};
+
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 1);
+
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_POST_SUCCESS(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The object value was expected to validate "
+                               "against the single defined property subschema");
 }
 
 TEST(JSONSchema_evaluator_draft4, pattern_1) {

--- a/test/jsonpointer/jsonpointer_try_get_test.cc
+++ b/test/jsonpointer/jsonpointer_try_get_test.cc
@@ -113,3 +113,41 @@ TEST(JSONPointer_try_get, complex_false) {
   const auto result{sourcemeta::jsontoolkit::try_get(document, pointer)};
   EXPECT_FALSE(result.has_value());
 }
+
+TEST(JSONPointer_try_get, complex_non_existent_property) {
+  const auto document{sourcemeta::jsontoolkit::parse(R"JSON({
+    "foo": {
+      "bar": [ 1, 2, { "baz": "qux" } ]
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", 2, "xxx"};
+  const auto result{sourcemeta::jsontoolkit::try_get(document, pointer)};
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(JSONPointer_try_get, complex_non_existent_index) {
+  const auto document{sourcemeta::jsontoolkit::parse(R"JSON({
+    "foo": {
+      "bar": [ 1, 2, { "baz": "qux" } ]
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", 9, "xxx"};
+  const auto result{sourcemeta::jsontoolkit::try_get(document, pointer)};
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(JSONPointer_try_get, non_object) {
+  const sourcemeta::jsontoolkit::JSON document{"foo"};
+  const sourcemeta::jsontoolkit::Pointer pointer{"bar"};
+  const auto result{sourcemeta::jsontoolkit::try_get(document, pointer)};
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(JSONPointer_try_get, non_array) {
+  const sourcemeta::jsontoolkit::JSON document{"foo"};
+  const sourcemeta::jsontoolkit::Pointer pointer{2};
+  const auto result{sourcemeta::jsontoolkit::try_get(document, pointer)};
+  EXPECT_FALSE(result.has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
