### PR TITLE
Handle top-level ref objects without properties in Draft 7 and older

### DIFF
--- a/test/jsonschema/jsonschema_bundle_draft4_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft4_test.cc
@@ -569,3 +569,26 @@ TEST(JSONSchema_bundle_draft4, hyperschema_ref_metaschema) {
   EXPECT_TRUE(document.at("definitions")
                   .defines("http://json-schema.org/draft-04/schema"));
 }
+
+TEST(JSONSchema_bundle_draft4, standalone_ref_with_default_dialect) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://www.sourcemeta.com/test-1"
+  })JSON");
+
+  sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
+                           test_resolver,
+                           "http://json-schema.org/draft-04/schema#");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/test-1" } ],
+    "definitions": {
+      "https://www.sourcemeta.com/test-1": {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "id": "https://www.sourcemeta.com/test-1",
+        "type": "string"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_bundle_draft6_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft6_test.cc
@@ -529,3 +529,26 @@ TEST(JSONSchema_bundle_draft6, hyperschema_ref_metaschema) {
   EXPECT_TRUE(document.at("definitions")
                   .defines("http://json-schema.org/draft-06/schema"));
 }
+
+TEST(JSONSchema_bundle_draft6, standalone_ref_with_default_dialect) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://www.sourcemeta.com/test-1"
+  })JSON");
+
+  sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
+                           test_resolver,
+                           "http://json-schema.org/draft-06/schema#");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/test-1" } ],
+    "definitions": {
+      "https://www.sourcemeta.com/test-1": {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$id": "https://www.sourcemeta.com/test-1",
+        "type": "string"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_bundle_draft7_test.cc
+++ b/test/jsonschema/jsonschema_bundle_draft7_test.cc
@@ -558,3 +558,26 @@ TEST(JSONSchema_bundle_draft7, bundle_to_defs) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(JSONSchema_bundle_draft7, standalone_ref_with_default_dialect) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://www.sourcemeta.com/test-1"
+  })JSON");
+
+  sourcemeta::core::bundle(document, sourcemeta::core::schema_official_walker,
+                           test_resolver,
+                           "http://json-schema.org/draft-07/schema#");
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "allOf": [ { "$ref": "https://www.sourcemeta.com/test-1" } ],
+    "definitions": {
+      "https://www.sourcemeta.com/test-1": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://www.sourcemeta.com/test-1",
+        "type": "string"
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}

--- a/test/jsonschema/jsonschema_dependencies_test.cc
+++ b/test/jsonschema/jsonschema_dependencies_test.cc
@@ -207,6 +207,29 @@ TEST(JSONSchema_dependencies,
                sourcemeta::core::SchemaResolutionError);
 }
 
+TEST(JSONSchema_dependencies,
+     across_dialects_from_top_level_ref_draft_with_default_dialect) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://www.sourcemeta.com/test-4"
+  })JSON");
+
+  std::vector<
+      std::tuple<std::optional<sourcemeta::core::JSON::String>,
+                 sourcemeta::core::Pointer, sourcemeta::core::JSON::String>>
+      traces;
+
+  sourcemeta::core::dependencies(
+      document, sourcemeta::core::schema_official_walker, test_resolver,
+      [&traces](const auto &origin, const auto &pointer, const auto &target,
+                const auto &) { traces.emplace_back(origin, pointer, target); },
+      "http://json-schema.org/draft-07/schema#");
+
+  EXPECT_EQ(traces.size(), 1);
+
+  EXPECT_DEPENDENCY(traces, 0, std::nullopt, "/$ref",
+                    "https://www.sourcemeta.com/test-4");
+}
+
 TEST(JSONSchema_dependencies, across_dialects_const) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "$id": "https://www.example.com",

--- a/test/jsonschema/jsonschema_wrap_test.cc
+++ b/test/jsonschema/jsonschema_wrap_test.cc
@@ -372,6 +372,22 @@ TEST(JSONSchema_wrap, schema_with_identifier_with_fragment) {
   EXPECT_EQ(result, expected);
 }
 
+TEST(JSONSchema_wrap, draft4_standalone_ref_with_default_dialect) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://example.com"
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver,
+      "http://json-schema.org/draft-04/schema#")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://example.com"
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
 TEST(JSONSchema_wrap, draft4_top_level_ref_with_id_empty) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -451,6 +467,22 @@ TEST(JSONSchema_wrap, draft4_top_level_ref_without_id_definitions_foo) {
       sourcemeta::core::SchemaError);
 }
 
+TEST(JSONSchema_wrap, draft6_standalone_ref_with_default_dialect) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://example.com"
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver,
+      "http://json-schema.org/draft-06/schema#")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://example.com"
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
+}
+
 TEST(JSONSchema_wrap, draft6_top_level_ref_with_id_empty) {
   const auto schema{sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
@@ -528,6 +560,22 @@ TEST(JSONSchema_wrap, draft6_top_level_ref_without_id_definitions_foo) {
       sourcemeta::core::wrap(schema, {"definitions", "foo"},
                              sourcemeta::core::schema_official_resolver),
       sourcemeta::core::SchemaError);
+}
+
+TEST(JSONSchema_wrap, draft7_standalone_ref_with_default_dialect) {
+  const auto schema{sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://example.com"
+  })JSON")};
+
+  const auto result{sourcemeta::core::wrap(
+      schema, {}, sourcemeta::core::schema_official_resolver,
+      "http://json-schema.org/draft-07/schema#")};
+
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "$ref": "https://example.com"
+  })JSON")};
+
+  EXPECT_EQ(result, expected);
 }
 
 TEST(JSONSchema_wrap, draft7_top_level_ref_with_id_empty) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
