### PR TITLE
Add a linter rule to remove unnecessary `$schema` declarations

### DIFF
--- a/src/core/jsonschema/transformer.cc
+++ b/src/core/jsonschema/transformer.cc
@@ -219,15 +219,15 @@ auto SchemaTransformer::apply(
             continue;
           }
 
-          const auto &target{destination.value().get().pointer};
+          const auto &target{destination.value().get()};
           // The destination still exists, so we don't have to do anything
-          if (try_get(schema, target)) {
+          if (try_get(schema, target.pointer)) {
             continue;
           }
 
           const auto new_fragment{rule->rereference(
-              reference.second.destination, reference.first.second, target,
-              entry.second.pointer)};
+              reference.second.destination, reference.first.second,
+              target.relative_pointer, entry.second.relative_pointer)};
 
           // Note we use the base from the original reference before any
           // canonicalisation takes place so that we don't overly change

--- a/src/extension/alterschema/CMakeLists.txt
+++ b/src/extension/alterschema/CMakeLists.txt
@@ -56,6 +56,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME alterschema
     linter/duplicate_anyof_branches.h
     linter/else_without_if.h
     linter/if_without_then_else.h
+    linter/ignored_metaschema.h
     linter/max_contains_without_contains.h
     linter/min_contains_without_contains.h
     linter/modern_official_dialect_with_empty_fragment.h

--- a/src/extension/alterschema/alterschema.cc
+++ b/src/extension/alterschema/alterschema.cc
@@ -77,6 +77,7 @@ inline auto APPLIES_TO_POINTERS(std::vector<Pointer> &&keywords)
 #include "linter/exclusive_maximum_number_and_maximum.h"
 #include "linter/exclusive_minimum_number_and_minimum.h"
 #include "linter/if_without_then_else.h"
+#include "linter/ignored_metaschema.h"
 #include "linter/items_array_default.h"
 #include "linter/items_schema_default.h"
 #include "linter/max_contains_without_contains.h"
@@ -123,6 +124,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
   bundle.add<DuplicateAnyOfBranches>();
   bundle.add<ElseWithoutIf>();
   bundle.add<IfWithoutThenElse>();
+  bundle.add<IgnoredMetaschema>();
   bundle.add<MaxContainsWithoutContains>();
   bundle.add<MinContainsWithoutContains>();
   bundle.add<NotFalse>();

--- a/src/extension/alterschema/linter/ignored_metaschema.h
+++ b/src/extension/alterschema/linter/ignored_metaschema.h
@@ -1,0 +1,29 @@
+class IgnoredMetaschema final : public SchemaTransformRule {
+public:
+  IgnoredMetaschema()
+      : SchemaTransformRule{
+            "ignored_metaschema",
+            "A `$schema` declaration without a sibling identifier (or with a "
+            "sibling `$ref` in Draft 7 and older dialects), is ignored"} {};
+
+  [[nodiscard]] auto
+  condition(const sourcemeta::core::JSON &schema,
+            const sourcemeta::core::JSON &,
+            const sourcemeta::core::Vocabularies &,
+            const sourcemeta::core::SchemaFrame &,
+            const sourcemeta::core::SchemaFrame::Location &location,
+            const sourcemeta::core::SchemaWalker &,
+            const sourcemeta::core::SchemaResolver &) const
+      -> sourcemeta::core::SchemaTransformRule::Result override {
+    ONLY_CONTINUE_IF(schema.is_object() && schema.defines("$schema") &&
+                     schema.at("$schema").is_string());
+    const auto dialect{sourcemeta::core::dialect(schema)};
+    ONLY_CONTINUE_IF(dialect.has_value());
+    ONLY_CONTINUE_IF(dialect.value() != location.dialect);
+    return APPLIES_TO_KEYWORDS("$schema");
+  }
+
+  auto transform(JSON &schema, const Result &) const -> void override {
+    schema.erase("$schema");
+  }
+};

--- a/test/alterschema/alterschema_lint_2020_12_test.cc
+++ b/test/alterschema/alterschema_lint_2020_12_test.cc
@@ -4271,8 +4271,45 @@ TEST(AlterSchema_lint_2020_12, invalid_embedded_resource_draft7_without_id) {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
       "embedded": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
         "$defs": {}
+      }
+    }
+  })JSON");
+
+  EXPECT_EQ(document, expected);
+}
+
+TEST(AlterSchema_lint_2020_12,
+     invalid_embedded_resource_draft7_with_sibling_ref) {
+  sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/main",
+    "$ref": "embedded",
+    "$defs": {
+      "embedded": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "embedded",
+        "$ref": "#/definitions/foo",
+        "definitions": {
+          "foo": { "type": "number" }
+        }
+      }
+    }
+  })JSON");
+
+  LINT_AND_FIX_FOR_READABILITY(document);
+
+  const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/main",
+    "$ref": "embedded",
+    "$defs": {
+      "embedded": {
+        "$id": "embedded",
+        "$ref": "#/$defs/foo",
+        "$defs": {
+          "foo": { "type": "number" }
+        }
       }
     }
   })JSON");


### PR DESCRIPTION
See: https://github.com/sourcemeta/studio/issues/67
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
