### PR TITLE
Fix traversal of nested schema resources in `unevaluated()`

### DIFF
--- a/src/jsonschema/unevaluated.cc
+++ b/src/jsonschema/unevaluated.cc
@@ -29,7 +29,7 @@ auto find_adjacent_dependencies(
     const std::set<JSON::String> &keywords, const FrameLocationsEntry &root,
     const FrameLocationsEntry &entry, const bool is_static,
     UnevaluatedEntry &result) -> void {
-  const auto &subschema{get(schema, entry.relative_pointer)};
+  const auto &subschema{get(schema, entry.pointer)};
   if (!subschema.is_object()) {
     return;
   }

--- a/test/jsonschema/jsonschema_unevaluated_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_unevaluated_2019_09_test.cc
@@ -78,6 +78,49 @@ TEST(JSONSchema_unevaluated_2019_09, unevaluatedProperties_2) {
                               "https://example.com#/unevaluatedProperties");
 }
 
+TEST(JSONSchema_unevaluated_2019_09, unevaluatedProperties_3) {
+  const auto schema = sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://example.com",
+    "$recursiveAnchor": true,
+    "$ref": "tree",
+    "properties": { "name": true },
+    "$defs": {
+      "tree": {
+        "$id": "tree",
+        "$recursiveAnchor": true,
+        "properties": {
+          "branches": {
+            "unevaluatedProperties": false,
+            "$recursiveRef": "#"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::FrameLocations frame;
+  sourcemeta::jsontoolkit::FrameReferences references;
+  sourcemeta::jsontoolkit::frame(schema, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver);
+  const auto result{sourcemeta::jsontoolkit::unevaluated(
+      schema, frame, references, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver)};
+
+  EXPECT_EQ(result.size(), 1);
+
+  EXPECT_UNEVALUATED_STATIC(
+      result,
+      "https://example.com/tree#/properties/branches/unevaluatedProperties", 0);
+  EXPECT_UNEVALUATED_DYNAMIC(
+      result,
+      "https://example.com/tree#/properties/branches/unevaluatedProperties", 0);
+  EXPECT_UNEVALUATED_UNRESOLVED(
+      result,
+      "https://example.com/tree#/properties/branches/unevaluatedProperties");
+}
+
 TEST(JSONSchema_unevaluated_2019_09, unevaluatedItems_1) {
   const auto schema = sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
