### PR TITLE
Use `$id` as a base URI for top-level `$ref` in Draft 7 and earlier

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema.h
@@ -160,6 +160,8 @@ auto identify(const JSON &schema, const SchemaResolver &resolver,
 /// of the schema.
 SOURCEMETA_CORE_JSONSCHEMA_EXPORT
 auto identify(const JSON &schema, const std::string &base_dialect,
+              const SchemaIdentificationStrategy strategy =
+                  SchemaIdentificationStrategy::Strict,
               const std::optional<std::string> &default_id = std::nullopt)
     -> std::optional<std::string>;
 

--- a/src/core/jsonschema/walker.cc
+++ b/src/core/jsonschema/walker.cc
@@ -94,7 +94,7 @@ auto walk(const std::optional<sourcemeta::core::Pointer> &parent,
   for (auto &pair : subschema.as_object()) {
     const auto keyword_info{walker(pair.first, vocabularies)};
 
-    // Ignore the current keyword sibling to `$ref in Draft 7 and older `if its
+    // Ignore the current keyword sibling to `$ref in Draft 7 and older if its
     // not a top-level container
     if (has_overriding_ref &&
         keyword_info.type != sourcemeta::core::SchemaKeywordType::Reference &&

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -548,20 +548,25 @@ TEST(JSONSchema_frame_draft3, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 4);
 
+  EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(
+      frame, "https://www.sourcemeta.com/schema",
+      "https://www.sourcemeta.com/schema", "",
+      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+
   // JSON Pointers
 
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "", "", "http://json-schema.org/draft-03/schema#",
-      "http://json-schema.org/draft-03/schema#", {""}, std::nullopt);
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/id", "/id", "http://json-schema.org/draft-03/schema#",
-      "http://json-schema.org/draft-03/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-03/schema#",
-      "http://json-schema.org/draft-03/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-03/schema#",
-      "http://json-schema.org/draft-03/schema#", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/id",
+      "https://www.sourcemeta.com/schema", "/id",
+      "https://www.sourcemeta.com/schema", "/id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
 
   // References
 
@@ -571,6 +576,96 @@ TEST(JSONSchema_frame_draft3, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-03/schema",
       "http://json-schema.org/draft-03/schema", std::nullopt,
       "http://json-schema.org/draft-03/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
-                          "/definitions/string", "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "#/definitions/string");
+}
+
+TEST(JSONSchema_frame_draft3, top_level_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "https://example.com/foo",
+    "$ref": "bar"
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 4);
+
+  EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(
+      frame, "https://example.com/foo", "https://example.com/foo", "",
+      "https://example.com/foo", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
+      "/$schema", "https://example.com/foo", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(frame, "https://example.com/foo#/id",
+                                     "https://example.com/foo", "/id",
+                                     "https://example.com/foo", "/id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
+      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-03/schema",
+      "http://json-schema.org/draft-03/schema", std::nullopt,
+      "http://json-schema.org/draft-03/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
+                          "https://example.com/bar", std::nullopt, "bar");
+}
+
+TEST(JSONSchema_frame_draft3, nested_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-03/schema#",
+    "id": "https://example.com",
+    "additionalProperties": {
+      "id": "https://nested.com",
+      "$ref": "bar"
+    }
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 6);
+
+  EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://example.com", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(frame, "https://example.com#/id",
+                                     "https://example.com", "/id",
+                                     "https://example.com", "/id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(frame, "https://example.com#/$schema",
+                                     "https://example.com", "/$schema",
+                                     "https://example.com", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_SUBSCHEMA(
+      frame, "https://example.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://example.com", "/additionalProperties",
+      {"/~?additionalProperties~/~P~"}, "");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://example.com#/additionalProperties/id",
+      "https://example.com", "/additionalProperties/id", "https://example.com",
+      "/additionalProperties/id", {}, "/additionalProperties");
+  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
+      frame, "https://example.com#/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref", {},
+      "/additionalProperties");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-03/schema",
+      "http://json-schema.org/draft-03/schema", std::nullopt,
+      "http://json-schema.org/draft-03/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/additionalProperties/$ref",
+                          "https://example.com/bar", "https://example.com/bar",
+                          std::nullopt, "bar");
 }

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -630,32 +630,38 @@ TEST(JSONSchema_frame_draft4, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 7);
 
+  EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(
+      frame, "https://www.sourcemeta.com/schema",
+      "https://www.sourcemeta.com/schema", "",
+      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+
   // JSON Pointers
 
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "", "", "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {""}, std::nullopt);
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/id", "/id", "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/definitions", "/definitions",
-      "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "#/definitions/string", "/definitions/string",
-      "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {""}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/definitions/string/type", "/definitions/string/type",
-      "http://json-schema.org/draft-04/schema#",
-      "http://json-schema.org/draft-04/schema#", {}, "/definitions/string");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/id",
+      "https://www.sourcemeta.com/schema", "/id",
+      "https://www.sourcemeta.com/schema", "/id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_SUBSCHEMA(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string", {""}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type", {},
+      "/definitions/string");
 
   // References
 
@@ -665,8 +671,10 @@ TEST(JSONSchema_frame_draft4, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-04/schema",
       "http://json-schema.org/draft-04/schema", std::nullopt,
       "http://json-schema.org/draft-04/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
-                          "/definitions/string", "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft4,
@@ -936,4 +944,92 @@ TEST(JSONSchema_frame_draft4, ref_invalidates_sibling_subschemas_and_refs) {
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
                           "#/definitions/enabled", std::nullopt,
                           "/definitions/enabled", "#/definitions/enabled");
+}
+
+TEST(JSONSchema_frame_draft4, top_level_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://example.com/foo",
+    "$ref": "bar"
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 4);
+
+  EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(
+      frame, "https://example.com/foo", "https://example.com/foo", "",
+      "https://example.com/foo", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
+      "/$schema", "https://example.com/foo", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(frame, "https://example.com/foo#/id",
+                                     "https://example.com/foo", "/id",
+                                     "https://example.com/foo", "/id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
+      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-04/schema",
+      "http://json-schema.org/draft-04/schema", std::nullopt,
+      "http://json-schema.org/draft-04/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
+                          "https://example.com/bar", std::nullopt, "bar");
+}
+
+TEST(JSONSchema_frame_draft4, nested_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://example.com",
+    "additionalProperties": {
+      "id": "https://nested.com",
+      "$ref": "bar"
+    }
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 6);
+
+  EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://example.com", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(frame, "https://example.com#/id",
+                                     "https://example.com", "/id",
+                                     "https://example.com", "/id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(frame, "https://example.com#/$schema",
+                                     "https://example.com", "/$schema",
+                                     "https://example.com", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_SUBSCHEMA(
+      frame, "https://example.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://example.com", "/additionalProperties",
+      {"/~?additionalProperties~/~P~"}, "");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://example.com#/additionalProperties/id",
+      "https://example.com", "/additionalProperties/id", "https://example.com",
+      "/additionalProperties/id", {}, "/additionalProperties");
+  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
+      frame, "https://example.com#/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref", {},
+      "/additionalProperties");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-04/schema",
+      "http://json-schema.org/draft-04/schema", std::nullopt,
+      "http://json-schema.org/draft-04/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/additionalProperties/$ref",
+                          "https://example.com/bar", "https://example.com/bar",
+                          std::nullopt, "bar");
 }

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -630,32 +630,38 @@ TEST(JSONSchema_frame_draft6, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 7);
 
+  EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(
+      frame, "https://www.sourcemeta.com/schema",
+      "https://www.sourcemeta.com/schema", "",
+      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+
   // JSON Pointers
 
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "", "", "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {""}, std::nullopt);
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$id", "/$id", "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/definitions", "/definitions",
-      "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "#/definitions/string", "/definitions/string",
-      "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {""}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/definitions/string/type", "/definitions/string/type",
-      "http://json-schema.org/draft-06/schema#",
-      "http://json-schema.org/draft-06/schema#", {}, "/definitions/string");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$id",
+      "https://www.sourcemeta.com/schema", "/$id",
+      "https://www.sourcemeta.com/schema", "/$id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_SUBSCHEMA(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string", {""}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type", {},
+      "/definitions/string");
 
   // References
 
@@ -665,8 +671,10 @@ TEST(JSONSchema_frame_draft6, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-06/schema",
       "http://json-schema.org/draft-06/schema", std::nullopt,
       "http://json-schema.org/draft-06/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
-                          "/definitions/string", "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft6, relative_base_uri_without_ref) {
@@ -842,4 +850,92 @@ TEST(JSONSchema_frame_draft6, ref_invalidates_sibling_subschemas_and_refs) {
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
                           "#/definitions/enabled", std::nullopt,
                           "/definitions/enabled", "#/definitions/enabled");
+}
+
+TEST(JSONSchema_frame_draft6, top_level_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com/foo",
+    "$ref": "bar"
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 4);
+
+  EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(
+      frame, "https://example.com/foo", "https://example.com/foo", "",
+      "https://example.com/foo", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
+      "/$schema", "https://example.com/foo", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(frame, "https://example.com/foo#/$id",
+                                     "https://example.com/foo", "/$id",
+                                     "https://example.com/foo", "/$id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
+      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-06/schema",
+      "http://json-schema.org/draft-06/schema", std::nullopt,
+      "http://json-schema.org/draft-06/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
+                          "https://example.com/bar", std::nullopt, "bar");
+}
+
+TEST(JSONSchema_frame_draft6, nested_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com",
+    "additionalProperties": {
+      "$id": "https://nested.com",
+      "$ref": "bar"
+    }
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 6);
+
+  EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://example.com", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(frame, "https://example.com#/$id",
+                                     "https://example.com", "/$id",
+                                     "https://example.com", "/$id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(frame, "https://example.com#/$schema",
+                                     "https://example.com", "/$schema",
+                                     "https://example.com", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_SUBSCHEMA(
+      frame, "https://example.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://example.com", "/additionalProperties",
+      {"/~?additionalProperties~/~P~"}, "");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://example.com#/additionalProperties/$id",
+      "https://example.com", "/additionalProperties/$id", "https://example.com",
+      "/additionalProperties/$id", {}, "/additionalProperties");
+  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
+      frame, "https://example.com#/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref", {},
+      "/additionalProperties");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-06/schema",
+      "http://json-schema.org/draft-06/schema", std::nullopt,
+      "http://json-schema.org/draft-06/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/additionalProperties/$ref",
+                          "https://example.com/bar", "https://example.com/bar",
+                          std::nullopt, "bar");
 }

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -630,32 +630,38 @@ TEST(JSONSchema_frame_draft7, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 7);
 
+  EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(
+      frame, "https://www.sourcemeta.com/schema",
+      "https://www.sourcemeta.com/schema", "",
+      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+
   // JSON Pointers
 
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "", "", "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {""}, std::nullopt);
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$id", "/$id", "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/definitions", "/definitions",
-      "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
-      frame, "#/definitions/string", "/definitions/string",
-      "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {""}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
-      frame, "#/definitions/string/type", "/definitions/string/type",
-      "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {}, "/definitions/string");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$id",
+      "https://www.sourcemeta.com/schema", "/$id",
+      "https://www.sourcemeta.com/schema", "/$id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema",
+      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref",
+      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions",
+      "https://www.sourcemeta.com/schema", "/definitions", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_SUBSCHEMA(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string", {""}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type",
+      "https://www.sourcemeta.com/schema", "/definitions/string/type", {},
+      "/definitions/string");
 
   // References
 
@@ -665,8 +671,10 @@ TEST(JSONSchema_frame_draft7, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
-                          "/definitions/string", "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
+      "https://www.sourcemeta.com/schema", "/definitions/string",
+      "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft7, ref_with_definitions) {
@@ -946,4 +954,92 @@ TEST(JSONSchema_frame_draft7, ref_invalidates_sibling_subschemas_and_refs) {
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
                           "#/definitions/enabled", std::nullopt,
                           "/definitions/enabled", "#/definitions/enabled");
+}
+
+TEST(JSONSchema_frame_draft7, top_level_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com/foo",
+    "$ref": "bar"
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 4);
+
+  EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(
+      frame, "https://example.com/foo", "https://example.com/foo", "",
+      "https://example.com/foo", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
+      "/$schema", "https://example.com/foo", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(frame, "https://example.com/foo#/$id",
+                                     "https://example.com/foo", "/$id",
+                                     "https://example.com/foo", "/$id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
+      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-07/schema",
+      "http://json-schema.org/draft-07/schema", std::nullopt,
+      "http://json-schema.org/draft-07/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
+                          "https://example.com/bar", std::nullopt, "bar");
+}
+
+TEST(JSONSchema_frame_draft7, nested_relative_ref_with_id) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com",
+    "additionalProperties": {
+      "$id": "https://nested.com",
+      "$ref": "bar"
+    }
+  })JSON");
+
+  sourcemeta::core::SchemaFrame frame{
+      sourcemeta::core::SchemaFrame::Mode::Instances};
+  frame.analyse(document, sourcemeta::core::schema_official_walker,
+                sourcemeta::core::schema_official_resolver);
+
+  EXPECT_EQ(frame.locations().size(), 6);
+
+  EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(
+      frame, "https://example.com", "https://example.com", "",
+      "https://example.com", "", {""}, std::nullopt);
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(frame, "https://example.com#/$id",
+                                     "https://example.com", "/$id",
+                                     "https://example.com", "/$id", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(frame, "https://example.com#/$schema",
+                                     "https://example.com", "/$schema",
+                                     "https://example.com", "/$schema", {}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_SUBSCHEMA(
+      frame, "https://example.com#/additionalProperties", "https://example.com",
+      "/additionalProperties", "https://example.com", "/additionalProperties",
+      {"/~?additionalProperties~/~P~"}, "");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://example.com#/additionalProperties/$id",
+      "https://example.com", "/additionalProperties/$id", "https://example.com",
+      "/additionalProperties/$id", {}, "/additionalProperties");
+  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
+      frame, "https://example.com#/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref",
+      "https://example.com", "/additionalProperties/$ref", {},
+      "/additionalProperties");
+
+  EXPECT_EQ(frame.references().size(), 2);
+
+  EXPECT_STATIC_REFERENCE(
+      frame, "/$schema", "http://json-schema.org/draft-07/schema",
+      "http://json-schema.org/draft-07/schema", std::nullopt,
+      "http://json-schema.org/draft-07/schema#");
+  EXPECT_STATIC_REFERENCE(frame, "/additionalProperties/$ref",
+                          "https://example.com/bar", "https://example.com/bar",
+                          std::nullopt, "bar");
 }

--- a/test/jsonschema/jsonschema_identify_test.cc
+++ b/test/jsonschema/jsonschema_identify_test.cc
@@ -271,3 +271,56 @@ TEST(JSONSchema_identify, reidentify_boolean) {
                                    sourcemeta::core::schema_official_resolver),
       sourcemeta::core::SchemaUnknownBaseDialectError);
 }
+
+TEST(JSONSchema_identify, draft7_top_level_id_and_ref_strict) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com/schema",
+    "$ref": "foo"
+  })JSON");
+
+  std::optional<std::string> id{sourcemeta::core::identify(
+      document, "http://json-schema.org/draft-07/schema#",
+      sourcemeta::core::SchemaIdentificationStrategy::Strict)};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_identify, draft7_top_level_id_and_ref_loose) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com/schema",
+    "$ref": "foo"
+  })JSON");
+
+  std::optional<std::string> id{sourcemeta::core::identify(
+      document, "http://json-schema.org/draft-07/schema#",
+      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+  EXPECT_TRUE(id.has_value());
+  EXPECT_EQ(id.value(), "https://example.com/schema");
+}
+
+TEST(JSONSchema_identify, draft7_ref_with_wrong_id_keyword_strict) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "id": "https://example.com/schema",
+    "$ref": "foo"
+  })JSON");
+
+  std::optional<std::string> id{sourcemeta::core::identify(
+      document, "http://json-schema.org/draft-07/schema#",
+      sourcemeta::core::SchemaIdentificationStrategy::Strict)};
+  EXPECT_FALSE(id.has_value());
+}
+
+TEST(JSONSchema_identify, draft7_ref_with_wrong_id_keyword_loose) {
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "id": "https://example.com/schema",
+    "$ref": "foo"
+  })JSON");
+
+  std::optional<std::string> id{sourcemeta::core::identify(
+      document, "http://json-schema.org/draft-07/schema#",
+      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+  EXPECT_FALSE(id.has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
