### PR TITLE
Introduce a `.find()` method for JSON objects

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_object.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_object.h
@@ -49,7 +49,8 @@ public:
 
     // Otherwise do value comparison for common properties
     for (const auto &[key, value] : this->data) {
-      if (other.data.contains(key) && value < other.data.at(key)) {
+      const auto other_entry{other.find(key)};
+      if (other_entry != other.cend() && value < other_entry->second) {
         return true;
       }
     }
@@ -104,6 +105,11 @@ public:
   auto cbegin() const noexcept -> const_iterator { return this->data.cbegin(); }
   /// Get a constant end iterator on the object
   auto cend() const noexcept -> const_iterator { return this->data.cend(); }
+
+  /// Attempt to find an entry by key
+  auto find(const Key &key) const -> const_iterator {
+    return this->data.find(key);
+  }
 
 private:
   friend Value;

--- a/src/json/json_value.cc
+++ b/src/json/json_value.cc
@@ -506,7 +506,8 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
 
 [[nodiscard]] auto JSON::defines(const JSON::String &key) const -> bool {
   assert(this->is_object());
-  return std::get<Object>(this->data).data.contains(key);
+  return std::get<Object>(this->data).find(key) !=
+         std::get<Object>(this->data).cend();
 }
 
 [[nodiscard]] auto

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -653,3 +653,12 @@ TEST(JSON_object, fast_hash_nested) {
       "{ \"foo\": 1, \"bar\": { \"bar\": true } }");
   EXPECT_EQ(document.fast_hash(), 32);
 }
+
+TEST(JSON_object, find) {
+  const auto document{sourcemeta::jsontoolkit::parse("{\"foo\":5}")};
+  EXPECT_NE(document.as_object().find("foo"), document.as_object().cend());
+  EXPECT_EQ(document.as_object().find("foo")->first, "foo");
+  EXPECT_TRUE(document.as_object().find("foo")->second.is_integer());
+  EXPECT_EQ(document.as_object().find("foo")->second.to_integer(), 5);
+  EXPECT_EQ(document.as_object().find("bar"), document.as_object().cend());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
