### PR TITLE
Fix `if` not affecting `unevaluated(Properties|Items)` evaluation

### DIFF
--- a/src/jsonschema/default_walker.cc
+++ b/src/jsonschema/default_walker.cc
@@ -36,7 +36,7 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK(HTTPS_BASE "2020-12/vocab/applicator", "anyOf",
        ApplicatorElementsInPlace)
   WALK(HTTPS_BASE "2020-12/vocab/applicator", "allOf", ApplicatorElementsInline)
-  WALK(HTTPS_BASE "2020-12/vocab/applicator", "if", ApplicatorValueOther)
+  WALK(HTTPS_BASE "2020-12/vocab/applicator", "if", ApplicatorValueInPlace)
   WALK(HTTPS_BASE "2020-12/vocab/applicator", "then", ApplicatorValueInPlace,
        "if")
   WALK(HTTPS_BASE "2020-12/vocab/applicator", "else", ApplicatorValueInPlace,
@@ -122,7 +122,7 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
        ApplicatorElementsInPlace)
   WALK(HTTPS_BASE "2019-09/vocab/applicator", "oneOf",
        ApplicatorElementsInPlace)
-  WALK(HTTPS_BASE "2019-09/vocab/applicator", "if", ApplicatorValueOther)
+  WALK(HTTPS_BASE "2019-09/vocab/applicator", "if", ApplicatorValueInPlace)
   WALK(HTTPS_BASE "2019-09/vocab/applicator", "then", ApplicatorValueInPlace,
        "if")
   WALK(HTTPS_BASE "2019-09/vocab/applicator", "else", ApplicatorValueInPlace,
@@ -232,7 +232,7 @@ auto sourcemeta::jsontoolkit::default_schema_walker(
   WALK(HTTP_BASE "draft-07/schema#", "dependencies", ApplicatorMembers, "$ref")
   WALK(HTTP_BASE "draft-07/schema#", "propertyNames", ApplicatorValueInPlace,
        "$ref")
-  WALK(HTTP_BASE "draft-07/schema#", "if", ApplicatorValueOther, "$ref")
+  WALK(HTTP_BASE "draft-07/schema#", "if", ApplicatorValueInPlace, "$ref")
   WALK(HTTP_BASE "draft-07/schema#", "then", ApplicatorValueInPlace, "if")
   WALK(HTTP_BASE "draft-07/schema#", "else", ApplicatorValueInPlace, "if")
   WALK(HTTP_BASE "draft-07/schema#", "allOf", ApplicatorElementsInline, "$ref")

--- a/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2019_09_test.cc
@@ -174,7 +174,7 @@ TEST(JSONSchema_default_walker_2019_09, applicator_if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("if", VOCABULARIES_2019_09_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOther);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.vocabulary.has_value());
   EXPECT_EQ(result.vocabulary.value(),
             "https://json-schema.org/draft/2019-09/vocab/applicator");

--- a/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_2020_12_test.cc
@@ -182,7 +182,7 @@ TEST(JSONSchema_default_walker_2020_12, applicator_if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{
       default_schema_walker("if", VOCABULARIES_2020_12_APPLICATOR)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOther);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.vocabulary.has_value());
   EXPECT_EQ(result.vocabulary.value(),
             "https://json-schema.org/draft/2020-12/vocab/applicator");

--- a/test/jsonschema/jsonschema_default_walker_draft7_test.cc
+++ b/test/jsonschema/jsonschema_default_walker_draft7_test.cc
@@ -108,7 +108,7 @@ TEST(JSONSchema_default_walker_draft7, not) {
 TEST(JSONSchema_default_walker_draft7, if) {
   using namespace sourcemeta::jsontoolkit;
   const auto result{default_schema_walker("if", VOCABULARIES_DRAFT7)};
-  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueOther);
+  EXPECT_EQ(result.strategy, SchemaWalkerStrategy::ApplicatorValueInPlace);
   EXPECT_TRUE(result.vocabulary.has_value());
   EXPECT_EQ(result.vocabulary.value(),
             "http://json-schema.org/draft-07/schema#");

--- a/test/jsonschema/jsonschema_unevaluated_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_unevaluated_2020_12_test.cc
@@ -139,7 +139,9 @@ TEST(JSONSchema_unevaluated_2020_12, unevaluatedProperties_4) {
 
   EXPECT_UNEVALUATED_STATIC(result, "#/unevaluatedProperties", 0);
 
-  EXPECT_UNEVALUATED_DYNAMIC(result, "#/unevaluatedProperties", 3);
+  EXPECT_UNEVALUATED_DYNAMIC(result, "#/unevaluatedProperties", 4);
+  EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
+                                        "/if/properties");
   EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",
                                         "/then/properties");
   EXPECT_UNEVALUATED_DYNAMIC_DEPENDENCY(result, "#/unevaluatedProperties",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
