### PR TITLE
Don't rely on `exhaustive` flag for `LogicalOr`

### DIFF
--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -496,9 +496,8 @@ auto evaluate_step(
       for (const auto &child : logical.children) {
         if (evaluate_step(child, callback, context)) {
           result = true;
-          // This boolean value controls whether we should still evaluate
-          // every disjunction even on fast mode
-          if (!logical.exhaustive && !logical.value) {
+          // This boolean value controls whether we should be exhaustive
+          if (!logical.value) {
             break;
           }
         }

--- a/src/jsonschema/default_compiler.cc
+++ b/src/jsonschema/default_compiler.cc
@@ -87,8 +87,6 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
   COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator",
           "additionalProperties",
           compiler_2019_09_applicator_additionalproperties);
-  COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator", "anyOf",
-          compiler_2019_09_applicator_anyof);
   COMPILE("https://json-schema.org/draft/2020-12/vocab/unevaluated",
           "unevaluatedProperties",
           compiler_2019_09_applicator_unevaluatedproperties);
@@ -129,6 +127,8 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
 
   COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator", "allOf",
           compiler_draft4_applicator_allof);
+  COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator", "anyOf",
+          compiler_draft4_applicator_anyof);
   COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator", "oneOf",
           compiler_draft4_applicator_oneof);
   COMPILE("https://json-schema.org/draft/2020-12/vocab/applicator", "not",
@@ -182,8 +182,6 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
           compiler_2019_09_applicator_items);
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator",
           "additionalItems", compiler_2019_09_applicator_additionalitems);
-  COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "anyOf",
-          compiler_2019_09_applicator_anyof);
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator",
           "properties", compiler_2019_09_applicator_properties);
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator",
@@ -225,6 +223,8 @@ auto sourcemeta::jsontoolkit::default_schema_compiler(
 
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "allOf",
           compiler_draft4_applicator_allof);
+  COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "anyOf",
+          compiler_draft4_applicator_anyof);
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "oneOf",
           compiler_draft4_applicator_oneof);
   COMPILE("https://json-schema.org/draft/2019-09/vocab/applicator", "not",

--- a/src/jsonschema/default_compiler_2019_09.h
+++ b/src/jsonschema/default_compiler_2019_09.h
@@ -315,20 +315,6 @@ auto compiler_2019_09_core_recursiveref(
       true, context, schema_context, dynamic_context, "")};
 }
 
-auto compiler_2019_09_applicator_anyof(
-    const SchemaCompilerContext &context,
-    const SchemaCompilerSchemaContext &schema_context,
-    const SchemaCompilerDynamicContext &dynamic_context)
-    -> SchemaCompilerTemplate {
-  return compiler_draft4_applicator_anyof_conditional_exhaustive(
-      context, schema_context, dynamic_context,
-      // TODO: This set to true means that every disjunction of `anyOf`
-      // is always evaluated. In fact, we only need to enable this if
-      // the schema makes any use of `unevaluatedItems` or
-      // `unevaluatedProperties`
-      true);
-}
-
 auto compiler_2019_09_applicator_properties(
     const SchemaCompilerContext &context,
     const SchemaCompilerSchemaContext &schema_context,

--- a/src/jsonschema/default_compiler_draft4.h
+++ b/src/jsonschema/default_compiler_draft4.h
@@ -312,10 +312,10 @@ auto compiler_draft4_applicator_allof(
       std::move(children))};
 }
 
-auto compiler_draft4_applicator_anyof_conditional_exhaustive(
+auto compiler_draft4_applicator_anyof(
     const SchemaCompilerContext &context,
     const SchemaCompilerSchemaContext &schema_context,
-    const SchemaCompilerDynamicContext &dynamic_context, const bool exhaustive)
+    const SchemaCompilerDynamicContext &dynamic_context)
     -> SchemaCompilerTemplate {
   assert(schema_context.schema.at(dynamic_context.keyword).is_array());
   assert(!schema_context.schema.at(dynamic_context.keyword).empty());
@@ -331,18 +331,13 @@ auto compiler_draft4_applicator_anyof_conditional_exhaustive(
                 {static_cast<Pointer::Token::Index>(index)})));
   }
 
+  const auto requires_exhaustive{
+      context.mode == SchemaCompilerMode::Exhaustive ||
+      context.uses_unevaluated_properties || context.uses_unevaluated_items};
+
   return {make<SchemaCompilerLogicalOr>(
       true, context, schema_context, dynamic_context,
-      SchemaCompilerValueBoolean{exhaustive}, std::move(disjunctors))};
-}
-
-auto compiler_draft4_applicator_anyof(
-    const SchemaCompilerContext &context,
-    const SchemaCompilerSchemaContext &schema_context,
-    const SchemaCompilerDynamicContext &dynamic_context)
-    -> SchemaCompilerTemplate {
-  return compiler_draft4_applicator_anyof_conditional_exhaustive(
-      context, schema_context, dynamic_context, false);
+      SchemaCompilerValueBoolean{requires_exhaustive}, std::move(disjunctors))};
 }
 
 auto compiler_draft4_applicator_oneof(


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
