### PR TITLE
Fix `json_auto.h` incorrectly handling tuple optionals

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_auto.h
+++ b/src/core/json/include/sourcemeta/core/json_auto.h
@@ -118,6 +118,8 @@ concept json_auto_tuple_poly =
 template <json_auto_map_like T> auto to_json(const T &value) -> JSON;
 template <typename L, typename R>
 auto to_json(const std::pair<L, R> &value) -> JSON;
+template <json_auto_tuple_mono T> auto to_json(const T &value) -> JSON;
+template <json_auto_tuple_poly T> auto to_json(const T &value) -> JSON;
 #endif
 
 /// @ingroup json

--- a/test/json/json_auto_test.cc
+++ b/test/json/json_auto_test.cc
@@ -114,6 +114,31 @@ TEST(JSON_auto, optional_without_value_2) {
   EXPECT_EQ(value, back.value());
 }
 
+TEST(JSON_auto, optional_tuple_1) {
+  using Type =
+      std::optional<std::tuple<std::uint64_t, std::uint64_t, std::uint64_t>>;
+  const Type value{
+      std::tuple<std::uint64_t, std::uint64_t, std::uint64_t>{1, 2, 3}};
+  const auto result{sourcemeta::core::to_json(value)};
+  const auto expected{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
+  EXPECT_EQ(result, expected);
+  const auto back{sourcemeta::core::from_json<Type>(result)};
+  EXPECT_TRUE(back.has_value());
+  EXPECT_EQ(value, back.value());
+}
+
+TEST(JSON_auto, optional_tuple_2) {
+  using Type =
+      std::optional<std::tuple<std::uint64_t, std::uint64_t, std::uint64_t>>;
+  const Type value;
+  const auto result{sourcemeta::core::to_json(value)};
+  const auto expected{sourcemeta::core::parse_json(R"JSON(null)JSON")};
+  EXPECT_EQ(result, expected);
+  const auto back{sourcemeta::core::from_json<Type>(result)};
+  EXPECT_TRUE(back.has_value());
+  EXPECT_EQ(value, back.value());
+}
+
 TEST(JSON_auto, vector_strings_without_iterators) {
   const std::vector<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(value)};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
