### PR TITLE
Don't try to workaround top-level `$ref` on `reidentify`

### DIFF
--- a/src/core/jsonschema/jsonschema.cc
+++ b/src/core/jsonschema/jsonschema.cc
@@ -188,44 +188,6 @@ auto sourcemeta::core::reidentify(JSON &schema,
   assert(is_schema(schema));
   assert(schema.is_object());
   schema.assign(id_keyword(base_dialect), JSON{new_identifier});
-
-  if (schema.defines("$ref")) {
-    // Workaround top-level `$ref` with `allOf`
-    if (base_dialect == "http://json-schema.org/draft-07/schema#" ||
-        base_dialect == "http://json-schema.org/draft-07/hyper-schema#" ||
-        base_dialect == "http://json-schema.org/draft-06/schema#" ||
-        base_dialect == "http://json-schema.org/draft-06/hyper-schema#" ||
-        base_dialect == "http://json-schema.org/draft-04/schema#" ||
-        base_dialect == "http://json-schema.org/draft-04/hyper-schema#") {
-      // Note that if the schema already has an `allOf`, we can safely
-      // remove it, as it was by definition ignored by `$ref` already
-      if (schema.defines("allOf")) {
-        schema.erase("allOf");
-      }
-
-      schema.assign("allOf", JSON::make_array());
-      auto conjunction{JSON::make_object()};
-      conjunction.assign("$ref", schema.at("$ref"));
-      schema.at("allOf").push_back(std::move(conjunction));
-      schema.erase("$ref");
-    }
-
-    // Workaround top-level `$ref` with `extends`
-    if (base_dialect == "http://json-schema.org/draft-03/schema#" ||
-        base_dialect == "http://json-schema.org/draft-03/hyper-schema#") {
-      // Note that if the schema already has an `extends`, we can safely
-      // remove it, as it was by definition ignored by `$ref` already
-      if (schema.defines("extends")) {
-        schema.erase("extends");
-      }
-
-      schema.assign("extends", JSON::make_object());
-      schema.at("extends").assign("$ref", schema.at("$ref"));
-      schema.erase("$ref");
-    }
-  }
-
-  assert(identify(schema, base_dialect).has_value());
 }
 
 auto sourcemeta::core::dialect(

--- a/test/jsonschema/jsonschema_identify_draft3_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft3_test.cc
@@ -227,7 +227,7 @@ TEST(JSONSchema_identify_draft3, reidentify_set_with_top_level_ref) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "extends": { "$ref": "https://example.com/schema" }
+    "$ref": "https://example.com/schema"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -247,7 +247,8 @@ TEST(JSONSchema_identify_draft3,
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "extends": { "$ref": "https://example.com/schema" }
+    "$ref": "https://example.com/schema",
+    "extends": { "type": "string" }
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/jsonschema/jsonschema_identify_draft4_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft4_test.cc
@@ -227,7 +227,7 @@ TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "$ref": "https://example.com/schema"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -246,7 +246,8 @@ TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref_and_allof) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "$ref": "https://example.com/schema",
+    "allOf": [ { "type": "string" } ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/jsonschema/jsonschema_identify_draft6_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft6_test.cc
@@ -227,7 +227,7 @@ TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "$ref": "https://example.com/schema"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -246,7 +246,8 @@ TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref_and_allof) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "$ref": "https://example.com/schema",
+    "allOf": [ { "type": "string" } ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/jsonschema/jsonschema_identify_draft7_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft7_test.cc
@@ -227,7 +227,7 @@ TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "$ref": "https://example.com/schema"
   })JSON");
 
   EXPECT_EQ(document, expected);
@@ -246,7 +246,8 @@ TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref_and_allof) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "$ref": "https://example.com/schema",
+    "allOf": [ { "type": "string" } ]
   })JSON");
 
   EXPECT_EQ(document, expected);


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/479
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
