### PR TITLE
Replace `std::optional` with C++ exceptions in the GZIP module

### DIFF
--- a/src/core/gzip/CMakeLists.txt
+++ b/src/core/gzip/CMakeLists.txt
@@ -1,4 +1,6 @@
-sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME gzip SOURCES gzip.cc)
+sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME gzip 
+  PRIVATE_HEADERS error.h
+  SOURCES gzip.cc)
 
 if(SOURCEMETA_CORE_INSTALL)
   sourcemeta_library_install(NAMESPACE sourcemeta PROJECT core NAME gzip)

--- a/src/core/gzip/include/sourcemeta/core/gzip.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip.h
@@ -5,8 +5,11 @@
 #include <sourcemeta/core/gzip_export.h>
 #endif
 
+// NOLINTBEGIN(misc-include-cleaner)
+#include <sourcemeta/core/gzip_error.h>
+// NOLINTEND(misc-include-cleaner)
+
 #include <istream>     // std::istream
-#include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -31,11 +34,9 @@ namespace sourcemeta::core {
 /// #include <cassert>
 ///
 /// const auto result{sourcemeta::core::gzip("Hello World")};
-/// assert(result.has_value());
-/// assert(!result.value().empty());
+/// assert(!result.empty());
 /// ```
-SOURCEMETA_CORE_GZIP_EXPORT auto gzip(std::string_view input)
-    -> std::optional<std::string>;
+SOURCEMETA_CORE_GZIP_EXPORT auto gzip(std::string_view input) -> std::string;
 
 /// @ingroup gzip
 ///
@@ -48,14 +49,11 @@ SOURCEMETA_CORE_GZIP_EXPORT auto gzip(std::string_view input)
 /// #include <sstream>
 ///
 /// const auto input{sourcemeta::core::gzip("Hello World")};
-/// assert(input.has_value());
-/// std::istringstream stream{input.value()};
+/// std::istringstream stream{input};
 /// const auto result{sourcemeta::core::gunzip(stream)};
-/// assert(result.has_value());
-/// assert(result.value() == "Hello World");
+/// assert(result == "Hello World");
 /// ```
-SOURCEMETA_CORE_GZIP_EXPORT auto gunzip(std::istream &stream)
-    -> std::optional<std::string>;
+SOURCEMETA_CORE_GZIP_EXPORT auto gunzip(std::istream &stream) -> std::string;
 
 } // namespace sourcemeta::core
 

--- a/src/core/gzip/include/sourcemeta/core/gzip_error.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip_error.h
@@ -1,0 +1,40 @@
+#ifndef SOURCEMETA_CORE_GZIP_ERROR_H_
+#define SOURCEMETA_CORE_GZIP_ERROR_H_
+
+#ifndef SOURCEMETA_CORE_GZIP_EXPORT
+#include <sourcemeta/core/gzip_export.h>
+#endif
+
+#include <exception> // std::exception
+#include <string>    // std::string
+#include <utility>   // std::move
+
+namespace sourcemeta::core {
+
+// Exporting symbols that depends on the standard C++ library is considered
+// safe.
+// https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170&redirectedfrom=MSDN
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251 4275)
+#endif
+
+/// @ingroup gzip
+/// An error that represents a general GZIP error event
+class SOURCEMETA_CORE_GZIP_EXPORT GZIPError : public std::exception {
+public:
+  GZIPError(std::string message) : message_{std::move(message)} {}
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return this->message_.c_str();
+  }
+
+private:
+  std::string message_;
+};
+
+#if defined(_MSC_VER)
+#pragma warning(default : 4251 4275)
+#endif
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/uri/include/sourcemeta/core/uri_error.h
+++ b/src/core/uri/include/sourcemeta/core/uri_error.h
@@ -8,7 +8,7 @@
 #include <cstdint>   // std::uint64_t
 #include <exception> // std::exception
 #include <string>    // std::string
-#include <utility>   // std::string
+#include <utility>   // std::move
 
 namespace sourcemeta::core {
 

--- a/test/gzip/gzip_test.cc
+++ b/test/gzip/gzip_test.cc
@@ -6,22 +6,18 @@
 
 TEST(GZIP, compress_string_1) {
   const auto result{sourcemeta::core::gzip("Hello World")};
-  EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().size(), 31);
+  EXPECT_EQ(result.size(), 31);
 }
 
 TEST(GZIP, decompress_string_stream_1) {
   const auto value{"Hello World"};
   const auto input{sourcemeta::core::gzip(value)};
-  EXPECT_TRUE(input.has_value());
-  std::istringstream stream{input.value()};
+  std::istringstream stream{input};
   const auto result{sourcemeta::core::gunzip(stream)};
-  EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), value);
+  EXPECT_EQ(result, value);
 }
 
 TEST(GZIP, decompress_string_stream_error_1) {
   std::istringstream stream{"not-zlib-content"};
-  const auto result{sourcemeta::core::gunzip(stream)};
-  EXPECT_FALSE(result.has_value());
+  EXPECT_THROW(sourcemeta::core::gunzip(stream), sourcemeta::core::GZIPError);
 }


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1884
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
