### PR TITLE
Correctly canonicalize relative URIs that do not begin with `/`

### DIFF
--- a/src/uri/uri.cc
+++ b/src/uri/uri.cc
@@ -93,7 +93,8 @@ static auto canonicalize_path(const std::string &path, const bool is_relative)
 
   // Reconstruct the canonical path
   std::string canonical_path;
-  std::string separator = is_relative ? "/" : "";
+  std::string separator = (is_relative && !has_leading_with_word) ? "/" : "";
+
   for (const auto &seg : segments) {
     canonical_path += separator + seg;
     separator = "/";

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -1709,7 +1709,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_on_relative_id) {
   EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
       frame, "", "", "https://json-schema.org/draft/2019-09/schema");
   EXPECT_ANONYMOUS_FRAME_STATIC_RESOURCE(
-      frame, "/middle", "/additionalItems",
+      frame, "middle", "/additionalItems",
       "https://json-schema.org/draft/2019-09/schema");
 
   // JSON Pointers
@@ -1739,7 +1739,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_on_relative_id) {
   EXPECT_ANONYMOUS_FRAME_DYNAMIC_ANCHOR(
       frame, "", "", "https://json-schema.org/draft/2019-09/schema");
   EXPECT_ANONYMOUS_FRAME_DYNAMIC_ANCHOR(
-      frame, "/middle", "/additionalItems",
+      frame, "middle", "/additionalItems",
       "https://json-schema.org/draft/2019-09/schema");
 
   // References

--- a/test/uri/uri_canonicalize_test.cc
+++ b/test/uri/uri_canonicalize_test.cc
@@ -77,7 +77,19 @@ TEST(URI_canonicalize, example_relative_1) {
 TEST(URI_canonicalize, example_relative_2) {
   sourcemeta::jsontoolkit::URI uri{"./foo"};
   uri.canonicalize();
-  EXPECT_EQ(uri.recompose(), "/foo");
+  EXPECT_EQ(uri.recompose(), "foo");
+}
+
+TEST(URI_canonicalize, example_relative_3) {
+  sourcemeta::jsontoolkit::URI uri{"foo"};
+  uri.canonicalize();
+  EXPECT_EQ(uri.recompose(), "foo");
+}
+
+TEST(URI_canonicalize, example_relative_4) {
+  sourcemeta::jsontoolkit::URI uri{"foo/bar"};
+  uri.canonicalize();
+  EXPECT_EQ(uri.recompose(), "foo/bar");
 }
 
 TEST(URI_canonicalize, example_12) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
