### PR TITLE
Always unroll `properties` under `oneOf`

### DIFF
--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -2925,7 +2925,14 @@ TEST(JSONSchema_evaluator_draft4, oneOf_5) {
           "version": { "enum": [ 1 ] },
           "one": { "items": { "type": "integer" } },
           "two": { "items": { "type": "boolean" } },
-          "three": { "items": { "type": "object" } }
+          "three": { "items": { "type": "object" } },
+          "four": { "items": { "type": "integer" } },
+          "five": { "items": { "type": "boolean" } },
+          "six": { "items": { "type": "object" } },
+          "seven": { "items": { "type": "object" } },
+          "eight": { "items": { "type": "object" } },
+          "nine": { "items": { "type": "object" } },
+          "then": { "items": { "type": "object" } }
         }
       },
       {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
