### PR TITLE
Support `definitions` in 2019-09 and 2020-12

### DIFF
--- a/src/jsonschema/default_compiler.cc
+++ b/src/jsonschema/default_compiler.cc
@@ -499,7 +499,8 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
            "https://json-schema.org/draft/2019-09/vocab/core") ||
        schema_context.vocabularies.contains(
            "https://json-schema.org/draft/2020-12/vocab/core")) &&
-      !dynamic_context.keyword.starts_with('$')) {
+      !dynamic_context.keyword.starts_with('$') &&
+      dynamic_context.keyword != "definitions") {
 
     // We handle these keywords as part of "contains"
     if ((schema_context.vocabularies.contains(

--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -55,6 +55,10 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK(HTTPS_BASE "2020-12/vocab/validation", "maximum", None, "type")
   WALK(HTTPS_BASE "2020-12/vocab/validation", "minimum", None, "type")
 
+  // JSON Schema still defines this for backwards-compatibility
+  // See https://json-schema.org/draft/2020-12/schema
+  WALK(HTTPS_BASE "2020-12/vocab/core", "definitions", Members)
+
   // 2019-09
   WALK(HTTPS_BASE "2019-09/vocab/core", "$defs", Members)
   WALK(HTTPS_BASE "2019-09/vocab/applicator", "items", ValueOrElements)
@@ -93,6 +97,10 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
                        "required")
   WALK(HTTPS_BASE "2019-09/vocab/validation", "maximum", None, "type")
   WALK(HTTPS_BASE "2019-09/vocab/validation", "minimum", None, "type")
+
+  // JSON Schema still defines this for backwards-compatibility
+  // See https://json-schema.org/draft/2019-09/schema
+  WALK(HTTPS_BASE "2019-09/vocab/core", "definitions", Members)
 
 #undef HTTPS_BASE
 

--- a/test/evaluator/evaluator_2019_09_test.cc
+++ b/test/evaluator/evaluator_2019_09_test.cc
@@ -3652,3 +3652,44 @@ TEST(JSONSchema_evaluator_2019_09, patternProperties_5) {
       "The object properties not covered by other adjacent object keywords "
       "were expected to validate against this subschema");
 }
+
+TEST(JSONSchema_evaluator_2019_09, definitions_1) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#/definitions/middle",
+    "definitions": {
+      "middle": { "$ref": "#/definitions/string" },
+      "string": { "type": "string" }
+    }
+  })JSON")};
+
+  const auto compiled_schema{sourcemeta::jsontoolkit::compile(
+      schema, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::default_schema_compiler)};
+
+  const sourcemeta::jsontoolkit::JSON instance{"foo"};
+  EVALUATE_WITH_TRACE_FAST_SUCCESS(compiled_schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/$ref", "#/$ref", "");
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/$ref/$ref", "#/definitions/middle/$ref",
+                     "");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/$ref/$ref/type",
+                     "#/definitions/string/type", "");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/$ref/$ref/type",
+                              "#/definitions/string/type", "");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/$ref/$ref",
+                              "#/definitions/middle/$ref", "");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/$ref", "#/$ref", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The string value was expected to validate "
+                               "against the statically referenced schema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The string value was expected to validate "
+                               "against the statically referenced schema");
+}

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -1844,3 +1844,81 @@ TEST(JSONSchema_frame_2019_09, ref_with_id) {
                           "https://www.sourcemeta.com/schema#/$defs/string",
                           "https://www.sourcemeta.com/schema", "/$defs/string");
 }
+
+TEST(JSONSchema_frame_2019_09, ref_from_definitions) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#/definitions/middle",
+    "definitions": {
+      "middle": { "$ref": "#/definitions/string" },
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 9);
+
+  EXPECT_FRAME_STATIC_2019_09_RESOURCE(frame,
+                                       "https://www.sourcemeta.com/schema",
+                                       "https://www.sourcemeta.com/schema", "",
+                                       "https://www.sourcemeta.com/schema", "");
+
+  // JSON Pointers
+
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$id",
+      "https://www.sourcemeta.com/schema", "/$id",
+      "https://www.sourcemeta.com/schema", "/$id");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/middle",
+      "https://www.sourcemeta.com/schema", "/definitions/middle",
+      "https://www.sourcemeta.com/schema", "/definitions/middle");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/middle/$ref",
+      "https://www.sourcemeta.com/schema", "/definitions/middle/$ref",
+      "https://www.sourcemeta.com/schema", "/definitions/middle/$ref");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string");
+  EXPECT_FRAME_STATIC_2019_09_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type");
+
+  // References
+
+  EXPECT_EQ(references.size(), 3);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "https://json-schema.org/draft/2019-09/schema",
+      "https://json-schema.org/draft/2019-09/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(
+      references, "/$ref",
+      "https://www.sourcemeta.com/schema#/definitions/middle",
+      "https://www.sourcemeta.com/schema", "/definitions/middle");
+  EXPECT_STATIC_REFERENCE(
+      references, "/definitions/middle/$ref",
+      "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string");
+}

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -1391,3 +1391,81 @@ TEST(JSONSchema_frame_2020_12, ref_with_id) {
                           "https://www.sourcemeta.com/schema#/$defs/string",
                           "https://www.sourcemeta.com/schema", "/$defs/string");
 }
+
+TEST(JSONSchema_frame_2020_12, ref_from_definitions) {
+  const sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/definitions/middle",
+    "definitions": {
+      "middle": { "$ref": "#/definitions/string" },
+      "string": { "type": "string" }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::ReferenceFrame frame;
+  sourcemeta::jsontoolkit::ReferenceMap references;
+  sourcemeta::jsontoolkit::frame(document, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver)
+      .wait();
+
+  EXPECT_EQ(frame.size(), 9);
+
+  EXPECT_FRAME_STATIC_2020_12_RESOURCE(frame,
+                                       "https://www.sourcemeta.com/schema",
+                                       "https://www.sourcemeta.com/schema", "",
+                                       "https://www.sourcemeta.com/schema", "");
+
+  // JSON Pointers
+
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$id",
+      "https://www.sourcemeta.com/schema", "/$id",
+      "https://www.sourcemeta.com/schema", "/$id");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/middle",
+      "https://www.sourcemeta.com/schema", "/definitions/middle",
+      "https://www.sourcemeta.com/schema", "/definitions/middle");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/middle/$ref",
+      "https://www.sourcemeta.com/schema", "/definitions/middle/$ref",
+      "https://www.sourcemeta.com/schema", "/definitions/middle/$ref");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string");
+  EXPECT_FRAME_STATIC_2020_12_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type");
+
+  // References
+
+  EXPECT_EQ(references.size(), 3);
+
+  EXPECT_STATIC_REFERENCE(
+      references, "/$schema", "https://json-schema.org/draft/2020-12/schema",
+      "https://json-schema.org/draft/2020-12/schema", std::nullopt);
+  EXPECT_STATIC_REFERENCE(
+      references, "/$ref",
+      "https://www.sourcemeta.com/schema#/definitions/middle",
+      "https://www.sourcemeta.com/schema", "/definitions/middle");
+  EXPECT_STATIC_REFERENCE(
+      references, "/definitions/middle/$ref",
+      "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string");
+}


### PR DESCRIPTION
JSON Schema actually defines it for backwards compatibility reasons.

Kudos to @michaelmior for catching this.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
