### PR TITLE
Extend `to_pointer` to convert weak pointers to non-weak pointers

### DIFF
--- a/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer.h
+++ b/src/jsonpointer/include/sourcemeta/jsontoolkit/jsonpointer.h
@@ -311,6 +311,24 @@ auto to_pointer(const std::basic_string<JSON::Char, JSON::CharTraits,
                                         std::allocator<JSON::Char>> &input)
     -> Pointer;
 
+/// @ingroup jsonpointer
+/// Convert a JSON WeakPointer into a JSON Pointer. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/jsontoolkit/jsonpointer.h>
+/// #include <cassert>
+///
+/// const std::string foo = "foo";
+/// const sourcemeta::jsontoolkit::WeakPointer pointer{std::cref(foo)};
+/// const sourcemeta::jsontoolkit::Pointer result{
+///   sourcemeta::jsontoolkit::to_pointer(pointer)}:
+/// assert(pointer.size() == 1);
+/// assert(pointer.at(0).is_property());
+/// assert(pointer.at(0).to_property() == "foo");
+/// ```
+SOURCEMETA_JSONTOOLKIT_JSONPOINTER_EXPORT
+auto to_pointer(const WeakPointer &pointer) -> Pointer;
+
 // TODO: Add an operator<< overload
 
 /// @ingroup jsonpointer

--- a/src/jsonpointer/jsonpointer.cc
+++ b/src/jsonpointer/jsonpointer.cc
@@ -246,6 +246,19 @@ auto to_pointer(const std::basic_string<JSON::Char, JSON::CharTraits,
   return to_pointer(parse(stream));
 }
 
+auto to_pointer(const WeakPointer &pointer) -> Pointer {
+  Pointer result;
+  for (const auto &token : pointer) {
+    if (token.is_property()) {
+      result.push_back(token.to_property());
+    } else {
+      result.push_back(token.to_index());
+    }
+  }
+
+  return result;
+}
+
 auto stringify(const Pointer &pointer,
                std::basic_ostream<JSON::Char, JSON::CharTraits> &stream)
     -> void {

--- a/test/jsonpointer/jsonpointer_weakpointer_test.cc
+++ b/test/jsonpointer/jsonpointer_weakpointer_test.cc
@@ -312,3 +312,21 @@ TEST(JSONWeakPointer_try_get, complex_false) {
   const auto result{sourcemeta::jsontoolkit::try_get(document, pointer)};
   EXPECT_FALSE(result.has_value());
 }
+
+TEST(JSONWeakPointer_pointer, to_pointer) {
+  const sourcemeta::jsontoolkit::WeakPointer weak{std::cref(foo), 0};
+  const sourcemeta::jsontoolkit::Pointer pointer{
+      sourcemeta::jsontoolkit::to_pointer(weak)};
+
+  EXPECT_EQ(weak.size(), 2);
+  EXPECT_TRUE(weak.at(0).is_property());
+  EXPECT_EQ(weak.at(0).to_property(), "foo");
+  EXPECT_TRUE(weak.at(1).is_index());
+  EXPECT_EQ(weak.at(1).to_index(), 0);
+
+  EXPECT_EQ(pointer.size(), 2);
+  EXPECT_TRUE(pointer.at(0).is_property());
+  EXPECT_EQ(pointer.at(0).to_property(), "foo");
+  EXPECT_TRUE(pointer.at(1).is_index());
+  EXPECT_EQ(pointer.at(1).to_index(), 0);
+}


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsontoolkit/issues/1362
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
