### PR TITLE
Don't collapse `properties` with only `type` on exhaustive mode

### DIFF
--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -516,7 +516,8 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
       // Optimize `properties` where its subschemas just include a type check,
       // as that's a very common pattern
 
-    } else if (substeps.size() == 1 &&
+    } else if (context.mode == SchemaCompilerMode::FastValidation &&
+               substeps.size() == 1 &&
                std::holds_alternative<SchemaCompilerAssertionTypeStrict>(
                    substeps.front())) {
       const auto &type_step{
@@ -528,7 +529,8 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
           type_step.keyword_location, type_step.schema_resource,
           type_step.dynamic, type_step.report, type_step.exhaustive,
           type_step.value});
-    } else if (substeps.size() == 1 &&
+    } else if (context.mode == SchemaCompilerMode::FastValidation &&
+               substeps.size() == 1 &&
                std::holds_alternative<SchemaCompilerAssertionType>(
                    substeps.front())) {
       const auto &type_step{
@@ -540,14 +542,16 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
           type_step.keyword_location, type_step.schema_resource,
           type_step.dynamic, type_step.report, type_step.exhaustive,
           type_step.value});
-    } else if (substeps.size() == 1 &&
+    } else if (context.mode == SchemaCompilerMode::FastValidation &&
+               substeps.size() == 1 &&
                std::holds_alternative<
                    SchemaCompilerAssertionPropertyTypeStrict>(
                    substeps.front())) {
       children.push_back(unroll<SchemaCompilerAssertionPropertyTypeStrict>(
           relative_dynamic_context, substeps.front(),
           dynamic_context.base_instance_location));
-    } else if (substeps.size() == 1 &&
+    } else if (context.mode == SchemaCompilerMode::FastValidation &&
+               substeps.size() == 1 &&
                std::holds_alternative<SchemaCompilerAssertionPropertyType>(
                    substeps.front())) {
       children.push_back(unroll<SchemaCompilerAssertionPropertyType>(
@@ -562,7 +566,8 @@ auto compiler_draft4_applicator_properties_conditional_annotation(
   }
 
   // Optimize away the wrapper when emitting a single instruction
-  if (children.size() == 1 &&
+  if (context.mode == SchemaCompilerMode::FastValidation &&
+      children.size() == 1 &&
       std::holds_alternative<SchemaCompilerAssertionPropertyTypeStrict>(
           children.front())) {
     return {unroll<SchemaCompilerAssertionPropertyTypeStrict>(

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -908,6 +908,42 @@ TEST(JSONSchema_evaluator_draft4, properties_2) {
                                "against the defined properties subschemas");
 }
 
+TEST(JSONSchema_evaluator_draft4, properties_2_exhaustive) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "foo": { "type": "string" },
+      "bar": { "type": "integer" }
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"bar\": 2, \"foo\": \"xxx\" }")};
+
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS(schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, AssertionTypeStrict, "/properties/bar/type",
+                     "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict, "/properties/foo/type",
+                     "#/properties/foo/type", "/foo");
+
+  EVALUATE_TRACE_POST_SUCCESS(0, AssertionTypeStrict, "/properties/bar/type",
+                              "#/properties/bar/type", "/bar");
+  EVALUATE_TRACE_POST_SUCCESS(1, AssertionTypeStrict, "/properties/foo/type",
+                              "#/properties/foo/type", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type integer");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The object value was expected to validate "
+                               "against the defined properties subschemas");
+}
+
 TEST(JSONSchema_evaluator_draft4, properties_3) {
   const sourcemeta::jsontoolkit::JSON schema{
       sourcemeta::jsontoolkit::parse(R"JSON({
@@ -959,6 +995,50 @@ TEST(JSONSchema_evaluator_draft4, properties_4) {
 
   EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
                                "The value was expected to be of type string");
+}
+
+TEST(JSONSchema_evaluator_draft4, properties_4_exhaustive) {
+  const sourcemeta::jsontoolkit::JSON schema{
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "foo": {
+        "properties": {
+          "bar": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  })JSON")};
+
+  const sourcemeta::jsontoolkit::JSON instance{
+      sourcemeta::jsontoolkit::parse("{ \"foo\": { \"bar\": \"baz\" } }")};
+
+  EVALUATE_WITH_TRACE_EXHAUSTIVE_SUCCESS(schema, instance, 3);
+
+  EVALUATE_TRACE_PRE(0, LogicalAnd, "/properties", "#/properties", "");
+  EVALUATE_TRACE_PRE(1, LogicalAnd, "/properties/foo/properties",
+                     "#/properties/foo/properties", "/foo");
+  EVALUATE_TRACE_PRE(2, AssertionTypeStrict,
+                     "/properties/foo/properties/bar/type",
+                     "#/properties/foo/properties/bar/type", "/foo/bar");
+
+  EVALUATE_TRACE_POST_SUCCESS(
+      0, AssertionTypeStrict, "/properties/foo/properties/bar/type",
+      "#/properties/foo/properties/bar/type", "/foo/bar");
+  EVALUATE_TRACE_POST_SUCCESS(1, LogicalAnd, "/properties/foo/properties",
+                              "#/properties/foo/properties", "/foo");
+  EVALUATE_TRACE_POST_SUCCESS(2, LogicalAnd, "/properties", "#/properties", "");
+
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 0,
+                               "The value was expected to be of type string");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 1,
+                               "The object value was expected to validate "
+                               "against the single defined property subschema");
+  EVALUATE_TRACE_POST_DESCRIBE(instance, 2,
+                               "The object value was expected to validate "
+                               "against the single defined property subschema");
 }
 
 TEST(JSONSchema_evaluator_draft4, properties_5) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
