### PR TITLE
Throw an exception when re-identifying and `$ref` overrides `($)id`

### DIFF
--- a/test/jsonschema/jsonschema_identify_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_identify_2019_09_test.cc
@@ -237,3 +237,24 @@ TEST(JSONSchema_identify_2019_09, reidentify_replace_base_dialect_shortcut) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_identify_2019_09, reidentify_set_with_top_level_ref) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  sourcemeta::jsontoolkit::reidentify(
+      document, "https://example.com/my-new-id",
+      sourcemeta::jsontoolkit::official_resolver);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-new-id",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_identify_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_identify_2020_12_test.cc
@@ -237,3 +237,24 @@ TEST(JSONSchema_identify_2020_12, reidentify_replace_base_dialect_shortcut) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_identify_2020_12, reidentify_set_with_top_level_ref) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  sourcemeta::jsontoolkit::reidentify(
+      document, "https://example.com/my-new-id",
+      sourcemeta::jsontoolkit::official_resolver);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/my-new-id",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_identify_draft3_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft3_test.cc
@@ -236,3 +236,16 @@ TEST(JSONSchema_identify_draft3, reidentify_replace_base_dialect_shortcut) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_identify_draft3, reidentify_set_with_top_level_ref) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  EXPECT_THROW(sourcemeta::jsontoolkit::reidentify(
+                   document, "https://example.com/my-new-id",
+                   sourcemeta::jsontoolkit::official_resolver),
+               sourcemeta::jsontoolkit::SchemaError);
+}

--- a/test/jsonschema/jsonschema_identify_draft4_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft4_test.cc
@@ -236,3 +236,16 @@ TEST(JSONSchema_identify_draft4, reidentify_replace_base_dialect_shortcut) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  EXPECT_THROW(sourcemeta::jsontoolkit::reidentify(
+                   document, "https://example.com/my-new-id",
+                   sourcemeta::jsontoolkit::official_resolver),
+               sourcemeta::jsontoolkit::SchemaError);
+}

--- a/test/jsonschema/jsonschema_identify_draft6_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft6_test.cc
@@ -236,3 +236,16 @@ TEST(JSONSchema_identify_draft6, reidentify_replace_base_dialect_shortcut) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  EXPECT_THROW(sourcemeta::jsontoolkit::reidentify(
+                   document, "https://example.com/my-new-id",
+                   sourcemeta::jsontoolkit::official_resolver),
+               sourcemeta::jsontoolkit::SchemaError);
+}

--- a/test/jsonschema/jsonschema_identify_draft7_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft7_test.cc
@@ -236,3 +236,16 @@ TEST(JSONSchema_identify_draft7, reidentify_replace_base_dialect_shortcut) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "https://example.com/schema"
+  })JSON");
+
+  EXPECT_THROW(sourcemeta::jsontoolkit::reidentify(
+                   document, "https://example.com/my-new-id",
+                   sourcemeta::jsontoolkit::official_resolver),
+               sourcemeta::jsontoolkit::SchemaError);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
