### PR TITLE
Put JSON's `Decimal` variant on the heap to reduce size

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -1749,7 +1749,10 @@ private:
     String data_string;
     Array data_array;
     Object data_object;
-    Decimal data_decimal;
+    // Move Decimal to the heap to reduce the size of the JSON class.
+    // Dealing with arbitrary precision numbers is not common, so we pay the
+    // indirection cost only when needed.
+    Decimal *data_decimal;
   };
 #if defined(_MSC_VER)
 #pragma warning(default : 4251)

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -12,6 +12,10 @@ TEST(JSON_value, general_traits) {
   EXPECT_TRUE(std::is_nothrow_destructible<sourcemeta::core::JSON>::value);
 }
 
+// BIG WARNING! Increase this number will make projects like Blaze slower,
+// as it will affect cache lines when dealing with JSON documents
+TEST(JSON_value, size) { EXPECT_EQ(sizeof(sourcemeta::core::JSON), 40); }
+
 TEST(JSON_value, copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::JSON>::value);
   EXPECT_TRUE(std::is_copy_constructible<sourcemeta::core::JSON>::value);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
