### PR TITLE
Extract `BundleOptions::WithoutIdentifiers` into its own `unidentify()`

### DIFF
--- a/src/jsonschema/CMakeLists.txt
+++ b/src/jsonschema/CMakeLists.txt
@@ -8,7 +8,7 @@ noa_library(NAMESPACE sourcemeta PROJECT jsontoolkit NAME jsonschema
     walker.h reference.h frame.h error.h unevaluated.h keywords.h
   SOURCES jsonschema.cc default_walker.cc frame.cc
     anchor.cc resolver.cc walker.cc bundle.cc
-    unevaluated.cc relativize.cc
+    unevaluated.cc relativize.cc unidentify.cc
     "${CMAKE_CURRENT_BINARY_DIR}/official_resolver.cc")
 
 if(JSONTOOLKIT_INSTALL)

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema.h
@@ -332,7 +332,7 @@ auto schema_format_compare(const JSON::String &left, const JSON::String &right)
 /// #include <sourcemeta/jsontoolkit/jsonschema.h>
 /// #include <cassert>
 ///
-/// sourcemeta::jsontoolkit::JSON document =
+/// sourcemeta::jsontoolkit::JSON schema =
 ///   sourcemeta::jsontoolkit::parse(R"JSON({
 ///   "$id": "https://www.example.com/schema",
 ///   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -340,7 +340,7 @@ auto schema_format_compare(const JSON::String &left, const JSON::String &right)
 /// })JSON");
 ///
 /// sourcemeta::jsontoolkit::relativize(schema,
-///   sourcemeta::jsontoolkit::default_dialect,
+///   sourcemeta::jsontoolkit::default_walker,
 ///   sourcemeta::jsontoolkit::official_resolver);
 ///
 /// const sourcemeta::jsontoolkit::JSON expected =
@@ -350,13 +350,47 @@ auto schema_format_compare(const JSON::String &left, const JSON::String &right)
 ///   "$ref": "another",
 /// })JSON");
 ///
-/// assert(document == expected);
+/// assert(schema == expected);
 /// ```
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto relativize(
     JSON &schema, const SchemaWalker &walker, const SchemaResolver &resolver,
     const std::optional<std::string> &default_dialect = std::nullopt,
     const std::optional<std::string> &default_id = std::nullopt) -> void;
+
+/// @ingroup jsonschema
+///
+/// Remove every identifer from a schema, rephrasing references (if any) as
+/// needed. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/jsontoolkit/json.h>
+/// #include <sourcemeta/jsontoolkit/jsonschema.h>
+/// #include <cassert>
+///
+/// sourcemeta::jsontoolkit::JSON schema =
+///   sourcemeta::jsontoolkit::parse(R"JSON({
+///   "$id": "https://www.example.com/schema",
+///   "$schema": "https://json-schema.org/draft/2020-12/schema",
+///   "$ref": "another",
+/// })JSON");
+///
+/// sourcemeta::jsontoolkit::unidentify(schema,
+///   sourcemeta::jsontoolkit::default_walker,
+///   sourcemeta::jsontoolkit::official_resolver);
+///
+/// const sourcemeta::jsontoolkit::JSON expected =
+///   sourcemeta::jsontoolkit::parse(R"JSON({
+///   "$schema": "https://json-schema.org/draft/2020-12/schema",
+///   "$ref": "https://www.example.com/another",
+/// })JSON");
+///
+/// assert(schema == expected);
+/// ```
+SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
+auto unidentify(
+    JSON &schema, const SchemaWalker &walker, const SchemaResolver &resolver,
+    const std::optional<std::string> &default_dialect = std::nullopt) -> void;
 
 } // namespace sourcemeta::jsontoolkit
 

--- a/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_bundle.h
+++ b/src/jsonschema/include/sourcemeta/jsontoolkit/jsonschema_bundle.h
@@ -18,20 +18,6 @@ namespace sourcemeta::jsontoolkit {
 // TODO: Optionally let users bundle the metaschema too
 
 /// @ingroup jsonschema
-/// A set of options that modify the behavior of bundling
-enum class BundleOptions : std::uint8_t {
-  /// Perform standard JSON Schema bundling
-  Default,
-
-  /// Perform standard JSON Schema bundling but without making
-  /// use of identifiers. This is helpful for delivering
-  /// schemas to some non-compliant implementations that do not
-  /// recognize identifiers (like Visua Studio Code at the time
-  /// of this writing)
-  WithoutIdentifiers
-};
-
-/// @ingroup jsonschema
 ///
 /// This function bundles a JSON Schema (starting from Draft 4) by embedding
 /// every remote reference into the top level schema resource, handling circular
@@ -83,7 +69,6 @@ enum class BundleOptions : std::uint8_t {
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto bundle(sourcemeta::jsontoolkit::JSON &schema, const SchemaWalker &walker,
             const SchemaResolver &resolver,
-            const BundleOptions options = BundleOptions::Default,
             const std::optional<std::string> &default_dialect = std::nullopt)
     -> void;
 
@@ -141,7 +126,6 @@ auto bundle(sourcemeta::jsontoolkit::JSON &schema, const SchemaWalker &walker,
 SOURCEMETA_JSONTOOLKIT_JSONSCHEMA_EXPORT
 auto bundle(const sourcemeta::jsontoolkit::JSON &schema,
             const SchemaWalker &walker, const SchemaResolver &resolver,
-            const BundleOptions options = BundleOptions::Default,
             const std::optional<std::string> &default_dialect = std::nullopt)
     -> sourcemeta::jsontoolkit::JSON;
 

--- a/src/jsonschema/unidentify.cc
+++ b/src/jsonschema/unidentify.cc
@@ -1,0 +1,49 @@
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+namespace sourcemeta::jsontoolkit {
+
+auto unidentify(JSON &schema, const SchemaWalker &walker,
+                const SchemaResolver &resolver,
+                const std::optional<std::string> &default_dialect) -> void {
+  // (1) Re-frame before changing anything
+  Frame frame;
+  frame.analyse(schema, walker, resolver, default_dialect);
+
+  // (2) Remove all identifiers and anchors
+  for (const auto &entry :
+       SchemaIterator{schema, walker, resolver, default_dialect}) {
+    auto &subschema{get(schema, entry.pointer)};
+    if (subschema.is_boolean()) {
+      continue;
+    }
+
+    assert(entry.base_dialect.has_value());
+    anonymize(subschema, entry.base_dialect.value());
+
+    if (entry.vocabularies.contains(
+            "https://json-schema.org/draft/2020-12/vocab/core")) {
+      subschema.erase("$anchor");
+      subschema.erase("$dynamicAnchor");
+    }
+
+    if (entry.vocabularies.contains(
+            "https://json-schema.org/draft/2019-09/vocab/core")) {
+      subschema.erase("$anchor");
+      subschema.erase("$recursiveAnchor");
+    }
+  }
+
+  // (3) Fix-up reference based on pointers from the root
+  for (const auto &[key, reference] : frame.references()) {
+    const auto result{frame.traverse(reference.destination)};
+    if (result.has_value()) {
+      set(schema, key.second,
+          JSON{to_uri(result.value().get().pointer).recompose()});
+    } else if (!key.second.empty() && key.second.back().is_property() &&
+               key.second.back().to_property() != "$schema") {
+      set(schema, key.second, JSON{reference.destination});
+    }
+  }
+}
+
+} // namespace sourcemeta::jsontoolkit

--- a/test/jsonschema/CMakeLists.txt
+++ b/test/jsonschema/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(sourcemeta_jsontoolkit_jsonschema_unit
   jsonschema_bundle_draft1_test.cc
   jsonschema_bundle_draft0_test.cc
   jsonschema_bundle_test.cc
+  jsonschema_unidentify_test.cc
   jsonschema_metaschema_test.cc
   jsonschema_dialect_test.cc
   jsonschema_dialect_2020_12_test.cc

--- a/test/jsonschema/jsonschema_bundle_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_bundle_2019_09_test.cc
@@ -449,7 +449,6 @@ TEST(JSONSchema_bundle_2019_09, anonymous_no_dialect) {
 
   sourcemeta::jsontoolkit::bundle(
       document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::Default,
       "https://json-schema.org/draft/2019-09/schema");
 
   const sourcemeta::jsontoolkit::JSON expected =
@@ -459,59 +458,6 @@ TEST(JSONSchema_bundle_2019_09, anonymous_no_dialect) {
       "https://www.sourcemeta.com/anonymous": {
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_2019_09, without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$id": "https://www.sourcemeta.com/top-level",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "properties": {
-      "foo": {
-        "$ref": "recursive#/properties/foo"
-      },
-      "baz": {
-        "$ref": "https://example.com/baz-anchor#baz"
-      }
-    }
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "properties": {
-      "foo": {
-        "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
-      },
-      "baz": {
-        "$ref": "#/$defs/https%3A~1~1example.com~1baz-anchor/$defs/baz"
-      }
-    },
-    "$defs": {
-      "https://www.sourcemeta.com/recursive": {
-        "$schema": "https://json-schema.org/draft/2019-09/schema",
-        "properties": {
-          "foo": {
-            "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive"
-          }
-        }
-      },
-      "https://example.com/baz-anchor": {
-        "$schema": "https://json-schema.org/draft/2019-09/schema",
-        "$defs": {
-          "baz": {
-            "type": "string"
-          }
-        }
       }
     }
   })JSON");
@@ -542,36 +488,6 @@ TEST(JSONSchema_bundle_2019_09, metaschema) {
       "https://example.com/meta/2.json": {
         "$schema": "https://json-schema.org/draft/2019-09/schema",
         "$id": "https://example.com/meta/2.json",
-        "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_2019_09, metaschema_without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://example.com/meta/1.json",
-    "type": "string"
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "#/$defs/https%3A~1~1example.com~1meta~11.json",
-    "type": "string",
-    "$defs": {
-      "https://example.com/meta/1.json": {
-        "$schema": "#/$defs/https%3A~1~1example.com~1meta~12.json",
-        "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
-      },
-      "https://example.com/meta/2.json": {
-        "$schema": "https://json-schema.org/draft/2019-09/schema",
         "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
       }
     }

--- a/test/jsonschema/jsonschema_bundle_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_bundle_2020_12_test.cc
@@ -489,7 +489,6 @@ TEST(JSONSchema_bundle_2020_12, anonymous_no_dialect) {
 
   sourcemeta::jsontoolkit::bundle(
       document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::Default,
       "https://json-schema.org/draft/2020-12/schema");
 
   const sourcemeta::jsontoolkit::JSON expected =
@@ -539,78 +538,31 @@ TEST(JSONSchema_bundle_2020_12, relative_in_target_without_id) {
   EXPECT_EQ(document, expected);
 }
 
-TEST(JSONSchema_bundle_2020_12, without_id) {
+TEST(JSONSchema_bundle_2020_12, relative_base_uri_with_ref) {
   sourcemeta::jsontoolkit::JSON document =
       sourcemeta::jsontoolkit::parse(R"JSON({
-    "$id": "https://www.sourcemeta.com/top-level",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-      "foo": {
-        "$ref": "recursive#/properties/foo"
-      },
-      "baz": {
-        "$ref": "https://example.com/baz-anchor#baz"
+    "$id": "common",
+    "allOf": [ { "$ref": "#reference" } ],
+    "definitions": {
+      "reference": {
+        "$anchor": "reference"
       }
     }
   })JSON");
 
   sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
+      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver);
 
   const sourcemeta::jsontoolkit::JSON expected =
       sourcemeta::jsontoolkit::parse(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-      "foo": {
-        "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
-      },
-      "baz": {
-        "$ref": "#/$defs/https%3A~1~1example.com~1baz-anchor/$defs/baz"
+    "$id": "common",
+    "allOf": [ { "$ref": "#reference" } ],
+    "definitions": {
+      "reference": {
+        "$anchor": "reference"
       }
-    },
-    "$defs": {
-      "https://www.sourcemeta.com/recursive": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "properties": {
-          "foo": {
-            "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive"
-          }
-        }
-      },
-      "https://example.com/baz-anchor": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$defs": {
-          "baz": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_2020_12, without_id_boolean_subschema) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$id": "https://www.sourcemeta.com/top-level",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-      "foo": true
-    }
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "properties": {
-      "foo": true
     }
   })JSON");
 
@@ -641,67 +593,6 @@ TEST(JSONSchema_bundle_2020_12, metaschema) {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "$id": "https://example.com/meta/2.json",
         "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_2020_12, metaschema_without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://example.com/meta/1.json",
-    "type": "string"
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "#/$defs/https%3A~1~1example.com~1meta~11.json",
-    "type": "string",
-    "$defs": {
-      "https://example.com/meta/1.json": {
-        "$schema": "#/$defs/https%3A~1~1example.com~1meta~12.json",
-        "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
-      },
-      "https://example.com/meta/2.json": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_2020_12, relative_base_uri_with_ref) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "common",
-    "allOf": [ { "$ref": "#reference" } ],
-    "definitions": {
-      "reference": {
-        "$anchor": "reference"
-      }
-    }
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "common",
-    "allOf": [ { "$ref": "#reference" } ],
-    "definitions": {
-      "reference": {
-        "$anchor": "reference"
       }
     }
   })JSON");

--- a/test/jsonschema/jsonschema_bundle_draft4_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft4_test.cc
@@ -449,7 +449,6 @@ TEST(JSONSchema_bundle_draft4, anonymous_no_dialect) {
 
   sourcemeta::jsontoolkit::bundle(
       document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::Default,
       "http://json-schema.org/draft-04/schema#");
 
   const sourcemeta::jsontoolkit::JSON expected =
@@ -459,45 +458,6 @@ TEST(JSONSchema_bundle_draft4, anonymous_no_dialect) {
       "https://www.sourcemeta.com/anonymous": {
         "id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_draft4, without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "id": "https://www.sourcemeta.com/top-level",
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "properties": {
-      "foo": {
-        "$ref": "recursive#/properties/foo"
-      }
-    }
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "properties": {
-      "foo": {
-        "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
-      }
-    },
-    "definitions": {
-      "https://www.sourcemeta.com/recursive": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "properties": {
-          "foo": {
-            "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive"
-          }
-        }
       }
     }
   })JSON");
@@ -527,34 +487,6 @@ TEST(JSONSchema_bundle_draft4, metaschema) {
       "https://example.com/meta/2.json": {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "id": "https://example.com/meta/2.json"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_draft4, metaschema_without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://example.com/meta/1.json",
-    "type": "string"
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "#/definitions/https%3A~1~1example.com~1meta~11.json",
-    "type": "string",
-    "definitions": {
-      "https://example.com/meta/1.json": {
-        "$schema": "#/definitions/https%3A~1~1example.com~1meta~12.json"
-      },
-      "https://example.com/meta/2.json": {
-        "$schema": "http://json-schema.org/draft-04/schema#"
       }
     }
   })JSON");

--- a/test/jsonschema/jsonschema_bundle_draft6_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft6_test.cc
@@ -424,7 +424,6 @@ TEST(JSONSchema_bundle_draft6, anonymous_no_dialect) {
 
   sourcemeta::jsontoolkit::bundle(
       document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::Default,
       "http://json-schema.org/draft-06/schema#");
 
   const sourcemeta::jsontoolkit::JSON expected =
@@ -434,45 +433,6 @@ TEST(JSONSchema_bundle_draft6, anonymous_no_dialect) {
       "https://www.sourcemeta.com/anonymous": {
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_draft6, without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$id": "https://www.sourcemeta.com/top-level",
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "properties": {
-      "foo": {
-        "$ref": "recursive#/properties/foo"
-      }
-    }
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "properties": {
-      "foo": {
-        "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
-      }
-    },
-    "definitions": {
-      "https://www.sourcemeta.com/recursive": {
-        "$schema": "http://json-schema.org/draft-06/schema#",
-        "properties": {
-          "foo": {
-            "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive"
-          }
-        }
       }
     }
   })JSON");
@@ -502,34 +462,6 @@ TEST(JSONSchema_bundle_draft6, metaschema) {
       "https://example.com/meta/2.json": {
         "$schema": "http://json-schema.org/draft-06/schema#",
         "$id": "https://example.com/meta/2.json"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_draft6, metaschema_without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://example.com/meta/1.json",
-    "type": "string"
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "#/definitions/https%3A~1~1example.com~1meta~11.json",
-    "type": "string",
-    "definitions": {
-      "https://example.com/meta/1.json": {
-        "$schema": "#/definitions/https%3A~1~1example.com~1meta~12.json"
-      },
-      "https://example.com/meta/2.json": {
-        "$schema": "http://json-schema.org/draft-06/schema#"
       }
     }
   })JSON");

--- a/test/jsonschema/jsonschema_bundle_draft7_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft7_test.cc
@@ -424,7 +424,6 @@ TEST(JSONSchema_bundle_draft7, anonymous_no_dialect) {
 
   sourcemeta::jsontoolkit::bundle(
       document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::Default,
       "http://json-schema.org/draft-07/schema#");
 
   const sourcemeta::jsontoolkit::JSON expected =
@@ -434,45 +433,6 @@ TEST(JSONSchema_bundle_draft7, anonymous_no_dialect) {
       "https://www.sourcemeta.com/anonymous": {
         "$id": "https://www.sourcemeta.com/anonymous",
         "type": "integer"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_draft7, without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$id": "https://www.sourcemeta.com/top-level",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-      "foo": {
-        "$ref": "recursive#/properties/foo"
-      }
-    }
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {
-      "foo": {
-        "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
-      }
-    },
-    "definitions": {
-      "https://www.sourcemeta.com/recursive": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "properties": {
-          "foo": {
-            "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive"
-          }
-        }
       }
     }
   })JSON");
@@ -502,34 +462,6 @@ TEST(JSONSchema_bundle_draft7, metaschema) {
       "https://example.com/meta/2.json": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "https://example.com/meta/2.json"
-      }
-    }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
-}
-
-TEST(JSONSchema_bundle_draft7, metaschema_without_id) {
-  sourcemeta::jsontoolkit::JSON document =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "https://example.com/meta/1.json",
-    "type": "string"
-  })JSON");
-
-  sourcemeta::jsontoolkit::bundle(
-      document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::WithoutIdentifiers);
-
-  const sourcemeta::jsontoolkit::JSON expected =
-      sourcemeta::jsontoolkit::parse(R"JSON({
-    "$schema": "#/definitions/https%3A~1~1example.com~1meta~11.json",
-    "type": "string",
-    "definitions": {
-      "https://example.com/meta/1.json": {
-        "$schema": "#/definitions/https%3A~1~1example.com~1meta~12.json"
-      },
-      "https://example.com/meta/2.json": {
-        "$schema": "http://json-schema.org/draft-07/schema#"
       }
     }
   })JSON");

--- a/test/jsonschema/jsonschema_bundle_test.cc
+++ b/test/jsonschema/jsonschema_bundle_test.cc
@@ -131,7 +131,6 @@ TEST(JSONSchema_bundle, with_default_dialect) {
 
   sourcemeta::jsontoolkit::bundle(
       document, sourcemeta::jsontoolkit::default_schema_walker, test_resolver,
-      sourcemeta::jsontoolkit::BundleOptions::Default,
       "https://json-schema.org/draft/2020-12/schema");
 
   const sourcemeta::jsontoolkit::JSON expected =

--- a/test/jsonschema/jsonschema_unidentify_test.cc
+++ b/test/jsonschema/jsonschema_unidentify_test.cc
@@ -1,0 +1,749 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/jsontoolkit/json.h>
+#include <sourcemeta/jsontoolkit/jsonschema.h>
+
+static auto test_resolver_2020_12(std::string_view identifier)
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
+  if (identifier == "https://example.com/foo/bar") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/foo/bar",
+      "$anchor": "baz"
+    })JSON");
+  } else if (identifier == "https://example.com/baz-anchor") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/baz-anchor",
+      "$defs": {
+        "baz": {
+          "$anchor": "baz",
+          "type": "string"
+        }
+      }
+    })JSON");
+  } else if (identifier == "https://www.sourcemeta.com/recursive") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://www.sourcemeta.com/recursive",
+      "properties": {
+        "foo": { "$ref": "#" }
+      }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/1.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://example.com/meta/2.json",
+      "$id": "https://example.com/meta/1.json",
+      "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/2.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://example.com/meta/2.json",
+      "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
+    })JSON");
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+}
+
+static auto test_resolver_2019_09(std::string_view identifier)
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
+  if (identifier == "https://example.com/foo/bar") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/foo/bar",
+      "$anchor": "baz"
+    })JSON");
+  } else if (identifier == "https://example.com/baz-anchor") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/baz-anchor",
+      "$defs": {
+        "baz": {
+          "$anchor": "baz",
+          "type": "string"
+        }
+      }
+    })JSON");
+  } else if (identifier == "https://www.sourcemeta.com/recursive") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://www.sourcemeta.com/recursive",
+      "properties": {
+        "foo": { "$ref": "#" }
+      }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/1.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://example.com/meta/2.json",
+      "$id": "https://example.com/meta/1.json",
+      "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/2.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://json-schema.org/draft/2019-09/schema",
+      "$id": "https://example.com/meta/2.json",
+      "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
+    })JSON");
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+}
+
+static auto test_resolver_draft7(std::string_view identifier)
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
+  if (identifier == "https://www.sourcemeta.com/recursive") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.sourcemeta.com/recursive",
+      "properties": {
+        "foo": { "$ref": "#" }
+      }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/1.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://example.com/meta/2.json",
+      "$id": "https://example.com/meta/1.json"
+    })JSON");
+  } else if (identifier == "https://example.com/meta/2.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://example.com/meta/2.json"
+    })JSON");
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+}
+
+static auto test_resolver_draft6(std::string_view identifier)
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
+  if (identifier == "https://www.sourcemeta.com/recursive") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "$id": "https://www.sourcemeta.com/recursive",
+      "properties": {
+        "foo": { "$ref": "#" }
+      }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/1.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://example.com/meta/2.json",
+      "$id": "https://example.com/meta/1.json"
+    })JSON");
+  } else if (identifier == "https://example.com/meta/2.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "http://json-schema.org/draft-06/schema#",
+      "$id": "https://example.com/meta/2.json"
+    })JSON");
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+}
+
+static auto test_resolver_draft4(std::string_view identifier)
+    -> std::optional<sourcemeta::jsontoolkit::JSON> {
+  if (identifier == "https://www.sourcemeta.com/recursive") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://www.sourcemeta.com/recursive",
+      "properties": {
+        "foo": { "$ref": "#" }
+      }
+    })JSON");
+  } else if (identifier == "https://example.com/meta/1.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "https://example.com/meta/2.json",
+      "id": "https://example.com/meta/1.json"
+    })JSON");
+  } else if (identifier == "https://example.com/meta/2.json") {
+    return sourcemeta::jsontoolkit::parse(R"JSON({
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "id": "https://example.com/meta/2.json"
+    })JSON");
+  } else {
+    return sourcemeta::jsontoolkit::official_resolver(identifier);
+  }
+}
+
+TEST(JSONSchema_unidentify, 2020_12) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      },
+      "baz": {
+        "$ref": "https://example.com/baz-anchor#baz"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "$ref": "https://www.sourcemeta.com/recursive#/properties/foo"
+      },
+      "baz": {
+        "$ref": "https://example.com/baz-anchor#baz"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, 2020_12_bundle) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      },
+      "baz": {
+        "$ref": "https://example.com/baz-anchor#baz"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": {
+        "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
+      },
+      "baz": {
+        "$ref": "#/$defs/https%3A~1~1example.com~1baz-anchor/$defs/baz"
+      }
+    },
+    "$defs": {
+      "https://www.sourcemeta.com/recursive": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "properties": {
+          "foo": {
+            "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive"
+          }
+        }
+      },
+      "https://example.com/baz-anchor": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+          "baz": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, 2020_12_bundle_boolean_subschema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": true
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": true
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, 2020_12_bundle_metaschema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://example.com/meta/1.json",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2020_12);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "#/$defs/https%3A~1~1example.com~1meta~11.json",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta/1.json": {
+        "$schema": "#/$defs/https%3A~1~1example.com~1meta~12.json",
+        "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
+      },
+      "https://example.com/meta/2.json": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$vocabulary": { "https://json-schema.org/draft/2020-12/vocab/core": true }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, 2019_09) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      },
+      "baz": {
+        "$ref": "https://example.com/baz-anchor#baz"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2019_09);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+      "foo": {
+        "$ref": "https://www.sourcemeta.com/recursive#/properties/foo"
+      },
+      "baz": {
+        "$ref": "https://example.com/baz-anchor#baz"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, 2019_09_bundle) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      },
+      "baz": {
+        "$ref": "https://example.com/baz-anchor#baz"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2019_09);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2019_09);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+      "foo": {
+        "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
+      },
+      "baz": {
+        "$ref": "#/$defs/https%3A~1~1example.com~1baz-anchor/$defs/baz"
+      }
+    },
+    "$defs": {
+      "https://www.sourcemeta.com/recursive": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "properties": {
+          "foo": {
+            "$ref": "#/$defs/https%3A~1~1www.sourcemeta.com~1recursive"
+          }
+        }
+      },
+      "https://example.com/baz-anchor": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$defs": {
+          "baz": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, 2019_09_bundle_metaschema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://example.com/meta/1.json",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2019_09);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_2019_09);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "#/$defs/https%3A~1~1example.com~1meta~11.json",
+    "type": "string",
+    "$defs": {
+      "https://example.com/meta/1.json": {
+        "$schema": "#/$defs/https%3A~1~1example.com~1meta~12.json",
+        "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
+      },
+      "https://example.com/meta/2.json": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$vocabulary": { "https://json-schema.org/draft/2019-09/vocab/core": true }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft7) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft7);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "https://www.sourcemeta.com/recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft7_bundle) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft7);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft7);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
+      }
+    },
+    "definitions": {
+      "https://www.sourcemeta.com/recursive": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "foo": {
+            "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft7_bundle_metaschema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://example.com/meta/1.json",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft7);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft7);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "#/definitions/https%3A~1~1example.com~1meta~11.json",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta/1.json": {
+        "$schema": "#/definitions/https%3A~1~1example.com~1meta~12.json"
+      },
+      "https://example.com/meta/2.json": {
+        "$schema": "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft6) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft6);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "https://www.sourcemeta.com/recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft6_bundle) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft6);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft6);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
+      }
+    },
+    "definitions": {
+      "https://www.sourcemeta.com/recursive": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "properties": {
+          "foo": {
+            "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft6_bundle_metaschema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://example.com/meta/1.json",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft6);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft6);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "#/definitions/https%3A~1~1example.com~1meta~11.json",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta/1.json": {
+        "$schema": "#/definitions/https%3A~1~1example.com~1meta~12.json"
+      },
+      "https://example.com/meta/2.json": {
+        "$schema": "http://json-schema.org/draft-06/schema#"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft4) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/top-level",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft4);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "https://www.sourcemeta.com/recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft4_bundle) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "id": "https://www.sourcemeta.com/top-level",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "recursive#/properties/foo"
+      }
+    }
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft4);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft4);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+      "foo": {
+        "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive/properties/foo"
+      }
+    },
+    "definitions": {
+      "https://www.sourcemeta.com/recursive": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "properties": {
+          "foo": {
+            "$ref": "#/definitions/https%3A~1~1www.sourcemeta.com~1recursive"
+          }
+        }
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_unidentify, draft4_bundle_metaschema) {
+  sourcemeta::jsontoolkit::JSON document =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "https://example.com/meta/1.json",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::jsontoolkit::bundle(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft4);
+  sourcemeta::jsontoolkit::unidentify(
+      document, sourcemeta::jsontoolkit::default_schema_walker,
+      test_resolver_draft4);
+
+  const sourcemeta::jsontoolkit::JSON expected =
+      sourcemeta::jsontoolkit::parse(R"JSON({
+    "$schema": "#/definitions/https%3A~1~1example.com~1meta~11.json",
+    "type": "string",
+    "definitions": {
+      "https://example.com/meta/1.json": {
+        "$schema": "#/definitions/https%3A~1~1example.com~1meta~12.json"
+      },
+      "https://example.com/meta/2.json": {
+        "$schema": "http://json-schema.org/draft-04/schema#"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
