### PR TITLE
Allow comments sibling to `$ref` in Draft 7 and older

### DIFF
--- a/src/extension/alterschema/linter/draft_ref_siblings.h
+++ b/src/extension/alterschema/linter/draft_ref_siblings.h
@@ -28,7 +28,8 @@ public:
     for (const auto &entry : schema.as_object()) {
       const auto metadata{walker(entry.first, vocabularies)};
       if (metadata.type == sourcemeta::core::SchemaKeywordType::Other ||
-          metadata.type == sourcemeta::core::SchemaKeywordType::Reference) {
+          metadata.type == sourcemeta::core::SchemaKeywordType::Reference ||
+          metadata.type == sourcemeta::core::SchemaKeywordType::Comment) {
         continue;
       } else {
         locations.push_back(Pointer{entry.first});

--- a/test/alterschema/alterschema_lint_draft0_test.cc
+++ b/test/alterschema/alterschema_lint_draft0_test.cc
@@ -239,7 +239,8 @@ TEST(AlterSchema_lint_draft0, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -261,7 +262,9 @@ TEST(AlterSchema_lint_draft0, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "default": null,
+    "title": "Test Schema"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -281,7 +284,8 @@ TEST(AlterSchema_lint_draft0, draft_ref_siblings_4) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/schema#",
     "id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation"
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -834,7 +834,8 @@ TEST(AlterSchema_lint_draft1, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -856,7 +857,9 @@ TEST(AlterSchema_lint_draft1, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "title": "Test Schema",
+    "default": null
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -876,7 +879,8 @@ TEST(AlterSchema_lint_draft1, draft_ref_siblings_4) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
     "id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation"
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -834,7 +834,8 @@ TEST(AlterSchema_lint_draft2, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -856,7 +857,9 @@ TEST(AlterSchema_lint_draft2, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "title": "Test Schema",
+    "default": null
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -876,7 +879,8 @@ TEST(AlterSchema_lint_draft2, draft_ref_siblings_4) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
     "id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation"
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -999,7 +999,8 @@ TEST(AlterSchema_lint_draft3, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1021,7 +1022,9 @@ TEST(AlterSchema_lint_draft3, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "title": "Test Schema",
+    "default": null
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1041,7 +1044,8 @@ TEST(AlterSchema_lint_draft3, draft_ref_siblings_4) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
     "id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation"
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -1457,7 +1457,8 @@ TEST(AlterSchema_lint_draft4, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1478,7 +1479,8 @@ TEST(AlterSchema_lint_draft4, draft_ref_siblings_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1495,7 +1497,8 @@ TEST(AlterSchema_lint_draft4, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation only"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1537,7 +1540,8 @@ TEST(AlterSchema_lint_draft4, draft_ref_siblings_6) {
     "type": "object",
     "properties": {
       "nested": {
-        "$ref": "#/definitions/foo"
+        "$ref": "#/definitions/foo",
+        "description": "ignored sibling"
       }
     }
   })JSON");

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -1830,7 +1830,8 @@ TEST(AlterSchema_lint_draft6, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1851,7 +1852,8 @@ TEST(AlterSchema_lint_draft6, draft_ref_siblings_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1868,7 +1870,8 @@ TEST(AlterSchema_lint_draft6, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation only"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -1908,7 +1911,8 @@ TEST(AlterSchema_lint_draft6, draft_ref_siblings_6) {
     "$schema": "http://json-schema.org/draft-06/schema#",
     "properties": {
       "nested": {
-        "$ref": "#/definitions/bar"
+        "$ref": "#/definitions/bar",
+        "description": "Nested schema with $ref"
       }
     }
   })JSON");

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -2089,7 +2089,8 @@ TEST(AlterSchema_lint_draft7, draft_ref_siblings_2) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "A string field"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -2112,7 +2113,9 @@ TEST(AlterSchema_lint_draft7, draft_ref_siblings_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "http://example.com/schema",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "$comment": "This is a comment",
+    "examples": [42]
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -2129,7 +2132,8 @@ TEST(AlterSchema_lint_draft7, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "#/definitions/foo"
+    "$ref": "#/definitions/foo",
+    "description": "Documentation only"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -2171,7 +2175,8 @@ TEST(AlterSchema_lint_draft7, draft_ref_siblings_6) {
     "type": "object",
     "properties": {
       "nested": {
-        "$ref": "#/definitions/foo"
+        "$ref": "#/definitions/foo",
+        "description": "ignored sibling"
       }
     }
   })JSON");
@@ -2557,14 +2562,15 @@ TEST(AlterSchema_lint_draft7, unknown_keywords_prefix_7) {
     "$ref": "#/definitions/MyType",
     "unknownKeyword": "should be removed due to $ref siblings rule",
     "type": "object",
-    "title": "should also be removed as per draft 7 ref siblings rule"
+    "title": "test"
   })JSON");
 
   LINT_AND_FIX_FOR_READABILITY(document);
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "#/definitions/MyType"
+    "$ref": "#/definitions/MyType",
+    "title": "test"
   })JSON");
 
   EXPECT_EQ(document, expected);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
