### PR TITLE
style(clang-tidy): Ignore public umbrella Headers

### DIFF
--- a/cmake/common/targets/clang-tidy.config
+++ b/cmake/common/targets/clang-tidy.config
@@ -2,17 +2,16 @@
 # See https://clang.llvm.org/extra/clang-tidy/index.html
 # First disable all default checks (with -*)
 Checks: '-*,
-          misc-include-cleaner'
-          # bugprone-*,-bugprone-branch-clone,-bugprone-easily-swappable-parameters,-bugprone-empty-catch,
-          # clang-analyzer-*,
-          # clang-diagnostic-*,
-          # modernize-*,
-          # concurrency-*,
-          # cppcoreguidelines-*,
-          # performance-*,
-          # portability-*,
-          # objc-*,
-          # misc-*,-misc-no-recursion'
+          bugprone-*,-bugprone-branch-clone,-bugprone-easily-swappable-parameters,-bugprone-empty-catch,
+          clang-analyzer-*,
+          clang-diagnostic-*,
+          modernize-*,
+          concurrency-*,
+          cppcoreguidelines-*,
+          performance-*,
+          portability-*,
+          objc-*,
+          misc-*,-misc-no-recursion'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
 FormatStyle: none


### PR DESCRIPTION
fixes #1684
The public umbrella headers are intentionally not including all the direct headers by design.