### PR TITLE
Fix `from_json` crashing on some JSON Pointers with backslashes 

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -644,7 +644,7 @@ auto from_json(const JSON &value) -> std::optional<T> {
   }
 
   try {
-    return to_pointer(value.to_string());
+    return to_pointer(value);
   } catch (const PointerParseError &) {
     return std::nullopt;
   }

--- a/test/jsonpointer/jsonpointer_json_auto_test.cc
+++ b/test/jsonpointer/jsonpointer_json_auto_test.cc
@@ -28,6 +28,17 @@ TEST(JSONPointer_json_auto, from_json_invalid_type) {
   EXPECT_FALSE(result.has_value());
 }
 
+TEST(JSONPointer_json_auto, from_json_regex_backslash_value) {
+  const auto input{sourcemeta::core::parse_json(R"JSON({
+    "value": "/[\\-]/type"
+  })JSON")};
+
+  const auto result{sourcemeta::core::from_json<sourcemeta::core::Pointer>(
+      input.at("value"))};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(sourcemeta::core::to_string(result.value()), "/[\\-]/type");
+}
+
 TEST(JSONWeakPointer_json_auto, to_json_foo_bar_baz) {
   const std::string foo{"foo"};
   const std::string bar{"bar"};

--- a/test/jsonpointer/jsonpointer_parse_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_test.cc
@@ -545,3 +545,13 @@ TEST(JSONPointer_parse, regex_caret) {
   EXPECT_TRUE(pointer.at(2).is_property());
   EXPECT_EQ(pointer.at(2).to_property(), "foo");
 }
+
+TEST(JSONPointer_parse, regex_backslash) {
+  const sourcemeta::core::Pointer pointer =
+      // Needs escaping because here we are interpreting as a C string and not
+      // as a JSON string
+      sourcemeta::core::to_pointer("/[\\\\-]");
+  EXPECT_EQ(pointer.size(), 1);
+  EXPECT_TRUE(pointer.at(0).is_property());
+  EXPECT_EQ(pointer.at(0).to_property(), "[\\-]");
+}


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/476
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
