### PR TITLE
Always add `$schema` at the root in `for_editor`

### DIFF
--- a/src/extension/editorschema/editorschema.cc
+++ b/src/extension/editorschema/editorschema.cc
@@ -26,6 +26,11 @@ auto for_editor(JSON &schema, const SchemaWalker &walker,
       continue;
     }
 
+    // Make sure that the top-level schema ALWAYS has a `$schema` declaration
+    if (entry.second.pointer.empty() && !subschema.defines("$schema")) {
+      subschema.assign("$schema", JSON{entry.second.base_dialect});
+    }
+
     // Get rid of the keywords we don't want anymore
     anonymize(subschema, entry.second.base_dialect);
     const auto vocabularies{frame.vocabularies(entry.second, resolver)};

--- a/test/editorschema/editorschema_test.cc
+++ b/test/editorschema/editorschema_test.cc
@@ -299,6 +299,50 @@ TEST(EditorSchema, 2020_12_bundle_boolean_subschema) {
   EXPECT_EQ(document, expected);
 }
 
+TEST(EditorSchema, 2020_12_default_base_dialect) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "properties": {
+      "foo": true
+    }
+  })JSON");
+
+  sourcemeta::core::for_editor(
+      document, sourcemeta::core::schema_official_walker, test_resolver_2020_12,
+      "https://json-schema.org/draft/2020-12/schema");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": true
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(EditorSchema, 2020_12_default_dialect) {
+  auto document = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://www.sourcemeta.com/top-level",
+    "properties": {
+      "foo": true
+    }
+  })JSON");
+
+  sourcemeta::core::for_editor(
+      document, sourcemeta::core::schema_official_walker, test_resolver_2020_12,
+      "https://example.com/meta/1.json");
+
+  const auto expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+      "foo": true
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
 TEST(EditorSchema, 2020_12_bundle_metaschema) {
   auto document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://example.com/meta/1.json",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
