### PR TITLE
Ensure `unevaluated` accounts for `additionalItems` without `items`

### DIFF
--- a/src/jsonschema/unevaluated.cc
+++ b/src/jsonschema/unevaluated.cc
@@ -41,6 +41,13 @@ auto find_adjacent_dependencies(
     if (property.first == current && entry.pointer == root.pointer) {
       continue;
     } else if (keywords.contains(property.first)) {
+      // In 2019-09, `additionalItems` takes no effect without `items`
+      if (subschema_vocabularies.contains(
+              "https://json-schema.org/draft/2019-09/vocab/applicator") &&
+          property.first == "additionalItems" && !subschema.defines("items")) {
+        continue;
+      }
+
       auto pointer{entry.pointer.concat({property.first})};
       if (is_static) {
         result.static_dependencies.emplace(std::move(pointer));

--- a/test/jsonschema/jsonschema_unevaluated_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_unevaluated_2019_09_test.cc
@@ -186,3 +186,26 @@ TEST(JSONSchema_unevaluated_2019_09, unevaluatedItems_2) {
                              0);
   EXPECT_UNEVALUATED_RESOLVED(result, "https://example.com#/unevaluatedItems");
 }
+
+TEST(JSONSchema_unevaluated_2019_09, unevaluatedItems_3) {
+  const auto schema = sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalItems": {"type": "number"},
+    "unevaluatedItems": {"type": "string"}
+  })JSON");
+
+  sourcemeta::jsontoolkit::FrameLocations frame;
+  sourcemeta::jsontoolkit::FrameReferences references;
+  sourcemeta::jsontoolkit::frame(schema, frame, references,
+                                 sourcemeta::jsontoolkit::default_schema_walker,
+                                 sourcemeta::jsontoolkit::official_resolver);
+  const auto result{sourcemeta::jsontoolkit::unevaluated(
+      schema, frame, references, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver)};
+
+  EXPECT_EQ(result.size(), 1);
+
+  EXPECT_UNEVALUATED_STATIC(result, "#/unevaluatedItems", 0);
+  EXPECT_UNEVALUATED_DYNAMIC(result, "#/unevaluatedItems", 0);
+  EXPECT_UNEVALUATED_RESOLVED(result, "#/unevaluatedItems");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
