### PR TITLE
Extend `Regex` to support non-full regex evaluation

### DIFF
--- a/src/regex/include/sourcemeta/jsontoolkit/regex.h
+++ b/src/regex/include/sourcemeta/jsontoolkit/regex.h
@@ -7,8 +7,10 @@
 
 #include <sourcemeta/jsontoolkit/json.h>
 
+#include <cstdint>  // std::uint8_t
 #include <optional> // std::optional
 #include <regex>    // std::regex
+#include <variant>  // std::variant
 
 /// @defgroup regex Regex
 /// @brief An ECMA-262 regex library for use with other JSON libraries
@@ -22,7 +24,20 @@
 namespace sourcemeta::jsontoolkit {
 
 /// @ingroup regex
-using Regex = std::regex;
+using RegexTypeEngine = std::regex;
+
+/// @ingroup regex
+using RegexTypePrefix = JSON::String;
+
+/// @ingroup regex
+struct RegexTypeNoop {};
+
+/// @ingroup regex
+using Regex = std::variant<RegexTypeEngine, RegexTypePrefix, RegexTypeNoop>;
+#if !defined(DOXYGEN)
+// For fast internal dispatching. It must stay in sync with the variant above
+enum class RegexIndex : std::uint8_t { Engine = 0, Prefix, Noop };
+#endif
 
 /// @ingroup regex
 ///

--- a/src/regex/regex.cc
+++ b/src/regex/regex.cc
@@ -3,7 +3,17 @@
 namespace sourcemeta::jsontoolkit {
 
 auto to_regex(const JSON::String &pattern) noexcept -> std::optional<Regex> {
+  if (pattern == ".*" || pattern == "^.*$" || pattern == "^(.*)$") {
+    return RegexTypeNoop{};
+  }
+
   try {
+    static const std::regex PREFIX_REGEX{R"(^\^([a-zA-Z0-9-_/]+)$)"};
+    std::smatch matches;
+    if (std::regex_match(pattern, matches, PREFIX_REGEX)) {
+      return RegexTypePrefix{matches[1].str()};
+    }
+
     return std::regex{pattern, std::regex::ECMAScript | std::regex::nosubs};
   } catch (...) {
     return std::nullopt;
@@ -11,7 +21,21 @@ auto to_regex(const JSON::String &pattern) noexcept -> std::optional<Regex> {
 }
 
 auto matches(const Regex &regex, const JSON::String &value) -> bool {
-  return std::regex_search(value, regex);
+  switch (static_cast<RegexIndex>(regex.index())) {
+    case RegexIndex::Engine:
+      return std::regex_search(value, std::get<RegexTypeEngine>(regex));
+    case RegexIndex::Prefix:
+      return value.starts_with(std::get<RegexTypePrefix>(regex));
+    case RegexIndex::Noop:
+      return true;
+  }
+
+    // See https://en.cppreference.com/w/cpp/utility/unreachable
+#if defined(_MSC_VER) && !defined(__clang__)
+  __assume(false);
+#else
+  __builtin_unreachable();
+#endif
 }
 
 } // namespace sourcemeta::jsontoolkit

--- a/test/regex/regex_matches_test.cc
+++ b/test/regex/regex_matches_test.cc
@@ -8,6 +8,24 @@ TEST(Regex_matches, match_true_1) {
   EXPECT_TRUE(sourcemeta::jsontoolkit::matches(regex.value(), "foobar"));
 }
 
+TEST(Regex_matches, match_true_2) {
+  const auto regex{sourcemeta::jsontoolkit::to_regex("^.*$")};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::jsontoolkit::matches(regex.value(), "foobar"));
+}
+
+TEST(Regex_matches, match_true_3) {
+  const auto regex{sourcemeta::jsontoolkit::to_regex("^(.*)$")};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::jsontoolkit::matches(regex.value(), "foobar"));
+}
+
+TEST(Regex_matches, match_true_4) {
+  const auto regex{sourcemeta::jsontoolkit::to_regex(".*")};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::jsontoolkit::matches(regex.value(), "foobar"));
+}
+
 TEST(Regex_matches, match_false_1) {
   const auto regex{sourcemeta::jsontoolkit::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
