### PR TITLE
Make use of `__uint128_t` if available for `KeyHash`

### DIFF
--- a/test/json/json_hash_test.cc
+++ b/test/json/json_hash_test.cc
@@ -8,10 +8,17 @@ TEST(JSON_key_hash, hash_empty) {
   const sourcemeta::jsontoolkit::JSON::String value{""};
   const auto hash{hasher(value)};
   EXPECT_FALSE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x0000000000000000);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_f) {
@@ -20,10 +27,17 @@ TEST(JSON_key_hash, hash_f) {
   const sourcemeta::jsontoolkit::JSON::String value{"f"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000006600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x0000000000006600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fo) {
@@ -32,10 +46,17 @@ TEST(JSON_key_hash, hash_fo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x00000000006f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x00000000006f6600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foo) {
@@ -44,10 +65,17 @@ TEST(JSON_key_hash, hash_foo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x000000006f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x000000006f6f6600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooo) {
@@ -56,10 +84,17 @@ TEST(JSON_key_hash, hash_fooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000006f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x0000006f6f6f6600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooo) {
@@ -68,10 +103,17 @@ TEST(JSON_key_hash, hash_foooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x00006f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x00006f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooo) {
@@ -80,10 +122,17 @@ TEST(JSON_key_hash, hash_fooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x006f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x006f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooo) {
@@ -92,10 +141,17 @@ TEST(JSON_key_hash, hash_foooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x0000000000000000);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooo) {
@@ -104,10 +160,17 @@ TEST(JSON_key_hash, hash_fooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x000000000000006f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x000000000000006f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooo) {
@@ -116,10 +179,17 @@ TEST(JSON_key_hash, hash_foooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000006f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x0000000000006f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooo) {
@@ -128,10 +198,17 @@ TEST(JSON_key_hash, hash_fooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x00000000006f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x00000000006f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooo) {
@@ -140,10 +217,17 @@ TEST(JSON_key_hash, hash_foooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x000000006f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x000000006f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooo) {
@@ -152,10 +236,17 @@ TEST(JSON_key_hash, hash_fooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000006f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x0000006f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooo) {
@@ -164,10 +255,17 @@ TEST(JSON_key_hash, hash_foooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x00006f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x00006f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooo) {
@@ -176,10 +274,17 @@ TEST(JSON_key_hash, hash_fooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x006f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x006f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooo) {
@@ -188,10 +293,17 @@ TEST(JSON_key_hash, hash_foooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000000000);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooo) {
@@ -200,10 +312,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x000000000000006f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x000000000000006f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooo) {
@@ -212,10 +331,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000006f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000000000006f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooo) {
@@ -224,10 +350,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x00000000006f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x00000000006f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooo) {
@@ -236,10 +369,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x000000006f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x000000006f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooo) {
@@ -248,10 +388,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000006f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x0000006f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooooo) {
@@ -260,10 +407,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x00006f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x00006f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooooo) {
@@ -272,10 +426,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x006f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x006f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooooooo) {
@@ -284,10 +445,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"foooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooooooo) {
@@ -296,10 +464,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooo) {
   const sourcemeta::jsontoolkit::JSON::String value{"fooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x000000000000006f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x000000000000006f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooooooooo) {
@@ -309,10 +484,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooo) {
       "foooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000006f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000000000006f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooooooooo) {
@@ -322,10 +504,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooo) {
       "fooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x00000000006f6f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x00000000006f6f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooooooooooo) {
@@ -335,10 +524,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooooo) {
       "foooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x000000006f6f6f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x000000006f6f6f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooo) {
@@ -348,10 +544,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooo) {
       "fooooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000006f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x0000006f6f6f6f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooo) {
@@ -361,10 +564,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooo) {
       "foooooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x00006f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x00006f6f6f6f6f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooo) {
@@ -374,10 +584,17 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooo) {
       "fooooooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x006f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x006f6f6f6f6f6f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooooo) {
@@ -387,10 +604,17 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooooo) {
       "foooooooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_TRUE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6600);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x6f6f6f6f6f6f6f6f} << 64) | 0x6f6f6f6f6f6f6f6f);
+#else
   EXPECT_EQ(hash.a, 0x6f6f6f6f6f6f6600);
   EXPECT_EQ(hash.b, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.c, 0x6f6f6f6f6f6f6f6f);
   EXPECT_EQ(hash.d, 0x6f6f6f6f6f6f6f6f);
+#endif
 }
 
 TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooooo) {
@@ -400,7 +624,16 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooooo) {
       "fooooooooooooooooooooooooooooooo"};
   const auto hash{hasher(value)};
   EXPECT_FALSE(hasher.is_perfect(hash));
+#if defined(__SIZEOF_INT128__)
+  EXPECT_EQ(hash.a,
+            (__uint128_t{0x0000000000000000} << 64) | 0x00000000000000f5);
+  EXPECT_EQ(hash.b,
+            (__uint128_t{0x0000000000000000} << 64) | 0x0000000000000000);
+#else
   // 0x20 (length) + 0x66 (f) + 0x6f (o)
   EXPECT_EQ(hash.a, 0x00000000000000f5);
   EXPECT_EQ(hash.b, 0x0000000000000000);
+  EXPECT_EQ(hash.c, 0x0000000000000000);
+  EXPECT_EQ(hash.d, 0x0000000000000000);
+#endif
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
