### PR TITLE
Don't change the ordering of enumeration values when removing duplicates

### DIFF
--- a/src/extension/alterschema/linter/duplicate_enum_values.h
+++ b/src/extension/alterschema/linter/duplicate_enum_values.h
@@ -29,11 +29,18 @@ public:
   }
 
   auto transform(JSON &schema) const -> void override {
-    auto collection = schema.at("enum");
-    std::sort(collection.as_array().begin(), collection.as_array().end());
-    auto last =
-        std::unique(collection.as_array().begin(), collection.as_array().end());
-    collection.erase(last, collection.as_array().end());
-    schema.at("enum").into(std::move(collection));
+    // We want to be super careful to maintain the current ordering
+    // as we delete the duplicates
+    auto &enumeration{schema.at("enum")};
+    std::unordered_set<JSON, HashJSON<JSON>> cache;
+    for (auto iterator = enumeration.as_array().cbegin();
+         iterator != enumeration.as_array().cend();) {
+      if (cache.contains(*iterator)) {
+        iterator = enumeration.erase(iterator);
+      } else {
+        cache.emplace(*iterator);
+        iterator++;
+      }
+    }
   }
 };

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -516,7 +516,7 @@ TEST(AlterSchema_lint_2019_09, duplicate_enum_values_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -519,7 +519,23 @@ TEST(AlterSchema_lint_2020_12, duplicate_enum_values_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12, duplicate_enum_values_2) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": [ "S", "C", "U", "F", "E", "N", "L", "R", "U", null ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "enum": [ "S", "C", "U", "F", "E", "N", "L", "R", null ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -154,7 +154,7 @@ TEST(AlterSchema_lint_draft1, duplicate_enum_values_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -154,7 +154,7 @@ TEST(AlterSchema_lint_draft2, duplicate_enum_values_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -154,7 +154,7 @@ TEST(AlterSchema_lint_draft3, duplicate_enum_values_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -154,7 +154,7 @@ TEST(AlterSchema_lint_draft4, duplicate_enum_values_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -187,7 +187,7 @@ TEST(AlterSchema_lint_draft6, duplicate_enum_values_6) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -283,7 +283,7 @@ TEST(AlterSchema_lint_draft7, duplicate_enum_values_7) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "enum": [ 1, 2, 3, {} ]
+    "enum": [ 1, {}, 2, 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1841
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
