### PR TITLE
Fix invalid vocabulary checks for Draft 1 and Draft 2 in `type_union_implicit`

### DIFF
--- a/src/extension/alterschema/canonicalizer/type_union_implicit.h
+++ b/src/extension/alterschema/canonicalizer/type_union_implicit.h
@@ -98,14 +98,12 @@ public:
       return false;
     }
 
-    if (vocabularies.contains(
-            "http://json-schema.org/draft-02/hyper-schema#") &&
+    if (vocabularies.contains("http://json-schema.org/draft-02/schema#") &&
         schema.defines_any({"enum", "disallow", "extends"})) {
       return false;
     }
 
-    if (vocabularies.contains(
-            "http://json-schema.org/draft-01/hyper-schema#") &&
+    if (vocabularies.contains("http://json-schema.org/draft-01/schema#") &&
         schema.defines_any({"enum", "disallow", "extends"})) {
       return false;
     }

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -371,8 +371,7 @@ TEST(AlterSchema_lint_draft1, type_boolean_as_enum_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "enum": [ false, true ],
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+    "enum": [ false, true ]
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -422,8 +421,7 @@ TEST(AlterSchema_lint_draft1, type_null_as_enum_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "enum": [ null ],
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+    "enum": [ null ]
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -516,8 +514,7 @@ TEST(AlterSchema_lint_draft1, equal_numeric_bounds_to_enum_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "enum": [ 3 ],
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+    "enum": [ 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -371,8 +371,7 @@ TEST(AlterSchema_lint_draft2, type_boolean_as_enum_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "enum": [ false, true ],
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+    "enum": [ false, true ]
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -422,8 +421,7 @@ TEST(AlterSchema_lint_draft2, type_null_as_enum_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "enum": [ null ],
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+    "enum": [ null ]
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -516,8 +514,7 @@ TEST(AlterSchema_lint_draft2, equal_numeric_bounds_to_enum_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "enum": [ 3 ],
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+    "enum": [ 3 ]
   })JSON");
 
   EXPECT_EQ(document, expected);


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/core/issues/1925
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
