### PR TITLE
Fix `relativize()` mistreating relative references with `..`

### DIFF
--- a/src/jsonschema/relativize.cc
+++ b/src/jsonschema/relativize.cc
@@ -30,8 +30,8 @@ auto relativize(JSON &schema, const SchemaWalker &walker,
       }
 
       URI reference{property.second.to_string()};
-      reference.canonicalize();
       reference.relative_to(base);
+      reference.canonicalize();
 
       if (reference.is_relative()) {
         subschema.assign(property.first, JSON{reference.recompose()});

--- a/src/uri/uri.cc
+++ b/src/uri/uri.cc
@@ -67,6 +67,12 @@ static auto uri_parse(const std::string &data, UriUriA *uri) -> void {
 
 static auto canonicalize_path(const std::string &path, const bool is_relative)
     -> std::optional<std::string> {
+  // TODO: This is a hack, as this whole function works badly for
+  // relative paths with ".."
+  if (path.starts_with("..")) {
+    return path;
+  }
+
   std::vector<std::string> segments;
   std::string segment;
 

--- a/test/jsonpointer/jsonpointer_to_uri_test.cc
+++ b/test/jsonpointer/jsonpointer_to_uri_test.cc
@@ -341,5 +341,5 @@ TEST(JSONPointer_to_uri, with_relative_base) {
   const sourcemeta::jsontoolkit::URI base{"../baz"};
   const sourcemeta::jsontoolkit::URI fragment{
       sourcemeta::jsontoolkit::to_uri(pointer, base)};
-  EXPECT_EQ(fragment.recompose(), "/baz#/foo/bar");
+  EXPECT_EQ(fragment.recompose(), "../baz#/foo/bar");
 }

--- a/test/jsonschema/jsonschema_relativize_test.cc
+++ b/test/jsonschema/jsonschema_relativize_test.cc
@@ -296,3 +296,23 @@ TEST(JSONSchema_relativize, 2020_12_1) {
 
   EXPECT_EQ(schema, expected);
 }
+
+TEST(JSONSchema_relativize, 2020_12_2) {
+  auto schema = sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/foo/bar/baz/qux",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "../../schema.json"
+  })JSON");
+
+  sourcemeta::jsontoolkit::relativize(
+      schema, sourcemeta::jsontoolkit::default_schema_walker,
+      sourcemeta::jsontoolkit::official_resolver);
+
+  const auto expected = sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://example.com/foo/bar/baz/qux",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "../../schema.json"
+  })JSON");
+
+  EXPECT_EQ(schema, expected);
+}

--- a/test/uri/uri_canonicalize_test.cc
+++ b/test/uri/uri_canonicalize_test.cc
@@ -71,7 +71,7 @@ TEST(URI_canonicalize, example_10) {
 TEST(URI_canonicalize, example_relative_1) {
   sourcemeta::jsontoolkit::URI uri{"../foo"};
   uri.canonicalize();
-  EXPECT_EQ(uri.recompose(), "/foo");
+  EXPECT_EQ(uri.recompose(), "../foo");
 }
 
 TEST(URI_canonicalize, example_relative_2) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
