### PR TITLE
Rename `.name()` to `.option()` in the Options-related error classes

### DIFF
--- a/src/extension/options/include/sourcemeta/core/options_error.h
+++ b/src/extension/options/include/sourcemeta/core/options_error.h
@@ -29,36 +29,38 @@ struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsError : public std::runtime_error {
 /// This class represents a unknown option error
 struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsUnknownOptionError
     : public OptionsError {
-  explicit OptionsUnknownOptionError(std::string name)
-      : OptionsError{"Unknown option"}, name_{std::move(name)} {}
-  [[nodiscard]] auto name() const -> const auto & { return this->name_; }
+  explicit OptionsUnknownOptionError(std::string option)
+      : OptionsError{"Unknown option"}, option_{std::move(option)} {}
+  [[nodiscard]] auto option() const -> const auto & { return this->option_; }
 
 private:
-  std::string name_;
+  std::string option_;
 };
 
 /// @ingroup options
 /// This class represents a value being passed to a flag
 struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsUnexpectedValueFlagError
     : public OptionsError {
-  explicit OptionsUnexpectedValueFlagError(std::string name)
-      : OptionsError{"This flag cannot take a value"}, name_{std::move(name)} {}
-  [[nodiscard]] auto name() const -> const auto & { return this->name_; }
+  explicit OptionsUnexpectedValueFlagError(std::string option)
+      : OptionsError{"This flag cannot take a value"},
+        option_{std::move(option)} {}
+  [[nodiscard]] auto option() const -> const auto & { return this->option_; }
 
 private:
-  std::string name_;
+  std::string option_;
 };
 
 /// @ingroup options
 /// This class represents a missing value from an option
 struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsMissingOptionValueError
     : public OptionsError {
-  explicit OptionsMissingOptionValueError(std::string name)
-      : OptionsError{"This option must take a value"}, name_{std::move(name)} {}
-  [[nodiscard]] auto name() const -> const auto & { return this->name_; }
+  explicit OptionsMissingOptionValueError(std::string option)
+      : OptionsError{"This option must take a value"},
+        option_{std::move(option)} {}
+  [[nodiscard]] auto option() const -> const auto & { return this->option_; }
 
 private:
-  std::string name_;
+  std::string option_;
 };
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
