### PR TITLE
Fix `URI::path` setter/getter invariant

### DIFF
--- a/src/core/uri/setters.cc
+++ b/src/core/uri/setters.cc
@@ -20,11 +20,6 @@ auto apply_leading_slash_transform(std::optional<std::string> parsed_path,
     if (path_value.empty() || !path_value.starts_with("/")) {
       return "/" + path_value;
     }
-    return parsed_path;
-  }
-
-  if (path_value.starts_with("/")) {
-    return path_value.substr(1);
   }
 
   return parsed_path;

--- a/test/uri/uri_fragment_test.cc
+++ b/test/uri/uri_fragment_test.cc
@@ -216,3 +216,41 @@ TEST(URI_fragment, set_non_ascii_character) {
   EXPECT_EQ(uri.fragment(), "/foo\xC3\xA9");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%C3%A9");
 }
+
+TEST(URI_fragment, getter_setter_invariant_simple) {
+  sourcemeta::core::URI uri{"https://example.com/path#foo"};
+  EXPECT_TRUE(uri.fragment().has_value());
+  EXPECT_EQ(uri.fragment().value(), "foo");
+
+  const auto original_fragment{uri.fragment().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.fragment(original_fragment);
+
+  EXPECT_EQ(uri.fragment().value(), original_fragment);
+  EXPECT_EQ(uri.recompose(), original_recompose);
+}
+
+TEST(URI_fragment, getter_setter_invariant_with_pointer) {
+  sourcemeta::core::URI uri{"https://example.com#/foo/bar"};
+  EXPECT_TRUE(uri.fragment().has_value());
+
+  const auto original_fragment{uri.fragment().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.fragment(original_fragment);
+
+  EXPECT_EQ(uri.fragment().value(), original_fragment);
+  EXPECT_EQ(uri.recompose(), original_recompose);
+}
+
+TEST(URI_fragment, getter_setter_invariant_empty) {
+  sourcemeta::core::URI uri{"https://example.com#"};
+  EXPECT_TRUE(uri.fragment().has_value());
+  EXPECT_EQ(uri.fragment().value(), "");
+
+  const auto original_fragment{uri.fragment().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.fragment(original_fragment);
+
+  EXPECT_EQ(uri.fragment().value(), original_fragment);
+  EXPECT_EQ(uri.recompose(), original_recompose);
+}

--- a/test/uri/uri_path_test.cc
+++ b/test/uri/uri_path_test.cc
@@ -211,26 +211,26 @@ TEST(URI_path_setter_no_scheme, set_path_on_host_only) {
   sourcemeta::core::URI uri{"example.com"};
 
   uri.path("/foo");
-  EXPECT_EQ(uri.path().value(), "foo");
-  EXPECT_EQ(uri.recompose(), "foo");
+  EXPECT_EQ(uri.path().value(), "/foo");
+  EXPECT_EQ(uri.recompose(), "/foo");
 
   std::string path{"/bar"};
   uri.path(std::move(path));
-  EXPECT_EQ(uri.path().value(), "bar");
-  EXPECT_EQ(uri.recompose(), "bar");
+  EXPECT_EQ(uri.path().value(), "/bar");
+  EXPECT_EQ(uri.recompose(), "/bar");
 }
 
 TEST(URI_path_setter_no_scheme, replace_existing_path) {
   sourcemeta::core::URI uri{"example.com/old"};
 
   uri.path("/new");
-  EXPECT_EQ(uri.path().value(), "new");
-  EXPECT_EQ(uri.recompose(), "new");
+  EXPECT_EQ(uri.path().value(), "/new");
+  EXPECT_EQ(uri.recompose(), "/new");
 
   std::string path{"/newer"};
   uri.path(std::move(path));
-  EXPECT_EQ(uri.path().value(), "newer");
-  EXPECT_EQ(uri.recompose(), "newer");
+  EXPECT_EQ(uri.path().value(), "/newer");
+  EXPECT_EQ(uri.recompose(), "/newer");
 }
 
 TEST(URI_path_setter_no_scheme, set_empty_path) {
@@ -250,13 +250,13 @@ TEST(URI_path_setter_no_scheme, set_path_on_ip_address) {
   sourcemeta::core::URI uri{"192.168.0.1"};
 
   uri.path("/admin");
-  EXPECT_EQ(uri.path().value(), "admin");
-  EXPECT_EQ(uri.recompose(), "admin");
+  EXPECT_EQ(uri.path().value(), "/admin");
+  EXPECT_EQ(uri.recompose(), "/admin");
 
   std::string path{"/admin2"};
   uri.path(std::move(path));
-  EXPECT_EQ(uri.path().value(), "admin2");
-  EXPECT_EQ(uri.recompose(), "admin2");
+  EXPECT_EQ(uri.path().value(), "/admin2");
+  EXPECT_EQ(uri.recompose(), "/admin2");
 }
 
 // TODO: dig why scheme return example.com
@@ -433,4 +433,60 @@ TEST(URI_path_getter, rfc3986_path_with_fragment_separator) {
   const sourcemeta::core::URI uri{"http://example.com/path#fragment"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path");
+}
+
+TEST(URI_path_setter, getter_setter_invariant_relative_with_leading_slash) {
+  sourcemeta::core::URI uri{"/test/no-serve/schema"};
+  EXPECT_TRUE(uri.path().has_value());
+  EXPECT_EQ(uri.path().value(), "/test/no-serve/schema");
+  EXPECT_EQ(uri.recompose(), "/test/no-serve/schema");
+
+  const auto original_path{uri.path().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.path(original_path);
+
+  EXPECT_EQ(uri.path().value(), original_path);
+  EXPECT_EQ(uri.recompose(), original_recompose);
+}
+
+TEST(URI_path_setter, getter_setter_invariant_relative_without_leading_slash) {
+  sourcemeta::core::URI uri{"test/no-serve/schema"};
+  EXPECT_TRUE(uri.path().has_value());
+  EXPECT_EQ(uri.path().value(), "test/no-serve/schema");
+  EXPECT_EQ(uri.recompose(), "test/no-serve/schema");
+
+  const auto original_path{uri.path().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.path(original_path);
+
+  EXPECT_EQ(uri.path().value(), original_path);
+  EXPECT_EQ(uri.recompose(), original_recompose);
+}
+
+TEST(URI_path_setter, getter_setter_invariant_absolute_uri) {
+  sourcemeta::core::URI uri{"http://example.com/foo/bar"};
+  EXPECT_TRUE(uri.path().has_value());
+  EXPECT_EQ(uri.path().value(), "/foo/bar");
+  EXPECT_EQ(uri.recompose(), "http://example.com/foo/bar");
+
+  const auto original_path{uri.path().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.path(original_path);
+
+  EXPECT_EQ(uri.path().value(), original_path);
+  EXPECT_EQ(uri.recompose(), original_recompose);
+}
+
+TEST(URI_path_setter, getter_setter_invariant_relative_dotdot) {
+  sourcemeta::core::URI uri{"../foo/bar"};
+  EXPECT_TRUE(uri.path().has_value());
+  EXPECT_EQ(uri.path().value(), "../foo/bar");
+  EXPECT_EQ(uri.recompose(), "../foo/bar");
+
+  const auto original_path{uri.path().value()};
+  const auto original_recompose{uri.recompose()};
+  uri.path(original_path);
+
+  EXPECT_EQ(uri.path().value(), original_path);
+  EXPECT_EQ(uri.recompose(), original_recompose);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
