### PR TITLE
style(clang-tidy): modernize use default member init

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -47,7 +47,7 @@ JSON::JSON(const bool value) : current_type{Type::Boolean} {
   this->data_boolean = value;
 }
 
-JSON::JSON(const std::nullptr_t) : current_type{Type::Null} {}
+JSON::JSON(const std::nullptr_t) {}
 
 JSON::JSON(const String &value) : current_type{Type::String} {
   new (&this->data_string) String{value};


### PR DESCRIPTION
fixes: #1674