### PR TITLE
Avoid inserting double slashes in `URI::append_path` when possible

### DIFF
--- a/src/core/uri/uri.cc
+++ b/src/core/uri/uri.cc
@@ -348,9 +348,13 @@ auto URI::append_path(const std::string &path) -> URI & {
   } else if (this->path_.has_value()) {
     if (!this->path_.value().ends_with('/') && !path.starts_with('/')) {
       this->path_.value() += '/';
+      this->path_.value() += path;
+    } else if (this->path_.value().ends_with('/') && path.starts_with('/')) {
+      this->path_.value() += path.substr(1);
+    } else {
+      this->path_.value() += path;
     }
 
-    this->path_.value() += path;
     return *this;
   } else {
     return this->path(path);

--- a/test/uri/uri_path_test.cc
+++ b/test/uri/uri_path_test.cc
@@ -324,9 +324,13 @@ TEST(URI_path, append_path_with_path_with_slash_only) {
 TEST(URI_path, append_path_with_path_trailing_slash_clash) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("/bar");
-  EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo//bar");
-  uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar");
+}
+
+TEST(URI_path, append_path_with_path_trailing_slash_in_argument) {
+  sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
+  uri.append_path("/bar//baz");
+  EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar//baz");
 }
 
 TEST(URI_path, append_path_with_path_trailing_slash) {


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1719
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
