### PR TITLE
Consider keys when detecting object tokens during parsing

### DIFF
--- a/test/json/json_parse_callback_test.cc
+++ b/test/json/json_parse_callback_test.cc
@@ -196,9 +196,9 @@ TEST(JSON_parse_callback, object_booleans) {
   const auto input{"{\n  \"foo\": true,\n  \"bar\": false\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Boolean, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Boolean, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Boolean, 2, 13, sourcemeta::core::JSON{true});
-  EXPECT_TRACE(3, Pre, Boolean, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, Boolean, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Boolean, 3, 14, sourcemeta::core::JSON{false});
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -207,9 +207,9 @@ TEST(JSON_parse_callback, object_nulls) {
   const auto input{"{\n  \"foo\": null,\n  \"bar\": null\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Null, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Null, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Null, 2, 13, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(3, Pre, Null, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, Null, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Null, 3, 13, sourcemeta::core::JSON{nullptr});
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -218,9 +218,9 @@ TEST(JSON_parse_callback, object_strings) {
   const auto input{"{\n  \"foo\": \"baz\",\n  \"bar\": \"qux\"\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, String, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, String, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, String, 2, 14, sourcemeta::core::JSON{"baz"});
-  EXPECT_TRACE(3, Pre, String, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, String, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, String, 3, 14, sourcemeta::core::JSON{"qux"});
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -229,9 +229,9 @@ TEST(JSON_parse_callback, object_integers) {
   const auto input{"{\n  \"foo\": 1,\n  \"bar\": 234\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Integer, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Integer, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Integer, 2, 10, sourcemeta::core::JSON{1});
-  EXPECT_TRACE(3, Pre, Integer, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, Integer, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Integer, 3, 12, sourcemeta::core::JSON{234});
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -240,9 +240,9 @@ TEST(JSON_parse_callback, object_reals) {
   const auto input{"{\n  \"foo\": 1.0,\n  \"bar\": 2.34\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Real, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Real, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Real, 2, 12, sourcemeta::core::JSON{1.0});
-  EXPECT_TRACE(3, Pre, Real, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, Real, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Real, 3, 13, sourcemeta::core::JSON{2.34});
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -251,9 +251,9 @@ TEST(JSON_parse_callback, object_empty_arrays) {
   const auto input{"{\n  \"foo\": [],\n  \"bar\": []\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Array, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Array, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Array, 2, 11, sourcemeta::core::parse_json("[]"));
-  EXPECT_TRACE(3, Pre, Array, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, Array, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Array, 3, 11, sourcemeta::core::parse_json("[]"));
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -262,9 +262,9 @@ TEST(JSON_parse_callback, object_empty_objects) {
   const auto input{"{\n  \"foo\": {},\n  \"bar\": {}\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Object, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Object, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Object, 2, 11, sourcemeta::core::parse_json("{}"));
-  EXPECT_TRACE(3, Pre, Object, 3, 10, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(3, Pre, Object, 3, 3, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Object, 3, 11, sourcemeta::core::parse_json("{}"));
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::parse_json(input));
 }
@@ -281,8 +281,8 @@ TEST(JSON_parse_callback, complex_1) {
   PARSE_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Array, 1, 1, sourcemeta::core::JSON{nullptr});
   EXPECT_TRACE(1, Pre, Object, 2, 3, sourcemeta::core::JSON{0});
-  EXPECT_TRACE(2, Pre, Object, 3, 12, sourcemeta::core::JSON{"foo"});
-  EXPECT_TRACE(3, Pre, Integer, 4, 14, sourcemeta::core::JSON{"bar"});
+  EXPECT_TRACE(2, Pre, Object, 3, 5, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(3, Pre, Integer, 4, 7, sourcemeta::core::JSON{"bar"});
   EXPECT_TRACE(4, Post, Integer, 4, 14, sourcemeta::core::JSON{3});
   EXPECT_TRACE(5, Post, Object, 5, 5,
                sourcemeta::core::parse_json(input).at(0).at("foo"));
@@ -295,7 +295,7 @@ TEST(JSON_parse_callback, read_json_stub_valid) {
   const auto input{std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json"};
   READ_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, Integer, 1, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, Integer, 1, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, Integer, 1, 10, sourcemeta::core::JSON{1});
   EXPECT_TRACE(3, Post, Object, 1, 12, sourcemeta::core::read_json(input));
 }

--- a/test/jsonpointer/jsonpointer_position_test.cc
+++ b/test/jsonpointer/jsonpointer_position_test.cc
@@ -30,12 +30,12 @@ TEST(JSONPointer_position, track_1) {
   sourcemeta::core::Pointer pointer_3{0, "foo"};
   EXPECT_TRUE(tracker.get(pointer_3).has_value());
   EXPECT_EQ(tracker.get(pointer_3).value(),
-            sourcemeta::core::PointerPositionTracker::Position({3, 12, 5, 5}));
+            sourcemeta::core::PointerPositionTracker::Position({3, 5, 5, 5}));
 
   sourcemeta::core::Pointer pointer_4{0, "foo", "bar"};
   EXPECT_TRUE(tracker.get(pointer_4).has_value());
   EXPECT_EQ(tracker.get(pointer_4).value(),
-            sourcemeta::core::PointerPositionTracker::Position({4, 14, 4, 14}));
+            sourcemeta::core::PointerPositionTracker::Position({4, 7, 4, 14}));
 }
 
 TEST(JSONPointer_position, to_json_1) {
@@ -53,8 +53,8 @@ TEST(JSONPointer_position, to_json_1) {
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "": [ 1, 1, 7, 1 ],
     "/0": [ 2, 3, 6, 3 ],
-    "/0/foo": [ 3, 12, 5, 5 ],
-    "/0/foo/bar": [ 4, 14, 4, 14 ]
+    "/0/foo": [ 3, 5, 5, 5 ],
+    "/0/foo/bar": [ 4, 7, 4, 14 ]
   })JSON")};
 
   EXPECT_EQ(tracker.to_json(), expected);

--- a/test/yaml/yaml_parse_callback_test.cc
+++ b/test/yaml/yaml_parse_callback_test.cc
@@ -40,9 +40,9 @@ TEST(YAML_parse_callback, yaml_or_json_stub_test_2) {
   const auto input{std::filesystem::path{STUBS_PATH} / "test_1.json"};
   READ_YAML_OR_JSON_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, sourcemeta::core::JSON{nullptr});
-  EXPECT_TRACE(1, Pre, String, 2, 10, sourcemeta::core::JSON{"foo"});
+  EXPECT_TRACE(1, Pre, String, 2, 3, sourcemeta::core::JSON{"foo"});
   EXPECT_TRACE(2, Post, String, 2, 14, sourcemeta::core::JSON{"bar"});
-  EXPECT_TRACE(3, Pre, Integer, 3, 10, sourcemeta::core::JSON{"baz"});
+  EXPECT_TRACE(3, Pre, Integer, 3, 3, sourcemeta::core::JSON{"baz"});
   EXPECT_TRACE(4, Post, Integer, 3, 10, sourcemeta::core::JSON{2});
   EXPECT_TRACE(5, Post, Object, 4, 1, sourcemeta::core::read_json(input));
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
