### PR TITLE
Ignore every keyword sibling to `$ref` in Draft 7 and older

### DIFF
--- a/src/core/jsonschema/bundle.cc
+++ b/src/core/jsonschema/bundle.cc
@@ -30,9 +30,8 @@ auto dependencies_internal(
   sourcemeta::core::SchemaFrame frame{
       sourcemeta::core::SchemaFrame::Mode::References};
   frame.analyse(schema, walker, resolver, default_dialect, default_id, paths);
-  const auto origin{sourcemeta::core::identify(
-      schema, resolver, sourcemeta::core::SchemaIdentificationStrategy::Strict,
-      default_dialect, default_id)};
+  const auto origin{sourcemeta::core::identify(schema, resolver,
+                                               default_dialect, default_id)};
 
   std::vector<
       std::tuple<sourcemeta::core::JSON,
@@ -263,9 +262,7 @@ auto bundle(JSON &schema, const SchemaWalker &walker,
   // implicit base URI will likely not resolve unless end users happen to
   // know that this implicit base URI is.
   if (default_id.has_value() &&
-      !identify(schema, resolver, SchemaIdentificationStrategy::Strict,
-                default_dialect)
-           .has_value()) {
+      !identify(schema, resolver, default_dialect).has_value()) {
     reidentify(schema, default_id.value(), resolver, default_dialect);
   }
 
@@ -287,6 +284,13 @@ auto bundle(JSON &schema, const SchemaWalker &walker,
              vocabularies.contains("http://json-schema.org/draft-04/schema#") ||
              vocabularies.contains(
                  "http://json-schema.org/draft-04/hyper-schema#")) {
+    if (schema.is_object() && schema.defines("$ref")) {
+      throw sourcemeta::core::SchemaError(
+          "Cannot bundle a JSON Schema Draft 7 or older with a top-level "
+          "`$ref` (which overrides sibling keywords) without introducing "
+          "undefined behavior");
+    }
+
     bundle_schema(schema, {"definitions"}, schema, frame, walker, resolver,
                   default_dialect, default_id, paths);
     return;

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -490,12 +490,9 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
     std::optional<JSON::String> root_id{
         // If we are dealing with nested schemas, then by definition
         // the root has no identifier
-        !path.empty()
-            ? std::nullopt
-            : sourcemeta::core::identify(
-                  schema, root_base_dialect.value(),
-                  sourcemeta::core::SchemaIdentificationStrategy::Loose,
-                  default_id)};
+        !path.empty() ? std::nullopt
+                      : sourcemeta::core::identify(
+                            schema, root_base_dialect.value(), default_id)};
     if (root_id.has_value()) {
       root_id = URI::canonicalize(root_id.value());
     }
@@ -549,7 +546,6 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
       // Schema identifier
       std::optional<JSON::String> id{sourcemeta::core::identify(
           entry.subschema.get(), entry.base_dialect.value(),
-          sourcemeta::core::SchemaIdentificationStrategy::Strict,
           entry.pointer.empty() ? root_id : std::nullopt)};
 
       // Store information
@@ -568,9 +564,8 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
     for (const auto &entry_index : current_subschema_entries) {
       const auto &entry{subschema_entries[entry_index]};
       if (entry.id.has_value()) {
-        const bool ref_overrides = ref_overrides_adjacent_keywords(
-                                       entry.common.base_dialect.value()) &&
-                                   !entry.common.pointer.empty();
+        const bool ref_overrides =
+            ref_overrides_adjacent_keywords(entry.common.base_dialect.value());
         const bool is_pre_2019_09_location_independent_identifier =
             supports_id_anchors(entry.common.base_dialect.value()) &&
             sourcemeta::core::URI{entry.id.value()}.is_fragment_only();

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema.h
@@ -142,14 +142,8 @@ auto is_empty_schema(const JSON &schema) -> bool;
 /// assert(id.has_value());
 /// assert(id.value() == "https://sourcemeta.com/example-schema");
 /// ```
-///
-/// You can opt-in to a loose identification strategy to attempt to play a
-/// guessing game. Often useful if you have a schema without a dialect and you
-/// want to at least try to get something.
 SOURCEMETA_CORE_JSONSCHEMA_EXPORT
 auto identify(const JSON &schema, const SchemaResolver &resolver,
-              const SchemaIdentificationStrategy strategy =
-                  SchemaIdentificationStrategy::Strict,
               const std::optional<std::string> &default_dialect = std::nullopt,
               const std::optional<std::string> &default_id = std::nullopt)
     -> std::optional<std::string>;
@@ -160,8 +154,6 @@ auto identify(const JSON &schema, const SchemaResolver &resolver,
 /// of the schema.
 SOURCEMETA_CORE_JSONSCHEMA_EXPORT
 auto identify(const JSON &schema, const std::string &base_dialect,
-              const SchemaIdentificationStrategy strategy =
-                  SchemaIdentificationStrategy::Strict,
               const std::optional<std::string> &default_id = std::nullopt)
     -> std::optional<std::string>;
 

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -184,6 +184,30 @@ private:
   Pointer location_;
 };
 
+/// @ingroup jsonschema
+/// In JSON Schema Draft 7 and older, a schema that defines `$ref` is a
+/// reference object where every other keywords are ignored
+class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaReferenceObjectResourceError
+    : public std::exception {
+public:
+  SchemaReferenceObjectResourceError(std::string identifier)
+      : identifier_{std::move(identifier)} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return "A schema with a top-level `$ref` in JSON Schema Draft 7 and older "
+           "dialects ignores every sibling keywords (like identifiers and "
+           "meta-schema declarations) and therefore many operations, like "
+           "bundling, are not possible without undefined behavior";
+  }
+
+  [[nodiscard]] auto identifier() const noexcept -> const auto & {
+    return this->identifier_;
+  }
+
+private:
+  std::string identifier_;
+};
+
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_types.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_types.h
@@ -36,16 +36,6 @@ using Vocabularies = std::unordered_map<JSON::String, bool>;
 using SchemaResolver = std::function<std::optional<JSON>(std::string_view)>;
 
 /// @ingroup jsonschema
-/// The strategy to follow when attempting to identify a schema
-enum class SchemaIdentificationStrategy : std::uint8_t {
-  /// Only proceed if we can guarantee the identifier is valid
-  Strict,
-
-  /// Attempt to guess even if we don't know the base dialect
-  Loose
-};
-
-/// @ingroup jsonschema
 /// The reference type
 enum class SchemaReferenceType : std::uint8_t { Static, Dynamic };
 

--- a/src/core/jsonschema/transformer.cc
+++ b/src/core/jsonschema/transformer.cc
@@ -104,9 +104,7 @@ auto SchemaTransformer::check(
 
   // If we use the default id when there is already one, framing will duplicate
   // the locations leading to duplicate check reports
-  if (sourcemeta::core::identify(schema, resolver,
-                                 SchemaIdentificationStrategy::Strict,
-                                 default_dialect)
+  if (sourcemeta::core::identify(schema, resolver, default_dialect)
           .has_value()) {
     frame.analyse(schema, walker, resolver, default_dialect);
   } else {

--- a/src/core/jsonschema/walker.cc
+++ b/src/core/jsonschema/walker.cc
@@ -49,18 +49,26 @@ auto walk(const std::optional<sourcemeta::core::Pointer> &parent,
   // / base dialect and ignore the invalid standalone `$schema`. The caller has
   // enough information to detect those cases and throw an error if they desire
   // to be more strict.
-  const auto maybe_current_dialect{
-      sourcemeta::core::dialect(subschema, dialect)};
+  auto maybe_current_dialect{sourcemeta::core::dialect(subschema, dialect)};
   assert(maybe_current_dialect.has_value());
-  const auto id{sourcemeta::core::identify(
-      subschema, resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
-      maybe_current_dialect)};
+
+  // TODO: Note that we determine the identifier here, but the framing does it
+  // all over again. Maybe we should be storing this instead?
+  auto id{
+      sourcemeta::core::identify(subschema, resolver, maybe_current_dialect)};
+  const auto different_parent_dialect{maybe_current_dialect.value() != dialect};
+  if (!id.has_value() && different_parent_dialect) {
+    id = sourcemeta::core::identify(subschema, base_dialect);
+    if (id.has_value()) {
+      maybe_current_dialect = dialect;
+    }
+  }
+
   const auto is_schema_resource{level == 0 || id.has_value()};
-  const auto current_dialect{is_schema_resource ? maybe_current_dialect.value()
-                                                : dialect};
-  const auto current_base_dialect{
-      is_schema_resource
+  const auto &current_dialect{is_schema_resource ? maybe_current_dialect.value()
+                                                 : dialect};
+  auto current_base_dialect{
+      is_schema_resource && current_dialect != dialect
           ? sourcemeta::core::base_dialect(subschema, resolver, current_dialect)
                 .value_or(base_dialect)
           : base_dialect};
@@ -94,13 +102,12 @@ auto walk(const std::optional<sourcemeta::core::Pointer> &parent,
   for (auto &pair : subschema.as_object()) {
     const auto keyword_info{walker(pair.first, vocabularies)};
 
-    // Ignore the current keyword sibling to `$ref in Draft 7 and older if its
-    // not a top-level container
+    // Ignore the current keyword sibling to `$ref in Draft 7 and older in EVERY
+    // case. Note that we purposely DO NOT try to add workarounds for the
+    // top-level, `$schema`, or anything else to be purely compliant and avoid
+    // lots of gray areas here
     if (has_overriding_ref &&
-        keyword_info.type != sourcemeta::core::SchemaKeywordType::Reference &&
-        (level > 0 ||
-         keyword_info.type !=
-             sourcemeta::core::SchemaKeywordType::LocationMembers)) {
+        keyword_info.type != sourcemeta::core::SchemaKeywordType::Reference) {
       continue;
     }
 

--- a/src/extension/alterschema/linter/draft_ref_siblings.h
+++ b/src/extension/alterschema/linter/draft_ref_siblings.h
@@ -27,9 +27,11 @@ public:
     std::vector<Pointer> locations;
     for (const auto &entry : schema.as_object()) {
       const auto metadata{walker(entry.first, vocabularies)};
-      if (metadata.type == sourcemeta::core::SchemaKeywordType::Other ||
-          metadata.type == sourcemeta::core::SchemaKeywordType::Reference ||
-          metadata.type == sourcemeta::core::SchemaKeywordType::Comment) {
+      if (metadata.type == sourcemeta::core::SchemaKeywordType::Reference ||
+          metadata.type == sourcemeta::core::SchemaKeywordType::Comment ||
+          // If we disallow this, we end up deleting it and the linter will fail
+          // with an error about not knowing the dialect
+          entry.first == "$schema") {
         continue;
       } else {
         locations.push_back(Pointer{entry.first});

--- a/test/alterschema/alterschema_lint_draft0_test.cc
+++ b/test/alterschema/alterschema_lint_draft0_test.cc
@@ -283,7 +283,6 @@ TEST(AlterSchema_lint_draft0, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/schema#",
-    "id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "description": "Documentation"
   })JSON");

--- a/test/alterschema/alterschema_lint_draft1_test.cc
+++ b/test/alterschema/alterschema_lint_draft1_test.cc
@@ -914,7 +914,6 @@ TEST(AlterSchema_lint_draft1, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "description": "Documentation"
   })JSON");

--- a/test/alterschema/alterschema_lint_draft2_test.cc
+++ b/test/alterschema/alterschema_lint_draft2_test.cc
@@ -914,7 +914,6 @@ TEST(AlterSchema_lint_draft2, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "description": "Documentation"
   })JSON");

--- a/test/alterschema/alterschema_lint_draft3_test.cc
+++ b/test/alterschema/alterschema_lint_draft3_test.cc
@@ -1079,7 +1079,6 @@ TEST(AlterSchema_lint_draft3, draft_ref_siblings_4) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "description": "Documentation"
   })JSON");

--- a/test/alterschema/alterschema_lint_draft4_test.cc
+++ b/test/alterschema/alterschema_lint_draft4_test.cc
@@ -1411,8 +1411,7 @@ TEST(AlterSchema_lint_draft4,
     "$schema": "http://json-schema.org/draft-04/schema#",
     "allOf": [
       {
-        "$ref": "https://example.com",
-        "id": "https://other.com"
+        "$ref": "https://example.com"
       }
     ]
   })JSON");
@@ -1730,7 +1729,6 @@ TEST(AlterSchema_lint_draft4, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "description": "Documentation"
   })JSON");

--- a/test/alterschema/alterschema_lint_draft6_test.cc
+++ b/test/alterschema/alterschema_lint_draft6_test.cc
@@ -1768,8 +1768,7 @@ TEST(AlterSchema_lint_draft6,
     "$schema": "http://json-schema.org/draft-06/schema#",
     "allOf": [
       {
-        "$ref": "https://example.com",
-        "$id": "https://other.com"
+        "$ref": "https://example.com"
       }
     ]
   })JSON");
@@ -2051,7 +2050,6 @@ TEST(AlterSchema_lint_draft6, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "description": "Documentation"
   })JSON");

--- a/test/alterschema/alterschema_lint_draft7_test.cc
+++ b/test/alterschema/alterschema_lint_draft7_test.cc
@@ -1963,8 +1963,7 @@ TEST(AlterSchema_lint_draft7,
     "$schema": "http://json-schema.org/draft-07/schema#",
     "allOf": [
       {
-        "$ref": "https://example.com",
-        "$id": "https://other.com"
+        "$ref": "https://example.com"
       }
     ]
   })JSON");
@@ -2404,7 +2403,6 @@ TEST(AlterSchema_lint_draft7, draft_ref_siblings_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://example.com/schema",
     "$ref": "#/definitions/foo",
     "$comment": "This is a comment",
     "examples": [42]

--- a/test/jsonschema/jsonschema_bundle_draft4_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft4_test.cc
@@ -371,7 +371,7 @@ TEST(JSONSchema_bundle_draft4, allof_ref_definitions_type_no_id_no_external) {
 TEST(JSONSchema_bundle_draft4, recursive) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -379,7 +379,7 @@ TEST(JSONSchema_bundle_draft4, recursive) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive" } ],
     "definitions": {
       "https://www.sourcemeta.com/recursive": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -397,7 +397,7 @@ TEST(JSONSchema_bundle_draft4, recursive) {
 TEST(JSONSchema_bundle_draft4, recursive_empty_fragment) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -405,7 +405,7 @@ TEST(JSONSchema_bundle_draft4, recursive_empty_fragment) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#" } ],
     "definitions": {
       "https://www.sourcemeta.com/recursive-empty-fragment": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -422,7 +422,7 @@ TEST(JSONSchema_bundle_draft4, recursive_empty_fragment) {
 
 TEST(JSONSchema_bundle_draft4, anonymous_no_dialect) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$ref": "https://www.sourcemeta.com/anonymous"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -430,7 +430,7 @@ TEST(JSONSchema_bundle_draft4, anonymous_no_dialect) {
                            "http://json-schema.org/draft-04/schema#");
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$ref": "https://www.sourcemeta.com/anonymous",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ],
     "definitions": {
       "https://www.sourcemeta.com/anonymous": {
         "id": "https://www.sourcemeta.com/anonymous",

--- a/test/jsonschema/jsonschema_bundle_draft6_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft6_test.cc
@@ -348,7 +348,7 @@ TEST(JSONSchema_bundle_draft6, taken_definitions_entry) {
 TEST(JSONSchema_bundle_draft6, recursive) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -356,7 +356,7 @@ TEST(JSONSchema_bundle_draft6, recursive) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive" } ],
     "definitions": {
       "https://www.sourcemeta.com/recursive": {
         "$schema": "http://json-schema.org/draft-06/schema#",
@@ -374,7 +374,7 @@ TEST(JSONSchema_bundle_draft6, recursive) {
 TEST(JSONSchema_bundle_draft6, recursive_empty_fragment) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -382,7 +382,7 @@ TEST(JSONSchema_bundle_draft6, recursive_empty_fragment) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#" } ],
     "definitions": {
       "https://www.sourcemeta.com/recursive-empty-fragment": {
         "$schema": "http://json-schema.org/draft-06/schema#",
@@ -399,7 +399,7 @@ TEST(JSONSchema_bundle_draft6, recursive_empty_fragment) {
 
 TEST(JSONSchema_bundle_draft6, anonymous_no_dialect) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$ref": "https://www.sourcemeta.com/anonymous"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -407,7 +407,7 @@ TEST(JSONSchema_bundle_draft6, anonymous_no_dialect) {
                            "http://json-schema.org/draft-06/schema#");
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$ref": "https://www.sourcemeta.com/anonymous",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ],
     "definitions": {
       "https://www.sourcemeta.com/anonymous": {
         "$id": "https://www.sourcemeta.com/anonymous",

--- a/test/jsonschema/jsonschema_bundle_draft7_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft7_test.cc
@@ -348,7 +348,7 @@ TEST(JSONSchema_bundle_draft7, taken_definitions_entry) {
 TEST(JSONSchema_bundle_draft7, recursive) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -356,7 +356,7 @@ TEST(JSONSchema_bundle_draft7, recursive) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive" } ],
     "definitions": {
       "https://www.sourcemeta.com/recursive": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -374,7 +374,7 @@ TEST(JSONSchema_bundle_draft7, recursive) {
 TEST(JSONSchema_bundle_draft7, recursive_empty_fragment) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -382,7 +382,7 @@ TEST(JSONSchema_bundle_draft7, recursive_empty_fragment) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/recursive-empty-fragment#" } ],
     "definitions": {
       "https://www.sourcemeta.com/recursive-empty-fragment": {
         "$schema": "http://json-schema.org/draft-07/schema#",
@@ -399,7 +399,7 @@ TEST(JSONSchema_bundle_draft7, recursive_empty_fragment) {
 
 TEST(JSONSchema_bundle_draft7, anonymous_no_dialect) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$ref": "https://www.sourcemeta.com/anonymous"
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ]
   })JSON");
 
   sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
@@ -407,7 +407,7 @@ TEST(JSONSchema_bundle_draft7, anonymous_no_dialect) {
                            "http://json-schema.org/draft-07/schema#");
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$ref": "https://www.sourcemeta.com/anonymous",
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/anonymous" } ],
     "definitions": {
       "https://www.sourcemeta.com/anonymous": {
         "$id": "https://www.sourcemeta.com/anonymous",

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -548,25 +548,25 @@ TEST(JSONSchema_frame_draft3, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 4);
 
-  EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(
-      frame, "https://www.sourcemeta.com/schema",
-      "https://www.sourcemeta.com/schema", "",
-      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+  // Note that `$ref` MUST override EVERY sibling keyword, so the `id`
+  // here is not considered at all
+  //
+  // However, note that we DO respect `$schema` at the top. This is because
+  // we START by checking `$schema` to figure out that `$ref` overrides,
+  // so we do know about the dialect anyway
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {""}, std::nullopt);
 
-  // JSON Pointers
-
-  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/id",
-      "https://www.sourcemeta.com/schema", "/id",
-      "https://www.sourcemeta.com/schema", "/id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/id", "/id", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {}, "");
 
   // References
 
@@ -576,10 +576,8 @@ TEST(JSONSchema_frame_draft3, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-03/schema",
       "http://json-schema.org/draft-03/schema", std::nullopt,
       "http://json-schema.org/draft-03/schema#");
-  EXPECT_STATIC_REFERENCE(
-      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+                          "/definitions/string", "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft3, top_level_relative_ref_with_id) {
@@ -596,18 +594,19 @@ TEST(JSONSchema_frame_draft3, top_level_relative_ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 4);
 
-  EXPECT_FRAME_STATIC_DRAFT3_RESOURCE(
-      frame, "https://example.com/foo", "https://example.com/foo", "",
-      "https://example.com/foo", "", {""}, std::nullopt);
-  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
-      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
-      "/$schema", "https://example.com/foo", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT3_POINTER(frame, "https://example.com/foo#/id",
-                                     "https://example.com/foo", "/id",
-                                     "https://example.com/foo", "/id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT3_POINTER(
-      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
-      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+  // Note that `id` is IGNORED given the sibling `$ref`
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {""}, std::nullopt);
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/id", "/id", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-03/schema#",
+      "http://json-schema.org/draft-03/schema#", {}, "");
 
   EXPECT_EQ(frame.references().size(), 2);
 
@@ -615,8 +614,7 @@ TEST(JSONSchema_frame_draft3, top_level_relative_ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-03/schema",
       "http://json-schema.org/draft-03/schema", std::nullopt,
       "http://json-schema.org/draft-03/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
-                          "https://example.com/bar", std::nullopt, "bar");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "bar", "bar", std::nullopt, "bar");
 }
 
 TEST(JSONSchema_frame_draft3, nested_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -630,38 +630,37 @@ TEST(JSONSchema_frame_draft4, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 7);
 
-  EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(
-      frame, "https://www.sourcemeta.com/schema",
-      "https://www.sourcemeta.com/schema", "",
-      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+  // Note that `$ref` MUST override EVERY sibling keyword, so the `id`
+  // here is not considered at all
+  //
+  // However, note that we DO respect `$schema` at the top. This is because
+  // we START by checking `$schema` to figure out that `$ref` overrides,
+  // so we do know about the dialect anyway
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {""}, std::nullopt);
 
-  // JSON Pointers
-
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/id",
-      "https://www.sourcemeta.com/schema", "/id",
-      "https://www.sourcemeta.com/schema", "/id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/definitions",
-      "https://www.sourcemeta.com/schema", "/definitions",
-      "https://www.sourcemeta.com/schema", "/definitions", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_SUBSCHEMA(
-      frame, "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string", {""}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
-      "https://www.sourcemeta.com/schema", "/definitions/string/type",
-      "https://www.sourcemeta.com/schema", "/definitions/string/type", {},
-      "/definitions/string");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/id", "/id", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions", "/definitions",
+      "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string", "/definitions/string",
+      "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string/type", "/definitions/string/type",
+      "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
 
   // References
 
@@ -671,10 +670,8 @@ TEST(JSONSchema_frame_draft4, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-04/schema",
       "http://json-schema.org/draft-04/schema", std::nullopt,
       "http://json-schema.org/draft-04/schema#");
-  EXPECT_STATIC_REFERENCE(
-      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+                          "/definitions/string", "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft4,
@@ -960,18 +957,19 @@ TEST(JSONSchema_frame_draft4, top_level_relative_ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 4);
 
-  EXPECT_FRAME_STATIC_DRAFT4_RESOURCE(
-      frame, "https://example.com/foo", "https://example.com/foo", "",
-      "https://example.com/foo", "", {""}, std::nullopt);
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
-      "/$schema", "https://example.com/foo", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(frame, "https://example.com/foo#/id",
-                                     "https://example.com/foo", "/id",
-                                     "https://example.com/foo", "/id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT4_POINTER(
-      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
-      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+  // Note that `id` is IGNORED given the sibling `$ref`
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {""}, std::nullopt);
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/id", "/id", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-04/schema#",
+      "http://json-schema.org/draft-04/schema#", {}, "");
 
   EXPECT_EQ(frame.references().size(), 2);
 
@@ -979,8 +977,7 @@ TEST(JSONSchema_frame_draft4, top_level_relative_ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-04/schema",
       "http://json-schema.org/draft-04/schema", std::nullopt,
       "http://json-schema.org/draft-04/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
-                          "https://example.com/bar", std::nullopt, "bar");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "bar", "bar", std::nullopt, "bar");
 }
 
 TEST(JSONSchema_frame_draft4, nested_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -630,38 +630,37 @@ TEST(JSONSchema_frame_draft6, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 7);
 
-  EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(
-      frame, "https://www.sourcemeta.com/schema",
-      "https://www.sourcemeta.com/schema", "",
-      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+  // Note that `$ref` MUST override EVERY sibling keyword, so the `$id`
+  // here is not considered at all
+  //
+  // However, note that we DO respect `$schema` at the top. This is because
+  // we START by checking `$schema` to figure out that `$ref` overrides,
+  // so we do know about the dialect anyway
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {""}, std::nullopt);
 
-  // JSON Pointers
-
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$id",
-      "https://www.sourcemeta.com/schema", "/$id",
-      "https://www.sourcemeta.com/schema", "/$id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/definitions",
-      "https://www.sourcemeta.com/schema", "/definitions",
-      "https://www.sourcemeta.com/schema", "/definitions", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_SUBSCHEMA(
-      frame, "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string", {""}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
-      "https://www.sourcemeta.com/schema", "/definitions/string/type",
-      "https://www.sourcemeta.com/schema", "/definitions/string/type", {},
-      "/definitions/string");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$id", "/$id", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions", "/definitions",
+      "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string", "/definitions/string",
+      "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string/type", "/definitions/string/type",
+      "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
 
   // References
 
@@ -671,10 +670,8 @@ TEST(JSONSchema_frame_draft6, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-06/schema",
       "http://json-schema.org/draft-06/schema", std::nullopt,
       "http://json-schema.org/draft-06/schema#");
-  EXPECT_STATIC_REFERENCE(
-      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+                          "/definitions/string", "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft6, relative_base_uri_without_ref) {
@@ -866,18 +863,19 @@ TEST(JSONSchema_frame_draft6, top_level_relative_ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 4);
 
-  EXPECT_FRAME_STATIC_DRAFT6_RESOURCE(
-      frame, "https://example.com/foo", "https://example.com/foo", "",
-      "https://example.com/foo", "", {""}, std::nullopt);
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
-      "/$schema", "https://example.com/foo", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(frame, "https://example.com/foo#/$id",
-                                     "https://example.com/foo", "/$id",
-                                     "https://example.com/foo", "/$id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT6_POINTER(
-      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
-      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+  // Note that `$id` is IGNORED given the sibling `$ref`
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {""}, std::nullopt);
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$id", "/$id", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-06/schema#",
+      "http://json-schema.org/draft-06/schema#", {}, "");
 
   EXPECT_EQ(frame.references().size(), 2);
 
@@ -885,8 +883,7 @@ TEST(JSONSchema_frame_draft6, top_level_relative_ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-06/schema",
       "http://json-schema.org/draft-06/schema", std::nullopt,
       "http://json-schema.org/draft-06/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
-                          "https://example.com/bar", std::nullopt, "bar");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "bar", "bar", std::nullopt, "bar");
 }
 
 TEST(JSONSchema_frame_draft6, nested_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -630,38 +630,37 @@ TEST(JSONSchema_frame_draft7, ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 7);
 
-  EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(
-      frame, "https://www.sourcemeta.com/schema",
-      "https://www.sourcemeta.com/schema", "",
-      "https://www.sourcemeta.com/schema", "", {""}, std::nullopt);
+  // Note that `$ref` MUST override EVERY sibling keyword, so the `$id`
+  // here is not considered at all
+  //
+  // However, note that we DO respect `$schema` at the top. This is because
+  // we START by checking `$schema` to figure out that `$ref` overrides,
+  // so we do know about the dialect anyway
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {""}, std::nullopt);
 
-  // JSON Pointers
-
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$id",
-      "https://www.sourcemeta.com/schema", "/$id",
-      "https://www.sourcemeta.com/schema", "/$id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema",
-      "https://www.sourcemeta.com/schema", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref",
-      "https://www.sourcemeta.com/schema", "/$ref", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/definitions",
-      "https://www.sourcemeta.com/schema", "/definitions",
-      "https://www.sourcemeta.com/schema", "/definitions", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_SUBSCHEMA(
-      frame, "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string", {""}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://www.sourcemeta.com/schema#/definitions/string/type",
-      "https://www.sourcemeta.com/schema", "/definitions/string/type",
-      "https://www.sourcemeta.com/schema", "/definitions/string/type", {},
-      "/definitions/string");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$id", "/$id", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions", "/definitions",
+      "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string", "/definitions/string",
+      "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/definitions/string/type", "/definitions/string/type",
+      "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
 
   // References
 
@@ -671,10 +670,8 @@ TEST(JSONSchema_frame_draft7, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(
-      frame, "/$ref", "https://www.sourcemeta.com/schema#/definitions/string",
-      "https://www.sourcemeta.com/schema", "/definitions/string",
-      "#/definitions/string");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+                          "/definitions/string", "#/definitions/string");
 }
 
 TEST(JSONSchema_frame_draft7, ref_with_definitions) {
@@ -708,14 +705,17 @@ TEST(JSONSchema_frame_draft7, ref_with_definitions) {
       frame, "#/definitions", "/definitions",
       "http://json-schema.org/draft-07/schema#",
       "http://json-schema.org/draft-07/schema#", {}, "");
-  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+
+  // Note that this is NOT considered to be a subschema, as `$ref` overrides it
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
       frame, "#/definitions/string", "/definitions/string",
       "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {""}, "");
+      "http://json-schema.org/draft-07/schema#", {}, "");
+
   EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
       frame, "#/definitions/string/type", "/definitions/string/type",
       "http://json-schema.org/draft-07/schema#",
-      "http://json-schema.org/draft-07/schema#", {}, "/definitions/string");
+      "http://json-schema.org/draft-07/schema#", {}, "");
 
   // References
 
@@ -970,18 +970,19 @@ TEST(JSONSchema_frame_draft7, top_level_relative_ref_with_id) {
 
   EXPECT_EQ(frame.locations().size(), 4);
 
-  EXPECT_FRAME_STATIC_DRAFT7_RESOURCE(
-      frame, "https://example.com/foo", "https://example.com/foo", "",
-      "https://example.com/foo", "", {""}, std::nullopt);
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://example.com/foo#/$schema", "https://example.com/foo",
-      "/$schema", "https://example.com/foo", "/$schema", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(frame, "https://example.com/foo#/$id",
-                                     "https://example.com/foo", "/$id",
-                                     "https://example.com/foo", "/$id", {}, "");
-  EXPECT_FRAME_STATIC_DRAFT7_POINTER(
-      frame, "https://example.com/foo#/$ref", "https://example.com/foo",
-      "/$ref", "https://example.com/foo", "/$ref", {}, "");
+  // Note that `$id` is IGNORED given the sibling `$ref`
+  EXPECT_ANONYMOUS_FRAME_STATIC_SUBSCHEMA(
+      frame, "", "", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {""}, std::nullopt);
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$schema", "/$schema", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$id", "/$id", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
+  EXPECT_ANONYMOUS_FRAME_STATIC_POINTER(
+      frame, "#/$ref", "/$ref", "http://json-schema.org/draft-07/schema#",
+      "http://json-schema.org/draft-07/schema#", {}, "");
 
   EXPECT_EQ(frame.references().size(), 2);
 
@@ -989,8 +990,7 @@ TEST(JSONSchema_frame_draft7, top_level_relative_ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "https://example.com/bar",
-                          "https://example.com/bar", std::nullopt, "bar");
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "bar", "bar", std::nullopt, "bar");
 }
 
 TEST(JSONSchema_frame_draft7, nested_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_identify_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_identify_2019_09_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_2019_09, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2019-09/schema")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_2019_09, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2019-09/schema")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_2019_09, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");

--- a/test/jsonschema/jsonschema_identify_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_identify_2020_12_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_2020_12, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_2020_12, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_2020_12, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");

--- a/test/jsonschema/jsonschema_identify_draft0_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft0_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft0, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-00/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft0, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-00/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft0, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");

--- a/test/jsonschema/jsonschema_identify_draft1_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft1_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft1, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-01/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft1, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-01/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft1, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");

--- a/test/jsonschema/jsonschema_identify_draft2_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft2_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft2, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-02/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft2, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-02/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft2, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");

--- a/test/jsonschema/jsonschema_identify_draft3_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft3_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft3, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-03/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft3, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-03/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft3, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
@@ -221,16 +218,10 @@ TEST(JSONSchema_identify_draft3, reidentify_set_with_top_level_ref) {
     "$ref": "https://example.com/schema"
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-03/schema#",
-    "$ref": "https://example.com/schema"
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }
 
 TEST(JSONSchema_identify_draft3,
@@ -241,15 +232,8 @@ TEST(JSONSchema_identify_draft3,
     "extends": { "type": "string" }
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-03/schema#",
-    "$ref": "https://example.com/schema",
-    "extends": { "type": "string" }
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }

--- a/test/jsonschema/jsonschema_identify_draft4_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft4_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft4, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-04/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft4, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-04/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft4, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
@@ -221,16 +218,10 @@ TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref) {
     "$ref": "https://example.com/schema"
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "https://example.com/schema"
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }
 
 TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref_and_allof) {
@@ -240,15 +231,8 @@ TEST(JSONSchema_identify_draft4, reidentify_set_with_top_level_ref_and_allof) {
     "allOf": [ { "type": "string" } ]
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "$ref": "https://example.com/schema",
-    "allOf": [ { "type": "string" } ]
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }

--- a/test/jsonschema/jsonschema_identify_draft6_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft6_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft6, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-06/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft6, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-06/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft6, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
@@ -221,16 +218,10 @@ TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref) {
     "$ref": "https://example.com/schema"
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "https://example.com/schema"
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }
 
 TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref_and_allof) {
@@ -240,15 +231,8 @@ TEST(JSONSchema_identify_draft6, reidentify_set_with_top_level_ref_and_allof) {
     "allOf": [ { "type": "string" } ]
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "https://example.com/schema",
-    "allOf": [ { "type": "string" } ]
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }

--- a/test/jsonschema/jsonschema_identify_draft7_test.cc
+++ b/test/jsonschema/jsonschema_identify_draft7_test.cc
@@ -40,7 +40,6 @@ TEST(JSONSchema_identify_draft7, id_boolean_default_dialect) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-07/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -49,7 +48,6 @@ TEST(JSONSchema_identify_draft7, empty_object_default_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-07/schema#")};
   EXPECT_FALSE(id.has_value());
 }
@@ -82,7 +80,6 @@ TEST(JSONSchema_identify_draft7, default_dialect_precedence) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-04/schema#")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://example.com/my-schema");
@@ -221,16 +218,10 @@ TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref) {
     "$ref": "https://example.com/schema"
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "https://example.com/schema"
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }
 
 TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref_and_allof) {
@@ -240,15 +231,8 @@ TEST(JSONSchema_identify_draft7, reidentify_set_with_top_level_ref_and_allof) {
     "allOf": [ { "type": "string" } ]
   })JSON");
 
-  sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
-                               sourcemeta::core::schema_official_resolver);
-
-  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
-    "$id": "https://example.com/my-new-id",
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$ref": "https://example.com/schema",
-    "allOf": [ { "type": "string" } ]
-  })JSON");
-
-  EXPECT_EQ(document, expected);
+  EXPECT_THROW(
+      sourcemeta::core::reidentify(document, "https://example.com/my-new-id",
+                                   sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaReferenceObjectResourceError);
 }

--- a/test/jsonschema/jsonschema_identify_test.cc
+++ b/test/jsonschema/jsonschema_identify_test.cc
@@ -13,8 +13,7 @@ TEST(JSONSchema_identify, boolean_no_dialect) {
 TEST(JSONSchema_identify, boolean_no_dialect_with_default_id) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict, std::nullopt,
+      document, sourcemeta::core::schema_official_resolver, std::nullopt,
       "https://www.sourcemeta.com/foo")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "https://www.sourcemeta.com/foo");
@@ -24,7 +23,6 @@ TEST(JSONSchema_identify, empty_old_no_dollar_sign_id_with_default) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "http://json-schema.org/draft-00/schema#",
       "https://example.com/my-schema")};
   EXPECT_TRUE(id.has_value());
@@ -35,7 +33,6 @@ TEST(JSONSchema_identify, empty_dollar_sign_id_with_default) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict,
       "https://json-schema.org/draft/2020-12/schema",
       "https://example.com/my-schema")};
   EXPECT_TRUE(id.has_value());
@@ -46,7 +43,6 @@ TEST(JSONSchema_identify, boolean_unknown_dialect) {
   const sourcemeta::core::JSON document{true};
   EXPECT_THROW(sourcemeta::core::identify(
                    document, sourcemeta::core::schema_official_resolver,
-                   sourcemeta::core::SchemaIdentificationStrategy::Strict,
                    "https://www.sourcemeta.com/invalid-dialect"),
                sourcemeta::core::SchemaResolutionError);
 }
@@ -62,7 +58,6 @@ TEST(JSONSchema_identify, empty_object_unknown_dialect) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   EXPECT_THROW(sourcemeta::core::identify(
                    document, sourcemeta::core::schema_official_resolver,
-                   sourcemeta::core::SchemaIdentificationStrategy::Strict,
                    "https://www.sourcemeta.com/invalid-dialect"),
                sourcemeta::core::SchemaResolutionError);
 }
@@ -88,8 +83,7 @@ TEST(JSONSchema_identify, object_with_id_with_no_dialect) {
 TEST(JSONSchema_identify, loose_boolean) {
   const sourcemeta::core::JSON document{true};
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+      document, sourcemeta::core::schema_official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -98,10 +92,8 @@ TEST(JSONSchema_identify, loose_with_valid_dollar_id) {
     "$id": "https://example.com/my-schema"
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+      document, sourcemeta::core::schema_official_resolver)};
+  EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, loose_with_invalid_dollar_id) {
@@ -109,8 +101,7 @@ TEST(JSONSchema_identify, loose_with_invalid_dollar_id) {
     "$id": false
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+      document, sourcemeta::core::schema_official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -119,10 +110,8 @@ TEST(JSONSchema_identify, loose_with_valid_id) {
     "id": "https://example.com/my-schema"
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+      document, sourcemeta::core::schema_official_resolver)};
+  EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, loose_with_invalid_id) {
@@ -130,8 +119,7 @@ TEST(JSONSchema_identify, loose_with_invalid_id) {
     "id": false
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+      document, sourcemeta::core::schema_official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -141,10 +129,8 @@ TEST(JSONSchema_identify, loose_with_valid_dollar_id_and_invalid_id) {
     "id": false
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+      document, sourcemeta::core::schema_official_resolver)};
+  EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, loose_with_valid_id_and_invalid_dollar_id) {
@@ -153,10 +139,8 @@ TEST(JSONSchema_identify, loose_with_valid_id_and_invalid_dollar_id) {
     "$id": false
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+      document, sourcemeta::core::schema_official_resolver)};
+  EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, loose_with_invalid_id_and_invalid_dollar_id) {
@@ -165,8 +149,7 @@ TEST(JSONSchema_identify, loose_with_invalid_id_and_invalid_dollar_id) {
     "id": false
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+      document, sourcemeta::core::schema_official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -176,10 +159,8 @@ TEST(JSONSchema_identify, loose_with_matching_id_and_dollar_id) {
     "id": "https://example.com/my-schema"
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+      document, sourcemeta::core::schema_official_resolver)};
+  EXPECT_FALSE(id.has_value());
 }
 
 TEST(JSONSchema_identify, loose_with_non_matching_id_and_dollar_id) {
@@ -188,8 +169,7 @@ TEST(JSONSchema_identify, loose_with_non_matching_id_and_dollar_id) {
     "id": "https://example.com/my-schema"
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+      document, sourcemeta::core::schema_official_resolver)};
   EXPECT_FALSE(id.has_value());
 }
 
@@ -200,7 +180,6 @@ TEST(JSONSchema_identify, loose_with_resolvable_default_dialect) {
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
       document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose,
       "https://json-schema.org/draft/2020-12/schema")};
   EXPECT_TRUE(id.has_value());
   EXPECT_EQ(id.value(), "http://example.com/my-schema");
@@ -218,27 +197,8 @@ TEST(JSONSchema_identify, strict_draft4_top_level_ref) {
     }
   })JSON");
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Strict)};
+      document, sourcemeta::core::schema_official_resolver)};
   EXPECT_FALSE(id.has_value());
-}
-
-TEST(JSONSchema_identify, loose_draft4_top_level_ref) {
-  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "http://example.com/my-schema",
-    "$ref": "#/definitions/foo",
-    "definitions": {
-      "foo": {
-        "type": "string"
-      }
-    }
-  })JSON");
-  std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "http://example.com/my-schema");
 }
 
 TEST(JSONSchema_identify, loose_with_unresolvable_dialect) {
@@ -246,11 +206,9 @@ TEST(JSONSchema_identify, loose_with_unresolvable_dialect) {
     "$id": "https://example.com/my-schema",
     "$schema": "https://www.sourcemeta.com/invalid-dialect"
   })JSON");
-  std::optional<std::string> id{sourcemeta::core::identify(
-      document, sourcemeta::core::schema_official_resolver,
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/my-schema");
+  EXPECT_THROW(sourcemeta::core::identify(
+                   document, sourcemeta::core::schema_official_resolver),
+               sourcemeta::core::SchemaResolutionError);
 }
 
 TEST(JSONSchema_identify, anonymize_with_unknown_base_dialect) {
@@ -280,23 +238,8 @@ TEST(JSONSchema_identify, draft7_top_level_id_and_ref_strict) {
   })JSON");
 
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, "http://json-schema.org/draft-07/schema#",
-      sourcemeta::core::SchemaIdentificationStrategy::Strict)};
+      document, "http://json-schema.org/draft-07/schema#")};
   EXPECT_FALSE(id.has_value());
-}
-
-TEST(JSONSchema_identify, draft7_top_level_id_and_ref_loose) {
-  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://example.com/schema",
-    "$ref": "foo"
-  })JSON");
-
-  std::optional<std::string> id{sourcemeta::core::identify(
-      document, "http://json-schema.org/draft-07/schema#",
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
-  EXPECT_TRUE(id.has_value());
-  EXPECT_EQ(id.value(), "https://example.com/schema");
 }
 
 TEST(JSONSchema_identify, draft7_ref_with_wrong_id_keyword_strict) {
@@ -307,20 +250,6 @@ TEST(JSONSchema_identify, draft7_ref_with_wrong_id_keyword_strict) {
   })JSON");
 
   std::optional<std::string> id{sourcemeta::core::identify(
-      document, "http://json-schema.org/draft-07/schema#",
-      sourcemeta::core::SchemaIdentificationStrategy::Strict)};
-  EXPECT_FALSE(id.has_value());
-}
-
-TEST(JSONSchema_identify, draft7_ref_with_wrong_id_keyword_loose) {
-  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "id": "https://example.com/schema",
-    "$ref": "foo"
-  })JSON");
-
-  std::optional<std::string> id{sourcemeta::core::identify(
-      document, "http://json-schema.org/draft-07/schema#",
-      sourcemeta::core::SchemaIdentificationStrategy::Loose)};
+      document, "http://json-schema.org/draft-07/schema#")};
   EXPECT_FALSE(id.has_value());
 }

--- a/test/jsonschema/jsonschema_wrap_test.cc
+++ b/test/jsonschema/jsonschema_wrap_test.cc
@@ -371,3 +371,458 @@ TEST(JSONSchema_wrap, schema_with_identifier_with_fragment) {
 
   EXPECT_EQ(result, expected);
 }
+
+TEST(JSONSchema_wrap, draft4_top_level_ref_with_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, draft4_top_level_ref_with_id_definitions_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_THROW(
+      sourcemeta::core::wrap(schema, {"definitions", "foo"},
+                             sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, draft4_top_level_ref_without_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, draft4_top_level_ref_without_id_definitions_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_THROW(
+      sourcemeta::core::wrap(schema, {"definitions", "foo"},
+                             sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, draft6_top_level_ref_with_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, draft6_top_level_ref_with_id_definitions_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_THROW(
+      sourcemeta::core::wrap(schema, {"definitions", "foo"},
+                             sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, draft6_top_level_ref_without_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, draft6_top_level_ref_without_id_definitions_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_THROW(
+      sourcemeta::core::wrap(schema, {"definitions", "foo"},
+                             sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, draft7_top_level_ref_with_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, draft7_top_level_ref_with_id_definitions_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://example.com",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_THROW(
+      sourcemeta::core::wrap(schema, {"definitions", "foo"},
+                             sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, draft7_top_level_ref_without_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, draft7_top_level_ref_without_id_definitions_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$ref": "#/definitions/foo",
+    "definitions": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_THROW(
+      sourcemeta::core::wrap(schema, {"definitions", "foo"},
+                             sourcemeta::core::schema_official_resolver),
+      sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, 2019_09_top_level_ref_with_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://example.com",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://example.com",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2019_09_top_level_ref_with_id_defs_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://example.com",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {"$defs", "foo"}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com#/$defs/foo",
+    "$defs": {
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": "https://example.com",
+        "$ref": "#/$defs/foo",
+        "$defs": {
+          "foo": {}
+        }
+      }
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2019_09_top_level_ref_without_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2019_09_top_level_ref_without_id_defs_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {"$defs", "foo"}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "__sourcemeta-core-wrap__#/$defs/foo",
+    "$defs": {
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": "__sourcemeta-core-wrap__",
+        "$ref": "#/$defs/foo",
+        "$defs": {
+          "foo": {}
+        }
+      }
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2020_12_top_level_ref_with_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2020_12_top_level_ref_with_id_defs_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {"$defs", "foo"}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "https://example.com#/$defs/foo",
+    "$defs": {
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "https://example.com",
+        "$ref": "#/$defs/foo",
+        "$defs": {
+          "foo": {}
+        }
+      }
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2020_12_top_level_ref_without_id_empty) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
+TEST(JSONSchema_wrap, 2020_12_top_level_ref_without_id_defs_foo) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/foo",
+    "$defs": {
+      "foo": {}
+    }
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {"$defs", "foo"}, sourcemeta::core::schema_official_resolver)};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "__sourcemeta-core-wrap__#/$defs/foo",
+    "$defs": {
+      "schema": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": "__sourcemeta-core-wrap__",
+        "$ref": "#/$defs/foo",
+        "$defs": {
+          "foo": {}
+        }
+      }
+    }
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}


### PR DESCRIPTION
See: https://github.com/sourcemeta/studio/issues/67
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
