### PR TITLE
style(clang-tidy): disable performance-enum-size

### DIFF
--- a/cmake/common/targets/clang-tidy.config
+++ b/cmake/common/targets/clang-tidy.config
@@ -8,7 +8,7 @@ Checks: '-*,
           modernize-*,
           concurrency-*,
           cppcoreguidelines-*,
-          performance-*,
+          performance-*,-performance-enum-size,
           portability-*,
           objc-*,
           misc-*,-misc-no-recursion'


### PR DESCRIPTION
fixes #1682

Clang-tidy does notifies the performance benefit of usign smaller data type for enum but doesn't recognize the proper usage.