### PR TITLE
Don't lint away `allOf` only consisting of 2 or more `$ref`s

### DIFF
--- a/src/extension/alterschema/linter/unnecessary_allof_wrapper_draft.h
+++ b/src/extension/alterschema/linter/unnecessary_allof_wrapper_draft.h
@@ -12,7 +12,7 @@ public:
             const sourcemeta::core::Vocabularies &vocabularies,
             const sourcemeta::core::SchemaFrame &,
             const sourcemeta::core::SchemaFrame::Location &location,
-            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaWalker &walker,
             const sourcemeta::core::SchemaResolver &) const
       -> sourcemeta::core::SchemaTransformRule::Result override {
     if (!contains_any(vocabularies,
@@ -30,6 +30,7 @@ public:
     std::ostringstream message;
     bool applies{false};
     const auto &all_of{schema.at("allOf")};
+    bool multi_ref_only{all_of.size() > 1};
     for (std::size_t index = 0; index < all_of.size(); index++) {
       const auto &entry{all_of.at(index)};
       if (entry.is_object()) {
@@ -41,10 +42,16 @@ public:
             // TODO: Ideally we also check for intersection of types in type
             // arrays or whether one is contained in the other
             schema.at("type") != entry.at("type")) {
+          multi_ref_only = false;
           continue;
         }
 
         for (const auto &subentry : entry.as_object()) {
+          if (walker(subentry.first, vocabularies).type !=
+              SchemaKeywordType::Reference) {
+            multi_ref_only = false;
+          }
+
           if (subentry.first != "$ref" && !schema.defines(subentry.first)) {
             applies = true;
             message << "- ";
@@ -56,7 +63,7 @@ public:
       }
     }
 
-    if (applies) {
+    if (applies && !multi_ref_only) {
       return message.str();
     } else {
       return false;

--- a/test/alterschema/alterschema_lint_2019_09_test.cc
+++ b/test/alterschema/alterschema_lint_2019_09_test.cc
@@ -1787,8 +1787,8 @@ TEST(AlterSchema_lint_2019_09, unnecessary_allof_wrapper_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$ref": "https://example.com/foo",
     "allOf": [
+      { "$ref": "https://example.com/foo" },
       { "$ref": "https://example.com/bar" }
     ]
   })JSON");

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -1947,8 +1947,8 @@ TEST(AlterSchema_lint_2020_12, unnecessary_allof_wrapper_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$ref": "https://example.com/foo",
     "allOf": [
+      { "$ref": "https://example.com/foo" },
       { "$ref": "https://example.com/bar" }
     ]
   })JSON");

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -913,6 +913,28 @@ TEST(AlterSchema_lint_draft4, unnecessary_allof_wrapper_2) {
       "- /allOf/0/type\n");
 }
 
+TEST(AlterSchema_lint_draft4, unnecessary_allof_wrapper_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
 TEST(AlterSchema_lint_draft4, multiple_of_default_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -1316,6 +1316,28 @@ TEST(AlterSchema_lint_draft6, unnecessary_allof_wrapper_2) {
       "- /allOf/0/type\n");
 }
 
+TEST(AlterSchema_lint_draft6, unnecessary_allof_wrapper_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
 TEST(AlterSchema_lint_draft6, multiple_of_default_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -1413,6 +1413,28 @@ TEST(AlterSchema_lint_draft7, unnecessary_allof_wrapper_2) {
       "- /allOf/0/type\n");
 }
 
+TEST(AlterSchema_lint_draft7, unnecessary_allof_wrapper_3) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      { "$ref": "https://example.com/foo" },
+      { "$ref": "https://example.com/bar" }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
 TEST(AlterSchema_lint_draft7, multiple_of_default_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This seems to be a recognised pattern out there when extending more than
one schema at the same time.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
