### PR TITLE
Fix top-level `$ref` workaround in `reidentify` breaking semantics

### DIFF
--- a/test/jsonschema/jsonschema_identify_draft3_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft3_test.cc
@@ -247,7 +247,35 @@ TEST(JSONSchema_identify_draft3,
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "extends": { "$ref": "https://example.com/schema" }
+    "extends": {
+      "$ref": "https://example.com/schema",
+      "extends": { "type": "string" }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_identify_draft3, reidentify_set_with_top_level_ref_and_others) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "$ref": "https://example.com/schema",
+    "title": "I will be removed",
+    "id": "https://example.com/i-will-be-removed-too",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                               sourcemeta::core::schema_official_resolver);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "id": "https://example.com/my-new-id",
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "extends": {
+      "$ref": "https://example.com/schema",
+      "title": "I will be removed",
+      "type": "string"
+    }
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/jsonschema/jsonschema_identify_draft4_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft4_test.cc
@@ -246,7 +246,39 @@ TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref_and_allof) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "allOf": [
+      {
+        "$ref": "https://example.com/schema",
+        "allOf": [ { "type": "string" } ]
+      }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref_and_others) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "https://example.com/schema",
+    "title": "I will be removed",
+    "id": "https://example.com/i-will-be-removed-too",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                               sourcemeta::core::schema_official_resolver);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "id": "https://example.com/my-new-id",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+      {
+        "$ref": "https://example.com/schema",
+        "title": "I will be removed",
+        "type": "string"
+      }
+    ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/jsonschema/jsonschema_identify_draft6_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft6_test.cc
@@ -246,7 +246,39 @@ TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref_and_allof) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "allOf": [
+      {
+        "$ref": "https://example.com/schema",
+        "allOf": [ { "type": "string" } ]
+      }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref_and_others) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "https://example.com/schema",
+    "title": "I will be removed",
+    "$id": "https://example.com/i-will-be-removed-too",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                               sourcemeta::core::schema_official_resolver);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/my-new-id",
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "allOf": [
+      {
+        "$ref": "https://example.com/schema",
+        "title": "I will be removed",
+        "type": "string"
+      }
+    ]
   })JSON");
 
   EXPECT_EQ(document, expected);

--- a/test/jsonschema/jsonschema_identify_draft7_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft7_test.cc
@@ -246,7 +246,39 @@ TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref_and_allof) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://example.com/my-new-id",
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "allOf": [ { "$ref": "https://example.com/schema" } ]
+    "allOf": [
+      {
+        "$ref": "https://example.com/schema",
+        "allOf": [ { "type": "string" } ]
+      }
+    ]
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref_and_others) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "https://example.com/schema",
+    "title": "I will be removed",
+    "$id": "https://example.com/i-will-be-removed-too",
+    "type": "string"
+  })JSON");
+
+  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                               sourcemeta::core::schema_official_resolver);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$id": "https://example.com/my-new-id",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "allOf": [
+      {
+        "$ref": "https://example.com/schema",
+        "title": "I will be removed",
+        "type": "string"
+      }
+    ]
   })JSON");
 
   EXPECT_EQ(document, expected);


### PR DESCRIPTION
See: https://github.com/sourcemeta/jsonschema/issues/479
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
