### PR TITLE
style(clang-tidy): Disable bugprone-branch-clone check

### DIFF
--- a/cmake/common/targets/clang-tidy.config
+++ b/cmake/common/targets/clang-tidy.config
@@ -1,7 +1,17 @@
 ---
 # See https://clang.llvm.org/extra/clang-tidy/index.html
 # First disable all default checks (with -*)
-Checks: '-*,bugprone-*,clang-analyzer-*,clang-diagnostic-*,modernize-*,concurrency-*,cppcoreguidelines-*,performance-*,portability-*,objc-*,misc-*,-misc-no-recursion,-bugprone-easily-swappable-parameters'
+Checks: '-*,
+          bugprone-*,-bugprone-branch-clone,-bugprone-easily-swappable-parameters,
+          clang-analyzer-*,
+          clang-diagnostic-*,
+          modernize-*,
+          concurrency-*,
+          cppcoreguidelines-*,
+          performance-*,
+          portability-*,
+          objc-*,
+          misc-*,-misc-no-recursion'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none


### PR DESCRIPTION
Refs #1654
The check is reporting mostly false positives.
It is creating more noise than value.