### PR TITLE
Extend `SchemaWalkerResult` to include the origin vocabulary

### DIFF
--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -6,6 +6,7 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
 #define WALK(vocabulary, _keyword, strategy, ...)                              \
   if (vocabularies.contains(vocabulary) && keyword == _keyword)                \
     return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::strategy,           \
+            vocabulary,                                                        \
             {__VA_ARGS__}};
 
 #define WALK_MAYBE_DEPENDENT(vocabulary, _keyword, strategy,                   \
@@ -262,7 +263,9 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   // $ref also takes precedence over any unknown keyword
   if (vocabularies.contains(HTTP_BASE "draft-07/schema#") &&
       keyword != "$ref") {
-    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, {"$ref"}};
+    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown,
+            std::nullopt,
+            {"$ref"}};
   }
 
   // Draft6
@@ -326,7 +329,9 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   // $ref also takes precedence over any unknown keyword
   if (vocabularies.contains(HTTP_BASE "draft-06/schema#") &&
       keyword != "$ref") {
-    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, {"$ref"}};
+    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown,
+            std::nullopt,
+            {"$ref"}};
   }
 
   // Draft4
@@ -378,7 +383,9 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   // $ref also takes precedence over any unknown keyword
   if (vocabularies.contains(HTTP_BASE "draft-04/schema#") &&
       keyword != "$ref") {
-    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, {"$ref"}};
+    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown,
+            std::nullopt,
+            {"$ref"}};
   }
 
   // Draft3
@@ -422,7 +429,9 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   // $ref also takes precedence over any unknown keyword
   if (vocabularies.contains(HTTP_BASE "draft-03/schema#") &&
       keyword != "$ref") {
-    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, {"$ref"}};
+    return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown,
+            std::nullopt,
+            {"$ref"}};
   }
 
   // Draft2
@@ -545,5 +554,6 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
 #undef HTTP_BASE
 #undef WALK
 #undef WALK_MAYBE_DEPENDENT
-  return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, {}};
+  return {
+      sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, std::nullopt, {}};
 }

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_walker.h
@@ -85,6 +85,8 @@ enum class SchemaWalkerStrategy : std::uint8_t {
 struct SchemaWalkerResult {
   /// The walker strategy to continue traversing across the schema
   const SchemaWalkerStrategy strategy;
+  /// The vocabulary associated with the keyword, if any
+  const std::optional<std::string> vocabulary;
   /// The keywords a given keyword depends on (if any) during the evaluation
   /// process
   const std::set<std::string> dependencies;
@@ -111,7 +113,7 @@ SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 inline auto schema_walker_none(std::string_view,
                                const std::map<std::string, bool> &)
     -> sourcemeta::jsontoolkit::SchemaWalkerResult {
-  return {SchemaWalkerStrategy::Unknown, {}};
+  return {SchemaWalkerStrategy::Unknown, std::nullopt, {}};
 }
 
 /// @ingroup jsonschema

--- a/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
@@ -35,6 +35,9 @@ TEST(JSONSchema_default_walker_2019_09, core_schema) {
   const auto result{
       default_schema_walker("$schema", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -43,6 +46,9 @@ TEST(JSONSchema_default_walker_2019_09, core_vocabulary) {
   const auto result{
       default_schema_walker("$vocabulary", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -50,6 +56,9 @@ TEST(JSONSchema_default_walker_2019_09, core_id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$id", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -58,6 +67,9 @@ TEST(JSONSchema_default_walker_2019_09, core_anchor) {
   const auto result{
       default_schema_walker("$anchor", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -66,6 +78,9 @@ TEST(JSONSchema_default_walker_2019_09, core_recursiveAnchor) {
   const auto result{
       default_schema_walker("$recursiveAnchor", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -73,6 +88,9 @@ TEST(JSONSchema_default_walker_2019_09, core_ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -81,6 +99,9 @@ TEST(JSONSchema_default_walker_2019_09, core_recursiveRef) {
   const auto result{
       default_schema_walker("$recursiveRef", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -88,6 +109,9 @@ TEST(JSONSchema_default_walker_2019_09, core_defs) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$defs", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -96,6 +120,9 @@ TEST(JSONSchema_default_walker_2019_09, core_comment) {
   const auto result{
       default_schema_walker("$comment", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -104,6 +131,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_allOf) {
   const auto result{
       default_schema_walker("allOf", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -112,6 +142,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_anyOf) {
   const auto result{
       default_schema_walker("anyOf", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -120,6 +153,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_oneOf) {
   const auto result{
       default_schema_walker("oneOf", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -128,6 +164,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_not) {
   const auto result{
       default_schema_walker("not", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -136,6 +175,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_if) {
   const auto result{
       default_schema_walker("if", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -144,6 +186,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_then) {
   const auto result{
       default_schema_walker("then", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -153,6 +198,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_else) {
   const auto result{
       default_schema_walker("else", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -162,6 +210,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_dependentSchemas) {
   const auto result{default_schema_walker("dependentSchemas",
                                           VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -170,6 +221,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_items) {
   const auto result{
       default_schema_walker("items", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -178,6 +232,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_additionalItems) {
   const auto result{default_schema_walker("additionalItems",
                                           VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -187,6 +244,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_contains_only) {
   const auto result{
       default_schema_walker("contains", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -201,6 +261,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_contains_with_validation) {
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("contains", vocabularies)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"minContains", "maxContains"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -210,6 +273,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_properties) {
   const auto result{
       default_schema_walker("properties", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -218,6 +284,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_patternProperties) {
   const auto result{default_schema_walker("patternProperties",
                                           VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -226,6 +295,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_additionalProperties) {
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -235,6 +307,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_propertyNames) {
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -243,6 +318,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_unevaluatedItems) {
   const auto result{default_schema_walker("unevaluatedItems",
                                           VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"items", "additionalItems"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -252,6 +330,9 @@ TEST(JSONSchema_default_walker_2019_09, applicator_unevaluatedProperties) {
   const auto result{default_schema_walker("unevaluatedProperties",
                                           VOCABULARIES_2019_09_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/applicator");
   const std::set<std::string> expected{"properties", "patternProperties",
                                        "additionalProperties"};
   EXPECT_EQ(result.dependencies, expected);
@@ -262,6 +343,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_type) {
   const auto result{
       default_schema_walker("type", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -270,6 +354,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_enum) {
   const auto result{
       default_schema_walker("enum", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -278,6 +365,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_const) {
   const auto result{
       default_schema_walker("const", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -286,6 +376,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_multipleOf) {
   const auto result{
       default_schema_walker("multipleOf", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -294,6 +387,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   const std::set<std::string> expected{"type"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -303,6 +399,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   const std::set<std::string> expected{"type"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -312,6 +411,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_exclusiveMaximum) {
   const auto result{default_schema_walker("exclusiveMaximum",
                                           VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -320,6 +422,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_exclusiveMinimum) {
   const auto result{default_schema_walker("exclusiveMinimum",
                                           VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -328,6 +433,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_maxLength) {
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -336,6 +444,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_minLength) {
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -344,6 +455,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_pattern) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -352,6 +466,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_maxItems) {
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -360,6 +477,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_minItems) {
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -368,6 +488,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_uniqueItems) {
   const auto result{
       default_schema_walker("uniqueItems", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -376,6 +499,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_maxContains) {
   const auto result{
       default_schema_walker("maxContains", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -384,6 +510,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_minContains) {
   const auto result{
       default_schema_walker("minContains", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -392,6 +521,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_maxProperties) {
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -400,6 +532,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_minProperties) {
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -408,6 +543,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_required) {
   const auto result{
       default_schema_walker("required", VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -416,6 +554,9 @@ TEST(JSONSchema_default_walker_2019_09, validation_dependentRequired) {
   const auto result{default_schema_walker("dependentRequired",
                                           VOCABULARIES_2019_09_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -424,6 +565,9 @@ TEST(JSONSchema_default_walker_2019_09, format_format) {
   const auto result{
       default_schema_walker("format", VOCABULARIES_2019_09_FORMAT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/format");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -432,6 +576,9 @@ TEST(JSONSchema_default_walker_2019_09, content_contentEncoding) {
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_2019_09_CONTENT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/content");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -440,6 +587,9 @@ TEST(JSONSchema_default_walker_2019_09, content_contentMediaType) {
   const auto result{
       default_schema_walker("contentMediaType", VOCABULARIES_2019_09_CONTENT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/content");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -448,6 +598,9 @@ TEST(JSONSchema_default_walker_2019_09, content_contentSchema) {
   const auto result{
       default_schema_walker("contentSchema", VOCABULARIES_2019_09_CONTENT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/content");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -456,6 +609,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_title) {
   const auto result{
       default_schema_walker("title", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -464,6 +620,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_description) {
   const auto result{
       default_schema_walker("description", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -472,6 +631,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_default) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -480,6 +642,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_deprecated) {
   const auto result{
       default_schema_walker("deprecated", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -488,6 +653,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_readOnly) {
   const auto result{
       default_schema_walker("readOnly", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -496,6 +664,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_writeOnly) {
   const auto result{
       default_schema_walker("writeOnly", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -504,6 +675,9 @@ TEST(JSONSchema_default_walker_2019_09, metadata_examples) {
   const auto result{
       default_schema_walker("examples", VOCABULARIES_2019_09_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -512,6 +686,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_base) {
   const auto result{
       default_schema_walker("base", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -520,6 +695,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -528,6 +704,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_ref) {
   const auto result{
       default_schema_walker("ref", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -536,6 +713,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -544,6 +722,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_anchor) {
   const auto result{
       default_schema_walker("anchor", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -552,6 +731,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_anchorPointer) {
   const auto result{
       default_schema_walker("anchorPointer", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -560,6 +740,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -568,6 +749,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_templatePointers) {
   const auto result{default_schema_walker("templatePointers",
                                           VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -576,6 +758,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_templateRequired) {
   const auto result{default_schema_walker("templateRequired",
                                           VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -584,6 +767,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_targetMediaType) {
   const auto result{default_schema_walker("targetMediaType",
                                           VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -592,6 +776,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_targetHints) {
   const auto result{
       default_schema_walker("targetHints", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -600,6 +785,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_submissionMediaType) {
   const auto result{default_schema_walker("submissionMediaType",
                                           VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -608,6 +794,9 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_hrefSchema) {
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -616,6 +805,9 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -624,6 +816,9 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_headerSchema) {
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -632,6 +827,9 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_submissionSchema) {
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_2019_09_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -639,6 +837,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_allOf_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -646,6 +845,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_anyOf_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -653,6 +853,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_oneOf_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -660,6 +861,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_not_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -667,6 +869,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_if_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("if", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -674,6 +877,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_then_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("then", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -681,6 +885,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_else_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("else", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -690,6 +895,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("dependentSchemas", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -699,6 +905,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -706,6 +913,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_items_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -715,6 +923,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("contains", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -724,6 +933,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("properties", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -733,6 +943,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -742,6 +953,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -751,6 +963,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -760,6 +973,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("unevaluatedItems", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -769,6 +983,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{default_schema_walker("unevaluatedProperties",
                                           VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -776,6 +991,7 @@ TEST(JSONSchema_default_walker_2019_09, validation_type_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -783,6 +999,7 @@ TEST(JSONSchema_default_walker_2019_09, validation_enum_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -790,6 +1007,7 @@ TEST(JSONSchema_default_walker_2019_09, validation_const_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("const", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -799,6 +1017,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("multipleOf", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -807,6 +1026,7 @@ TEST(JSONSchema_default_walker_2019_09, validation_maximum_without_vocabulary) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -815,6 +1035,7 @@ TEST(JSONSchema_default_walker_2019_09, validation_minimum_without_vocabulary) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -824,6 +1045,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("exclusiveMaximum", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -833,6 +1055,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("exclusiveMinimum", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -842,6 +1065,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -851,6 +1075,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -859,6 +1084,7 @@ TEST(JSONSchema_default_walker_2019_09, validation_pattern_without_vocabulary) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -868,6 +1094,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -877,6 +1104,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -886,6 +1114,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("uniqueItems", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -895,6 +1124,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("maxContains", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -904,6 +1134,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("minContains", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -913,6 +1144,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -922,6 +1154,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -931,6 +1164,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("required", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -940,6 +1174,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("dependentRequired", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -947,6 +1182,7 @@ TEST(JSONSchema_default_walker_2019_09, format_format_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -956,6 +1192,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -965,6 +1202,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("contentMediaType", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -974,6 +1212,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("contentSchema", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -981,6 +1220,7 @@ TEST(JSONSchema_default_walker_2019_09, metadata_title_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -990,6 +1230,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("description", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -998,6 +1239,7 @@ TEST(JSONSchema_default_walker_2019_09, metadata_default_without_vocabulary) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1007,6 +1249,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("deprecated", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1015,6 +1258,7 @@ TEST(JSONSchema_default_walker_2019_09, metadata_readOnly_without_vocabulary) {
   const auto result{
       default_schema_walker("readOnly", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1023,6 +1267,7 @@ TEST(JSONSchema_default_walker_2019_09, metadata_writeOnly_without_vocabulary) {
   const auto result{
       default_schema_walker("writeOnly", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1031,6 +1276,7 @@ TEST(JSONSchema_default_walker_2019_09, metadata_examples_without_vocabulary) {
   const auto result{
       default_schema_walker("examples", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1038,6 +1284,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_base_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("base", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1045,6 +1292,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_links_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1052,6 +1300,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_ref_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("ref", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1059,6 +1308,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_href_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1066,6 +1316,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_anchor_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anchor", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1075,6 +1326,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("anchorPointer", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1082,6 +1334,7 @@ TEST(JSONSchema_default_walker_2019_09, hyperschema_rel_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1091,6 +1344,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("templatePointers", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1100,6 +1354,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("templateRequired", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1109,6 +1364,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("targetMediaType", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1118,6 +1374,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("targetHints", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1127,6 +1384,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("submissionMediaType", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1136,6 +1394,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1145,6 +1404,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1154,6 +1414,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1163,6 +1424,7 @@ TEST(JSONSchema_default_walker_2019_09,
   const auto result{
       default_schema_walker("submissionSchema", VOCABULARIES_2019_09_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
@@ -43,6 +43,9 @@ TEST(JSONSchema_default_walker_2020_12, core_schema) {
   const auto result{
       default_schema_walker("$schema", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -51,6 +54,9 @@ TEST(JSONSchema_default_walker_2020_12, core_vocabulary) {
   const auto result{
       default_schema_walker("$vocabulary", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -58,6 +64,9 @@ TEST(JSONSchema_default_walker_2020_12, core_id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$id", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -66,6 +75,9 @@ TEST(JSONSchema_default_walker_2020_12, core_anchor) {
   const auto result{
       default_schema_walker("$anchor", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -74,6 +86,9 @@ TEST(JSONSchema_default_walker_2020_12, core_dynamicAnchor) {
   const auto result{
       default_schema_walker("$dynamicAnchor", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -81,6 +96,9 @@ TEST(JSONSchema_default_walker_2020_12, core_ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -89,6 +107,9 @@ TEST(JSONSchema_default_walker_2020_12, core_dynamicRef) {
   const auto result{
       default_schema_walker("$dynamicRef", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -96,6 +117,9 @@ TEST(JSONSchema_default_walker_2020_12, core_defs) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$defs", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -104,6 +128,9 @@ TEST(JSONSchema_default_walker_2020_12, core_comment) {
   const auto result{
       default_schema_walker("$comment", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/core");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -112,6 +139,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_allOf) {
   const auto result{
       default_schema_walker("allOf", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -120,6 +150,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_anyOf) {
   const auto result{
       default_schema_walker("anyOf", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -128,6 +161,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_oneOf) {
   const auto result{
       default_schema_walker("oneOf", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -136,6 +172,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_not) {
   const auto result{
       default_schema_walker("not", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -144,6 +183,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_if) {
   const auto result{
       default_schema_walker("if", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -152,6 +194,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_then) {
   const auto result{
       default_schema_walker("then", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -161,6 +206,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_else) {
   const auto result{
       default_schema_walker("else", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -170,6 +218,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_dependentSchemas) {
   const auto result{default_schema_walker("dependentSchemas",
                                           VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -178,6 +229,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_prefixItems) {
   const auto result{
       default_schema_walker("prefixItems", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -186,6 +240,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_items) {
   const auto result{
       default_schema_walker("items", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   const std::set<std::string> expected{"prefixItems"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -195,6 +252,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_contains_only) {
   const auto result{
       default_schema_walker("contains", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -209,6 +269,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_contains_with_validation) {
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("contains", vocabularies)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   const std::set<std::string> expected{"minContains", "maxContains"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -218,6 +281,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_properties) {
   const auto result{
       default_schema_walker("properties", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -226,6 +292,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_patternProperties) {
   const auto result{default_schema_walker("patternProperties",
                                           VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -234,6 +303,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_additionalProperties) {
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -243,6 +315,9 @@ TEST(JSONSchema_default_walker_2020_12, applicator_propertyNames) {
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_2020_12_APPLICATOR)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/applicator");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -251,6 +326,9 @@ TEST(JSONSchema_default_walker_2020_12, unevaluated_unevaluatedItems_only) {
   const auto result{default_schema_walker("unevaluatedItems",
                                           VOCABULARIES_2020_12_UNEVALUATED)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/unevaluated");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -266,6 +344,9 @@ TEST(JSONSchema_default_walker_2020_12,
             std::inserter(vocabularies, vocabularies.end()));
   const auto result{default_schema_walker("unevaluatedItems", vocabularies)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/unevaluated");
   const std::set<std::string> expected{"prefixItems", "items", "contains"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -276,6 +357,9 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{default_schema_walker("unevaluatedProperties",
                                           VOCABULARIES_2020_12_UNEVALUATED)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/unevaluated");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -292,6 +376,9 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("unevaluatedProperties", vocabularies)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/unevaluated");
   const std::set<std::string> expected{"properties", "patternProperties",
                                        "additionalProperties"};
   EXPECT_EQ(result.dependencies, expected);
@@ -302,6 +389,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_type) {
   const auto result{
       default_schema_walker("type", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -310,6 +400,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_enum) {
   const auto result{
       default_schema_walker("enum", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -318,6 +411,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_const) {
   const auto result{
       default_schema_walker("const", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -326,6 +422,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_multipleOf) {
   const auto result{
       default_schema_walker("multipleOf", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -334,6 +433,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   const std::set<std::string> expected{"type"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -343,6 +445,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   const std::set<std::string> expected{"type"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -352,6 +457,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_exclusiveMaximum) {
   const auto result{default_schema_walker("exclusiveMaximum",
                                           VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -360,6 +468,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_exclusiveMinimum) {
   const auto result{default_schema_walker("exclusiveMinimum",
                                           VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -368,6 +479,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_maxLength) {
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -376,6 +490,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_minLength) {
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -384,6 +501,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_pattern) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -392,6 +512,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_maxItems) {
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -400,6 +523,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_minItems) {
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -408,6 +534,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_uniqueItems) {
   const auto result{
       default_schema_walker("uniqueItems", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -416,6 +545,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_maxContains) {
   const auto result{
       default_schema_walker("maxContains", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -424,6 +556,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_minContains) {
   const auto result{
       default_schema_walker("minContains", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -432,6 +567,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_maxProperties) {
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -440,6 +578,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_minProperties) {
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -448,6 +589,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_required) {
   const auto result{
       default_schema_walker("required", VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -456,6 +600,9 @@ TEST(JSONSchema_default_walker_2020_12, validation_dependentRequired) {
   const auto result{default_schema_walker("dependentRequired",
                                           VOCABULARIES_2020_12_VALIDATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/validation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -464,6 +611,9 @@ TEST(JSONSchema_default_walker_2020_12, format_annotation_format) {
   const auto result{
       default_schema_walker("format", VOCABULARIES_2020_12_FORMAT_ANNOTATION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/format-annotation");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -472,6 +622,9 @@ TEST(JSONSchema_default_walker_2020_12, format_assertion_format) {
   const auto result{
       default_schema_walker("format", VOCABULARIES_2020_12_FORMAT_ASSERTION)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/format-assertion");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -480,6 +633,9 @@ TEST(JSONSchema_default_walker_2020_12, content_contentEncoding) {
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_2020_12_CONTENT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/content");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -488,6 +644,9 @@ TEST(JSONSchema_default_walker_2020_12, content_contentMediaType) {
   const auto result{
       default_schema_walker("contentMediaType", VOCABULARIES_2020_12_CONTENT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/content");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -496,6 +655,9 @@ TEST(JSONSchema_default_walker_2020_12, content_contentSchema) {
   const auto result{
       default_schema_walker("contentSchema", VOCABULARIES_2020_12_CONTENT)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/content");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -504,6 +666,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_title) {
   const auto result{
       default_schema_walker("title", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -512,6 +677,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_description) {
   const auto result{
       default_schema_walker("description", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -520,6 +688,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_default) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -528,6 +699,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_deprecated) {
   const auto result{
       default_schema_walker("deprecated", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -536,6 +710,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_readOnly) {
   const auto result{
       default_schema_walker("readOnly", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -544,6 +721,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_writeOnly) {
   const auto result{
       default_schema_walker("writeOnly", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -552,6 +732,9 @@ TEST(JSONSchema_default_walker_2020_12, metadata_examples) {
   const auto result{
       default_schema_walker("examples", VOCABULARIES_2020_12_METADATA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Annotation);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2020-12/vocab/meta-data");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -560,6 +743,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_base) {
   const auto result{
       default_schema_walker("base", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -568,6 +752,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -576,6 +761,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_ref) {
   const auto result{
       default_schema_walker("ref", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -584,6 +770,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -592,6 +779,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_anchor) {
   const auto result{
       default_schema_walker("anchor", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -600,6 +788,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_anchorPointer) {
   const auto result{
       default_schema_walker("anchorPointer", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -608,6 +797,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -616,6 +806,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_templatePointers) {
   const auto result{default_schema_walker("templatePointers",
                                           VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -624,6 +815,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_templateRequired) {
   const auto result{default_schema_walker("templateRequired",
                                           VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -632,6 +824,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_targetMediaType) {
   const auto result{default_schema_walker("targetMediaType",
                                           VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -640,6 +833,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_targetHints) {
   const auto result{
       default_schema_walker("targetHints", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -648,6 +842,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_submissionMediaType) {
   const auto result{default_schema_walker("submissionMediaType",
                                           VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -656,6 +851,9 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_hrefSchema) {
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -664,6 +862,9 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -672,6 +873,9 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_headerSchema) {
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -680,6 +884,9 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_submissionSchema) {
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_2020_12_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "https://json-schema.org/draft/2019-09/vocab/hyper-schema");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -687,6 +894,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_allOf_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -694,6 +902,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_anyOf_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -701,6 +910,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_oneOf_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -708,6 +918,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_not_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -715,6 +926,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_if_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("if", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -722,6 +934,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_then_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("then", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -729,6 +942,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_else_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("else", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -738,6 +952,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("dependentSchemas", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -747,6 +962,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("prefixItems", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -754,6 +970,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_items_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -763,6 +980,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("contains", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -772,6 +990,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("properties", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -781,6 +1000,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -790,6 +1010,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -799,6 +1020,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -808,6 +1030,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("unevaluatedItems", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -817,6 +1040,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{default_schema_walker("unevaluatedProperties",
                                           VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -824,6 +1048,7 @@ TEST(JSONSchema_default_walker_2020_12, validation_type_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -831,6 +1056,7 @@ TEST(JSONSchema_default_walker_2020_12, validation_enum_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -838,6 +1064,7 @@ TEST(JSONSchema_default_walker_2020_12, validation_const_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("const", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -847,6 +1074,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("multipleOf", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -855,6 +1083,7 @@ TEST(JSONSchema_default_walker_2020_12, validation_maximum_without_vocabulary) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -863,6 +1092,7 @@ TEST(JSONSchema_default_walker_2020_12, validation_minimum_without_vocabulary) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -872,6 +1102,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("exclusiveMaximum", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -881,6 +1112,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("exclusiveMinimum", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -890,6 +1122,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -899,6 +1132,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -907,6 +1141,7 @@ TEST(JSONSchema_default_walker_2020_12, validation_pattern_without_vocabulary) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -916,6 +1151,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -925,6 +1161,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -934,6 +1171,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("uniqueItems", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -943,6 +1181,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("maxContains", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -952,6 +1191,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("minContains", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -961,6 +1201,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -970,6 +1211,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -979,6 +1221,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("required", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -988,6 +1231,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("dependentRequired", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -996,6 +1240,7 @@ TEST(JSONSchema_default_walker_2020_12,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1004,6 +1249,7 @@ TEST(JSONSchema_default_walker_2020_12,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1013,6 +1259,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1022,6 +1269,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("contentMediaType", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1031,6 +1279,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("contentSchema", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1038,6 +1287,7 @@ TEST(JSONSchema_default_walker_2020_12, metadata_title_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1047,6 +1297,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("description", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1055,6 +1306,7 @@ TEST(JSONSchema_default_walker_2020_12, metadata_default_without_vocabulary) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1064,6 +1316,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("deprecated", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1072,6 +1325,7 @@ TEST(JSONSchema_default_walker_2020_12, metadata_readOnly_without_vocabulary) {
   const auto result{
       default_schema_walker("readOnly", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1080,6 +1334,7 @@ TEST(JSONSchema_default_walker_2020_12, metadata_writeOnly_without_vocabulary) {
   const auto result{
       default_schema_walker("writeOnly", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1088,6 +1343,7 @@ TEST(JSONSchema_default_walker_2020_12, metadata_examples_without_vocabulary) {
   const auto result{
       default_schema_walker("examples", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1095,6 +1351,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_base_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("base", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1102,6 +1359,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_links_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1109,6 +1367,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_ref_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("ref", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1116,6 +1375,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_href_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1123,6 +1383,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_anchor_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anchor", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1132,6 +1393,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("anchorPointer", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1139,6 +1401,7 @@ TEST(JSONSchema_default_walker_2020_12, hyperschema_rel_without_vocabulary) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1148,6 +1411,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("templatePointers", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1157,6 +1421,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("templateRequired", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1166,6 +1431,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("targetMediaType", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1175,6 +1441,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("targetHints", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1184,6 +1451,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("submissionMediaType", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1193,6 +1461,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1202,6 +1471,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1211,6 +1481,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -1220,6 +1491,7 @@ TEST(JSONSchema_default_walker_2020_12,
   const auto result{
       default_schema_walker("submissionSchema", VOCABULARIES_2020_12_CORE)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft0_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft0_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft0, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -18,6 +21,9 @@ TEST(JSONSchema_default_walker_draft0, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("id", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -25,6 +31,9 @@ TEST(JSONSchema_default_walker_draft0, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -32,6 +41,9 @@ TEST(JSONSchema_default_walker_draft0, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -39,6 +51,9 @@ TEST(JSONSchema_default_walker_draft0, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -47,6 +62,9 @@ TEST(JSONSchema_default_walker_draft0, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -55,6 +73,9 @@ TEST(JSONSchema_default_walker_draft0, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -62,6 +83,9 @@ TEST(JSONSchema_default_walker_draft0, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -69,6 +93,9 @@ TEST(JSONSchema_default_walker_draft0, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -76,6 +103,9 @@ TEST(JSONSchema_default_walker_draft0, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -84,6 +114,9 @@ TEST(JSONSchema_default_walker_draft0, maximumCanEqual) {
   const auto result{
       default_schema_walker("maximumCanEqual", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -92,6 +125,9 @@ TEST(JSONSchema_default_walker_draft0, minimumCanEqual) {
   const auto result{
       default_schema_walker("minimumCanEqual", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -99,6 +135,9 @@ TEST(JSONSchema_default_walker_draft0, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -106,6 +145,9 @@ TEST(JSONSchema_default_walker_draft0, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -113,6 +155,9 @@ TEST(JSONSchema_default_walker_draft0, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -120,6 +165,9 @@ TEST(JSONSchema_default_walker_draft0, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -127,6 +175,9 @@ TEST(JSONSchema_default_walker_draft0, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -134,6 +185,9 @@ TEST(JSONSchema_default_walker_draft0, requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("requires", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -141,6 +195,9 @@ TEST(JSONSchema_default_walker_draft0, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -148,6 +205,9 @@ TEST(JSONSchema_default_walker_draft0, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -155,6 +215,9 @@ TEST(JSONSchema_default_walker_draft0, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -162,6 +225,9 @@ TEST(JSONSchema_default_walker_draft0, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -169,6 +235,9 @@ TEST(JSONSchema_default_walker_draft0, disallow) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("disallow", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -177,6 +246,9 @@ TEST(JSONSchema_default_walker_draft0, extends) {
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -185,6 +257,9 @@ TEST(JSONSchema_default_walker_draft0, contentEncoding) {
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -192,6 +267,9 @@ TEST(JSONSchema_default_walker_draft0, optional) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("optional", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -199,6 +277,9 @@ TEST(JSONSchema_default_walker_draft0, maxDecimal) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxDecimal", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -207,6 +288,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -215,6 +297,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_fragmentResolution) {
   const auto result{default_schema_walker("fragmentResolution",
                                           VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -223,6 +306,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_root) {
   const auto result{
       default_schema_walker("root", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -231,6 +315,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_readonly) {
   const auto result{
       default_schema_walker("readonly", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -239,6 +324,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_pathStart) {
   const auto result{
       default_schema_walker("pathStart", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -247,6 +333,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_mediaType) {
   const auto result{
       default_schema_walker("mediaType", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -255,6 +342,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_alternate) {
   const auto result{
       default_schema_walker("alternate", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -263,6 +351,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -271,6 +360,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -279,6 +369,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_method) {
   const auto result{
       default_schema_walker("method", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -287,6 +378,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_enctype) {
   const auto result{
       default_schema_walker("enctype", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -295,6 +387,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_schema) {
   const auto result{
       default_schema_walker("$schema", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -303,6 +396,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_id) {
   const auto result{
       default_schema_walker("id", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -311,6 +405,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_ref) {
   const auto result{
       default_schema_walker("$ref", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -319,6 +414,9 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_items) {
   const auto result{
       default_schema_walker("items", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -327,6 +425,9 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_properties) {
   const auto result{
       default_schema_walker("properties", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -335,6 +436,9 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_additionalProperties) {
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/hyper-schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -344,6 +448,9 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_type) {
   const auto result{
       default_schema_walker("type", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -352,6 +459,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_enum) {
   const auto result{
       default_schema_walker("enum", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -360,6 +468,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -368,6 +477,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -376,6 +486,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_maximumCanEqual) {
   const auto result{default_schema_walker("maximumCanEqual",
                                           VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -384,6 +495,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_minimumCanEqual) {
   const auto result{default_schema_walker("minimumCanEqual",
                                           VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -392,6 +504,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_maxLength) {
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -400,6 +513,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_minLength) {
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -408,6 +522,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_pattern) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -416,6 +531,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_maxItems) {
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -424,6 +540,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_minItems) {
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -432,6 +549,9 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_requires) {
   const auto result{
       default_schema_walker("requires", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -440,6 +560,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_format) {
   const auto result{
       default_schema_walker("format", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -448,6 +569,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_title) {
   const auto result{
       default_schema_walker("title", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -456,6 +578,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_description) {
   const auto result{
       default_schema_walker("description", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -464,6 +587,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_default) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -472,6 +596,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_disallow) {
   const auto result{
       default_schema_walker("disallow", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -481,6 +606,9 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_extends) {
       default_schema_walker("extends", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-00/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -489,6 +617,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_contentEncoding) {
   const auto result{default_schema_walker("contentEncoding",
                                           VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -497,6 +626,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_optional) {
   const auto result{
       default_schema_walker("optional", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -505,6 +635,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_maxDecimal) {
   const auto result{
       default_schema_walker("maxDecimal", VOCABULARIES_DRAFT0_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -512,6 +643,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -521,6 +653,7 @@ TEST(JSONSchema_default_walker_draft0,
   const auto result{
       default_schema_walker("fragmentResolution", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -528,6 +661,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_root_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("root", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -536,6 +670,7 @@ TEST(JSONSchema_default_walker_draft0,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readonly", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -544,6 +679,7 @@ TEST(JSONSchema_default_walker_draft0,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pathStart", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -552,6 +688,7 @@ TEST(JSONSchema_default_walker_draft0,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("mediaType", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -560,6 +697,7 @@ TEST(JSONSchema_default_walker_draft0,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("alternate", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -567,6 +705,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -574,6 +713,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -581,6 +721,7 @@ TEST(JSONSchema_default_walker_draft0, hyperschema_method_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("method", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -589,6 +730,7 @@ TEST(JSONSchema_default_walker_draft0,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enctype", VOCABULARIES_DRAFT0)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft1_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft1_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft1, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -18,6 +21,9 @@ TEST(JSONSchema_default_walker_draft1, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("id", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -25,6 +31,9 @@ TEST(JSONSchema_default_walker_draft1, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -32,6 +41,9 @@ TEST(JSONSchema_default_walker_draft1, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -39,6 +51,9 @@ TEST(JSONSchema_default_walker_draft1, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -47,6 +62,9 @@ TEST(JSONSchema_default_walker_draft1, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -55,6 +73,9 @@ TEST(JSONSchema_default_walker_draft1, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -62,6 +83,9 @@ TEST(JSONSchema_default_walker_draft1, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -69,6 +93,9 @@ TEST(JSONSchema_default_walker_draft1, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -76,6 +103,9 @@ TEST(JSONSchema_default_walker_draft1, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -84,6 +114,9 @@ TEST(JSONSchema_default_walker_draft1, maximumCanEqual) {
   const auto result{
       default_schema_walker("maximumCanEqual", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -92,6 +125,9 @@ TEST(JSONSchema_default_walker_draft1, minimumCanEqual) {
   const auto result{
       default_schema_walker("minimumCanEqual", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -99,6 +135,9 @@ TEST(JSONSchema_default_walker_draft1, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -106,6 +145,9 @@ TEST(JSONSchema_default_walker_draft1, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -113,6 +155,9 @@ TEST(JSONSchema_default_walker_draft1, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -120,6 +165,9 @@ TEST(JSONSchema_default_walker_draft1, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -127,6 +175,9 @@ TEST(JSONSchema_default_walker_draft1, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -134,6 +185,9 @@ TEST(JSONSchema_default_walker_draft1, requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("requires", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -141,6 +195,9 @@ TEST(JSONSchema_default_walker_draft1, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -148,6 +205,9 @@ TEST(JSONSchema_default_walker_draft1, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -155,6 +215,9 @@ TEST(JSONSchema_default_walker_draft1, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -162,6 +225,9 @@ TEST(JSONSchema_default_walker_draft1, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -169,6 +235,9 @@ TEST(JSONSchema_default_walker_draft1, disallow) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("disallow", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -177,6 +246,9 @@ TEST(JSONSchema_default_walker_draft1, extends) {
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -185,6 +257,9 @@ TEST(JSONSchema_default_walker_draft1, contentEncoding) {
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -192,6 +267,9 @@ TEST(JSONSchema_default_walker_draft1, optional) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("optional", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -199,6 +277,9 @@ TEST(JSONSchema_default_walker_draft1, maxDecimal) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxDecimal", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -207,6 +288,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -215,6 +297,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_fragmentResolution) {
   const auto result{default_schema_walker("fragmentResolution",
                                           VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -223,6 +306,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_root) {
   const auto result{
       default_schema_walker("root", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -231,6 +315,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_readonly) {
   const auto result{
       default_schema_walker("readonly", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -239,6 +324,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_pathStart) {
   const auto result{
       default_schema_walker("pathStart", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -247,6 +333,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_mediaType) {
   const auto result{
       default_schema_walker("mediaType", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -255,6 +342,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_alternate) {
   const auto result{
       default_schema_walker("alternate", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -263,6 +351,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -271,6 +360,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -279,6 +369,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_method) {
   const auto result{
       default_schema_walker("method", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -287,6 +378,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_enctype) {
   const auto result{
       default_schema_walker("enctype", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -295,6 +387,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_schema) {
   const auto result{
       default_schema_walker("$schema", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -303,6 +396,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_id) {
   const auto result{
       default_schema_walker("id", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -311,6 +405,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_ref) {
   const auto result{
       default_schema_walker("$ref", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -319,6 +414,9 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_items) {
   const auto result{
       default_schema_walker("items", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -327,6 +425,9 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_properties) {
   const auto result{
       default_schema_walker("properties", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -335,6 +436,9 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_additionalProperties) {
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/hyper-schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -344,6 +448,9 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_type) {
   const auto result{
       default_schema_walker("type", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -352,6 +459,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_enum) {
   const auto result{
       default_schema_walker("enum", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -360,6 +468,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -368,6 +477,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -376,6 +486,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_maximumCanEqual) {
   const auto result{default_schema_walker("maximumCanEqual",
                                           VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -384,6 +495,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_minimumCanEqual) {
   const auto result{default_schema_walker("minimumCanEqual",
                                           VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -392,6 +504,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_maxLength) {
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -400,6 +513,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_minLength) {
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -408,6 +522,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_pattern) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -416,6 +531,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_maxItems) {
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -424,6 +540,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_minItems) {
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -432,6 +549,9 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_requires) {
   const auto result{
       default_schema_walker("requires", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -440,6 +560,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_format) {
   const auto result{
       default_schema_walker("format", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -448,6 +569,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_title) {
   const auto result{
       default_schema_walker("title", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -456,6 +578,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_description) {
   const auto result{
       default_schema_walker("description", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -464,6 +587,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_default) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -472,6 +596,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_disallow) {
   const auto result{
       default_schema_walker("disallow", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -481,6 +606,9 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_extends) {
       default_schema_walker("extends", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-01/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -489,6 +617,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_contentEncoding) {
   const auto result{default_schema_walker("contentEncoding",
                                           VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -497,6 +626,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_optional) {
   const auto result{
       default_schema_walker("optional", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -505,6 +635,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_maxDecimal) {
   const auto result{
       default_schema_walker("maxDecimal", VOCABULARIES_DRAFT1_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -512,6 +643,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -521,6 +653,7 @@ TEST(JSONSchema_default_walker_draft1,
   const auto result{
       default_schema_walker("fragmentResolution", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -528,6 +661,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_root_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("root", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -536,6 +670,7 @@ TEST(JSONSchema_default_walker_draft1,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readonly", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -544,6 +679,7 @@ TEST(JSONSchema_default_walker_draft1,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pathStart", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -552,6 +688,7 @@ TEST(JSONSchema_default_walker_draft1,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("mediaType", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -560,6 +697,7 @@ TEST(JSONSchema_default_walker_draft1,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("alternate", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -567,6 +705,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -574,6 +713,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -581,6 +721,7 @@ TEST(JSONSchema_default_walker_draft1, hyperschema_method_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("method", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -589,6 +730,7 @@ TEST(JSONSchema_default_walker_draft1,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enctype", VOCABULARIES_DRAFT1)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft2_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft2_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft2, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -18,6 +21,9 @@ TEST(JSONSchema_default_walker_draft2, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("id", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -25,6 +31,9 @@ TEST(JSONSchema_default_walker_draft2, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -32,6 +41,9 @@ TEST(JSONSchema_default_walker_draft2, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -39,6 +51,9 @@ TEST(JSONSchema_default_walker_draft2, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -47,6 +62,9 @@ TEST(JSONSchema_default_walker_draft2, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -55,6 +73,9 @@ TEST(JSONSchema_default_walker_draft2, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -62,6 +83,9 @@ TEST(JSONSchema_default_walker_draft2, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -69,6 +93,9 @@ TEST(JSONSchema_default_walker_draft2, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -76,6 +103,9 @@ TEST(JSONSchema_default_walker_draft2, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -84,6 +114,9 @@ TEST(JSONSchema_default_walker_draft2, maximumCanEqual) {
   const auto result{
       default_schema_walker("maximumCanEqual", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -92,6 +125,9 @@ TEST(JSONSchema_default_walker_draft2, minimumCanEqual) {
   const auto result{
       default_schema_walker("minimumCanEqual", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -99,6 +135,9 @@ TEST(JSONSchema_default_walker_draft2, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -106,6 +145,9 @@ TEST(JSONSchema_default_walker_draft2, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -113,6 +155,9 @@ TEST(JSONSchema_default_walker_draft2, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -120,6 +165,9 @@ TEST(JSONSchema_default_walker_draft2, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -127,6 +175,9 @@ TEST(JSONSchema_default_walker_draft2, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -134,6 +185,9 @@ TEST(JSONSchema_default_walker_draft2, uniqueItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("uniqueItems", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -141,6 +195,9 @@ TEST(JSONSchema_default_walker_draft2, requires) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("requires", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -148,6 +205,9 @@ TEST(JSONSchema_default_walker_draft2, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -155,6 +215,9 @@ TEST(JSONSchema_default_walker_draft2, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -162,6 +225,9 @@ TEST(JSONSchema_default_walker_draft2, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -169,6 +235,9 @@ TEST(JSONSchema_default_walker_draft2, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -176,6 +245,9 @@ TEST(JSONSchema_default_walker_draft2, divisibleBy) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("divisibleBy", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -183,6 +255,9 @@ TEST(JSONSchema_default_walker_draft2, disallow) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("disallow", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -191,6 +266,9 @@ TEST(JSONSchema_default_walker_draft2, extends) {
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -199,6 +277,9 @@ TEST(JSONSchema_default_walker_draft2, contentEncoding) {
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -207,6 +288,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -215,6 +297,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_fragmentResolution) {
   const auto result{default_schema_walker("fragmentResolution",
                                           VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -223,6 +306,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_root) {
   const auto result{
       default_schema_walker("root", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -231,6 +315,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_readonly) {
   const auto result{
       default_schema_walker("readonly", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -239,6 +324,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_pathStart) {
   const auto result{
       default_schema_walker("pathStart", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -247,6 +333,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_mediaType) {
   const auto result{
       default_schema_walker("mediaType", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -255,6 +342,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_alternate) {
   const auto result{
       default_schema_walker("alternate", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -263,6 +351,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -271,6 +360,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -279,6 +369,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_method) {
   const auto result{
       default_schema_walker("method", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -287,6 +378,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_enctype) {
   const auto result{
       default_schema_walker("enctype", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -295,6 +387,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -302,6 +397,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -310,6 +406,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_schema) {
   const auto result{
       default_schema_walker("$schema", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -318,6 +415,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_id) {
   const auto result{
       default_schema_walker("id", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -326,6 +424,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_ref) {
   const auto result{
       default_schema_walker("$ref", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -334,6 +433,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_items) {
   const auto result{
       default_schema_walker("items", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -342,6 +444,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_properties) {
   const auto result{
       default_schema_walker("properties", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -350,6 +455,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_additionalProperties) {
   const auto result{default_schema_walker("additionalProperties",
                                           VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -359,6 +467,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_type) {
   const auto result{
       default_schema_walker("type", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -367,6 +478,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_enum) {
   const auto result{
       default_schema_walker("enum", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -375,6 +487,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_maximum) {
   const auto result{
       default_schema_walker("maximum", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -383,6 +496,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_minimum) {
   const auto result{
       default_schema_walker("minimum", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -391,6 +505,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_maximumCanEqual) {
   const auto result{default_schema_walker("maximumCanEqual",
                                           VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -399,6 +514,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_minimumCanEqual) {
   const auto result{default_schema_walker("minimumCanEqual",
                                           VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -407,6 +523,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_maxLength) {
   const auto result{
       default_schema_walker("maxLength", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -415,6 +532,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_minLength) {
   const auto result{
       default_schema_walker("minLength", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -423,6 +541,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_pattern) {
   const auto result{
       default_schema_walker("pattern", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -431,6 +550,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_maxItems) {
   const auto result{
       default_schema_walker("maxItems", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -439,6 +559,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_minItems) {
   const auto result{
       default_schema_walker("minItems", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -447,6 +568,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_uniqueItems) {
   const auto result{
       default_schema_walker("uniqueItems", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -455,6 +577,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_requires) {
   const auto result{
       default_schema_walker("requires", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -463,6 +588,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_format) {
   const auto result{
       default_schema_walker("format", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -471,6 +597,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_title) {
   const auto result{
       default_schema_walker("title", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -479,6 +606,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_description) {
   const auto result{
       default_schema_walker("description", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -487,6 +615,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_default) {
   const auto result{
       default_schema_walker("default", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -495,6 +624,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_divisibleBy) {
   const auto result{
       default_schema_walker("divisibleBy", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -503,6 +633,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_disallow) {
   const auto result{
       default_schema_walker("disallow", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -512,6 +643,9 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_extends) {
       default_schema_walker("extends", VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-02/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -520,6 +654,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_contentEncoding) {
   const auto result{default_schema_walker("contentEncoding",
                                           VOCABULARIES_DRAFT2_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -529,6 +664,7 @@ TEST(JSONSchema_default_walker_draft2,
   const auto result{
       default_schema_walker("fragmentResolution", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -536,6 +672,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_root_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("root", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -544,6 +681,7 @@ TEST(JSONSchema_default_walker_draft2,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readonly", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -552,6 +690,7 @@ TEST(JSONSchema_default_walker_draft2,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pathStart", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -560,6 +699,7 @@ TEST(JSONSchema_default_walker_draft2,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("mediaType", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -568,6 +708,7 @@ TEST(JSONSchema_default_walker_draft2,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("alternate", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -575,6 +716,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -582,6 +724,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -589,6 +732,7 @@ TEST(JSONSchema_default_walker_draft2, hyperschema_method_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("method", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -597,6 +741,7 @@ TEST(JSONSchema_default_walker_draft2,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enctype", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -605,6 +750,7 @@ TEST(JSONSchema_default_walker_draft2,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("targetSchema", VOCABULARIES_DRAFT2)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 

--- a/test/jsonschema/jsonschema_default_walker_draft3_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft3_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft3, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -19,6 +22,9 @@ TEST(JSONSchema_default_walker_draft3, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("id", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -27,6 +33,9 @@ TEST(JSONSchema_default_walker_draft3, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -34,6 +43,9 @@ TEST(JSONSchema_default_walker_draft3, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -43,6 +55,9 @@ TEST(JSONSchema_default_walker_draft3, additionalItems) {
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -51,6 +66,9 @@ TEST(JSONSchema_default_walker_draft3, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -60,6 +78,9 @@ TEST(JSONSchema_default_walker_draft3, patternProperties) {
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -68,6 +89,9 @@ TEST(JSONSchema_default_walker_draft3, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -77,6 +101,9 @@ TEST(JSONSchema_default_walker_draft3, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -85,6 +112,9 @@ TEST(JSONSchema_default_walker_draft3, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -93,6 +123,9 @@ TEST(JSONSchema_default_walker_draft3, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -101,6 +134,9 @@ TEST(JSONSchema_default_walker_draft3, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -109,6 +145,9 @@ TEST(JSONSchema_default_walker_draft3, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -118,6 +157,9 @@ TEST(JSONSchema_default_walker_draft3, exclusiveMaximum) {
   const auto result{
       default_schema_walker("exclusiveMaximum", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -127,6 +169,9 @@ TEST(JSONSchema_default_walker_draft3, exclusiveMinimum) {
   const auto result{
       default_schema_walker("exclusiveMinimum", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -135,6 +180,9 @@ TEST(JSONSchema_default_walker_draft3, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -143,6 +191,9 @@ TEST(JSONSchema_default_walker_draft3, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -151,6 +202,9 @@ TEST(JSONSchema_default_walker_draft3, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -159,6 +213,9 @@ TEST(JSONSchema_default_walker_draft3, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -167,6 +224,9 @@ TEST(JSONSchema_default_walker_draft3, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -175,6 +235,9 @@ TEST(JSONSchema_default_walker_draft3, uniqueItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("uniqueItems", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -183,6 +246,9 @@ TEST(JSONSchema_default_walker_draft3, required) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("required", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -191,6 +257,9 @@ TEST(JSONSchema_default_walker_draft3, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -199,6 +268,9 @@ TEST(JSONSchema_default_walker_draft3, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -207,6 +279,9 @@ TEST(JSONSchema_default_walker_draft3, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -215,6 +290,9 @@ TEST(JSONSchema_default_walker_draft3, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -223,6 +301,9 @@ TEST(JSONSchema_default_walker_draft3, divisibleBy) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("divisibleBy", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -231,6 +312,9 @@ TEST(JSONSchema_default_walker_draft3, disallow) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("disallow", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -240,6 +324,9 @@ TEST(JSONSchema_default_walker_draft3, extends) {
   const auto result{default_schema_walker("extends", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy,
             SchemaWalkerStrategy::ApplicatorValueOrElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -249,6 +336,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -257,6 +345,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_fragmentResolution) {
   const auto result{default_schema_walker("fragmentResolution",
                                           VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -265,6 +354,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_root) {
   const auto result{
       default_schema_walker("root", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -273,6 +363,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_readonly) {
   const auto result{
       default_schema_walker("readonly", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -281,6 +372,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_contentEncoding) {
   const auto result{default_schema_walker("contentEncoding",
                                           VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -289,6 +381,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_pathStart) {
   const auto result{
       default_schema_walker("pathStart", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -297,6 +390,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_mediaType) {
   const auto result{
       default_schema_walker("mediaType", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -305,6 +399,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_alternate) {
   const auto result{
       default_schema_walker("alternate", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -313,6 +408,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -321,6 +417,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -329,6 +426,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_method) {
   const auto result{
       default_schema_walker("method", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -337,6 +435,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_enctype) {
   const auto result{
       default_schema_walker("enctype", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -345,6 +444,9 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT3_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-03/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -352,6 +454,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -362,6 +465,7 @@ TEST(JSONSchema_default_walker_draft3,
   const auto result{
       default_schema_walker("fragmentResolution", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -370,6 +474,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_root_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("root", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -379,6 +484,7 @@ TEST(JSONSchema_default_walker_draft3,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readonly", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -389,6 +495,7 @@ TEST(JSONSchema_default_walker_draft3,
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -398,6 +505,7 @@ TEST(JSONSchema_default_walker_draft3,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pathStart", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -407,6 +515,7 @@ TEST(JSONSchema_default_walker_draft3,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("mediaType", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -416,6 +525,7 @@ TEST(JSONSchema_default_walker_draft3,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("alternate", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -424,6 +534,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -432,6 +543,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -440,6 +552,7 @@ TEST(JSONSchema_default_walker_draft3, hyperschema_method_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("method", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -449,6 +562,7 @@ TEST(JSONSchema_default_walker_draft3,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enctype", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -458,6 +572,7 @@ TEST(JSONSchema_default_walker_draft3,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("targetSchema", VOCABULARIES_DRAFT3)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }

--- a/test/jsonschema/jsonschema_default_walker_draft4_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft4_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft4, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -19,6 +22,9 @@ TEST(JSONSchema_default_walker_draft4, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("id", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -27,6 +33,9 @@ TEST(JSONSchema_default_walker_draft4, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -34,6 +43,9 @@ TEST(JSONSchema_default_walker_draft4, definitions) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("definitions", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -42,6 +54,9 @@ TEST(JSONSchema_default_walker_draft4, allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -50,6 +65,9 @@ TEST(JSONSchema_default_walker_draft4, anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -58,6 +76,9 @@ TEST(JSONSchema_default_walker_draft4, oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -66,6 +87,9 @@ TEST(JSONSchema_default_walker_draft4, not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -74,6 +98,9 @@ TEST(JSONSchema_default_walker_draft4, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -83,6 +110,9 @@ TEST(JSONSchema_default_walker_draft4, additionalItems) {
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -91,6 +121,9 @@ TEST(JSONSchema_default_walker_draft4, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref", "required"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -100,6 +133,9 @@ TEST(JSONSchema_default_walker_draft4, patternProperties) {
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -108,6 +144,9 @@ TEST(JSONSchema_default_walker_draft4, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -117,6 +156,9 @@ TEST(JSONSchema_default_walker_draft4, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -125,6 +167,9 @@ TEST(JSONSchema_default_walker_draft4, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -133,6 +178,9 @@ TEST(JSONSchema_default_walker_draft4, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -141,6 +189,9 @@ TEST(JSONSchema_default_walker_draft4, multipleOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("multipleOf", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -149,6 +200,9 @@ TEST(JSONSchema_default_walker_draft4, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -157,6 +211,9 @@ TEST(JSONSchema_default_walker_draft4, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -166,6 +223,9 @@ TEST(JSONSchema_default_walker_draft4, exclusiveMaximum) {
   const auto result{
       default_schema_walker("exclusiveMaximum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -175,6 +235,9 @@ TEST(JSONSchema_default_walker_draft4, exclusiveMinimum) {
   const auto result{
       default_schema_walker("exclusiveMinimum", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -183,6 +246,9 @@ TEST(JSONSchema_default_walker_draft4, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -191,6 +257,9 @@ TEST(JSONSchema_default_walker_draft4, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -199,6 +268,9 @@ TEST(JSONSchema_default_walker_draft4, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -207,6 +279,9 @@ TEST(JSONSchema_default_walker_draft4, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -215,6 +290,9 @@ TEST(JSONSchema_default_walker_draft4, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -223,6 +301,9 @@ TEST(JSONSchema_default_walker_draft4, uniqueItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("uniqueItems", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -232,6 +313,9 @@ TEST(JSONSchema_default_walker_draft4, maxProperties) {
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -241,6 +325,9 @@ TEST(JSONSchema_default_walker_draft4, minProperties) {
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -249,6 +336,9 @@ TEST(JSONSchema_default_walker_draft4, required) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("required", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -257,6 +347,9 @@ TEST(JSONSchema_default_walker_draft4, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -265,6 +358,9 @@ TEST(JSONSchema_default_walker_draft4, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -273,6 +369,9 @@ TEST(JSONSchema_default_walker_draft4, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -281,6 +380,9 @@ TEST(JSONSchema_default_walker_draft4, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -290,6 +392,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -298,6 +401,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_media) {
   const auto result{
       default_schema_walker("media", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -306,6 +410,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_pathStart) {
   const auto result{
       default_schema_walker("pathStart", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -314,6 +419,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -322,6 +428,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -330,6 +437,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_mediaType) {
   const auto result{
       default_schema_walker("mediaType", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -338,6 +446,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_method) {
   const auto result{
       default_schema_walker("method", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -346,6 +455,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_encType) {
   const auto result{
       default_schema_walker("encType", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -354,6 +464,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_readOnly) {
   const auto result{
       default_schema_walker("readOnly", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -362,6 +473,9 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -370,6 +484,9 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_schema) {
   const auto result{
       default_schema_walker("schema", VOCABULARIES_DRAFT4_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-04/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -377,6 +494,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -385,6 +503,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_media_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("media", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -394,6 +513,7 @@ TEST(JSONSchema_default_walker_draft4,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pathStart", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -402,6 +522,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -410,6 +531,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -419,6 +541,7 @@ TEST(JSONSchema_default_walker_draft4,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("mediaType", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -427,6 +550,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_method_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("method", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -436,6 +560,7 @@ TEST(JSONSchema_default_walker_draft4,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("encType", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -445,6 +570,7 @@ TEST(JSONSchema_default_walker_draft4,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readOnly", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -454,6 +580,7 @@ TEST(JSONSchema_default_walker_draft4,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("targetSchema", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -462,6 +589,7 @@ TEST(JSONSchema_default_walker_draft4, hyperschema_schema_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("schema", VOCABULARIES_DRAFT4)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }

--- a/test/jsonschema/jsonschema_default_walker_draft6_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft6_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft6, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -19,6 +22,9 @@ TEST(JSONSchema_default_walker_draft6, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$id", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -27,6 +33,9 @@ TEST(JSONSchema_default_walker_draft6, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -34,6 +43,9 @@ TEST(JSONSchema_default_walker_draft6, definitions) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("definitions", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -42,6 +54,9 @@ TEST(JSONSchema_default_walker_draft6, allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -50,6 +65,9 @@ TEST(JSONSchema_default_walker_draft6, anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -58,6 +76,9 @@ TEST(JSONSchema_default_walker_draft6, oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -66,6 +87,9 @@ TEST(JSONSchema_default_walker_draft6, not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -74,6 +98,9 @@ TEST(JSONSchema_default_walker_draft6, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -83,6 +110,9 @@ TEST(JSONSchema_default_walker_draft6, additionalItems) {
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -91,6 +121,9 @@ TEST(JSONSchema_default_walker_draft6, contains) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("contains", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -99,6 +132,9 @@ TEST(JSONSchema_default_walker_draft6, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref", "required"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -108,6 +144,9 @@ TEST(JSONSchema_default_walker_draft6, patternProperties) {
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -116,6 +155,9 @@ TEST(JSONSchema_default_walker_draft6, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -125,6 +167,9 @@ TEST(JSONSchema_default_walker_draft6, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -134,6 +179,9 @@ TEST(JSONSchema_default_walker_draft6, propertyNames) {
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -142,6 +190,9 @@ TEST(JSONSchema_default_walker_draft6, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -150,6 +201,9 @@ TEST(JSONSchema_default_walker_draft6, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -158,6 +212,9 @@ TEST(JSONSchema_default_walker_draft6, const) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("const", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -166,6 +223,9 @@ TEST(JSONSchema_default_walker_draft6, multipleOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("multipleOf", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -174,6 +234,9 @@ TEST(JSONSchema_default_walker_draft6, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -182,6 +245,9 @@ TEST(JSONSchema_default_walker_draft6, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -191,6 +257,9 @@ TEST(JSONSchema_default_walker_draft6, exclusiveMaximum) {
   const auto result{
       default_schema_walker("exclusiveMaximum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -200,6 +269,9 @@ TEST(JSONSchema_default_walker_draft6, exclusiveMinimum) {
   const auto result{
       default_schema_walker("exclusiveMinimum", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -208,6 +280,9 @@ TEST(JSONSchema_default_walker_draft6, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -216,6 +291,9 @@ TEST(JSONSchema_default_walker_draft6, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -224,6 +302,9 @@ TEST(JSONSchema_default_walker_draft6, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -232,6 +313,9 @@ TEST(JSONSchema_default_walker_draft6, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -240,6 +324,9 @@ TEST(JSONSchema_default_walker_draft6, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -248,6 +335,9 @@ TEST(JSONSchema_default_walker_draft6, uniqueItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("uniqueItems", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -257,6 +347,9 @@ TEST(JSONSchema_default_walker_draft6, maxProperties) {
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -266,6 +359,9 @@ TEST(JSONSchema_default_walker_draft6, minProperties) {
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -274,6 +370,9 @@ TEST(JSONSchema_default_walker_draft6, required) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("required", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -282,6 +381,9 @@ TEST(JSONSchema_default_walker_draft6, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -290,6 +392,9 @@ TEST(JSONSchema_default_walker_draft6, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -298,6 +403,9 @@ TEST(JSONSchema_default_walker_draft6, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -306,6 +414,9 @@ TEST(JSONSchema_default_walker_draft6, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -314,6 +425,9 @@ TEST(JSONSchema_default_walker_draft6, examples) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("examples", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -323,6 +437,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -331,6 +446,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -339,6 +455,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -347,6 +464,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_mediaType) {
   const auto result{
       default_schema_walker("mediaType", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -355,6 +473,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_submissionEncType) {
   const auto result{default_schema_walker("submissionEncType",
                                           VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -363,6 +482,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_base) {
   const auto result{
       default_schema_walker("base", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -371,6 +491,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_media) {
   const auto result{
       default_schema_walker("media", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -379,6 +500,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_readOnly) {
   const auto result{
       default_schema_walker("readOnly", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -387,6 +509,9 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_hrefSchema) {
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -395,6 +520,9 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -403,6 +531,9 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_submissionSchema) {
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_DRAFT6_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -410,6 +541,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -418,6 +550,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -426,6 +559,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -435,6 +569,7 @@ TEST(JSONSchema_default_walker_draft6,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("mediaType", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -445,6 +580,7 @@ TEST(JSONSchema_default_walker_draft6,
   const auto result{
       default_schema_walker("submissionEncType", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -453,6 +589,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_base_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("base", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -461,6 +598,7 @@ TEST(JSONSchema_default_walker_draft6, hyperschema_media_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("media", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -470,6 +608,9 @@ TEST(JSONSchema_default_walker_draft6,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readOnly", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-06/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -479,6 +620,7 @@ TEST(JSONSchema_default_walker_draft6,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("hrefSchema", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -488,6 +630,7 @@ TEST(JSONSchema_default_walker_draft6,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("targetSchema", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -498,6 +641,7 @@ TEST(JSONSchema_default_walker_draft6,
   const auto result{
       default_schema_walker("submissionSchema", VOCABULARIES_DRAFT6)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }

--- a/test/jsonschema/jsonschema_default_walker_draft7_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft7_test.cc
@@ -11,6 +11,9 @@ TEST(JSONSchema_default_walker_draft7, schema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$schema", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -19,6 +22,9 @@ TEST(JSONSchema_default_walker_draft7, id) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$id", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -27,6 +33,9 @@ TEST(JSONSchema_default_walker_draft7, ref) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$ref", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Reference);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -34,6 +43,9 @@ TEST(JSONSchema_default_walker_draft7, definitions) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("definitions", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::LocationMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -42,6 +54,9 @@ TEST(JSONSchema_default_walker_draft7, comment) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("$comment", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -50,6 +65,9 @@ TEST(JSONSchema_default_walker_draft7, allOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("allOf", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -58,6 +76,9 @@ TEST(JSONSchema_default_walker_draft7, anyOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anyOf", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -66,6 +87,9 @@ TEST(JSONSchema_default_walker_draft7, oneOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("oneOf", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorElementsInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -74,6 +98,9 @@ TEST(JSONSchema_default_walker_draft7, not) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("not", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -82,6 +109,9 @@ TEST(JSONSchema_default_walker_draft7, if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("if", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -90,6 +120,9 @@ TEST(JSONSchema_default_walker_draft7, then) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("then", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -98,6 +131,9 @@ TEST(JSONSchema_default_walker_draft7, else) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("else", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"if"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -106,6 +142,9 @@ TEST(JSONSchema_default_walker_draft7, items) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("items", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOrElements);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -115,6 +154,9 @@ TEST(JSONSchema_default_walker_draft7, additionalItems) {
   const auto result{
       default_schema_walker("additionalItems", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"items"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -123,6 +165,9 @@ TEST(JSONSchema_default_walker_draft7, contains) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("contains", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -131,6 +176,9 @@ TEST(JSONSchema_default_walker_draft7, properties) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("properties", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref", "required"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -140,6 +188,9 @@ TEST(JSONSchema_default_walker_draft7, patternProperties) {
   const auto result{
       default_schema_walker("patternProperties", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -148,6 +199,9 @@ TEST(JSONSchema_default_walker_draft7, dependencies) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("dependencies", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorMembers);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -157,6 +211,9 @@ TEST(JSONSchema_default_walker_draft7, additionalProperties) {
   const auto result{
       default_schema_walker("additionalProperties", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"properties", "patternProperties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -166,6 +223,9 @@ TEST(JSONSchema_default_walker_draft7, propertyNames) {
   const auto result{
       default_schema_walker("propertyNames", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -174,6 +234,9 @@ TEST(JSONSchema_default_walker_draft7, type) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("type", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"properties"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -182,6 +245,9 @@ TEST(JSONSchema_default_walker_draft7, enum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("enum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -190,6 +256,9 @@ TEST(JSONSchema_default_walker_draft7, const) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("const", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -198,6 +267,9 @@ TEST(JSONSchema_default_walker_draft7, multipleOf) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("multipleOf", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -206,6 +278,9 @@ TEST(JSONSchema_default_walker_draft7, maximum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maximum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -214,6 +289,9 @@ TEST(JSONSchema_default_walker_draft7, minimum) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minimum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -223,6 +301,9 @@ TEST(JSONSchema_default_walker_draft7, exclusiveMaximum) {
   const auto result{
       default_schema_walker("exclusiveMaximum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -232,6 +313,9 @@ TEST(JSONSchema_default_walker_draft7, exclusiveMinimum) {
   const auto result{
       default_schema_walker("exclusiveMinimum", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -240,6 +324,9 @@ TEST(JSONSchema_default_walker_draft7, maxLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxLength", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -248,6 +335,9 @@ TEST(JSONSchema_default_walker_draft7, minLength) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minLength", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -256,6 +346,9 @@ TEST(JSONSchema_default_walker_draft7, pattern) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("pattern", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -264,6 +357,9 @@ TEST(JSONSchema_default_walker_draft7, maxItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("maxItems", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -272,6 +368,9 @@ TEST(JSONSchema_default_walker_draft7, minItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("minItems", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -280,6 +379,9 @@ TEST(JSONSchema_default_walker_draft7, uniqueItems) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("uniqueItems", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -289,6 +391,9 @@ TEST(JSONSchema_default_walker_draft7, maxProperties) {
   const auto result{
       default_schema_walker("maxProperties", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -298,6 +403,9 @@ TEST(JSONSchema_default_walker_draft7, minProperties) {
   const auto result{
       default_schema_walker("minProperties", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -306,6 +414,9 @@ TEST(JSONSchema_default_walker_draft7, required) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("required", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Assertion);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -314,6 +425,9 @@ TEST(JSONSchema_default_walker_draft7, format) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("format", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -323,6 +437,9 @@ TEST(JSONSchema_default_walker_draft7, contentEncoding) {
   const auto result{
       default_schema_walker("contentEncoding", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -332,6 +449,9 @@ TEST(JSONSchema_default_walker_draft7, contentMediaType) {
   const auto result{
       default_schema_walker("contentMediaType", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -340,6 +460,9 @@ TEST(JSONSchema_default_walker_draft7, title) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("title", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -348,6 +471,9 @@ TEST(JSONSchema_default_walker_draft7, description) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("description", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -356,6 +482,9 @@ TEST(JSONSchema_default_walker_draft7, default) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("default", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -364,6 +493,9 @@ TEST(JSONSchema_default_walker_draft7, readOnly) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("readOnly", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -372,6 +504,9 @@ TEST(JSONSchema_default_walker_draft7, writeOnly) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("writeOnly", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -380,6 +515,9 @@ TEST(JSONSchema_default_walker_draft7, examples) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("examples", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Other);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/schema#");
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -389,6 +527,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_links) {
   const auto result{
       default_schema_walker("links", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -397,6 +536,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_base) {
   const auto result{
       default_schema_walker("base", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -405,6 +545,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_anchor) {
   const auto result{
       default_schema_walker("anchor", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -413,6 +554,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_anchorPointer) {
   const auto result{
       default_schema_walker("anchorPointer", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -421,6 +563,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_rel) {
   const auto result{
       default_schema_walker("rel", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -429,6 +572,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_href) {
   const auto result{
       default_schema_walker("href", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -437,6 +581,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_templatePointers) {
   const auto result{default_schema_walker("templatePointers",
                                           VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -445,6 +590,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_templateRequired) {
   const auto result{default_schema_walker("templateRequired",
                                           VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -453,6 +599,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_targetMediaType) {
   const auto result{default_schema_walker("targetMediaType",
                                           VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -461,6 +608,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_targetHints) {
   const auto result{
       default_schema_walker("targetHints", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -469,6 +617,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_submissionMediaType) {
   const auto result{default_schema_walker("submissionMediaType",
                                           VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -477,6 +626,9 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_hrefSchema) {
   const auto result{
       default_schema_walker("hrefSchema", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -485,6 +637,9 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_targetSchema) {
   const auto result{
       default_schema_walker("targetSchema", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -493,6 +648,9 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_headerSchema) {
   const auto result{
       default_schema_walker("headerSchema", VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -501,6 +659,9 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_submissionSchema) {
   const auto result{default_schema_walker("submissionSchema",
                                           VOCABULARIES_DRAFT7_HYPERSCHEMA)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValue);
+  EXPECT_TRUE(result.vocabulary.has_value());
+  EXPECT_EQ(result.vocabulary.value(),
+            "http://json-schema.org/draft-07/hyper-schema#");
   EXPECT_TRUE(result.dependencies.empty());
 }
 
@@ -508,6 +669,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_links_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("links", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -516,6 +678,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_base_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("base", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -524,6 +687,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_anchor_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("anchor", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -534,6 +698,7 @@ TEST(JSONSchema_default_walker_draft7,
   const auto result{
       default_schema_walker("anchorPointer", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -542,6 +707,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_rel_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("rel", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -550,6 +716,7 @@ TEST(JSONSchema_default_walker_draft7, hyperschema_href_without_hyperschema) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("href", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -560,6 +727,7 @@ TEST(JSONSchema_default_walker_draft7,
   const auto result{
       default_schema_walker("templatePointers", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -570,6 +738,7 @@ TEST(JSONSchema_default_walker_draft7,
   const auto result{
       default_schema_walker("templateRequired", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -580,6 +749,7 @@ TEST(JSONSchema_default_walker_draft7,
   const auto result{
       default_schema_walker("targetMediaType", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -589,6 +759,7 @@ TEST(JSONSchema_default_walker_draft7,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("targetHints", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -599,6 +770,7 @@ TEST(JSONSchema_default_walker_draft7,
   const auto result{
       default_schema_walker("submissionMediaType", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -608,6 +780,7 @@ TEST(JSONSchema_default_walker_draft7,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("hrefSchema", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -617,6 +790,7 @@ TEST(JSONSchema_default_walker_draft7,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("targetSchema", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -626,6 +800,7 @@ TEST(JSONSchema_default_walker_draft7,
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("headerSchema", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }
@@ -636,6 +811,7 @@ TEST(JSONSchema_default_walker_draft7,
   const auto result{
       default_schema_walker("submissionSchema", VOCABULARIES_DRAFT7)};
   EXPECT_EQ(result.strategy, SchemaWalkerStrategy::Unknown);
+  EXPECT_FALSE(result.vocabulary.has_value());
   const std::set<std::string> expected{"$ref"};
   EXPECT_EQ(result.dependencies, expected);
 }

--- a/test/jsonschema/jsonschema_walker_test.cc
+++ b/test/jsonschema/jsonschema_walker_test.cc
@@ -38,28 +38,33 @@ static auto test_walker(std::string_view keyword,
       vocabularies.end()) {
     if (keyword == "schema") {
       return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorValue,
+              "https://sourcemeta.com/vocab/test-1",
               {}};
     }
 
     if (keyword == "schemas") {
       return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorElements,
+              "https://sourcemeta.com/vocab/test-1",
               {}};
     }
 
     if (keyword == "schemaMap") {
       return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorMembers,
+              "https://sourcemeta.com/vocab/test-1",
               {}};
     }
 
     if (keyword == "schemaOrSchemas") {
       return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::
                   ApplicatorValueOrElements,
+              "https://sourcemeta.com/vocab/test-1",
               {}};
     }
 
     if (keyword == "schemasOrMap") {
       return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::
                   ApplicatorElementsOrMembers,
+              "https://sourcemeta.com/vocab/test-1",
               {}};
     }
   }
@@ -68,11 +73,13 @@ static auto test_walker(std::string_view keyword,
       vocabularies.end()) {
     if (keyword == "custom") {
       return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::ApplicatorValue,
+              "https://sourcemeta.com/vocab/test-2",
               {}};
     }
   }
 
-  return {sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, {}};
+  return {
+      sourcemeta::jsontoolkit::SchemaWalkerStrategy::Unknown, std::nullopt, {}};
 }
 
 TEST(JSONSchema_walker, true) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
