### PR TITLE
Revise `SchemaWalkerStrategy` to make space for non-applicator types

### DIFF
--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -18,131 +18,159 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
 
 #define HTTPS_BASE "https://json-schema.org/draft/"
   // 2020-12
-  WALK(HTTPS_BASE "2020-12/vocab/core", "$defs", Members)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "prefixItems", Elements)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "dependentSchemas", Members)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "patternProperties", Members)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "allOf", ElementsInPlace)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "anyOf", ElementsInPlace)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "oneOf", ElementsInPlace)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "not", ValueInPlace)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "if", ValueInPlace)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "propertyNames", ValueInPlace)
-  WALK(HTTPS_BASE "2020-12/vocab/content", "contentSchema", ValueInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/core", "$defs", LocationMembers)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "prefixItems", ApplicatorElements)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "dependentSchemas",
+       ApplicatorMembers)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "patternProperties",
+       ApplicatorMembers)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "allOf",
+       ApplicatorElementsInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "anyOf",
+       ApplicatorElementsInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "oneOf",
+       ApplicatorElementsInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "not", ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "if", ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "propertyNames",
+       ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2020-12/vocab/content", "contentSchema",
+       ApplicatorValueInPlace)
   WALK(HTTPS_BASE "2020-12/vocab/validation", "maximum", None, "type")
   WALK(HTTPS_BASE "2020-12/vocab/validation", "minimum", None, "type")
 
   // See https://json-schema.org/blog/posts/schema-static-analysis for a study
   // of 2020-12 keyword dependency
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "items", Value, "prefixItems")
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "then", ValueInPlace, "if")
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "else", ValueInPlace, "if")
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "additionalProperties", Value,
-       "properties", "patternProperties")
-  WALK_MAYBE_DEPENDENT(HTTPS_BASE "2020-12/vocab/applicator", "contains",
-                       ValueInPlace, HTTPS_BASE "2020-12/vocab/validation",
-                       "minContains", "maxContains")
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "items", ApplicatorValue,
+       "prefixItems")
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "then", ApplicatorValueInPlace,
+       "if")
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "else", ApplicatorValueInPlace,
+       "if")
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "additionalProperties",
+       ApplicatorValue, "properties", "patternProperties")
+  WALK_MAYBE_DEPENDENT(
+      HTTPS_BASE "2020-12/vocab/applicator", "contains", ApplicatorValueInPlace,
+      HTTPS_BASE "2020-12/vocab/validation", "minContains", "maxContains")
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2020-12/vocab/unevaluated",
-                       "unevaluatedProperties", Value,
+                       "unevaluatedProperties", ApplicatorValue,
                        HTTPS_BASE "2020-12/vocab/applicator", "properties",
                        "patternProperties", "additionalProperties")
-  WALK_MAYBE_DEPENDENT(
-      HTTPS_BASE "2020-12/vocab/unevaluated", "unevaluatedItems", Value,
-      HTTPS_BASE "2020-12/vocab/applicator", "prefixItems", "items", "contains")
+  WALK_MAYBE_DEPENDENT(HTTPS_BASE "2020-12/vocab/unevaluated",
+                       "unevaluatedItems", ApplicatorValue,
+                       HTTPS_BASE "2020-12/vocab/applicator", "prefixItems",
+                       "items", "contains")
 
   // For the purpose of compiler optimizations
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2020-12/vocab/applicator", "properties",
-                       Members, HTTPS_BASE "2020-12/vocab/validation",
+                       ApplicatorMembers, HTTPS_BASE "2020-12/vocab/validation",
                        "required")
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2020-12/vocab/validation", "type", None,
                        HTTPS_BASE "2020-12/vocab/applicator", "properties")
 
   // JSON Schema still defines this for backwards-compatibility
   // See https://json-schema.org/draft/2020-12/schema
-  WALK(HTTPS_BASE "2020-12/vocab/core", "definitions", Members)
+  WALK(HTTPS_BASE "2020-12/vocab/core", "definitions", LocationMembers)
 
   // 2019-09
-  WALK(HTTPS_BASE "2019-09/vocab/core", "$defs", Members)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "items", ValueOrElements)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "dependentSchemas", Members)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "patternProperties", Members)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "allOf", ElementsInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "anyOf", ElementsInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "oneOf", ElementsInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "not", ValueInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "if", ValueInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "propertyNames", ValueInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/content", "contentSchema", ValueInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "hrefSchema", Value)
-  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "targetSchema", Value)
-  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "headerSchema", Value)
-  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "submissionSchema", Value)
+  WALK(HTTPS_BASE "2019-09/vocab/core", "$defs", LocationMembers)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "items",
+       ApplicatorValueOrElements)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "dependentSchemas",
+       ApplicatorMembers)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "patternProperties",
+       ApplicatorMembers)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "allOf",
+       ApplicatorElementsInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "anyOf",
+       ApplicatorElementsInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "oneOf",
+       ApplicatorElementsInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "not", ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "if", ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "propertyNames",
+       ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/content", "contentSchema",
+       ApplicatorValueInPlace)
+  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "hrefSchema", ApplicatorValue)
+  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "targetSchema", ApplicatorValue)
+  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "headerSchema", ApplicatorValue)
+  WALK(HTTPS_BASE "2019-09/vocab/hyper-schema", "submissionSchema",
+       ApplicatorValue)
   WALK(HTTPS_BASE "2019-09/vocab/validation", "maximum", None, "type")
   WALK(HTTPS_BASE "2019-09/vocab/validation", "minimum", None, "type")
 
   // See
   // https://json-schema.org/draft/2019-09/draft-handrews-json-schema-02#rfc.section.9.1
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "additionalItems", Value, "items")
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "then", ValueInPlace, "if")
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "else", ValueInPlace, "if")
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "additionalProperties", Value,
-       "properties", "patternProperties")
-  WALK_MAYBE_DEPENDENT(HTTPS_BASE "2019-09/vocab/applicator", "contains",
-                       ValueInPlace, HTTPS_BASE "2019-09/vocab/validation",
-                       "minContains", "maxContains")
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "unevaluatedProperties", Value,
-       "properties", "patternProperties", "additionalProperties")
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "unevaluatedItems", Value,
-       "items", "additionalItems")
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "additionalItems",
+       ApplicatorValue, "items")
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "then", ApplicatorValueInPlace,
+       "if")
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "else", ApplicatorValueInPlace,
+       "if")
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "additionalProperties",
+       ApplicatorValue, "properties", "patternProperties")
+  WALK_MAYBE_DEPENDENT(
+      HTTPS_BASE "2019-09/vocab/applicator", "contains", ApplicatorValueInPlace,
+      HTTPS_BASE "2019-09/vocab/validation", "minContains", "maxContains")
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "unevaluatedProperties",
+       ApplicatorValue, "properties", "patternProperties",
+       "additionalProperties")
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "unevaluatedItems",
+       ApplicatorValue, "items", "additionalItems")
 
   // For the purpose of compiler optimizations
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2019-09/vocab/applicator", "properties",
-                       Members, HTTPS_BASE "2019-09/vocab/validation",
+                       ApplicatorMembers, HTTPS_BASE "2019-09/vocab/validation",
                        "required")
   WALK_MAYBE_DEPENDENT(HTTPS_BASE "2019-09/vocab/validation", "type", None,
                        HTTPS_BASE "2019-09/vocab/applicator", "properties")
 
   // JSON Schema still defines this for backwards-compatibility
   // See https://json-schema.org/draft/2019-09/schema
-  WALK(HTTPS_BASE "2019-09/vocab/core", "definitions", Members)
+  WALK(HTTPS_BASE "2019-09/vocab/core", "definitions", LocationMembers)
 
 #undef HTTPS_BASE
 
 #define HTTP_BASE "http://json-schema.org/"
   // Draft7
-  WALK(HTTP_BASE "draft-07/schema#", "definitions", Members, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "dependencies", Members, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "items", ValueOrElements, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "patternProperties", Members, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "allOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "anyOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "oneOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "not", ValueInPlace, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "if", ValueInPlace, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "contains", ValueInPlace, "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "propertyNames", ValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "definitions", LocationMembers, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "dependencies", ApplicatorMembers, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "items", ApplicatorValueOrElements, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "patternProperties", ApplicatorMembers,
+       "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "allOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "anyOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "oneOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "not", ApplicatorValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "if", ApplicatorValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "contains", ApplicatorValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "propertyNames", ApplicatorValueInPlace,
+       "$ref")
   WALK(HTTP_BASE "draft-07/schema#", "maximum", None, "$ref")
   WALK(HTTP_BASE "draft-07/schema#", "minimum", None, "$ref")
 
-  WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-07/hyper-schema#", "hrefSchema", Value,
-                       HTTP_BASE "draft-07/schema#", "$ref")
+  WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-07/hyper-schema#", "hrefSchema",
+                       ApplicatorValue, HTTP_BASE "draft-07/schema#", "$ref")
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-07/hyper-schema#", "targetSchema",
-                       Value, HTTP_BASE "draft-07/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-07/schema#", "$ref")
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-07/hyper-schema#", "headerSchema",
-                       Value, HTTP_BASE "draft-07/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-07/schema#", "$ref")
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-07/hyper-schema#", "submissionSchema",
-                       Value, HTTP_BASE "draft-07/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-07/schema#", "$ref")
 
   // See
   // https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01
-  WALK(HTTP_BASE "draft-07/schema#", "additionalItems", Value, "items")
-  WALK(HTTP_BASE "draft-07/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-07/schema#", "additionalItems", ApplicatorValue,
+       "items")
+  WALK(HTTP_BASE "draft-07/schema#", "additionalProperties", ApplicatorValue,
        "properties", "patternProperties")
-  WALK(HTTP_BASE "draft-07/schema#", "then", ValueInPlace, "if")
-  WALK(HTTP_BASE "draft-07/schema#", "else", ValueInPlace, "if")
+  WALK(HTTP_BASE "draft-07/schema#", "then", ApplicatorValueInPlace, "if")
+  WALK(HTTP_BASE "draft-07/schema#", "else", ApplicatorValueInPlace, "if")
 
   // For the purpose of compiler optimizations
-  WALK(HTTP_BASE "draft-07/schema#", "properties", Members, "$ref", "required")
+  WALK(HTTP_BASE "draft-07/schema#", "properties", ApplicatorMembers, "$ref",
+       "required")
   WALK(HTTP_BASE "draft-07/schema#", "type", None, "properties")
 
   // $ref also takes precedence over any unknown keyword
@@ -152,33 +180,37 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   }
 
   // Draft6
-  WALK(HTTP_BASE "draft-06/schema#", "definitions", Members, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "dependencies", Members, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "items", ValueOrElements, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "patternProperties", Members, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "allOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "anyOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "oneOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "not", ValueInPlace, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "contains", ValueInPlace, "$ref")
-  WALK(HTTP_BASE "draft-06/schema#", "propertyNames", ValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "definitions", LocationMembers, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "dependencies", ApplicatorMembers, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "items", ApplicatorValueOrElements, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "patternProperties", ApplicatorMembers,
+       "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "allOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "anyOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "oneOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "not", ApplicatorValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "contains", ApplicatorValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-06/schema#", "propertyNames", ApplicatorValueInPlace,
+       "$ref")
   WALK(HTTP_BASE "draft-06/schema#", "maximum", None, "$ref")
   WALK(HTTP_BASE "draft-06/schema#", "minimum", None, "$ref")
 
-  WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-06/hyper-schema#", "hrefSchema", Value,
-                       HTTP_BASE "draft-06/schema#", "$ref")
+  WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-06/hyper-schema#", "hrefSchema",
+                       ApplicatorValue, HTTP_BASE "draft-06/schema#", "$ref")
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-06/hyper-schema#", "targetSchema",
-                       Value, HTTP_BASE "draft-06/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-06/schema#", "$ref")
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-06/hyper-schema#", "submissionSchema",
-                       Value, HTTP_BASE "draft-06/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-06/schema#", "$ref")
 
   // See https://json-schema.org/draft-06/draft-wright-json-schema-validation-01
-  WALK(HTTP_BASE "draft-06/schema#", "additionalItems", Value, "items")
-  WALK(HTTP_BASE "draft-06/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-06/schema#", "additionalItems", ApplicatorValue,
+       "items")
+  WALK(HTTP_BASE "draft-06/schema#", "additionalProperties", ApplicatorValue,
        "properties", "patternProperties")
 
   // For the purpose of compiler optimizations
-  WALK(HTTP_BASE "draft-06/schema#", "properties", Members, "$ref", "required")
+  WALK(HTTP_BASE "draft-06/schema#", "properties", ApplicatorMembers, "$ref",
+       "required")
   WALK(HTTP_BASE "draft-06/schema#", "type", None, "properties")
 
   // $ref also takes precedence over any unknown keyword
@@ -188,14 +220,15 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   }
 
   // Draft4
-  WALK(HTTP_BASE "draft-04/schema#", "definitions", Members, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "items", ValueOrElements, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "patternProperties", Members, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "allOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "anyOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "oneOf", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "not", ValueInPlace, "$ref")
-  WALK(HTTP_BASE "draft-04/schema#", "dependencies", Members, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "definitions", LocationMembers, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "items", ApplicatorValueOrElements, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "patternProperties", ApplicatorMembers,
+       "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "allOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "anyOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "oneOf", ApplicatorElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "not", ApplicatorValueInPlace, "$ref")
+  WALK(HTTP_BASE "draft-04/schema#", "dependencies", ApplicatorMembers, "$ref")
   WALK(HTTP_BASE "draft-04/schema#", "required", None, "$ref")
   WALK(HTTP_BASE "draft-04/schema#", "uniqueItems", None, "$ref")
   WALK(HTTP_BASE "draft-04/schema#", "pattern", None, "$ref")
@@ -210,17 +243,19 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK(HTTP_BASE "draft-04/schema#", "minProperties", None, "$ref")
 
   // These dependencies are only for the purpose of compiler optimizations
-  WALK(HTTP_BASE "draft-04/schema#", "properties", Members, "$ref", "required")
+  WALK(HTTP_BASE "draft-04/schema#", "properties", ApplicatorMembers, "$ref",
+       "required")
   WALK(HTTP_BASE "draft-04/schema#", "type", None, "properties")
 
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-04/hyper-schema#", "targetSchema",
-                       Value, HTTP_BASE "draft-04/schema#", "$ref")
-  WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-04/hyper-schema#", "schema", Value,
-                       HTTP_BASE "draft-04/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-04/schema#", "$ref")
+  WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-04/hyper-schema#", "schema",
+                       ApplicatorValue, HTTP_BASE "draft-04/schema#", "$ref")
 
   // See https://json-schema.org/draft-04/draft-fge-json-schema-validation-00
-  WALK(HTTP_BASE "draft-04/schema#", "additionalItems", Value, "items")
-  WALK(HTTP_BASE "draft-04/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-04/schema#", "additionalItems", ApplicatorValue,
+       "items")
+  WALK(HTTP_BASE "draft-04/schema#", "additionalProperties", ApplicatorValue,
        "properties", "patternProperties")
 
   // $ref also takes precedence over any unknown keyword
@@ -230,20 +265,24 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   }
 
   // Draft3
-  WALK(HTTP_BASE "draft-03/schema#", "type", Elements, "$ref")
-  WALK(HTTP_BASE "draft-03/schema#", "dependencies", Members, "$ref")
-  WALK(HTTP_BASE "draft-03/schema#", "items", ValueOrElements, "$ref")
-  WALK(HTTP_BASE "draft-03/schema#", "properties", Members, "$ref")
-  WALK(HTTP_BASE "draft-03/schema#", "patternProperties", Members, "$ref")
-  WALK(HTTP_BASE "draft-03/schema#", "disallow", ElementsInPlace, "$ref")
-  WALK(HTTP_BASE "draft-03/schema#", "extends", ValueOrElementsInPlace, "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "type", ApplicatorElements, "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "dependencies", ApplicatorMembers, "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "items", ApplicatorValueOrElements, "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "properties", ApplicatorMembers, "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "patternProperties", ApplicatorMembers,
+       "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "disallow", ApplicatorElementsInPlace,
+       "$ref")
+  WALK(HTTP_BASE "draft-03/schema#", "extends",
+       ApplicatorValueOrElementsInPlace, "$ref")
 
   WALK_MAYBE_DEPENDENT(HTTP_BASE "draft-03/hyper-schema#", "targetSchema",
-                       Value, HTTP_BASE "draft-03/schema#", "$ref")
+                       ApplicatorValue, HTTP_BASE "draft-03/schema#", "$ref")
 
   // See https://json-schema.org/draft-03/draft-zyp-json-schema-03.pdf
-  WALK(HTTP_BASE "draft-03/schema#", "additionalItems", Value, "items")
-  WALK(HTTP_BASE "draft-03/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-03/schema#", "additionalItems", ApplicatorValue,
+       "items")
+  WALK(HTTP_BASE "draft-03/schema#", "additionalProperties", ApplicatorValue,
        "properties", "patternProperties")
 
   // $ref also takes precedence over any unknown keyword
@@ -253,59 +292,65 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   }
 
   // Draft2
-  WALK(HTTP_BASE "draft-02/schema#", "type", Elements)
-  WALK(HTTP_BASE "draft-02/schema#", "items", ValueOrElements)
-  WALK(HTTP_BASE "draft-02/schema#", "properties", Members)
-  WALK(HTTP_BASE "draft-02/schema#", "extends", ValueOrElementsInPlace)
-  WALK(HTTP_BASE "draft-02/schema#", "requires", ValueInPlace)
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "targetSchema", Value)
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "type", Elements)
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "items", ValueOrElements)
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "properties", Members)
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "extends", ValueOrElementsInPlace)
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "requires", ValueInPlace)
+  WALK(HTTP_BASE "draft-02/schema#", "type", ApplicatorElements)
+  WALK(HTTP_BASE "draft-02/schema#", "items", ApplicatorValueOrElements)
+  WALK(HTTP_BASE "draft-02/schema#", "properties", ApplicatorMembers)
+  WALK(HTTP_BASE "draft-02/schema#", "extends",
+       ApplicatorValueOrElementsInPlace)
+  WALK(HTTP_BASE "draft-02/schema#", "requires", ApplicatorValueInPlace)
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "targetSchema", ApplicatorValue)
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "type", ApplicatorElements)
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "items", ApplicatorValueOrElements)
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "properties", ApplicatorMembers)
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "extends",
+       ApplicatorValueOrElementsInPlace)
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "requires", ApplicatorValueInPlace)
 
   // See https://json-schema.org/draft-02/draft-zyp-json-schema-02.txt
-  WALK(HTTP_BASE "draft-02/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-02/schema#", "additionalProperties", ApplicatorValue,
        "properties")
-  WALK(HTTP_BASE "draft-02/hyper-schema#", "additionalProperties", Value,
-       "properties")
+  WALK(HTTP_BASE "draft-02/hyper-schema#", "additionalProperties",
+       ApplicatorValue, "properties")
 
   // Draft1
-  WALK(HTTP_BASE "draft-01/schema#", "type", Elements)
-  WALK(HTTP_BASE "draft-01/schema#", "items", ValueOrElements)
-  WALK(HTTP_BASE "draft-01/schema#", "properties", Members)
-  WALK(HTTP_BASE "draft-01/schema#", "extends", ValueOrElementsInPlace)
-  WALK(HTTP_BASE "draft-01/schema#", "requires", ValueInPlace)
-  WALK(HTTP_BASE "draft-01/hyper-schema#", "type", Elements)
-  WALK(HTTP_BASE "draft-01/hyper-schema#", "items", ValueOrElements)
-  WALK(HTTP_BASE "draft-01/hyper-schema#", "properties", Members)
-  WALK(HTTP_BASE "draft-01/hyper-schema#", "extends", ValueOrElementsInPlace)
-  WALK(HTTP_BASE "draft-01/hyper-schema#", "requires", ValueInPlace)
+  WALK(HTTP_BASE "draft-01/schema#", "type", ApplicatorElements)
+  WALK(HTTP_BASE "draft-01/schema#", "items", ApplicatorValueOrElements)
+  WALK(HTTP_BASE "draft-01/schema#", "properties", ApplicatorMembers)
+  WALK(HTTP_BASE "draft-01/schema#", "extends",
+       ApplicatorValueOrElementsInPlace)
+  WALK(HTTP_BASE "draft-01/schema#", "requires", ApplicatorValueInPlace)
+  WALK(HTTP_BASE "draft-01/hyper-schema#", "type", ApplicatorElements)
+  WALK(HTTP_BASE "draft-01/hyper-schema#", "items", ApplicatorValueOrElements)
+  WALK(HTTP_BASE "draft-01/hyper-schema#", "properties", ApplicatorMembers)
+  WALK(HTTP_BASE "draft-01/hyper-schema#", "extends",
+       ApplicatorValueOrElementsInPlace)
+  WALK(HTTP_BASE "draft-01/hyper-schema#", "requires", ApplicatorValueInPlace)
 
   // See https://json-schema.org/draft-01/draft-zyp-json-schema-01
-  WALK(HTTP_BASE "draft-01/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-01/schema#", "additionalProperties", ApplicatorValue,
        "properties")
-  WALK(HTTP_BASE "draft-01/hyper-schema#", "additionalProperties", Value,
-       "properties")
+  WALK(HTTP_BASE "draft-01/hyper-schema#", "additionalProperties",
+       ApplicatorValue, "properties")
 
   // Draft0
-  WALK(HTTP_BASE "draft-00/schema#", "type", Elements)
-  WALK(HTTP_BASE "draft-00/schema#", "items", ValueOrElements)
-  WALK(HTTP_BASE "draft-00/schema#", "properties", Members)
-  WALK(HTTP_BASE "draft-00/schema#", "extends", ValueOrElementsInPlace)
-  WALK(HTTP_BASE "draft-00/schema#", "requires", ValueInPlace)
-  WALK(HTTP_BASE "draft-00/hyper-schema#", "type", Elements)
-  WALK(HTTP_BASE "draft-00/hyper-schema#", "items", ValueOrElements)
-  WALK(HTTP_BASE "draft-00/hyper-schema#", "properties", Members)
-  WALK(HTTP_BASE "draft-00/hyper-schema#", "extends", ValueOrElementsInPlace)
-  WALK(HTTP_BASE "draft-00/hyper-schema#", "requires", ValueInPlace)
+  WALK(HTTP_BASE "draft-00/schema#", "type", ApplicatorElements)
+  WALK(HTTP_BASE "draft-00/schema#", "items", ApplicatorValueOrElements)
+  WALK(HTTP_BASE "draft-00/schema#", "properties", ApplicatorMembers)
+  WALK(HTTP_BASE "draft-00/schema#", "extends",
+       ApplicatorValueOrElementsInPlace)
+  WALK(HTTP_BASE "draft-00/schema#", "requires", ApplicatorValueInPlace)
+  WALK(HTTP_BASE "draft-00/hyper-schema#", "type", ApplicatorElements)
+  WALK(HTTP_BASE "draft-00/hyper-schema#", "items", ApplicatorValueOrElements)
+  WALK(HTTP_BASE "draft-00/hyper-schema#", "properties", ApplicatorMembers)
+  WALK(HTTP_BASE "draft-00/hyper-schema#", "extends",
+       ApplicatorValueOrElementsInPlace)
+  WALK(HTTP_BASE "draft-00/hyper-schema#", "requires", ApplicatorValueInPlace)
 
   // See https://json-schema.org/draft-00/draft-zyp-json-schema-00.txt
-  WALK(HTTP_BASE "draft-00/schema#", "additionalProperties", Value,
+  WALK(HTTP_BASE "draft-00/schema#", "additionalProperties", ApplicatorValue,
        "properties")
-  WALK(HTTP_BASE "draft-00/hyper-schema#", "additionalProperties", Value,
-       "properties")
+  WALK(HTTP_BASE "draft-00/hyper-schema#", "additionalProperties",
+       ApplicatorValue, "properties")
 #undef HTTP_BASE
 #undef WALK
 #undef WALK_MAYBE_DEPENDENT

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
@@ -34,35 +34,39 @@ enum class SchemaWalkerStrategy : std::uint8_t {
   None,
   /// The JSON Schema keyword is an applicator that potentially
   /// takes a JSON Schema definition as an argument
-  Value,
+  ApplicatorValue,
   /// The JSON Schema keyword is an applicator that potentially
   /// takes a JSON Schema definition as an argument without affecting the
   /// instance location
-  ValueInPlace,
+  ApplicatorValueInPlace,
   /// The JSON Schema keyword is an applicator that potentially
   /// takes an array of potentially JSON Schema definitions
   /// as an argument
-  Elements,
+  ApplicatorElements,
   /// The JSON Schema keyword is an applicator that potentially
   /// takes an array of potentially JSON Schema definitions
   /// as an argument without affecting the instance location
-  ElementsInPlace,
+  ApplicatorElementsInPlace,
   /// The JSON Schema keyword is an applicator that potentially
   /// takes an object as argument, whose values are potentially
   /// JSON Schema definitions
-  Members,
+  ApplicatorMembers,
   /// The JSON Schema keyword is an applicator that may take a JSON Schema
   /// definition or an array of potentially JSON Schema definitions
   /// as an argument
-  ValueOrElements,
+  ApplicatorValueOrElements,
   /// The JSON Schema keyword is an applicator that may take a JSON Schema
   /// definition or an array of potentially JSON Schema definitions
   /// as an argument without affecting the instance location
-  ValueOrElementsInPlace,
+  ApplicatorValueOrElementsInPlace,
   /// The JSON Schema keyword is an applicator that may take an array of
   /// potentially JSON Schema definitions or an object whose values are
   /// potentially JSON Schema definitions as an argument
-  ElementsOrMembers
+  ApplicatorElementsOrMembers,
+  /// The JSON Schema keyword is a reserved location that potentially
+  /// takes an object as argument, whose values are potentially
+  /// JSON Schema definitions
+  LocationMembers,
 };
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop

--- a/src/jsonschema/walker.cc
+++ b/src/jsonschema/walker.cc
@@ -62,17 +62,19 @@ auto walk(sourcemeta::jsontoolkit::Pointer &pointer,
 
   for (auto &pair : subschema.as_object()) {
     switch (walker(pair.first, vocabularies).strategy) {
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::Value:
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorValue:
         [[fallthrough]];
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ValueInPlace: {
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::
+          ApplicatorValueInPlace: {
         sourcemeta::jsontoolkit::Pointer new_pointer{pointer};
         new_pointer.emplace_back(pair.first);
         walk(new_pointer, subschemas, pair.second, walker, resolver,
              new_dialect, type, level + 1);
       } break;
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::Elements:
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorElements:
         [[fallthrough]];
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ElementsInPlace:
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::
+          ApplicatorElementsInPlace:
         if (pair.second.is_array()) {
           for (std::size_t index = 0; index < pair.second.size(); index++) {
             sourcemeta::jsontoolkit::Pointer new_pointer{pointer};
@@ -84,7 +86,9 @@ auto walk(sourcemeta::jsontoolkit::Pointer &pointer,
         }
 
         break;
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::Members:
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorMembers:
+        [[fallthrough]];
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::LocationMembers:
         if (pair.second.is_object()) {
           for (auto &subpair : pair.second.as_object()) {
             sourcemeta::jsontoolkit::Pointer new_pointer{pointer};
@@ -96,10 +100,11 @@ auto walk(sourcemeta::jsontoolkit::Pointer &pointer,
         }
 
         break;
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ValueOrElements:
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::
+          ApplicatorValueOrElements:
         [[fallthrough]];
       case sourcemeta::jsontoolkit::SchemaWalkerStrategy::
-          ValueOrElementsInPlace:
+          ApplicatorValueOrElementsInPlace:
         if (pair.second.is_array()) {
           for (std::size_t index = 0; index < pair.second.size(); index++) {
             sourcemeta::jsontoolkit::Pointer new_pointer{pointer};
@@ -116,7 +121,8 @@ auto walk(sourcemeta::jsontoolkit::Pointer &pointer,
         }
 
         break;
-      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::ElementsOrMembers:
+      case sourcemeta::jsontoolkit::SchemaWalkerStrategy::
+          ApplicatorElementsOrMembers:
         if (pair.second.is_array()) {
           for (std::size_t index = 0; index < pair.second.size(); index++) {
             sourcemeta::jsontoolkit::Pointer new_pointer{pointer};

--- a/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
@@ -87,7 +87,7 @@ TEST(JSONSchema_default_walker_2019_09, core_recursiveRef) {
 TEST(JSONSchema_default_walker_2019_09, core_defs) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$defs", VOCABULARIES_2019_09_CORE)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -103,7 +103,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("allOf", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -111,7 +111,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("anyOf", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -119,7 +119,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("oneOf", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -127,7 +127,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("not", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -135,7 +135,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("if", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -143,7 +143,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_then) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("then", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -152,7 +152,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_else) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("else", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -161,7 +161,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_dependentSchemas) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependentSchemas",
                                           VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -169,7 +169,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("items", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -177,7 +177,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_additionalItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("additionalItems",
                                           VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -186,7 +186,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_contains_only) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("contains", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -200,7 +200,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_contains_with_validation) {
             VOCABULARIES_2019_09_VALIDATION.cend(),
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("contains", vocabularies)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"minContains", "maxContains"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -209,7 +209,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("properties", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -217,7 +217,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_patternProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("patternProperties",
                                           VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -225,7 +225,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -234,7 +234,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_propertyNames) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -242,7 +242,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_unevaluatedItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("unevaluatedItems",
                                           VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"items", "additionalItems"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -251,7 +251,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_unevaluatedProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("unevaluatedProperties",
                                           VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties",
                                        "additionalProperties"};
   EXPECT_EQ(result.dependencies, expected);
@@ -447,7 +447,7 @@ TEST(JSONSchema_default_walker_2019_09, content_contentSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("contentSchema", VOCABULARIES_2019_09_CONTENT)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -607,7 +607,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_hrefSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_2019_09_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -615,7 +615,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_2019_09_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -623,7 +623,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_headerSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_2019_09_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -631,7 +631,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_submissionSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_2019_09_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
@@ -95,7 +95,7 @@ TEST(JSONSchema_default_walker_2020_12, core_dynamicRef) {
 TEST(JSONSchema_default_walker_2020_12, core_defs) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$defs", VOCABULARIES_2020_12_CORE)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -111,7 +111,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("allOf", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -119,7 +119,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("anyOf", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -127,7 +127,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("oneOf", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -135,7 +135,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("not", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -143,7 +143,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("if", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -151,7 +151,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_then) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("then", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -160,7 +160,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_else) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("else", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -169,7 +169,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_dependentSchemas) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependentSchemas",
                                           VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -177,7 +177,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_prefixItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("prefixItems", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -185,7 +185,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("items", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"prefixItems"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -194,7 +194,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_contains_only) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("contains", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -208,7 +208,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_contains_with_validation) {
             VOCABULARIES_2020_12_VALIDATION.cend(),
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("contains", vocabularies)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"minContains", "maxContains"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -217,7 +217,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("properties", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -225,7 +225,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_patternProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("patternProperties",
                                           VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -233,7 +233,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -242,7 +242,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_propertyNames) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -250,7 +250,7 @@ TEST(JSONSchema_default_walker_2020_12, unevaluated_unevaluatedItems_only) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("unevaluatedItems",
                                           VOCABULARIES_2020_12_UNEVALUATED)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -265,7 +265,7 @@ TEST(JSONSchema_default_walker_2020_12,
             VOCABULARIES_2020_12_APPLICATOR.cend(),
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("unevaluatedItems", vocabularies)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"prefixItems", "items", "contains"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -275,7 +275,7 @@ TEST(JSONSchema_default_walker_2020_12,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("unevaluatedProperties",
                                           VOCABULARIES_2020_12_UNEVALUATED)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -291,7 +291,7 @@ TEST(JSONSchema_default_walker_2020_12,
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{
       default_schema_walker("unevaluatedProperties", vocabularies)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties",
                                        "additionalProperties"};
   EXPECT_EQ(result.dependencies, expected);
@@ -495,7 +495,7 @@ TEST(JSONSchema_default_walker_2020_12, content_contentSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("contentSchema", VOCABULARIES_2020_12_CONTENT)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -655,7 +655,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_hrefSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_2020_12_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -663,7 +663,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_2020_12_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -671,7 +671,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_headerSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_2020_12_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -679,7 +679,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_submissionSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_2020_12_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft0_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft0_test.cc
@@ -31,14 +31,14 @@ TEST(JSONSchema_default_walker_draft0, ref) {
 TEST(JSONSchema_default_walker_draft0, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT0)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
 TEST(JSONSchema_default_walker_draft0, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT0)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -46,7 +46,7 @@ TEST(JSONSchema_default_walker_draft0, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT0)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -54,7 +54,7 @@ TEST(JSONSchema_default_walker_draft0, additionalProperties) {
 TEST(JSONSchema_default_walker_draft0, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT0)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -133,7 +133,7 @@ TEST(JSONSchema_default_walker_draft0, minItems) {
 TEST(JSONSchema_default_walker_draft0, requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("requires", VOCABULARIES_DRAFT0)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -175,7 +175,8 @@ TEST(JSONSchema_default_walker_draft0, disallow) {
 TEST(JSONSchema_default_walker_draft0, extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT0)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -317,7 +318,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("items", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -325,7 +326,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("properties", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -333,7 +334,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_DRAFT0_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -342,7 +343,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("type", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -430,7 +431,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("requires", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -478,7 +479,8 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("extends", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft1_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft1_test.cc
@@ -31,14 +31,14 @@ TEST(JSONSchema_default_walker_draft1, ref) {
 TEST(JSONSchema_default_walker_draft1, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT1)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
 TEST(JSONSchema_default_walker_draft1, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT1)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -46,7 +46,7 @@ TEST(JSONSchema_default_walker_draft1, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT1)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -54,7 +54,7 @@ TEST(JSONSchema_default_walker_draft1, additionalProperties) {
 TEST(JSONSchema_default_walker_draft1, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT1)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -133,7 +133,7 @@ TEST(JSONSchema_default_walker_draft1, minItems) {
 TEST(JSONSchema_default_walker_draft1, requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("requires", VOCABULARIES_DRAFT1)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -175,7 +175,8 @@ TEST(JSONSchema_default_walker_draft1, disallow) {
 TEST(JSONSchema_default_walker_draft1, extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT1)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -317,7 +318,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("items", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -325,7 +326,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("properties", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -333,7 +334,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_DRAFT1_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -342,7 +343,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("type", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -430,7 +431,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("requires", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -478,7 +479,8 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("extends", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft2_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft2_test.cc
@@ -31,14 +31,14 @@ TEST(JSONSchema_default_walker_draft2, ref) {
 TEST(JSONSchema_default_walker_draft2, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT2)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
 TEST(JSONSchema_default_walker_draft2, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT2)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -46,7 +46,7 @@ TEST(JSONSchema_default_walker_draft2, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT2)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -54,7 +54,7 @@ TEST(JSONSchema_default_walker_draft2, additionalProperties) {
 TEST(JSONSchema_default_walker_draft2, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT2)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -140,7 +140,7 @@ TEST(JSONSchema_default_walker_draft2, uniqueItems) {
 TEST(JSONSchema_default_walker_draft2, requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("requires", VOCABULARIES_DRAFT2)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -189,7 +189,8 @@ TEST(JSONSchema_default_walker_draft2, disallow) {
 TEST(JSONSchema_default_walker_draft2, extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT2)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -293,7 +294,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -332,7 +333,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("items", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -340,7 +341,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("properties", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -348,7 +349,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -357,7 +358,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("type", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -453,7 +454,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("requires", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -509,7 +510,8 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("extends", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft3_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft3_test.cc
@@ -33,7 +33,7 @@ TEST(JSONSchema_default_walker_draft3, ref) {
 TEST(JSONSchema_default_walker_draft3, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -42,7 +42,7 @@ TEST(JSONSchema_default_walker_draft3, additionalItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -50,7 +50,7 @@ TEST(JSONSchema_default_walker_draft3, additionalItems) {
 TEST(JSONSchema_default_walker_draft3, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -59,7 +59,7 @@ TEST(JSONSchema_default_walker_draft3, patternProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -67,7 +67,7 @@ TEST(JSONSchema_default_walker_draft3, patternProperties) {
 TEST(JSONSchema_default_walker_draft3, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -76,7 +76,7 @@ TEST(JSONSchema_default_walker_draft3, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -84,7 +84,7 @@ TEST(JSONSchema_default_walker_draft3, additionalProperties) {
 TEST(JSONSchema_default_walker_draft3, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Elements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -230,7 +230,7 @@ TEST(JSONSchema_default_walker_draft3, divisibleBy) {
 TEST(JSONSchema_default_walker_draft3, disallow) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("disallow", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -238,7 +238,8 @@ TEST(JSONSchema_default_walker_draft3, disallow) {
 TEST(JSONSchema_default_walker_draft3, extends) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT3)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElementsInPlace);
+  EXPECT_EQ(result.strategy,
+            SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -343,7 +344,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft4_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft4_test.cc
@@ -33,7 +33,7 @@ TEST(JSONSchema_default_walker_draft4, ref) {
 TEST(JSONSchema_default_walker_draft4, definitions) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("definitions", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -41,7 +41,7 @@ TEST(JSONSchema_default_walker_draft4, definitions) {
 TEST(JSONSchema_default_walker_draft4, allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -49,7 +49,7 @@ TEST(JSONSchema_default_walker_draft4, allOf) {
 TEST(JSONSchema_default_walker_draft4, anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -57,7 +57,7 @@ TEST(JSONSchema_default_walker_draft4, anyOf) {
 TEST(JSONSchema_default_walker_draft4, oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -65,7 +65,7 @@ TEST(JSONSchema_default_walker_draft4, oneOf) {
 TEST(JSONSchema_default_walker_draft4, not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -73,7 +73,7 @@ TEST(JSONSchema_default_walker_draft4, not) {
 TEST(JSONSchema_default_walker_draft4, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -82,7 +82,7 @@ TEST(JSONSchema_default_walker_draft4, additionalItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -90,7 +90,7 @@ TEST(JSONSchema_default_walker_draft4, additionalItems) {
 TEST(JSONSchema_default_walker_draft4, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref", "required"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -99,7 +99,7 @@ TEST(JSONSchema_default_walker_draft4, patternProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -107,7 +107,7 @@ TEST(JSONSchema_default_walker_draft4, patternProperties) {
 TEST(JSONSchema_default_walker_draft4, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -116,7 +116,7 @@ TEST(JSONSchema_default_walker_draft4, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT4)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -361,7 +361,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -369,7 +369,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("schema", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft6_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft6_test.cc
@@ -33,7 +33,7 @@ TEST(JSONSchema_default_walker_draft6, ref) {
 TEST(JSONSchema_default_walker_draft6, definitions) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("definitions", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -41,7 +41,7 @@ TEST(JSONSchema_default_walker_draft6, definitions) {
 TEST(JSONSchema_default_walker_draft6, allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -49,7 +49,7 @@ TEST(JSONSchema_default_walker_draft6, allOf) {
 TEST(JSONSchema_default_walker_draft6, anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -57,7 +57,7 @@ TEST(JSONSchema_default_walker_draft6, anyOf) {
 TEST(JSONSchema_default_walker_draft6, oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -65,7 +65,7 @@ TEST(JSONSchema_default_walker_draft6, oneOf) {
 TEST(JSONSchema_default_walker_draft6, not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -73,7 +73,7 @@ TEST(JSONSchema_default_walker_draft6, not) {
 TEST(JSONSchema_default_walker_draft6, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -82,7 +82,7 @@ TEST(JSONSchema_default_walker_draft6, additionalItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -90,7 +90,7 @@ TEST(JSONSchema_default_walker_draft6, additionalItems) {
 TEST(JSONSchema_default_walker_draft6, contains) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("contains", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -98,7 +98,7 @@ TEST(JSONSchema_default_walker_draft6, contains) {
 TEST(JSONSchema_default_walker_draft6, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref", "required"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -107,7 +107,7 @@ TEST(JSONSchema_default_walker_draft6, patternProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -115,7 +115,7 @@ TEST(JSONSchema_default_walker_draft6, patternProperties) {
 TEST(JSONSchema_default_walker_draft6, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -124,7 +124,7 @@ TEST(JSONSchema_default_walker_draft6, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -133,7 +133,7 @@ TEST(JSONSchema_default_walker_draft6, propertyNames) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_DRAFT6)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -386,7 +386,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_hrefSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -394,7 +394,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -402,7 +402,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_submissionSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_DRAFT6_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft7_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft7_test.cc
@@ -33,7 +33,7 @@ TEST(JSONSchema_default_walker_draft7, ref) {
 TEST(JSONSchema_default_walker_draft7, definitions) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("definitions", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -49,7 +49,7 @@ TEST(JSONSchema_default_walker_draft7, comment) {
 TEST(JSONSchema_default_walker_draft7, allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -57,7 +57,7 @@ TEST(JSONSchema_default_walker_draft7, allOf) {
 TEST(JSONSchema_default_walker_draft7, anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -65,7 +65,7 @@ TEST(JSONSchema_default_walker_draft7, anyOf) {
 TEST(JSONSchema_default_walker_draft7, oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ElementsInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -73,7 +73,7 @@ TEST(JSONSchema_default_walker_draft7, oneOf) {
 TEST(JSONSchema_default_walker_draft7, not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -81,7 +81,7 @@ TEST(JSONSchema_default_walker_draft7, not) {
 TEST(JSONSchema_default_walker_draft7, if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("if", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -89,7 +89,7 @@ TEST(JSONSchema_default_walker_draft7, if) {
 TEST(JSONSchema_default_walker_draft7, then) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("then", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -97,7 +97,7 @@ TEST(JSONSchema_default_walker_draft7, then) {
 TEST(JSONSchema_default_walker_draft7, else) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("else", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -105,7 +105,7 @@ TEST(JSONSchema_default_walker_draft7, else) {
 TEST(JSONSchema_default_walker_draft7, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueOrElements);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -114,7 +114,7 @@ TEST(JSONSchema_default_walker_draft7, additionalItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -122,7 +122,7 @@ TEST(JSONSchema_default_walker_draft7, additionalItems) {
 TEST(JSONSchema_default_walker_draft7, contains) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("contains", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -130,7 +130,7 @@ TEST(JSONSchema_default_walker_draft7, contains) {
 TEST(JSONSchema_default_walker_draft7, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref", "required"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -139,7 +139,7 @@ TEST(JSONSchema_default_walker_draft7, patternProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -147,7 +147,7 @@ TEST(JSONSchema_default_walker_draft7, patternProperties) {
 TEST(JSONSchema_default_walker_draft7, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Members);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -156,7 +156,7 @@ TEST(JSONSchema_default_walker_draft7, additionalProperties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -165,7 +165,7 @@ TEST(JSONSchema_default_walker_draft7, propertyNames) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ValueInPlace);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -476,7 +476,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_hrefSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -484,7 +484,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_targetSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -492,7 +492,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_headerSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -500,7 +500,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_submissionSchema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_DRAFT7_HYPERSCHEMA)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Value);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_walker_test.cc
+++ b/test/jsonschema/jsonschema_walker_test.cc
@@ -37,24 +37,29 @@ static auto test_walker(std::string_view keyword,
   if (vocabularies.find("https://sourcemeta.com/vocab/test-1") !=
       vocabularies.end()) {
     if (keyword == "schema") {
-      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Value, {}};
+      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorValue,
+              {}};
     }
 
     if (keyword == "schemas") {
-      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Elements, {}};
+      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorElements,
+              {}};
     }
 
     if (keyword == "schemaMap") {
-      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Members, {}};
+      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorMembers,
+              {}};
     }
 
     if (keyword == "schemaOrSchemas") {
-      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ValueOrElements,
+      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::
+                  ApplicatorValueOrElements,
               {}};
     }
 
     if (keyword == "schemasOrMap") {
-      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ElementsOrMembers,
+      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::
+                  ApplicatorElementsOrMembers,
               {}};
     }
   }
@@ -62,7 +67,8 @@ static auto test_walker(std::string_view keyword,
   if (vocabularies.find("https://sourcemeta.com/vocab/test-2") !=
       vocabularies.end()) {
     if (keyword == "custom") {
-      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Value, {}};
+      return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorValue,
+              {}};
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
