### PR TITLE
Don't use `constexpr` `static` members for higher compatibility

### DIFF
--- a/src/extension/options/include/sourcemeta/core/options.h
+++ b/src/extension/options/include/sourcemeta/core/options.h
@@ -110,7 +110,7 @@ private:
 #pragma warning(disable : 4251 4275)
 #endif
   static constexpr std::string_view POSITIONAL_ARGUMENT_NAME{""};
-  static constexpr std::vector<std::string_view> EMPTY{};
+  static const std::vector<std::string_view> EMPTY;
 
   std::vector<std::unique_ptr<std::string>> storage;
   std::unordered_map<std::string_view, std::string_view> aliases_;

--- a/src/extension/options/options.cc
+++ b/src/extension/options/options.cc
@@ -27,6 +27,8 @@ auto find_canonical_name(const T &aliases, const typename T::key_type &alias)
 
 namespace sourcemeta::core {
 
+const std::vector<std::string_view> Options::EMPTY = {};
+
 auto Options::option(std::string &&name,
                      std::initializer_list<std::string> aliases) -> void {
   assert(!name.empty());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
