### PR TITLE
Get rid of `std::future` everywhere

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,5 +1,5 @@
 vendorpull https://github.com/sourcemeta/vendorpull 70342aaf458e6cb80baeb5b718901075fc42ede6
-noa https://github.com/sourcemeta/noa 5e78f6b6ebd9e2061f0f2022d665d08a539dcac1
+noa https://github.com/sourcemeta/noa 7d850d8aecdcf8abdba70325f511faf2d73fba9a
 jsontestsuite https://github.com/nst/JSONTestSuite d64aefb55228d9584d3e5b2433f720ea8fd00c82
 googletest https://github.com/google/googletest a7f443b80b105f940225332ed3c31f2790092f47
 jsonschema-2020-12 https://github.com/json-schema-org/json-schema-spec 769daad75a9553562333a8937a187741cb708c72

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -37,16 +37,6 @@ foreach(component ${JSONTOOLKIT_COMPONENTS})
     include("${CMAKE_CURRENT_LIST_DIR}/sourcemeta_jsontoolkit_json.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/sourcemeta_jsontoolkit_jsonpointer.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/sourcemeta_jsontoolkit_evaluator.cmake")
-
-    # GCC does not allow the use of std::promise, std::future
-    # without compiling with pthreads support.
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-      set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-      include(CMakeFindDependencyMacro)
-      find_dependency(Threads)
-    endif()
-
     include("${CMAKE_CURRENT_LIST_DIR}/sourcemeta_jsontoolkit_jsonschema.cmake")
   elseif(component STREQUAL "evaluator")
     include("${CMAKE_CURRENT_LIST_DIR}/sourcemeta_jsontoolkit_uri.cmake")

--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -32,12 +32,3 @@ target_link_libraries(sourcemeta_jsontoolkit_jsonschema PRIVATE
   sourcemeta::jsontoolkit::uri)
 target_link_libraries(sourcemeta_jsontoolkit_jsonschema PUBLIC
   sourcemeta::jsontoolkit::evaluator)
-
-# GCC does not allow the use of std::promise, std::future
-# without compiling with pthreads support.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
-  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  find_package(Threads REQUIRED)
-  target_link_libraries(sourcemeta_jsontoolkit_jsonschema PUBLIC Threads::Threads)
-endif()

--- a/src/jsonschema/anchor.cc
+++ b/src/jsonschema/anchor.cc
@@ -8,13 +8,10 @@ namespace sourcemeta::jsontoolkit {
 
 auto anchors(const JSON &schema, const SchemaResolver &resolver,
              const std::optional<std::string> &default_dialect)
-    -> std::future<std::map<std::string, AnchorType>> {
+    -> std::map<std::string, AnchorType> {
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(schema, resolver, default_dialect)
-          .get()};
-  std::promise<std::map<std::string, AnchorType>> promise;
-  promise.set_value(anchors(schema, vocabularies));
-  return promise.get_future();
+      sourcemeta::jsontoolkit::vocabularies(schema, resolver, default_dialect)};
+  return anchors(schema, vocabularies);
 }
 
 auto anchors(const JSON &schema,

--- a/src/jsonschema/bundle.cc
+++ b/src/jsonschema/bundle.cc
@@ -47,7 +47,7 @@ auto is_official_metaschema_reference(
   return !pointer.empty() && pointer.back().is_property() &&
          pointer.back().to_property() == "$schema" &&
          sourcemeta::jsontoolkit::official_resolver(destination)
-             .get()
+
              .has_value();
 }
 
@@ -60,8 +60,7 @@ auto bundle_schema(sourcemeta::jsontoolkit::JSON &root,
                    const std::optional<std::string> &default_dialect) -> void {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(subschema, frame, references, walker, resolver,
-                                 default_dialect)
-      .wait();
+                                 default_dialect);
 
   for (const auto &[key, reference] : references) {
     if (frame.contains({sourcemeta::jsontoolkit::ReferenceType::Static,
@@ -86,7 +85,7 @@ auto bundle_schema(sourcemeta::jsontoolkit::JSON &root,
 
     assert(reference.base.has_value());
     const auto identifier{reference.base.value()};
-    const auto remote{resolver(identifier).get()};
+    const auto remote{resolver(identifier)};
     if (!remote.has_value()) {
       if (frame.contains(
               {sourcemeta::jsontoolkit::ReferenceType::Static, identifier}) ||
@@ -138,8 +137,7 @@ auto remove_identifiers(sourcemeta::jsontoolkit::JSON &schema,
   sourcemeta::jsontoolkit::ReferenceFrame frame;
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(schema, frame, references, walker, resolver,
-                                 default_dialect)
-      .wait();
+                                 default_dialect);
 
   // (2) Remove all identifiers and anchors
   for (const auto &entry : sourcemeta::jsontoolkit::SchemaIterator{
@@ -199,8 +197,7 @@ auto bundle(sourcemeta::jsontoolkit::JSON &schema, const SchemaWalker &walker,
             const SchemaResolver &resolver, const BundleOptions options,
             const std::optional<std::string> &default_dialect) -> void {
   const auto vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(schema, resolver, default_dialect)
-          .get()};
+      sourcemeta::jsontoolkit::vocabularies(schema, resolver, default_dialect)};
   sourcemeta::jsontoolkit::ReferenceFrame frame;
   bundle_schema(schema, definitions_keyword(vocabularies), schema, frame,
                 walker, resolver, default_dialect);

--- a/src/jsonschema/compile.cc
+++ b/src/jsonschema/compile.cc
@@ -78,15 +78,13 @@ auto compile(const JSON &schema, const SchemaWalker &walker,
   ReferenceFrame frame;
   ReferenceMap references;
   sourcemeta::jsontoolkit::frame(result, frame, references, walker, resolver,
-                                 default_dialect)
-      .wait();
+                                 default_dialect);
 
   const std::string base{
       URI{sourcemeta::jsontoolkit::identify(
               schema, resolver,
               sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
               default_dialect)
-              .get()
               .value_or("")}
           .canonicalize()
           .recompose()};
@@ -107,7 +105,7 @@ auto compile(const JSON &schema, const SchemaWalker &walker,
   sourcemeta::jsontoolkit::SchemaCompilerSchemaContext schema_context{
       empty_pointer,
       result,
-      vocabularies(schema, resolver, root_frame_entry.dialect).get(),
+      vocabularies(schema, resolver, root_frame_entry.dialect),
       root_frame_entry.base,
       {},
       {}};
@@ -187,7 +185,7 @@ auto compile(const JSON &schema, const SchemaWalker &walker,
       // schema resource that we are precompiling
       auto subschema{get(result, entry.second.pointer)};
       auto nested_vocabularies{
-          vocabularies(subschema, resolver, entry.second.dialect).get()};
+          vocabularies(subschema, resolver, entry.second.dialect)};
       const sourcemeta::jsontoolkit::SchemaCompilerSchemaContext
           nested_schema_context{entry.second.relative_pointer,
                                 std::move(subschema),
@@ -256,8 +254,7 @@ auto compile(const SchemaCompilerContext &context,
   return compile_subschema(
       context,
       {entry.relative_pointer, new_schema,
-       vocabularies(new_schema, context.resolver, entry.dialect).get(),
-       entry.base,
+       vocabularies(new_schema, context.resolver, entry.dialect), entry.base,
        // TODO: This represents a copy
        schema_context.labels, schema_context.references},
       {dynamic_context.keyword, destination_pointer,

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -12,7 +12,6 @@
 #include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
 #include <sourcemeta/jsontoolkit/jsonschema_walker.h>
 
-#include <future>   // std::future
 #include <map>      // std::map
 #include <optional> // std::optional
 #include <string>   // std::string
@@ -71,7 +70,7 @@ enum class IdentificationStrategy : std::uint8_t {
 /// })JSON");
 ///
 /// std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
-///   document, sourcemeta::jsontoolkit::official_resolver).get()};
+///   document, sourcemeta::jsontoolkit::official_resolver)};
 /// assert(id.has_value());
 /// assert(id.value() == "https://sourcemeta.com/example-schema");
 /// ```
@@ -85,7 +84,7 @@ auto identify(
     const IdentificationStrategy strategy = IdentificationStrategy::Strict,
     const std::optional<std::string> &default_dialect = std::nullopt,
     const std::optional<std::string> &default_id = std::nullopt)
-    -> std::future<std::optional<std::string>>;
+    -> std::optional<std::string>;
 
 /// @ingroup jsonschema
 ///
@@ -118,7 +117,7 @@ auto identify(const JSON &schema, const std::string &base_dialect,
 ///   "https://json-schema.org/draft/2020-12/schema");
 ///
 /// std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
-///   document, sourcemeta::jsontoolkit::official_resolver).get()};
+///   document, sourcemeta::jsontoolkit::official_resolver)};
 /// assert(!id.has_value());
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
@@ -145,7 +144,7 @@ auto anonymize(JSON &schema, const std::string &base_dialect) -> void;
 ///   sourcemeta::jsontoolkit::official_resolver);
 ///
 /// std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
-///   document, sourcemeta::jsontoolkit::official_resolver).get()};
+///   document, sourcemeta::jsontoolkit::official_resolver)};
 /// assert(id.has_value());
 /// assert(id.value() == "https://example.com/my-new-id");
 /// ```
@@ -239,7 +238,7 @@ auto metaschema(
 ///
 /// const std::optional<std::string> base_dialect{
 ///   sourcemeta::jsontoolkit::base_dialect(
-///     document, sourcemeta::jsontoolkit::official_resolver).get()};
+///     document, sourcemeta::jsontoolkit::official_resolver)};
 ///
 /// assert(base_dialect.has_value());
 /// assert(base_dialect.value() ==
@@ -248,7 +247,7 @@ auto metaschema(
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto base_dialect(const JSON &schema, const SchemaResolver &resolver,
                   const std::optional<std::string> &default_dialect =
-                      std::nullopt) -> std::future<std::optional<std::string>>;
+                      std::nullopt) -> std::optional<std::string>;
 
 /// @ingroup jsonschema
 ///
@@ -272,7 +271,7 @@ auto base_dialect(const JSON &schema, const SchemaResolver &resolver,
 ///
 /// const std::map<std::string, bool> vocabularies{
 ///   sourcemeta::jsontoolkit::vocabularies(
-///     document, sourcemeta::jsontoolkit::official_resolver).get()};
+///     document, sourcemeta::jsontoolkit::official_resolver)};
 ///
 /// assert(vocabularies.at("https://json-schema.org/draft/2020-12/vocab/core"));
 /// assert(vocabularies.at("https://json-schema.org/draft/2020-12/vocab/applicator"));
@@ -285,7 +284,7 @@ auto base_dialect(const JSON &schema, const SchemaResolver &resolver,
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto vocabularies(const JSON &schema, const SchemaResolver &resolver,
                   const std::optional<std::string> &default_dialect =
-                      std::nullopt) -> std::future<std::map<std::string, bool>>;
+                      std::nullopt) -> std::map<std::string, bool>;
 
 /// @ingroup jsonschema
 ///
@@ -294,7 +293,7 @@ auto vocabularies(const JSON &schema, const SchemaResolver &resolver,
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto vocabularies(const SchemaResolver &resolver,
                   const std::string &base_dialect, const std::string &dialect)
-    -> std::future<std::map<std::string, bool>>;
+    -> std::map<std::string, bool>;
 
 /// @ingroup jsonschema
 ///

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_anchor.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_anchor.h
@@ -7,7 +7,6 @@
 #include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
 
 #include <cstdint>  // std::uint8_t
-#include <future>   // std::promise, std::future
 #include <map>      // std::map
 #include <optional> // std::optional
 #include <string>   // std::string
@@ -38,7 +37,7 @@ enum class AnchorType : std::uint8_t { Static, Dynamic, All };
 /// })JSON");
 ///
 /// const auto anchors{sourcemeta::jsontoolkit::anchors(
-///   document, sourcemeta::jsontoolkit::official_resolver).get()};
+///   document, sourcemeta::jsontoolkit::official_resolver)};
 /// assert(anchors.size() == 1);
 /// assert(anchors.contains("foo"));
 /// // This is a static anchor
@@ -47,7 +46,7 @@ enum class AnchorType : std::uint8_t { Static, Dynamic, All };
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto anchors(const JSON &schema, const SchemaResolver &resolver,
              const std::optional<std::string> &default_dialect = std::nullopt)
-    -> std::future<std::map<std::string, AnchorType>>;
+    -> std::map<std::string, AnchorType>;
 
 /// @ingroup jsonschema
 ///

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_bundle.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_bundle.h
@@ -8,7 +8,6 @@
 #include <sourcemeta/jsontoolkit/jsonschema_walker.h>
 
 #include <cstdint>  // std::uint8_t
-#include <future>   // std::future
 #include <optional> // std::optional, std::nullopt
 #include <string>   // std::string
 
@@ -43,20 +42,16 @@ enum class BundleOptions : std::uint8_t {
 ///
 /// // A custom resolver that knows about an additional schema
 /// static auto test_resolver(std::string_view identifier)
-///     -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-///   std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+///     -> std::optional<sourcemeta::jsontoolkit::JSON> {
 ///   if (identifier == "https://www.example.com/test") {
-///     promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+///     return sourcemeta::jsontoolkit::parse(R"JSON({
 ///       "$id": "https://www.example.com/test",
 ///       "$schema": "https://json-schema.org/draft/2020-12/schema",
 ///       "type": "string"
-///     })JSON"));
+///     })JSON");
 ///   } else {
-///     promise.set_value(
-///         sourcemeta::jsontoolkit::official_resolver(identifier).get());
+///     return sourcemeta::jsontoolkit::official_resolver(identifier);
 ///   }
-///
-///   return promise.get_future();
 /// }
 ///
 /// sourcemeta::jsontoolkit::JSON document =
@@ -104,20 +99,16 @@ auto bundle(sourcemeta::jsontoolkit::JSON &schema, const SchemaWalker &walker,
 ///
 /// // A custom resolver that knows about an additional schema
 /// static auto test_resolver(std::string_view identifier)
-///     -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-///   std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+///     -> std::optional<sourcemeta::jsontoolkit::JSON> {
 ///   if (identifier == "https://www.example.com/test") {
-///     promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+///     return sourcemeta::jsontoolkit::parse(R"JSON({
 ///       "$id": "https://www.example.com/test",
 ///       "$schema": "https://json-schema.org/draft/2020-12/schema",
 ///       "type": "string"
-///     })JSON"));
+///     })JSON");
 ///   } else {
-///     promise.set_value(
-///         sourcemeta::jsontoolkit::official_resolver(identifier).get());
+///     return sourcemeta::jsontoolkit::official_resolver(identifier);
 ///   }
-///
-///   return promise.get_future();
 /// }
 ///
 /// const sourcemeta::jsontoolkit::JSON document =

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_reference.h
@@ -8,7 +8,6 @@
 #include <sourcemeta/jsontoolkit/jsonschema_walker.h>
 
 #include <cstdint>  // std::uint8_t
-#include <future>   // std::future
 #include <map>      // std::map
 #include <optional> // std::optional
 #include <string>   // std::string
@@ -102,11 +101,9 @@ using ReferenceMap =
 ///
 /// sourcemeta::jsontoolkit::ReferenceFrame frame;
 /// sourcemeta::jsontoolkit::ReferenceMap references;
-/// sourcemeta::jsontoolkit::frame(document, frame,
-/// references,
+/// sourcemeta::jsontoolkit::frame(document, frame, references,
 ///                                sourcemeta::jsontoolkit::default_schema_walker,
-///                                sourcemeta::jsontoolkit::official_resolver)
-///     .wait();
+///                                sourcemeta::jsontoolkit::official_resolver);
 ///
 /// // IDs
 /// assert(frame.contains({sourcemeta::jsontoolkit::ReferenceType::Static,
@@ -159,8 +156,7 @@ SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto frame(const JSON &schema, ReferenceFrame &frame, ReferenceMap &references,
            const SchemaWalker &walker, const SchemaResolver &resolver,
            const std::optional<std::string> &default_dialect = std::nullopt,
-           const std::optional<std::string> &default_id = std::nullopt)
-    -> std::future<void>;
+           const std::optional<std::string> &default_id = std::nullopt) -> void;
 
 } // namespace sourcemeta::jsontoolkit
 

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_resolver.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_resolver.h
@@ -6,7 +6,6 @@
 #include <sourcemeta/jsontoolkit/json.h>
 
 #include <functional>  // std::function
-#include <future>      // std::future
 #include <map>         // std::map
 #include <optional>    // std::optional
 #include <string_view> // std::string_view
@@ -28,14 +27,13 @@ namespace sourcemeta::jsontoolkit {
 /// requests, or anything your application might require. Unless your resolver
 /// is trivial, it is recommended to create a callable object that implements
 /// the function interface.
-using SchemaResolver =
-    std::function<std::future<std::optional<JSON>>(std::string_view)>;
+using SchemaResolver = std::function<std::optional<JSON>(std::string_view)>;
 
 /// @ingroup jsonschema
 /// A default resolver that relies on built-in official schemas.
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto official_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>>;
+    -> std::optional<sourcemeta::jsontoolkit::JSON>;
 
 /// @ingroup jsonschema
 /// This is a convenient helper for constructing schema resolvers at runtime.
@@ -60,7 +58,7 @@ auto official_resolver(std::string_view identifier)
 /// // (2) Register a schema
 /// resolver.add(schema);
 ///
-/// assert(resolver("https://www.example.com").get().has_value());
+/// assert(resolver("https://www.example.com").has_value());
 /// ```
 class SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT MapSchemaResolver {
 public:
@@ -78,8 +76,7 @@ public:
            const std::optional<std::string> &default_id = std::nullopt) -> void;
 
   /// Attempt to resolve a schema
-  auto operator()(std::string_view identifier) const
-      -> std::future<std::optional<JSON>>;
+  auto operator()(std::string_view identifier) const -> std::optional<JSON>;
 
 private:
 // Exporting symbols that depends on the standard C++ library is considered

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
@@ -262,7 +262,7 @@ private:
 ///
 /// const auto vocabularies{
 ///   sourcemeta::jsontoolkit::vocabularies(
-///     document, sourcemeta::jsontoolkit::official_resolver).get()};
+///     document, sourcemeta::jsontoolkit::official_resolver)};
 ///
 /// assert(sourcemeta::jsontoolkit::keyword_priority(
 ///   "prefixItems", vocabularies,

--- a/src/jsonschema/official_resolver.in.cc
+++ b/src/jsonschema/official_resolver.in.cc
@@ -1,229 +1,218 @@
 #include <sourcemeta/jsontoolkit/jsonschema_resolver.h>
 
 auto sourcemeta::jsontoolkit::official_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   // JSON Schema 2020-12
   if (identifier == "https://json-schema.org/draft/2020-12/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_2020_12@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_2020_12@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/applicator") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_APPLICATOR@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_APPLICATOR@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/content") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_CONTENT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_CONTENT@)EOF");
   } else if (identifier == "https://json-schema.org/draft/2020-12/meta/core") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_CORE@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_CORE@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/format-annotation") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_FORMAT_ANNOTATION@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_FORMAT_ANNOTATION@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/format-assertion") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_FORMAT_ASSERTION@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_FORMAT_ASSERTION@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_HYPER_SCHEMA@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_HYPER_SCHEMA@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/meta-data") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_META_DATA@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_META_DATA@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/unevaluated") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_UNEVALUATED@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_UNEVALUATED@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/meta/validation") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_VALIDATION@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_VALIDATION@)EOF");
   } else if (identifier == "https://json-schema.org/draft/2020-12/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_2020_12@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_LINKS_2020_12@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2020-12/output/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_OUTPUT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2020_12_OUTPUT@)EOF");
 
     // JSON Schema 2019-09
   } else if (identifier == "https://json-schema.org/draft/2019-09/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_2019_09@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_2019_09@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/meta/applicator") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_APPLICATOR@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_APPLICATOR@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/meta/content") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_CONTENT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_CONTENT@)EOF");
   } else if (identifier == "https://json-schema.org/draft/2019-09/meta/core") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_CORE@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_CORE@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/meta/format") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_FORMAT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_FORMAT@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/meta/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_HYPER_SCHEMA@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_HYPER_SCHEMA@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/meta/meta-data") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_META_DATA@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_META_DATA@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/meta/validation") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_VALIDATION@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_VALIDATION@)EOF");
   } else if (identifier == "https://json-schema.org/draft/2019-09/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_2019_09@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_LINKS_2019_09@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/output/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_OUTPUT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_2019_09_OUTPUT@)EOF");
   } else if (identifier ==
              "https://json-schema.org/draft/2019-09/output/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_2019_09_OUTPUT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_2019_09_OUTPUT@)EOF");
 
     // JSON Schema Draft7
   } else if (identifier == "http://json-schema.org/draft-07/schema#" ||
              identifier == "http://json-schema.org/draft-07/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT7@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT7@)EOF");
   } else if (identifier == "http://json-schema.org/draft-07/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-07/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT7@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT7@)EOF");
   } else if (identifier == "http://json-schema.org/draft-07/links#" ||
              identifier == "http://json-schema.org/draft-07/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT7@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT7@)EOF");
   } else if (identifier ==
              "http://json-schema.org/draft-07/hyper-schema-output") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT7_OUTPUT@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT7_OUTPUT@)EOF");
 
     // JSON Schema Draft6
   } else if (identifier == "http://json-schema.org/draft-06/schema#" ||
              identifier == "http://json-schema.org/draft-06/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT6@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT6@)EOF");
   } else if (identifier == "http://json-schema.org/draft-06/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-06/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT6@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT6@)EOF");
   } else if (identifier == "http://json-schema.org/draft-06/links#" ||
              identifier == "http://json-schema.org/draft-06/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT6@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT6@)EOF");
 
     // JSON Schema Draft4
   } else if (identifier == "http://json-schema.org/draft-04/schema#" ||
              identifier == "http://json-schema.org/draft-04/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT4@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT4@)EOF");
   } else if (identifier == "http://json-schema.org/draft-04/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-04/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT4@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT4@)EOF");
   } else if (identifier == "http://json-schema.org/draft-04/links#" ||
              identifier == "http://json-schema.org/draft-04/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT4@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT4@)EOF");
 
     // JSON Schema Draft3
   } else if (identifier == "http://json-schema.org/draft-03/schema#" ||
              identifier == "http://json-schema.org/draft-03/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT3@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT3@)EOF");
   } else if (identifier == "http://json-schema.org/draft-03/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-03/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT3@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT3@)EOF");
   } else if (identifier == "http://json-schema.org/draft-03/links#" ||
              identifier == "http://json-schema.org/draft-03/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT3@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT3@)EOF");
   } else if (identifier == "http://json-schema.org/draft-03/json-ref#" ||
              identifier == "http://json-schema.org/draft-03/json-ref") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSON_REF_DRAFT3@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSON_REF_DRAFT3@)EOF");
 
     // JSON Schema Draft2
   } else if (identifier == "http://json-schema.org/draft-02/schema#" ||
              identifier == "http://json-schema.org/draft-02/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT2@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT2@)EOF");
   } else if (identifier == "http://json-schema.org/draft-02/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-02/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT2@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT2@)EOF");
   } else if (identifier == "http://json-schema.org/draft-02/links#" ||
              identifier == "http://json-schema.org/draft-02/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT2@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT2@)EOF");
   } else if (identifier == "http://json-schema.org/draft-02/json-ref#" ||
              identifier == "http://json-schema.org/draft-02/json-ref") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSON_REF_DRAFT2@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSON_REF_DRAFT2@)EOF");
 
     // JSON Schema Draft1
   } else if (identifier == "http://json-schema.org/draft-01/schema#" ||
              identifier == "http://json-schema.org/draft-01/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT1@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT1@)EOF");
   } else if (identifier == "http://json-schema.org/draft-01/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-01/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT1@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT1@)EOF");
   } else if (identifier == "http://json-schema.org/draft-01/links#" ||
              identifier == "http://json-schema.org/draft-01/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT1@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT1@)EOF");
   } else if (identifier == "http://json-schema.org/draft-01/json-ref#" ||
              identifier == "http://json-schema.org/draft-01/json-ref") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSON_REF_DRAFT1@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSON_REF_DRAFT1@)EOF");
 
     // JSON Schema Draft0
   } else if (identifier == "http://json-schema.org/draft-00/schema#" ||
              identifier == "http://json-schema.org/draft-00/schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT0@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSONSCHEMA_DRAFT0@)EOF");
   } else if (identifier == "http://json-schema.org/draft-00/hyper-schema#" ||
              identifier == "http://json-schema.org/draft-00/hyper-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT0@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_HYPERSCHEMA_DRAFT0@)EOF");
   } else if (identifier == "http://json-schema.org/draft-00/links#" ||
              identifier == "http://json-schema.org/draft-00/links") {
-    promise.set_value(
-        sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT0@)EOF"));
+    return sourcemeta::jsontoolkit::parse(R"EOF(@METASCHEMA_LINKS_DRAFT0@)EOF");
   } else if (identifier == "http://json-schema.org/draft-00/json-ref#" ||
              identifier == "http://json-schema.org/draft-00/json-ref") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(
-        R"EOF(@METASCHEMA_JSON_REF_DRAFT0@)EOF"));
+    return sourcemeta::jsontoolkit::parse(
+        R"EOF(@METASCHEMA_JSON_REF_DRAFT0@)EOF");
 
     // Otherwise
   } else {
-    promise.set_value(std::nullopt);
+    return std::nullopt;
   }
-
-  return promise.get_future();
 }

--- a/src/jsonschema/reference.cc
+++ b/src/jsonschema/reference.cc
@@ -130,7 +130,7 @@ auto sourcemeta::jsontoolkit::frame(
     const sourcemeta::jsontoolkit::SchemaWalker &walker,
     const sourcemeta::jsontoolkit::SchemaResolver &resolver,
     const std::optional<std::string> &default_dialect,
-    const std::optional<std::string> &default_id) -> std::future<void> {
+    const std::optional<std::string> &default_id) -> void {
   std::vector<InternalEntry> subschema_entries;
   std::map<sourcemeta::jsontoolkit::Pointer, std::vector<std::string>>
       base_uris;
@@ -138,8 +138,7 @@ auto sourcemeta::jsontoolkit::frame(
       base_dialects;
 
   const std::optional<std::string> root_base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(schema, resolver, default_dialect)
-          .get()};
+      sourcemeta::jsontoolkit::base_dialect(schema, resolver, default_dialect)};
   assert(root_base_dialect.has_value());
 
   const std::optional<std::string> root_id{sourcemeta::jsontoolkit::identify(
@@ -463,6 +462,4 @@ auto sourcemeta::jsontoolkit::frame(
       }
     }
   }
-
-  return std::promise<void>{}.get_future();
 }

--- a/src/jsonschema/resolver.cc
+++ b/src/jsonschema/resolver.cc
@@ -22,8 +22,7 @@ auto MapSchemaResolver::add(const JSON &schema,
   ReferenceFrame entries;
   ReferenceMap references;
   frame(schema, entries, references, default_schema_walker, *this,
-        default_dialect, default_id)
-      .wait();
+        default_dialect, default_id);
 
   for (const auto &[key, entry] : entries) {
     if (entry.type != ReferenceEntryType::Resource) {
@@ -33,11 +32,10 @@ auto MapSchemaResolver::add(const JSON &schema,
     auto subschema{get(schema, entry.pointer)};
     // TODO: Set the base dialect in the frame entries
     const auto subschema_base_dialect{
-        base_dialect(subschema, *this, entry.dialect).get()};
+        base_dialect(subschema, *this, entry.dialect)};
     assert(subschema_base_dialect.has_value());
     const auto subschema_vocabularies{
-        vocabularies(*this, subschema_base_dialect.value(), entry.dialect)
-            .get()};
+        vocabularies(*this, subschema_base_dialect.value(), entry.dialect)};
 
     // Given we might be resolving embedded resources, we fully
     // resolve their dialect and identifiers, otherwise the
@@ -69,21 +67,17 @@ auto MapSchemaResolver::add(const JSON &schema,
 }
 
 auto MapSchemaResolver::operator()(std::string_view identifier) const
-    -> std::future<std::optional<JSON>> {
+    -> std::optional<JSON> {
   const std::string string_identifier{identifier};
   if (this->schemas.contains(string_identifier)) {
-    std::promise<std::optional<JSON>> promise;
-    promise.set_value(this->schemas.at(string_identifier));
-    return promise.get_future();
+    return this->schemas.at(string_identifier);
   }
 
   if (this->default_resolver) {
     return this->default_resolver(identifier);
   }
 
-  std::promise<std::optional<JSON>> promise;
-  promise.set_value(std::nullopt);
-  return promise.get_future();
+  return std::nullopt;
 }
 
 } // namespace sourcemeta::jsontoolkit

--- a/src/jsonschema/walker.cc
+++ b/src/jsonschema/walker.cc
@@ -44,13 +44,11 @@ auto walk(sourcemeta::jsontoolkit::Pointer &pointer,
   const std::string &new_dialect{current_dialect.value()};
 
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(subschema, resolver, new_dialect)
-          .get()};
+      sourcemeta::jsontoolkit::base_dialect(subschema, resolver, new_dialect)};
   assert(base_dialect.has_value());
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(resolver, base_dialect.value(),
-                                            new_dialect)
-          .get()};
+                                            new_dialect)};
 
   if (type == SchemaWalkerType_t::Deep || level > 0) {
     subschemas.push_back(
@@ -193,13 +191,12 @@ sourcemeta::jsontoolkit::SchemaKeywordIterator::SchemaKeywordIterator(
   const std::optional<std::string> dialect{
       sourcemeta::jsontoolkit::dialect(schema, default_dialect)};
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(schema, resolver, dialect).get()};
+      sourcemeta::jsontoolkit::base_dialect(schema, resolver, dialect)};
 
   std::map<std::string, bool> vocabularies;
   if (base_dialect.has_value() && dialect.has_value()) {
     vocabularies.merge(sourcemeta::jsontoolkit::vocabularies(
-                           resolver, base_dialect.value(), dialect.value())
-                           .get());
+        resolver, base_dialect.value(), dialect.value()));
   }
 
   for (const auto &[key, value] : schema.as_object()) {

--- a/test/evaluator/evaluator_draft4_test.cc
+++ b/test/evaluator/evaluator_draft4_test.cc
@@ -8,8 +8,7 @@
 
 TEST(JSONSchema_evaluator_draft4, metaschema) {
   const auto metaschema{sourcemeta::jsontoolkit::official_resolver(
-                            "http://json-schema.org/draft-04/schema#")
-                            .get()};
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(metaschema.has_value());
 
   const sourcemeta::jsontoolkit::JSON instance{
@@ -820,14 +819,13 @@ TEST(JSONSchema_evaluator_draft4, ref_12) {
     "$ref": "https://example.com#/i-dont-exist"
   })JSON")};
 
-  auto test_resolver = [](const std::string_view identifier) {
+  auto test_resolver = [](const std::string_view identifier)
+      -> std::optional<sourcemeta::jsontoolkit::JSON> {
     if (identifier == "https://example.com") {
-      std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-      promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      return sourcemeta::jsontoolkit::parse(R"JSON({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "id": "https://example.com"
-              })JSON"));
-      return promise.get_future();
+              })JSON");
     }
 
     return sourcemeta::jsontoolkit::official_resolver(identifier);
@@ -847,14 +845,13 @@ TEST(JSONSchema_evaluator_draft4, ref_13) {
     "$ref": "https://example.com#i-dont-exist"
   })JSON")};
 
-  auto test_resolver = [](const std::string_view identifier) {
+  auto test_resolver = [](const std::string_view identifier)
+      -> std::optional<sourcemeta::jsontoolkit::JSON> {
     if (identifier == "https://example.com") {
-      std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-      promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+      return sourcemeta::jsontoolkit::parse(R"JSON({
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "id": "https://example.com"
-              })JSON"));
-      return promise.get_future();
+              })JSON");
     }
 
     return sourcemeta::jsontoolkit::official_resolver(identifier);

--- a/test/evaluator/evaluator_draft6_test.cc
+++ b/test/evaluator/evaluator_draft6_test.cc
@@ -8,8 +8,7 @@
 
 TEST(JSONSchema_evaluator_draft6, metaschema) {
   const auto metaschema{sourcemeta::jsontoolkit::official_resolver(
-                            "http://json-schema.org/draft-06/schema#")
-                            .get()};
+      "http://json-schema.org/draft-06/schema#")};
   EXPECT_TRUE(metaschema.has_value());
 
   const sourcemeta::jsontoolkit::JSON instance{

--- a/test/evaluator/evaluator_draft7_test.cc
+++ b/test/evaluator/evaluator_draft7_test.cc
@@ -8,8 +8,7 @@
 
 TEST(JSONSchema_evaluator_draft7, metaschema) {
   const auto metaschema{sourcemeta::jsontoolkit::official_resolver(
-                            "http://json-schema.org/draft-07/schema#")
-                            .get()};
+      "http://json-schema.org/draft-07/schema#")};
   EXPECT_TRUE(metaschema.has_value());
 
   const sourcemeta::jsontoolkit::JSON instance{

--- a/test/evaluator/evaluator_test.cc
+++ b/test/evaluator/evaluator_test.cc
@@ -7,23 +7,19 @@
 #include "evaluator_utils.h"
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://example.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/metaschema",
       "$vocabulary": {
         "https://json-schema.org/draft/2020-12/vocab/core": true,
         "https://example.com/vocab/custom": true
       }
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_evaluator, unknown_vocabulary_required) {

--- a/test/evaluator/officialsuite.cc
+++ b/test/evaluator/officialsuite.cc
@@ -18,16 +18,13 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   const std::filesystem::path remotes_path{
       std::filesystem::path{OFFICIAL_SUITE_PATH} / "remotes"};
 
 #define READ_SCHEMA_FILE(uri, relative_path)                                   \
   if (identifier == (uri)) {                                                   \
-    std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;        \
-    promise.set_value(                                                         \
-        sourcemeta::jsontoolkit::from_file(remotes_path / (relative_path)));   \
-    return promise.get_future();                                               \
+    return sourcemeta::jsontoolkit::from_file(remotes_path / (relative_path)); \
   }
 
   // We keep an explicit list instead of dynamically reading into the directory

--- a/test/jsonschema/jsonschema_anchor_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2019_09_test.cc
@@ -6,9 +6,8 @@ TEST(JSONSchema_anchor_2019_09, boolean_schema) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("true");
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "https://json-schema.org/draft/2019-09/schema")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "https://json-schema.org/draft/2019-09/schema")};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -19,8 +18,7 @@ TEST(JSONSchema_anchor_2019_09, top_level_no_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -32,8 +30,7 @@ TEST(JSONSchema_anchor_2019_09, top_level_static_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -47,8 +44,7 @@ TEST(JSONSchema_anchor_2019_09, top_level_dynamic_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -60,8 +56,7 @@ TEST(JSONSchema_anchor_2019_09, top_level_recursive_anchor_false) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
 
   EXPECT_TRUE(anchors.empty());
 }
@@ -74,8 +69,7 @@ TEST(JSONSchema_anchor_2019_09, top_level_recursive_anchor_true) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
 
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains(""));
@@ -91,8 +85,7 @@ TEST(JSONSchema_anchor_2019_09, top_level_recursive_anchor_true_and_empty) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
 
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains(""));
@@ -106,9 +99,8 @@ TEST(JSONSchema_anchor_2019_09, nested_static_with_default_dialect) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "https://json-schema.org/draft/2019-09/schema")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "https://json-schema.org/draft/2019-09/schema")};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -123,8 +115,7 @@ TEST(JSONSchema_anchor_2019_09, vocabularies_shortcut) {
 
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
   EXPECT_EQ(anchors.size(), 1);
@@ -140,7 +131,6 @@ TEST(JSONSchema_anchor_2019_09, old_id_anchor_not_recognized) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }

--- a/test/jsonschema/jsonschema_anchor_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_anchor_2020_12_test.cc
@@ -6,9 +6,8 @@ TEST(JSONSchema_anchor_2020_12, boolean_schema) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("true");
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "https://json-schema.org/draft/2020-12/schema")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -19,8 +18,7 @@ TEST(JSONSchema_anchor_2020_12, top_level_no_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -32,8 +30,7 @@ TEST(JSONSchema_anchor_2020_12, top_level_static_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -47,8 +44,7 @@ TEST(JSONSchema_anchor_2020_12, top_level_dynamic_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Dynamic);
@@ -63,8 +59,7 @@ TEST(JSONSchema_anchor_2020_12, top_level_static_and_dynamic_anchor_different) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 2);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_TRUE(anchors.contains("bar"));
@@ -81,8 +76,7 @@ TEST(JSONSchema_anchor_2020_12, top_level_static_and_dynamic_anchor_same) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::All);
@@ -95,9 +89,8 @@ TEST(JSONSchema_anchor_2020_12, nested_static_with_default_dialect) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "https://json-schema.org/draft/2020-12/schema")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -113,8 +106,7 @@ TEST(JSONSchema_anchor_2020_12, vocabularies_shortcut) {
 
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
   EXPECT_EQ(anchors.size(), 2);
@@ -132,7 +124,6 @@ TEST(JSONSchema_anchor_2020_12, old_id_anchor_not_recognized) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }

--- a/test/jsonschema/jsonschema_anchor_draft4_test.cc
+++ b/test/jsonschema/jsonschema_anchor_draft4_test.cc
@@ -7,9 +7,8 @@ TEST(JSONSchema_anchor_draft4, boolean_schema) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("true");
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "http://json-schema.org/draft-04/schema#")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -20,8 +19,7 @@ TEST(JSONSchema_anchor_draft4, top_level_no_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -33,8 +31,7 @@ TEST(JSONSchema_anchor_draft4, top_level_static_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -47,9 +44,8 @@ TEST(JSONSchema_anchor_draft4, nested_static_with_default_dialect) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "http://json-schema.org/draft-04/schema#")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -64,8 +60,7 @@ TEST(JSONSchema_anchor_draft4, vocabularies_shortcut) {
 
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
   EXPECT_EQ(anchors.size(), 1);
@@ -81,8 +76,7 @@ TEST(JSONSchema_anchor_draft4, non_fragment_relative_id) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -94,7 +88,6 @@ TEST(JSONSchema_anchor_draft4, not_only_fragment) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }

--- a/test/jsonschema/jsonschema_anchor_draft6_test.cc
+++ b/test/jsonschema/jsonschema_anchor_draft6_test.cc
@@ -7,9 +7,8 @@ TEST(JSONSchema_anchor_draft6, boolean_schema) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("true");
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "http://json-schema.org/draft-06/schema#")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "http://json-schema.org/draft-06/schema#")};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -20,8 +19,7 @@ TEST(JSONSchema_anchor_draft6, top_level_no_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -33,8 +31,7 @@ TEST(JSONSchema_anchor_draft6, top_level_static_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -47,9 +44,8 @@ TEST(JSONSchema_anchor_draft6, nested_static_with_default_dialect) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "http://json-schema.org/draft-06/schema#")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "http://json-schema.org/draft-06/schema#")};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -64,8 +60,7 @@ TEST(JSONSchema_anchor_draft6, vocabularies_shortcut) {
 
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
   EXPECT_EQ(anchors.size(), 1);
@@ -81,8 +76,7 @@ TEST(JSONSchema_anchor_draft6, non_fragment_relative_id) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -94,7 +88,6 @@ TEST(JSONSchema_anchor_draft6, not_only_fragment) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }

--- a/test/jsonschema/jsonschema_anchor_draft7_test.cc
+++ b/test/jsonschema/jsonschema_anchor_draft7_test.cc
@@ -7,9 +7,8 @@ TEST(JSONSchema_anchor_draft7, boolean_schema) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("true");
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "http://json-schema.org/draft-07/schema#")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "http://json-schema.org/draft-07/schema#")};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -20,8 +19,7 @@ TEST(JSONSchema_anchor_draft7, top_level_no_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -33,8 +31,7 @@ TEST(JSONSchema_anchor_draft7, top_level_static_anchor) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -47,9 +44,8 @@ TEST(JSONSchema_anchor_draft7, nested_static_with_default_dialect) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver,
-                         "http://json-schema.org/draft-07/schema#")
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver,
+      "http://json-schema.org/draft-07/schema#")};
   EXPECT_EQ(anchors.size(), 1);
   EXPECT_TRUE(anchors.contains("foo"));
   EXPECT_EQ(anchors.at("foo"), sourcemeta::jsontoolkit::AnchorType::Static);
@@ -64,8 +60,7 @@ TEST(JSONSchema_anchor_draft7, vocabularies_shortcut) {
 
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(document, vocabularies)};
   EXPECT_EQ(anchors.size(), 1);
@@ -81,8 +76,7 @@ TEST(JSONSchema_anchor_draft7, non_fragment_relative_id) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }
 
@@ -94,7 +88,6 @@ TEST(JSONSchema_anchor_draft7, not_only_fragment) {
   })JSON");
 
   const auto anchors{sourcemeta::jsontoolkit::anchors(
-                         document, sourcemeta::jsontoolkit::official_resolver)
-                         .get()};
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(anchors.empty());
 }

--- a/test/jsonschema/jsonschema_base_dialect_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_2019_09_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/hyper-schema");
@@ -39,8 +37,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -53,8 +50,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_output) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -67,8 +63,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_output_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -81,8 +76,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_applicator) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -95,8 +89,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_content) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -109,8 +102,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_core) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -123,8 +115,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_format) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -137,8 +128,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/hyper-schema");
@@ -151,8 +141,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_meta_data) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");
@@ -165,8 +154,7 @@ TEST(JSONSchema_base_dialect_2019_09, jsonschema_meta_validation) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2019-09/schema");

--- a/test/jsonschema/jsonschema_base_dialect_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_2020_12_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/hyper-schema");
@@ -39,8 +37,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -53,8 +50,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_output) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -67,8 +63,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_applicator) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -81,8 +76,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_content) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -95,8 +89,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_core) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -109,8 +102,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_format_annotation) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -123,8 +115,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_format_assertion) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -137,8 +128,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/hyper-schema");
@@ -151,8 +141,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_meta_data) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -165,8 +154,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_unevaluated) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");
@@ -179,8 +167,7 @@ TEST(JSONSchema_base_dialect_2020_12, jsonschema_meta_validation) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "https://json-schema.org/draft/2020-12/schema");

--- a/test/jsonschema/jsonschema_base_dialect_draft0_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft0_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_draft0, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-00/hyper-schema#");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_draft0, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-00/hyper-schema#");
@@ -39,8 +37,7 @@ TEST(JSONSchema_base_dialect_draft0, jsonschema_draft_jsonref) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-00/hyper-schema#");
@@ -53,8 +50,7 @@ TEST(JSONSchema_base_dialect_draft0, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-00/hyper-schema#");

--- a/test/jsonschema/jsonschema_base_dialect_draft1_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft1_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_draft1, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-01/hyper-schema#");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_draft1, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-01/hyper-schema#");
@@ -39,8 +37,7 @@ TEST(JSONSchema_base_dialect_draft1, jsonschema_draft_jsonref) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-01/hyper-schema#");
@@ -53,8 +50,7 @@ TEST(JSONSchema_base_dialect_draft1, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-01/hyper-schema#");

--- a/test/jsonschema/jsonschema_base_dialect_draft2_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft2_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_draft2, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-02/hyper-schema#");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_draft2, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-02/hyper-schema#");
@@ -39,8 +37,7 @@ TEST(JSONSchema_base_dialect_draft2, jsonschema_draft_jsonref) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-02/hyper-schema#");
@@ -53,8 +50,7 @@ TEST(JSONSchema_base_dialect_draft2, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-02/hyper-schema#");

--- a/test/jsonschema/jsonschema_base_dialect_draft3_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft3_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_draft3, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-03/hyper-schema#");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_draft3, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-03/schema#");
 }
@@ -38,8 +36,7 @@ TEST(JSONSchema_base_dialect_draft3, jsonschema_draft_jsonref) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-03/hyper-schema#");
@@ -52,8 +49,7 @@ TEST(JSONSchema_base_dialect_draft3, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-03/hyper-schema#");

--- a/test/jsonschema/jsonschema_base_dialect_draft4_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft4_test.cc
@@ -3,24 +3,20 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema_1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema_1",
       "$schema": "http://json-schema.org/draft-04/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/metaschema_2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema_2",
       "$schema": "https://sourcemeta.com/metaschema_1"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(std::nullopt);
+    return std::nullopt;
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_base_dialect_draft4, jsonschema_draft_hyperschema) {
@@ -31,8 +27,7 @@ TEST(JSONSchema_base_dialect_draft4, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-04/hyper-schema#");
@@ -46,8 +41,7 @@ TEST(JSONSchema_base_dialect_draft4, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-04/schema#");
 }
@@ -59,8 +53,7 @@ TEST(JSONSchema_base_dialect_draft4, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-04/hyper-schema#");
@@ -72,7 +65,7 @@ TEST(JSONSchema_base_dialect_draft4, jsonschema_base_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema_1"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-04/schema#");
 }
@@ -83,7 +76,7 @@ TEST(JSONSchema_base_dialect_draft4, jsonschema_base_two_hops) {
     "$schema": "https://sourcemeta.com/metaschema_2"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-04/schema#");
 }

--- a/test/jsonschema/jsonschema_base_dialect_draft6_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft6_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_draft6, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-06/hyper-schema#");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_draft6, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-06/schema#");
 }
@@ -38,8 +36,7 @@ TEST(JSONSchema_base_dialect_draft6, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-06/hyper-schema#");

--- a/test/jsonschema/jsonschema_base_dialect_draft7_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_draft7_test.cc
@@ -10,8 +10,7 @@ TEST(JSONSchema_base_dialect_draft7, jsonschema_draft_hyperschema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-07/hyper-schema#");
@@ -25,8 +24,7 @@ TEST(JSONSchema_base_dialect_draft7, jsonschema_draft_schema) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-07/schema#");
 }
@@ -38,8 +36,7 @@ TEST(JSONSchema_base_dialect_draft7, jsonschema_draft_links) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(),
             "http://json-schema.org/draft-07/hyper-schema#");
@@ -52,8 +49,7 @@ TEST(JSONSchema_base_dialect_draft7, jsonschema_draft_hyperschema_output) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+          document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "http://json-schema.org/draft-07/schema#");
 }

--- a/test/jsonschema/jsonschema_base_dialect_test.cc
+++ b/test/jsonschema/jsonschema_base_dialect_test.cc
@@ -2,49 +2,44 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema_1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema_1",
       "$schema": "https://sourcemeta.com/metaschema_1"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/metaschema_2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema_2",
       "$schema": "https://sourcemeta.com/metaschema_1"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/no-schema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/no-schema"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/metaschema_3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema_3",
       "$schema": "https://sourcemeta.com/no-schema"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/metaschema_4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema_4",
       "$schema": "https://sourcemeta.com/metaschema_4"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(std::nullopt);
+    return std::nullopt;
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_base_dialect, boolean_schema_true) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("true");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_FALSE(base_dialect.has_value());
 }
 
@@ -52,7 +47,7 @@ TEST(JSONSchema_base_dialect, boolean_schema_false) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("false");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_FALSE(base_dialect.has_value());
 }
 
@@ -61,8 +56,7 @@ TEST(JSONSchema_base_dialect, boolean_schema_default_dialect_one_hop) {
       sourcemeta::jsontoolkit::parse("true");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_1")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_1")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -72,8 +66,7 @@ TEST(JSONSchema_base_dialect, boolean_schema_default_dialect_two_hops) {
       sourcemeta::jsontoolkit::parse("true");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_2")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_2")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -85,7 +78,7 @@ TEST(JSONSchema_base_dialect, self_descriptive_schema) {
     "$schema": "https://example.com/my-schema"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://example.com/my-schema");
 }
@@ -125,7 +118,7 @@ TEST(JSONSchema_base_dialect, id_with_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema_1"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -137,7 +130,7 @@ TEST(JSONSchema_base_dialect, id_with_two_hops) {
     "$schema": "https://sourcemeta.com/metaschema_2"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -148,7 +141,7 @@ TEST(JSONSchema_base_dialect, no_id_with_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema_1"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -159,7 +152,7 @@ TEST(JSONSchema_base_dialect, no_id_with_two_hops) {
     "$schema": "https://sourcemeta.com/metaschema_2"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -171,7 +164,7 @@ TEST(JSONSchema_base_dialect, self_descriptive_metaschema_without_schema) {
     "$schema": "https://sourcemeta.com/no-schema"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/no-schema");
 }
@@ -182,7 +175,7 @@ TEST(JSONSchema_base_dialect, metaschema_without_schema_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema_3"
   })JSON");
   const std::optional<std::string> base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::base_dialect(document, test_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/no-schema");
 }
@@ -194,8 +187,7 @@ TEST(JSONSchema_base_dialect, id_self_descriptive_default_dialect) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(document, test_resolver,
-                                            "https://sourcemeta.com/foo-bar")
-          .get()};
+                                            "https://sourcemeta.com/foo-bar")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/foo-bar");
 }
@@ -207,8 +199,7 @@ TEST(JSONSchema_base_dialect, id_default_dialect_one_hop) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_1")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_1")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -220,8 +211,7 @@ TEST(JSONSchema_base_dialect, id_default_dialect_two_hops) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_2")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_2")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -231,8 +221,7 @@ TEST(JSONSchema_base_dialect, default_dialect_one_hop) {
       sourcemeta::jsontoolkit::parse("{}");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_1")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_1")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -242,8 +231,7 @@ TEST(JSONSchema_base_dialect, default_dialect_two_hops) {
       sourcemeta::jsontoolkit::parse("{}");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_2")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_2")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_1");
 }
@@ -255,8 +243,7 @@ TEST(JSONSchema_base_dialect, default_dialect_precedence) {
   })JSON");
   const std::optional<std::string> base_dialect{
       sourcemeta::jsontoolkit::base_dialect(
-          document, test_resolver, "https://sourcemeta.com/metaschema_1")
-          .get()};
+          document, test_resolver, "https://sourcemeta.com/metaschema_1")};
   EXPECT_TRUE(base_dialect.has_value());
   EXPECT_EQ(base_dialect.value(), "https://sourcemeta.com/metaschema_4");
 }

--- a/test/jsonschema/jsonschema_bundle_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_bundle_2019_09_test.cc
@@ -3,21 +3,19 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://example.com/foo/bar") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://example.com/foo/bar",
       "$anchor": "baz"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/baz-anchor") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://example.com/baz-anchor",
       "$defs": {
@@ -26,70 +24,67 @@ static auto test_resolver(std::string_view identifier)
           "type": "string"
         }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/test-2",
       "$ref": "test-3"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/test-3",
       "$ref": "test-1"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/test-4",
       "type": "boolean"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/recursive") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/recursive",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://www.sourcemeta.com/recursive-empty-fragment") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/recursive-empty-fragment#",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/anonymous") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "type": "integer"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/1.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://example.com/meta/2.json",
       "$id": "https://example.com/meta/1.json",
       "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/2.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://example.com/meta/2.json",
       "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_2019_09, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_bundle_2020_12_test.cc
@@ -3,21 +3,19 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://example.com/foo/bar") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/foo/bar",
       "$anchor": "baz"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/baz-anchor") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/baz-anchor",
       "$defs": {
@@ -26,80 +24,77 @@ static auto test_resolver(std::string_view identifier)
           "type": "string"
         }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/test-2",
       "$ref": "test-3"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/test-3",
       "$ref": "test-1"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/test-4",
       "type": "boolean"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/recursive") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/recursive",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://www.sourcemeta.com/recursive-empty-fragment") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/recursive-empty-fragment#",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/anonymous") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "type": "integer"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/nested/ref-string.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$ref": "string.json"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/nested/string.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/1.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://example.com/meta/2.json",
       "$id": "https://example.com/meta/1.json",
       "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/2.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://example.com/meta/2.json",
       "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_2020_12, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft0_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft0_test.cc
@@ -3,25 +3,20 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-00/schema#",
       "id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft0, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft1_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft1_test.cc
@@ -3,25 +3,20 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-01/schema#",
       "id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft1, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft2_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft2_test.cc
@@ -3,25 +3,20 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-02/schema#",
       "id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft2, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft3_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft3_test.cc
@@ -3,25 +3,20 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-03/schema#",
       "id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft3, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft4_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft4_test.cc
@@ -3,80 +3,75 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://example.com/foo/bar") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://example.com/foo/bar",
       "$anchor": "baz"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/test-2",
       "allOf": [ { "$ref": "test-3" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/test-3",
       "allOf": [ { "$ref": "test-1" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/test-4",
       "type": "boolean"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/recursive") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/recursive",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://www.sourcemeta.com/recursive-empty-fragment") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/recursive-empty-fragment#",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/anonymous") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "type": "integer"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/1.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://example.com/meta/2.json",
       "id": "https://example.com/meta/1.json"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/2.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://example.com/meta/2.json"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft4, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft6_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft6_test.cc
@@ -3,80 +3,75 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://example.com/foo/bar") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://example.com/foo/bar",
       "$anchor": "baz"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/test-2",
       "allOf": [ { "$ref": "test-3" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/test-3",
       "allOf": [ { "$ref": "test-1" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/test-4",
       "type": "boolean"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/recursive") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/recursive",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://www.sourcemeta.com/recursive-empty-fragment") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/recursive-empty-fragment#",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/anonymous") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "type": "integer"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/1.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://example.com/meta/2.json",
       "$id": "https://example.com/meta/1.json"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/2.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://example.com/meta/2.json"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft6, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_draft7_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft7_test.cc
@@ -3,80 +3,75 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://example.com/foo/bar") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://example.com/foo/bar",
       "$anchor": "baz"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://www.sourcemeta.com/test-2",
       "allOf": [ { "$ref": "test-3" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://www.sourcemeta.com/test-3",
       "allOf": [ { "$ref": "test-1" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://www.sourcemeta.com/test-4",
       "type": "boolean"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/recursive") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://www.sourcemeta.com/recursive",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://www.sourcemeta.com/recursive-empty-fragment") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://www.sourcemeta.com/recursive-empty-fragment#",
       "properties": {
         "foo": { "$ref": "#" }
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/anonymous") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "type": "integer"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/1.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://example.com/meta/2.json",
       "$id": "https://example.com/meta/1.json"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://example.com/meta/2.json") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$id": "https://example.com/meta/2.json"
-    })JSON"));
+    })JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle_draft7, no_references_no_id) {

--- a/test/jsonschema/jsonschema_bundle_test.cc
+++ b/test/jsonschema/jsonschema_bundle_test.cc
@@ -3,51 +3,46 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future>      // std::promise, std::future
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://www.sourcemeta.com/test-1") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://www.sourcemeta.com/test-1",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-2") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$id": "https://www.sourcemeta.com/test-2",
       "$ref": "test-3"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-3") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$id": "https://www.sourcemeta.com/test-3",
       "allOf": [ { "$ref": "test-4" } ]
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/test-4") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "http://json-schema.org/draft-04/schema#",
       "id": "https://www.sourcemeta.com/test-4",
       "type": "string"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/no-dialect") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "foo": 1
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://www.sourcemeta.com/array") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON([
+    return sourcemeta::jsontoolkit::parse(R"JSON([
       "foo", "bar", "baz"
-    ])JSON"));
+    ])JSON");
   } else {
-    promise.set_value(
-        sourcemeta::jsontoolkit::official_resolver(identifier).get());
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_bundle, across_dialects) {

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -45,8 +45,7 @@ TEST(JSONSchema_frame_2019_09, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -91,8 +90,7 @@ TEST(JSONSchema_frame_2019_09, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_2019_09_RESOURCE(frame,
@@ -135,8 +133,7 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_2019_09_RESOURCE(frame,
@@ -199,8 +196,7 @@ TEST(JSONSchema_frame_2019_09, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 14);
 
@@ -292,8 +288,7 @@ TEST(JSONSchema_frame_2019_09, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_2019_09_RESOURCE(frame,
@@ -374,8 +369,7 @@ TEST(JSONSchema_frame_2019_09, nested_schemas) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 30);
 
@@ -533,8 +527,7 @@ TEST(JSONSchema_frame_2019_09, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -552,8 +545,7 @@ TEST(JSONSchema_frame_2019_09, static_anchor_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -570,8 +562,7 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2019-09/schema",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_2019_09_RESOURCE(frame,
@@ -611,8 +602,7 @@ TEST(JSONSchema_frame_2019_09, anchor_top_level) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -675,8 +665,7 @@ TEST(JSONSchema_frame_2019_09, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2019-09/schema",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 38);
 
@@ -802,8 +791,7 @@ TEST(JSONSchema_frame_2019_09, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 
@@ -847,8 +835,7 @@ TEST(JSONSchema_frame_2019_09, location_independent_identifier_anonymous) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -864,8 +851,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_true_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -919,8 +905,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_false_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 4);
 
@@ -970,8 +955,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_true_without_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -1023,8 +1007,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_false_without_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -1068,8 +1051,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_no_recursive_anchor_anonymous) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 4);
 
@@ -1111,8 +1093,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_no_recursive_anchor) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -1164,8 +1145,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_false_anonymous) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -1211,8 +1191,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_false) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -1268,8 +1247,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_true_anonymous) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -1320,8 +1298,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_true) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 
@@ -1386,8 +1363,7 @@ TEST(JSONSchema_frame_2019_09,
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 10);
 
@@ -1455,8 +1431,7 @@ TEST(JSONSchema_frame_2019_09,
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 11);
 
@@ -1529,8 +1504,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_nested_recursive_anchor_true) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 
@@ -1597,8 +1571,7 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_multiple_recursive_anchor_true) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 14);
 
@@ -1693,8 +1666,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_conflict) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -1711,8 +1683,7 @@ TEST(JSONSchema_frame_2019_09, invalid_recursive_ref) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -1731,8 +1702,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_on_relative_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 10);
 
@@ -1796,8 +1766,7 @@ TEST(JSONSchema_frame_2019_09, ref_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 
@@ -1861,8 +1830,7 @@ TEST(JSONSchema_frame_2019_09, ref_from_definitions) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
 

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -45,8 +45,7 @@ TEST(JSONSchema_frame_2020_12, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -91,8 +90,7 @@ TEST(JSONSchema_frame_2020_12, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_2020_12_RESOURCE(frame,
@@ -135,8 +133,7 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_2020_12_RESOURCE(frame,
@@ -199,8 +196,7 @@ TEST(JSONSchema_frame_2020_12, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 14);
   EXPECT_FRAME_STATIC_2020_12_RESOURCE(
@@ -291,8 +287,7 @@ TEST(JSONSchema_frame_2020_12, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_2020_12_RESOURCE(frame,
@@ -365,8 +360,7 @@ TEST(JSONSchema_frame_2020_12, nested_schemas) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 30);
 
@@ -524,8 +518,7 @@ TEST(JSONSchema_frame_2020_12, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -543,8 +536,7 @@ TEST(JSONSchema_frame_2020_12, static_anchor_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -561,8 +553,7 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_2020_12_RESOURCE(frame,
@@ -602,8 +593,7 @@ TEST(JSONSchema_frame_2020_12, anchor_top_level) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -666,8 +656,7 @@ TEST(JSONSchema_frame_2020_12, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 38);
 
@@ -817,8 +806,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_refs_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 7);
 
@@ -881,8 +869,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_refs_with_no_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 7);
 
@@ -925,8 +912,7 @@ TEST(JSONSchema_frame_2020_12, ref_to_dynamic_anchor) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 2);
 
@@ -955,8 +941,7 @@ TEST(JSONSchema_frame_2020_12, different_dynamic_and_refs_in_same_object) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 3);
 
@@ -993,8 +978,7 @@ TEST(JSONSchema_frame_2020_12, same_dynamic_and_refs_in_same_object) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 3);
 
@@ -1034,8 +1018,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_anchor_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 21);
 
@@ -1159,8 +1142,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_anchor_without_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 
@@ -1216,8 +1198,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_anchor_same_on_schema_resource) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -1236,8 +1217,7 @@ TEST(JSONSchema_frame_2020_12, no_id_recursive_empty_pointer) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 5);
 
@@ -1278,8 +1258,7 @@ TEST(JSONSchema_frame_2020_12, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 
@@ -1323,8 +1302,7 @@ TEST(JSONSchema_frame_2020_12, location_independent_identifier_anonymous) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -1343,8 +1321,7 @@ TEST(JSONSchema_frame_2020_12, ref_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 
@@ -1408,8 +1385,7 @@ TEST(JSONSchema_frame_2020_12, ref_from_definitions) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
 

--- a/test/jsonschema/jsonschema_frame_draft0_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft0_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft0, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft0, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT0_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT0_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft0, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT0_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft0, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT0_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft0, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-00/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT0_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft0, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-00/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft0, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 

--- a/test/jsonschema/jsonschema_frame_draft1_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft1_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft1, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft1, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT1_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT1_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft1, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT1_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft1, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT1_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft1, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-01/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT1_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft1, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-01/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft1, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 

--- a/test/jsonschema/jsonschema_frame_draft2_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft2_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft2, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft2, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT2_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT2_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft2, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT2_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft2, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT2_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft2, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-02/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT2_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft2, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-02/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft2, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft3, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft3, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft3, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft3, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft3, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-03/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft3, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-03/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft3, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 
@@ -503,8 +494,7 @@ TEST(JSONSchema_frame_draft3, ref_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 4);
 

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft4, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft4, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft4, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft4, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft4, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-04/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft4, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-04/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft4, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 
@@ -509,8 +500,7 @@ TEST(JSONSchema_frame_draft4, location_independent_identifier_anonymous) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
 
@@ -571,8 +561,7 @@ TEST(JSONSchema_frame_draft4, ref_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft6, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft6, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft6, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft6, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft6, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-06/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft6, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-06/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft6, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 
@@ -509,8 +500,7 @@ TEST(JSONSchema_frame_draft6, location_independent_identifier_anonymous) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
 
@@ -571,8 +561,7 @@ TEST(JSONSchema_frame_draft6, ref_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame_draft7, anonymous_with_nested_schema_resource) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 6);
 
@@ -77,8 +76,7 @@ TEST(JSONSchema_frame_draft7, empty_schema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(frame,
@@ -121,8 +119,7 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_without_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
   EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(frame,
@@ -182,8 +179,7 @@ TEST(JSONSchema_frame_draft7, one_level_applicators_with_identifiers) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(
@@ -250,8 +246,7 @@ TEST(JSONSchema_frame_draft7, subschema_absolute_identifier) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 9);
   EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(frame,
@@ -316,8 +311,7 @@ TEST(JSONSchema_frame_draft7, id_override) {
   EXPECT_THROW(sourcemeta::jsontoolkit::frame(
                    document, frame, references,
                    sourcemeta::jsontoolkit::default_schema_walker,
-                   sourcemeta::jsontoolkit::official_resolver)
-                   .wait(),
+                   sourcemeta::jsontoolkit::official_resolver),
                sourcemeta::jsontoolkit::SchemaError);
 }
 
@@ -334,8 +328,7 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_same) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-07/schema#",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 3);
   EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(frame,
@@ -384,8 +377,7 @@ TEST(JSONSchema_frame_draft7, explicit_argument_id_different) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "http://json-schema.org/draft-07/schema#",
-                                 "https://www.example.com")
-      .wait();
+                                 "https://www.example.com");
 
   EXPECT_EQ(frame.size(), 22);
 
@@ -466,8 +458,7 @@ TEST(JSONSchema_frame_draft7, ref_metaschema) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 3);
 
@@ -509,8 +500,7 @@ TEST(JSONSchema_frame_draft7, location_independent_identifier_anonymous) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 8);
 
@@ -571,8 +561,7 @@ TEST(JSONSchema_frame_draft7, ref_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 7);
 

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -31,8 +31,7 @@ TEST(JSONSchema_frame, nested_schemas_mixing_dialects) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 21);
 
@@ -173,8 +172,7 @@ TEST(JSONSchema_frame, no_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 14);
 
@@ -251,8 +249,7 @@ TEST(JSONSchema_frame, no_id_with_default) {
                                  sourcemeta::jsontoolkit::default_schema_walker,
                                  sourcemeta::jsontoolkit::official_resolver,
                                  "https://json-schema.org/draft/2020-12/schema",
-                                 "https://www.sourcemeta.com/schema")
-      .wait();
+                                 "https://www.sourcemeta.com/schema");
 
   EXPECT_EQ(frame.size(), 4);
   EXPECT_FRAME_STATIC_RESOURCE(frame, "https://www.sourcemeta.com/schema",
@@ -300,8 +297,7 @@ TEST(JSONSchema_frame, anchor_on_absolute_subid) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(frame.size(), 12);
   EXPECT_FRAME_STATIC_RESOURCE(frame, "https://www.example.com",
@@ -382,8 +378,7 @@ TEST(JSONSchema_frame, uri_iterators) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   std::set<std::string> uris;
   for (const auto &entry : frame) {
@@ -487,8 +482,7 @@ TEST(JSONSchema_frame, no_refs) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 1);
 
@@ -523,8 +517,7 @@ TEST(JSONSchema_frame, refs_with_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 5);
   EXPECT_STATIC_REFERENCE(
@@ -570,8 +563,7 @@ TEST(JSONSchema_frame, refs_with_no_id) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 5);
   EXPECT_STATIC_REFERENCE(
@@ -602,8 +594,7 @@ TEST(JSONSchema_frame, no_dynamic_ref_on_old_drafts) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 1);
 
@@ -627,8 +618,7 @@ TEST(JSONSchema_frame, remote_refs) {
   sourcemeta::jsontoolkit::ReferenceMap references;
   sourcemeta::jsontoolkit::frame(document, frame, references,
                                  sourcemeta::jsontoolkit::default_schema_walker,
-                                 sourcemeta::jsontoolkit::official_resolver)
-      .wait();
+                                 sourcemeta::jsontoolkit::official_resolver);
 
   EXPECT_EQ(references.size(), 4);
   EXPECT_STATIC_REFERENCE(

--- a/test/jsonschema/jsonschema_identify_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_identify_2019_09_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema",
       "$schema": "https://json-schema.org/draft/2019-09/schema"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_2019_09, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_2019_09, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_2019_09, old_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_2019_09, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2019-09/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2019-09/schema")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_2019_09, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2019-09/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2019-09/schema")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_2019_09, valid_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_2019_09, old_id) {
     "id": "https://example.com/my-schema",
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_2019_09, default_dialect_precedence) {
     "$id": "https://example.com/my-schema",
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-04/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_2019_09, anonymize_with_base_dialect) {
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_2019_09, anonymize_with_base_dialect_no_id) {
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_2019_09, sibling_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -240,10 +222,8 @@ TEST(JSONSchema_identify_2019_09, reidentify_replace_base_dialect_shortcut) {
     "$schema": "https://json-schema.org/draft/2019-09/schema"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_identify_2020_12_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema",
       "$schema": "https://json-schema.org/draft/2020-12/schema"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_2020_12, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_2020_12, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_2020_12, old_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_2020_12, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_2020_12, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_2020_12, valid_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_2020_12, old_id) {
     "id": "https://example.com/my-schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_2020_12, default_dialect_precedence) {
     "$id": "https://example.com/my-schema",
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-04/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_2020_12, anonymize_with_base_dialect) {
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_2020_12, anonymize_with_base_dialect_no_id) {
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_2020_12, sibling_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -240,10 +222,8 @@ TEST(JSONSchema_identify_2020_12, reidentify_replace_base_dialect_shortcut) {
     "$schema": "https://json-schema.org/draft/2020-12/schema"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft0_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft0_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-00/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft0, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft0, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft0, new_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft0, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-00/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-00/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft0, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-00/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-00/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft0, valid_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft0, new_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft0, default_dialect_precedence) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft0, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft0, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft0, sibling_unknown_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -240,10 +222,8 @@ TEST(JSONSchema_identify_draft0, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-00/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft1_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft1_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-01/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft1, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft1, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft1, new_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft1, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-01/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-01/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft1, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-01/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-01/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft1, valid_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft1, new_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft1, default_dialect_precedence) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft1, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft1, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft1, sibling_unknown_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -240,10 +222,8 @@ TEST(JSONSchema_identify_draft1, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-01/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft2_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft2_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-02/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft2, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft2, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft2, new_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft2, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-02/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-02/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft2, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-02/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-02/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft2, valid_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft2, new_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft2, default_dialect_precedence) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft2, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft2, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft2, sibling_unknown_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -240,10 +222,8 @@ TEST(JSONSchema_identify_draft2, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-02/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft3_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft3_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-03/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft3, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft3, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft3, new_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft3, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-03/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-03/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft3, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-03/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-03/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft3, valid_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft3, new_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft3, default_dialect_precedence) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft3, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft3, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft3, sibling_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -239,10 +221,8 @@ TEST(JSONSchema_identify_draft3, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-03/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft4_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft4_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-04/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft4, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft4, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft4, new_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft4, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-04/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft4, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-04/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft4, valid_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft4, new_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft4, default_dialect_precedence) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft4, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft4, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft4, sibling_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -239,10 +221,8 @@ TEST(JSONSchema_identify_draft4, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-04/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft6_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft6_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-06/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft6, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft6, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft6, old_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft6, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-06/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-06/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft6, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-06/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-06/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft6, valid_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft6, old_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft6, default_dialect_precedence) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-04/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft6, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft6, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft6, sibling_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -239,10 +221,8 @@ TEST(JSONSchema_identify_draft6, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-06/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_draft7_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft7_test.cc
@@ -3,19 +3,15 @@
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/metaschema",
       "$schema": "http://json-schema.org/draft-07/schema#"
-    })JSON"));
+    })JSON");
   } else {
     return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 TEST(JSONSchema_identify_draft7, valid_one_hop) {
@@ -25,7 +21,7 @@ TEST(JSONSchema_identify_draft7, valid_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -37,30 +33,26 @@ TEST(JSONSchema_identify_draft7, old_one_hop) {
     "$schema": "https://sourcemeta.com/metaschema"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft7, id_boolean_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-07/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-07/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify_draft7, empty_object_default_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-07/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-07/schema#")};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -70,10 +62,8 @@ TEST(JSONSchema_identify_draft7, valid_id) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -84,10 +74,8 @@ TEST(JSONSchema_identify_draft7, old_id) {
     "id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,12 +85,10 @@ TEST(JSONSchema_identify_draft7, default_dialect_precedence) {
     "$id": "https://example.com/my-schema",
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-04/schema#")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -126,10 +112,8 @@ TEST(JSONSchema_identify_draft7, anonymize_with_base_dialect) {
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -147,10 +131,8 @@ TEST(JSONSchema_identify_draft7, anonymize_with_base_dialect_no_id) {
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
   sourcemeta::jsontoolkit::anonymize(document, base_dialect.value());
 
@@ -170,7 +152,7 @@ TEST(JSONSchema_identify_draft7, sibling_ref) {
     "$ref": "#"
   })JSON");
   std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::identify(document, test_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -239,10 +221,8 @@ TEST(JSONSchema_identify_draft7, reidentify_replace_base_dialect_shortcut) {
     "$schema": "http://json-schema.org/draft-07/schema#"
   })JSON");
 
-  const auto base_dialect{
-      sourcemeta::jsontoolkit::base_dialect(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  const auto base_dialect{sourcemeta::jsontoolkit::base_dialect(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_TRUE(base_dialect.has_value());
 
   sourcemeta::jsontoolkit::reidentify(document, "https://example.com/my-new-id",

--- a/test/jsonschema/jsonschema_identify_test.cc
+++ b/test/jsonschema/jsonschema_identify_test.cc
@@ -4,21 +4,17 @@
 
 TEST(JSONSchema_identify, boolean_no_dialect) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, boolean_no_dialect_with_default_id) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict, std::nullopt,
-          "https://www.sourcemeta.com/foo")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict, std::nullopt,
+      "https://www.sourcemeta.com/foo")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://www.sourcemeta.com/foo");
 }
@@ -26,13 +22,11 @@ TEST(JSONSchema_identify, boolean_no_dialect_with_default_id) {
 TEST(JSONSchema_identify, empty_old_no_dollar_sign_id_with_default) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "http://json-schema.org/draft-00/schema#",
-          "https://example.com/my-schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "http://json-schema.org/draft-00/schema#",
+      "https://example.com/my-schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -40,13 +34,11 @@ TEST(JSONSchema_identify, empty_old_no_dollar_sign_id_with_default) {
 TEST(JSONSchema_identify, empty_dollar_sign_id_with_default) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
-          "https://json-schema.org/draft/2020-12/schema",
-          "https://example.com/my-schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Strict,
+      "https://json-schema.org/draft/2020-12/schema",
+      "https://example.com/my-schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -63,10 +55,8 @@ TEST(JSONSchema_identify, boolean_unknown_dialect) {
 TEST(JSONSchema_identify, empty_object_no_dialect) {
   const sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse("{}");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -85,10 +75,8 @@ TEST(JSONSchema_identify, object_with_dollar_id_with_no_dialect) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -97,20 +85,16 @@ TEST(JSONSchema_identify, object_with_id_with_no_dialect) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, loose_boolean) {
   const sourcemeta::jsontoolkit::JSON document{true};
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -119,11 +103,9 @@ TEST(JSONSchema_identify, loose_with_valid_dollar_id) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -133,11 +115,9 @@ TEST(JSONSchema_identify, loose_with_invalid_dollar_id) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$id": false
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -146,11 +126,9 @@ TEST(JSONSchema_identify, loose_with_valid_id) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -160,11 +138,9 @@ TEST(JSONSchema_identify, loose_with_invalid_id) {
       sourcemeta::jsontoolkit::parse(R"JSON({
     "id": false
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -174,11 +150,9 @@ TEST(JSONSchema_identify, loose_with_valid_dollar_id_and_invalid_id) {
     "$id": "https://example.com/my-schema",
     "id": false
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -189,11 +163,9 @@ TEST(JSONSchema_identify, loose_with_valid_id_and_invalid_dollar_id) {
     "id": "https://example.com/my-schema",
     "$id": false
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -204,11 +176,9 @@ TEST(JSONSchema_identify, loose_with_invalid_id_and_invalid_dollar_id) {
     "$id": 1,
     "id": false
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -218,11 +188,9 @@ TEST(JSONSchema_identify, loose_with_matching_id_and_dollar_id) {
     "$id": "https://example.com/my-schema",
     "id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }
@@ -233,11 +201,9 @@ TEST(JSONSchema_identify, loose_with_non_matching_id_and_dollar_id) {
     "$id": "http://example.com/my-schema",
     "id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -247,12 +213,10 @@ TEST(JSONSchema_identify, loose_with_resolvable_default_dialect) {
     "$id": "http://example.com/my-schema",
     "id": "https://example.com/my-schema"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose,
-          "https://json-schema.org/draft/2020-12/schema")
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose,
+      "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "http://example.com/my-schema");
 }
@@ -263,11 +227,9 @@ TEST(JSONSchema_identify, loose_with_unresolvable_dialect) {
     "$id": "https://example.com/my-schema",
     "$schema": "https://www.sourcemeta.com/invalid-dialect"
   })JSON");
-  std::optional<std::string> id{
-      sourcemeta::jsontoolkit::identify(
-          document, sourcemeta::jsontoolkit::official_resolver,
-          sourcemeta::jsontoolkit::IdentificationStrategy::Loose)
-          .get()};
+  std::optional<std::string> id{sourcemeta::jsontoolkit::identify(
+      document, sourcemeta::jsontoolkit::official_resolver,
+      sourcemeta::jsontoolkit::IdentificationStrategy::Loose)};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
 }

--- a/test/jsonschema/jsonschema_map_resolver_test.cc
+++ b/test/jsonschema/jsonschema_map_resolver_test.cc
@@ -4,21 +4,18 @@
 
 TEST(JSONSchema_MapSchemaResolver, empty_no_fallback) {
   sourcemeta::jsontoolkit::MapSchemaResolver resolver;
-  EXPECT_FALSE(resolver("https://json-schema.org/draft/2020-12/schema")
-                   .get()
-                   .has_value());
+  EXPECT_FALSE(
+      resolver("https://json-schema.org/draft/2020-12/schema").has_value());
 }
 
 TEST(JSONSchema_MapSchemaResolver, empty_with_fallback) {
   sourcemeta::jsontoolkit::MapSchemaResolver resolver{
       sourcemeta::jsontoolkit::official_resolver};
-  EXPECT_TRUE(resolver("https://json-schema.org/draft/2020-12/schema")
-                  .get()
-                  .has_value());
-  EXPECT_EQ(resolver("https://json-schema.org/draft/2020-12/schema").get(),
+  EXPECT_TRUE(
+      resolver("https://json-schema.org/draft/2020-12/schema").has_value());
+  EXPECT_EQ(resolver("https://json-schema.org/draft/2020-12/schema"),
             sourcemeta::jsontoolkit::official_resolver(
-                "https://json-schema.org/draft/2020-12/schema")
-                .get());
+                "https://json-schema.org/draft/2020-12/schema"));
 }
 
 TEST(JSONSchema_MapSchemaResolver, single_schema) {
@@ -32,9 +29,8 @@ TEST(JSONSchema_MapSchemaResolver, single_schema) {
 
   resolver.add(document);
 
-  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").get().has_value());
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").get().value(),
-            document);
+  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").has_value());
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").value(), document);
 }
 
 TEST(JSONSchema_MapSchemaResolver, single_schema_with_default_dialect) {
@@ -53,9 +49,8 @@ TEST(JSONSchema_MapSchemaResolver, single_schema_with_default_dialect) {
 
   resolver.add(document, "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").get().has_value());
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").get().value(),
-            expected);
+  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").has_value());
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").value(), expected);
 }
 
 TEST(JSONSchema_MapSchemaResolver, single_schema_anonymous_with_default) {
@@ -74,9 +69,8 @@ TEST(JSONSchema_MapSchemaResolver, single_schema_anonymous_with_default) {
 
   resolver.add(document, std::nullopt, "https://www.sourcemeta.com/test");
 
-  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").get().has_value());
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").get().value(),
-            expected);
+  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").has_value());
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").value(), expected);
 }
 
 TEST(JSONSchema_MapSchemaResolver, single_schema_idempotent) {
@@ -92,9 +86,8 @@ TEST(JSONSchema_MapSchemaResolver, single_schema_idempotent) {
   resolver.add(document);
   resolver.add(document);
 
-  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").get().has_value());
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").get().value(),
-            document);
+  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").has_value());
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").value(), document);
 }
 
 TEST(JSONSchema_MapSchemaResolver, duplicate_ids) {
@@ -141,10 +134,8 @@ TEST(JSONSchema_MapSchemaResolver, embedded_resource) {
     "type": "string"
   })JSON");
 
-  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").get().has_value());
-  EXPECT_TRUE(resolver("https://www.sourcemeta.com/string").get().has_value());
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").get().value(),
-            document);
-  EXPECT_EQ(resolver("https://www.sourcemeta.com/string").get().value(),
-            embedded);
+  EXPECT_TRUE(resolver("https://www.sourcemeta.com/test").has_value());
+  EXPECT_TRUE(resolver("https://www.sourcemeta.com/string").has_value());
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/test").value(), document);
+  EXPECT_EQ(resolver("https://www.sourcemeta.com/string").value(), embedded);
 }

--- a/test/jsonschema/jsonschema_metaschema_test.cc
+++ b/test/jsonschema/jsonschema_metaschema_test.cc
@@ -14,11 +14,9 @@ TEST(JSONSchema_metaschema, example_2020_12) {
   EXPECT_TRUE(metaschema.is_object());
   EXPECT_TRUE(sourcemeta::jsontoolkit::official_resolver(
                   "https://json-schema.org/draft/2020-12/schema")
-                  .get()
                   .has_value());
   EXPECT_EQ(metaschema, sourcemeta::jsontoolkit::official_resolver(
                             "https://json-schema.org/draft/2020-12/schema")
-                            .get()
                             .value());
 }
 
@@ -33,11 +31,10 @@ TEST(JSONSchema_metaschema, with_default_dialect) {
   EXPECT_TRUE(metaschema.is_object());
   EXPECT_TRUE(sourcemeta::jsontoolkit::official_resolver(
                   "https://json-schema.org/draft/2020-12/schema")
-                  .get()
+
                   .has_value());
   EXPECT_EQ(metaschema, sourcemeta::jsontoolkit::official_resolver(
                             "https://json-schema.org/draft/2020-12/schema")
-                            .get()
                             .value());
 }
 

--- a/test/jsonschema/jsonschema_official_resolver_test.cc
+++ b/test/jsonschema/jsonschema_official_resolver_test.cc
@@ -6,14 +6,12 @@
 #define EXPECT_SCHEMA(identifier)                                              \
   {                                                                            \
     const std::optional<sourcemeta::jsontoolkit::JSON> result{                 \
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};         \
+        sourcemeta::jsontoolkit::official_resolver(identifier)};               \
     EXPECT_TRUE(result.has_value());                                           \
     const sourcemeta::jsontoolkit::JSON &document{result.value()};             \
     EXPECT_TRUE(sourcemeta::jsontoolkit::is_schema(document));                 \
-    std::optional<std::string> id{                                             \
-        sourcemeta::jsontoolkit::identify(                                     \
-            document, sourcemeta::jsontoolkit::official_resolver)              \
-            .get()};                                                           \
+    std::optional<std::string> id{sourcemeta::jsontoolkit::identify(           \
+        document, sourcemeta::jsontoolkit::official_resolver)};                \
     EXPECT_TRUE(id.has_value());                                               \
     EXPECT_EQ(                                                                 \
         sourcemeta::jsontoolkit::URI{id.value()}.canonicalize().recompose(),   \
@@ -143,7 +141,6 @@ TEST(JSONSchema_official_resolver, idempotency) {
 
 TEST(JSONSchema_official_resolver, invalid) {
   const std::optional<sourcemeta::jsontoolkit::JSON> result{
-      sourcemeta::jsontoolkit::official_resolver("https://example.com/foobar")
-          .get()};
+      sourcemeta::jsontoolkit::official_resolver("https://example.com/foobar")};
   EXPECT_FALSE(result.has_value());
 }

--- a/test/jsonschema/jsonschema_vocabulary_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_2019_09_test.cc
@@ -2,15 +2,12 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/2019-09-custom-vocabularies") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/2019-09-custom-vocabularies",
       "$schema": "https://json-schema.org/draft/2019-09/schema",
       "$vocabulary": {
@@ -18,29 +15,21 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2019-09/vocab/applicator": true,
         "https://json-schema.org/draft/2019-09/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/2019-09-no-vocabularies") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/2019-09-no-vocabularies",
       "$schema": "https://json-schema.org/draft/2019-09/schema"
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://sourcemeta.com/2019-09-hyper-no-vocabularies") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/2019-09-hyper-no-vocabularies",
       "$schema": "https://json-schema.org/draft/2019-09/hyper-schema"
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -57,7 +46,7 @@ TEST(JSONSchema_vocabulary_2019_09, no_vocabularies) {
     "$schema": "https://sourcemeta.com/2019-09-no-vocabularies"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2019-09/vocab/core");
@@ -69,7 +58,7 @@ TEST(JSONSchema_vocabulary_2019_09, no_vocabularies_hyper) {
     "$schema": "https://sourcemeta.com/2019-09-hyper-no-vocabularies"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2019-09/vocab/core");
@@ -81,7 +70,7 @@ TEST(JSONSchema_vocabulary_2019_09, hyper) {
     "$schema": "https://json-schema.org/draft/2019-09/hyper-schema"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 7);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2019-09/vocab/core");
@@ -105,7 +94,7 @@ TEST(JSONSchema_vocabulary_2019_09, custom_vocabularies) {
     "$schema": "https://sourcemeta.com/2019-09-custom-vocabularies"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 3);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2019-09/vocab/core");

--- a/test/jsonschema/jsonschema_vocabulary_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_2020_12_test.cc
@@ -2,15 +2,12 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/2020-12-custom-vocabularies") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/2020-12-custom-vocabularies",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$vocabulary": {
@@ -18,47 +15,39 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/optional-core") {
     // Optional core
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/optional-core",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$vocabulary": {
         "https://json-schema.org/draft/2020-12/vocab/core": false
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/no-core") {
     // Missing core
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/no-core",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$vocabulary": {
         "https://json-schema.org/draft/2020-12/vocab/validation": true
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/2020-12-no-vocabularies") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/2020-12-no-vocabularies",
       "$schema": "https://json-schema.org/draft/2020-12/schema"
-    })JSON"));
+    })JSON");
   } else if (identifier ==
              "https://sourcemeta.com/2020-12-hyper-no-vocabularies") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/2020-12-hyper-no-vocabularies",
       "$schema": "https://json-schema.org/draft/2020-12/hyper-schema"
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -74,8 +63,7 @@ TEST(JSONSchema_vocabulary_2020_12, core_vocabularies_boolean_with_default) {
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
           document, test_resolver,
-          "https://sourcemeta.com/2020-12-custom-vocabularies")
-          .get()};
+          "https://sourcemeta.com/2020-12-custom-vocabularies")};
   EXPECT_EQ(vocabularies.size(), 3);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2020-12/vocab/core");
@@ -94,8 +82,7 @@ TEST(JSONSchema_vocabulary_2020_12,
   const std::map<std::string, bool> vocabularies{
       sourcemeta::jsontoolkit::vocabularies(
           document, test_resolver,
-          "https://sourcemeta.com/2020-12-custom-vocabularies")
-          .get()};
+          "https://sourcemeta.com/2020-12-custom-vocabularies")};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2020-12/vocab/core");
@@ -127,7 +114,7 @@ TEST(JSONSchema_vocabulary_2020_12, no_vocabularies) {
     "$schema": "https://sourcemeta.com/2020-12-no-vocabularies"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2020-12/vocab/core");
@@ -139,7 +126,7 @@ TEST(JSONSchema_vocabulary_2020_12, no_vocabularies_hyper) {
     "$schema": "https://sourcemeta.com/2020-12-hyper-no-vocabularies"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2020-12/vocab/core");
@@ -151,7 +138,7 @@ TEST(JSONSchema_vocabulary_2020_12, hyper) {
     "$schema": "https://json-schema.org/draft/2020-12/hyper-schema"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 8);
   EXPECT_VOCABULARY_REQUIRED(
       vocabularies, "https://json-schema.org/draft/2020-12/vocab/core");

--- a/test/jsonschema/jsonschema_vocabulary_draft0_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft0_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-00/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-00/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft0, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-00/hyper-schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft0, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-00/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft0, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-00/hyper-schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft0, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-00/hyper-schema#");

--- a/test/jsonschema/jsonschema_vocabulary_draft1_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft1_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-01/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-01/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft1, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-01/hyper-schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft1, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-01/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft1, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-01/hyper-schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft1, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-01/hyper-schema#");

--- a/test/jsonschema/jsonschema_vocabulary_draft2_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft2_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-02/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-02/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft2, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-02/hyper-schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft2, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-02/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft2, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-02/hyper-schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft2, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-02/hyper-schema#");

--- a/test/jsonschema/jsonschema_vocabulary_draft3_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft3_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-03/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-03/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft3, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-03/schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft3, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-03/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft3, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-03/schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft3, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-03/schema#");

--- a/test/jsonschema/jsonschema_vocabulary_draft4_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft4_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-04/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-04/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft4, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-04/schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft4, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-04/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft4, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-04/schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft4, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-04/schema#");

--- a/test/jsonschema/jsonschema_vocabulary_draft6_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft6_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-06/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-06/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft6, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-06/schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft6, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-06/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft6, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-06/schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft6, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-06/schema#");

--- a/test/jsonschema/jsonschema_vocabulary_draft7_test.cc
+++ b/test/jsonschema/jsonschema_vocabulary_draft7_test.cc
@@ -2,20 +2,17 @@
 #include <sourcemeta/jsontoolkit/json.h>
 #include <sourcemeta/jsontoolkit/jsonschema.h>
 
-#include <future> // std::promise, std::future
 #include <string> // std::string
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
-
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/one-hop") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/one-hop",
       "$schema": "http://json-schema.org/draft-07/schema#"
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/with-vocabulary") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$id": "https://sourcemeta.com/with-vocabulary",
       "$schema": "http://json-schema.org/draft-07/schema#",
       "$vocabulary": {
@@ -23,18 +20,10 @@ static auto test_resolver(std::string_view identifier)
         "https://json-schema.org/draft/2020-12/vocab/applicator": true,
         "https://json-schema.org/draft/2020-12/vocab/validation": false
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 #define EXPECT_VOCABULARY_REQUIRED(vocabularies, vocabulary)                   \
@@ -52,7 +41,7 @@ TEST(JSONSchema_vocabulary_draft7, schema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-07/schema#");
@@ -65,7 +54,7 @@ TEST(JSONSchema_vocabulary_draft7, hyperschema) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-07/hyper-schema#");
@@ -78,7 +67,7 @@ TEST(JSONSchema_vocabulary_draft7, one_hop) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-07/schema#");
@@ -91,7 +80,7 @@ TEST(JSONSchema_vocabulary_draft7, ignore_vocabulary) {
     "type": "object"
   })JSON");
   const std::map<std::string, bool> vocabularies{
-      sourcemeta::jsontoolkit::vocabularies(document, test_resolver).get()};
+      sourcemeta::jsontoolkit::vocabularies(document, test_resolver)};
   EXPECT_EQ(vocabularies.size(), 1);
   EXPECT_VOCABULARY_REQUIRED(vocabularies,
                              "http://json-schema.org/draft-07/schema#");

--- a/test/jsonschema/jsonschema_walker_test.cc
+++ b/test/jsonschema/jsonschema_walker_test.cc
@@ -7,37 +7,28 @@
 #include <vector>
 
 static auto test_resolver(std::string_view identifier)
-    -> std::future<std::optional<sourcemeta::jsontoolkit::JSON>> {
-  std::promise<std::optional<sourcemeta::jsontoolkit::JSON>> promise;
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
   if (identifier == "https://sourcemeta.com/test-metaschema") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://sourcemeta.com/test-metaschema",
       "$vocabulary": {
         "https://json-schema.org/draft/2020-12/vocab/core": true,
         "https://sourcemeta.com/vocab/test-1": true
       }
-    })JSON"));
+    })JSON");
   } else if (identifier == "https://sourcemeta.com/custom-vocab") {
-    promise.set_value(sourcemeta::jsontoolkit::parse(R"JSON({
+    return sourcemeta::jsontoolkit::parse(R"JSON({
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://sourcemeta.com/custom-vocab",
       "$vocabulary": {
         "https://json-schema.org/draft/2020-12/vocab/core": true,
         "https://sourcemeta.com/vocab/test-2": true
       }
-    })JSON"));
+    })JSON");
   } else {
-    const std::optional<sourcemeta::jsontoolkit::JSON> result{
-        sourcemeta::jsontoolkit::official_resolver(identifier).get()};
-    if (result.has_value()) {
-      promise.set_value(result.value());
-    } else {
-      promise.set_value(std::nullopt);
-    }
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
   }
-
-  return promise.get_future();
 }
 
 static auto test_walker(std::string_view keyword,

--- a/test/jsonschema/referencingsuite.cc
+++ b/test/jsonschema/referencingsuite.cc
@@ -54,8 +54,7 @@ public:
       sourcemeta::jsontoolkit::frame(
           schema.first, frame, references,
           sourcemeta::jsontoolkit::default_schema_walker,
-          sourcemeta::jsontoolkit::official_resolver, this->dialect, uri)
-          .wait();
+          sourcemeta::jsontoolkit::official_resolver, this->dialect, uri);
       for (const auto &[key, entry] : frame) {
         new_entries.insert(
             {key.second,

--- a/vendor/noa/cmake/noa/compiler/options.cmake
+++ b/vendor/noa/cmake/noa/compiler/options.cmake
@@ -85,6 +85,8 @@ function(noa_add_default_options visibility target)
       -fno-trapping-math
       # Newer versions of GCC (i.e. 14) seem to print a lot of false-positives here
       -Wno-dangling-reference
+      # GCC seems to print a lot of false-positives here
+      -Wno-free-nonheap-object
       # Disables runtime type information
       -fno-rtti)
   endif()


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsontoolkit/issues/651
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
