### PR TITLE
Extract JSON string logical size method as `static`

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -218,6 +218,18 @@ public:
   /// objects.
   static auto make_object() -> JSON;
 
+  /// This function calculates the logical size of a string according to the
+  /// JSON specification. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/jsontoolkit/json.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::jsontoolkit::JSON::String value{"foo"};
+  /// assert(sourcemeta::jsontoolkit::JSON::size(value) == 3);
+  /// ```
+  static auto size(const String &value) noexcept -> std::size_t;
+
   /*
    * Operators
    */

--- a/test/json/json_parse_test.cc
+++ b/test/json/json_parse_test.cc
@@ -99,6 +99,7 @@ TEST(JSON_parse, string_empty) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 0);
+  EXPECT_EQ(sourcemeta::jsontoolkit::JSON::size(document.to_string()), 0);
   EXPECT_EQ(document.to_string(), "");
 }
 
@@ -108,6 +109,7 @@ TEST(JSON_parse, string_with_null) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 9);
+  EXPECT_EQ(sourcemeta::jsontoolkit::JSON::size(document.to_string()), 9);
 
   // See https://stackoverflow.com/a/164274
   using namespace std::string_literals;
@@ -120,6 +122,7 @@ TEST(JSON_parse, string_foo) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 3);
+  EXPECT_EQ(sourcemeta::jsontoolkit::JSON::size(document.to_string()), 3);
   EXPECT_EQ(document.to_string(), "foo");
 }
 
@@ -129,6 +132,7 @@ TEST(JSON_parse, string_foo_with_spacing) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 3);
+  EXPECT_EQ(sourcemeta::jsontoolkit::JSON::size(document.to_string()), 3);
   EXPECT_EQ(document.to_string(), "foo");
 }
 
@@ -138,6 +142,7 @@ TEST(JSON_parse, string_foo_padded) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 9);
+  EXPECT_EQ(sourcemeta::jsontoolkit::JSON::size(document.to_string()), 9);
   EXPECT_EQ(document.to_string(), "   foo   ");
 }
 
@@ -147,6 +152,7 @@ TEST(JSON_parse, string_escape_quote) {
       sourcemeta::jsontoolkit::parse(input);
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.size(), 7);
+  EXPECT_EQ(sourcemeta::jsontoolkit::JSON::size(document.to_string()), 7);
   EXPECT_EQ(document.to_string(), "foo\"bar");
 }
 


### PR DESCRIPTION
There are cases in which we want to check the logical size of a string
according to the JSON grammar without turning the string into a JSON
document (for performance reasons).

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
