### PR TITLE
Don't consider exhausive evaluation on `LogicalNot`

### DIFF
--- a/src/evaluator/evaluator.cc
+++ b/src/evaluator/evaluator.cc
@@ -644,9 +644,7 @@ auto evaluate_step(
       for (const auto &child : logical.children) {
         if (!evaluate_step(child, callback, context)) {
           result = true;
-          if (!logical.exhaustive) {
-            break;
-          }
+          break;
         }
       }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
