### PR TITLE
Clarify that `Decimal::is_integer` considers real integers

### DIFF
--- a/src/lang/numeric/include/sourcemeta/core/numeric_decimal.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_decimal.h
@@ -106,6 +106,7 @@ public:
   [[nodiscard]] auto is_zero() const -> bool;
 
   /// Check if the decimal number represents an integer value
+  /// NOTE: This returns `true` for values like `3.0`
   [[nodiscard]] auto is_integer() const -> bool;
 
   /// Check if the decimal number is finite

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -382,6 +382,21 @@ TEST(Numeric_decimal, is_integer_predicate) {
   EXPECT_FALSE(decimal.is_integer());
 }
 
+TEST(Numeric_decimal, is_integer_real_with_zero_positive) {
+  const sourcemeta::core::Decimal value{"42.0"};
+  EXPECT_TRUE(value.is_integer());
+}
+
+TEST(Numeric_decimal, is_integer_real_with_zero_negative) {
+  const sourcemeta::core::Decimal value{"-42.0"};
+  EXPECT_TRUE(value.is_integer());
+}
+
+TEST(Numeric_decimal, is_integer_real_with_zero_zero) {
+  const sourcemeta::core::Decimal value{"0.0"};
+  EXPECT_TRUE(value.is_integer());
+}
+
 TEST(Numeric_decimal, is_finite_predicate) {
   const sourcemeta::core::Decimal value{123};
   EXPECT_TRUE(value.is_finite());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
