### PR TITLE
Mask GoogleTest and GoogleBenchmark on `vendorpull`

### DIFF
--- a/vendorpull.mask
+++ b/vendorpull.mask
@@ -34,3 +34,5 @@ cmake/FindGoogleTest.cmake
 Brewfile
 Brewfile.lock.json
 CHANGELOG.markdown
+vendor/noa/vendor/googletest
+vendor/noa/vendor/googlebenchmark


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
