### PR TITLE
Make `SchemaTransformRule::rereference` throw a special new exception

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -116,6 +116,13 @@ private:
 };
 
 /// @ingroup jsonschema
+/// An error that represents a broken schema resolution event
+class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaBrokenReferenceError
+    : public SchemaReferenceError {
+  using SchemaReferenceError::SchemaReferenceError;
+};
+
+/// @ingroup jsonschema
 /// An error that represents that a schema operation cannot continue
 class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaAbortError
     : public std::exception {

--- a/src/core/jsonschema/transformer.cc
+++ b/src/core/jsonschema/transformer.cc
@@ -46,8 +46,8 @@ auto SchemaTransformRule::transform(JSON &, const Result &) const -> void {
 auto SchemaTransformRule::rereference(const std::string &reference,
                                       const Pointer &origin, const Pointer &,
                                       const Pointer &) const -> Pointer {
-  throw SchemaReferenceError(reference, origin,
-                             "The reference broke after transformation");
+  throw SchemaBrokenReferenceError(reference, origin,
+                                   "The reference broke after transformation");
 }
 
 auto SchemaTransformRule::apply(JSON &schema, const JSON &root,

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -857,7 +857,7 @@ TEST(JSONSchema_transformer, rereference_not_fixed_ref) {
                  sourcemeta::core::schema_official_resolver,
                  transformer_callback_trace(entries));
     FAIL() << "The transformation was expected to throw";
-  } catch (const sourcemeta::core::SchemaReferenceError &error) {
+  } catch (const sourcemeta::core::SchemaBrokenReferenceError &error) {
     EXPECT_EQ(error.id(), "#/definitions/foo");
     EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/$ref");
     SUCCEED();


### PR DESCRIPTION
Fixes: https://github.com/sourcemeta/jsonschema/issues/458
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
