### PR TITLE
Fix typo on `FindGoogleBenchmark`

### DIFF
--- a/cmake/FindGoogleBenchmark.cmake
+++ b/cmake/FindGoogleBenchmark.cmake
@@ -1,5 +1,5 @@
-if(NOT Benchnark_FOUND)
+if(NOT Benchmark_FOUND)
   set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Enable testing of the benchmark library.")
   add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/googlebenchmark")
-  set(Benchnark_FOUND ON)
+  set(Benchmark_FOUND ON)
 endif()


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
