### PR TITLE
Implement a `.defines()` JSON overload that takes a property hash

### DIFF
--- a/src/json/include/sourcemeta/jsontoolkit/json_value.h
+++ b/src/json/include/sourcemeta/jsontoolkit/json_value.h
@@ -1007,6 +1007,23 @@ public:
   /// ```
   [[nodiscard]] auto defines(const String &key) const -> bool;
 
+  /// This method checks whether an input JSON object defines a specific key
+  /// given a pre-calculated property hash. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/jsontoolkit/json.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::jsontoolkit::JSON document =
+  ///   sourcemeta::jsontoolkit::parse("{ \"foo\": 1 }");
+  /// const sourcemeta::jsontoolkit::Hash hasher;
+  /// assert(document.defines("foo", hasher("foo")));
+  /// assert(!document.defines("bar", hasher("bar")));
+  /// ```
+  [[nodiscard]] auto
+  defines(const String &key,
+          const typename Object::Container::hash_type hash) const -> bool;
+
   /// This method checks whether an input JSON object defines a specific integer
   /// key. For example:
   ///

--- a/src/json/json_value.cc
+++ b/src/json/json_value.cc
@@ -542,6 +542,14 @@ JSON::try_at(const String &key,
 }
 
 [[nodiscard]] auto
+JSON::defines(const JSON::String &key,
+              const typename JSON::Object::Container::hash_type hash) const
+    -> bool {
+  assert(this->is_object());
+  return std::get<Object>(this->data).data.contains(key, hash);
+}
+
+[[nodiscard]] auto
 JSON::defines(const typename JSON::Array::size_type index) const -> bool {
   return this->defines(std::to_string(index));
 }

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -698,3 +698,17 @@ TEST(JSON_object, at_hash_non_const) {
   EXPECT_FALSE(document.at("foo", hash_foo).to_boolean());
   EXPECT_TRUE(document.at("bar", hash_bar).to_boolean());
 }
+
+TEST(JSON_object, defines_hash_const) {
+  const sourcemeta::jsontoolkit::JSON document{
+      {"foo", sourcemeta::jsontoolkit::JSON{false}},
+      {"bar", sourcemeta::jsontoolkit::JSON{true}}};
+  EXPECT_TRUE(document.is_object());
+  EXPECT_EQ(document.size(), 2);
+  EXPECT_EQ(document.object_size(), 2);
+
+  const sourcemeta::jsontoolkit::Hash hasher;
+  EXPECT_TRUE(document.defines("foo", hasher("foo")));
+  EXPECT_TRUE(document.defines("bar", hasher("bar")));
+  EXPECT_FALSE(document.defines("baz", hasher("baz")));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
