### PR TITLE
Implement a JSON Pointer `starts_with` variant that takes a token tail

### DIFF
--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer_pointer.h
@@ -451,6 +451,28 @@ public:
                       this->data.cbegin());
   }
 
+  /// Check whether a JSON Pointer plus a given tail starts with another JSON
+  /// Pointer. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/jsontoolkit/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar"};
+  /// const sourcemeta::jsontoolkit::Pointer::Token tail{"baz"};
+  /// const sourcemeta::jsontoolkit::Pointer prefix{"foo", "bar", "baz"};
+  /// assert(pointer.starts_with(prefix, tail));
+  /// ```
+  auto starts_with(const GenericPointer<PropertyT> &other,
+                   const Token &tail) const -> bool {
+    if (other.size() == this->size() + 1) {
+      assert(!other.empty());
+      return other.starts_with(*this) && other.back() == tail;
+    } else {
+      return this->starts_with(other);
+    }
+  }
+
   /// Check whether a JSON Pointer starts with the initial part of another JSON
   /// Pointer. For example:
   ///

--- a/test/jsonpointer/jsonpointer_starts_with_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_test.cc
@@ -67,3 +67,66 @@ TEST(JSONPointer_starts_with, empty_empty) {
   const sourcemeta::jsontoolkit::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
+
+TEST(JSONPointer_starts_with, tail_equal_initial) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"foo", "bar", "baz"};
+  EXPECT_TRUE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_subset_initial_true) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"foo", "bar"};
+  EXPECT_TRUE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_subset_initial_false) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"foo", "qux"};
+  EXPECT_FALSE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_equal_initial_plus_tail_true) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"foo", "bar", "baz", "qux"};
+  EXPECT_TRUE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_equal_initial_plus_tail_false) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"foo", "bar", "baz", "xxx"};
+  EXPECT_FALSE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_equal_tail) {
+  const sourcemeta::jsontoolkit::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"qux"};
+  EXPECT_FALSE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_empty_initial_true) {
+  const sourcemeta::jsontoolkit::Pointer pointer;
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"qux"};
+  EXPECT_TRUE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_empty_initial_false) {
+  const sourcemeta::jsontoolkit::Pointer pointer;
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix{"bar"};
+  EXPECT_FALSE(pointer.starts_with(prefix, tail));
+}
+
+TEST(JSONPointer_starts_with, tail_empty_prefix) {
+  const sourcemeta::jsontoolkit::Pointer pointer;
+  const sourcemeta::jsontoolkit::Pointer::Token tail{"qux"};
+  const sourcemeta::jsontoolkit::Pointer prefix;
+  EXPECT_TRUE(pointer.starts_with(prefix, tail));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
