### PR TITLE
Always parse JSON numbers with exponential notation as `Decimal`

### DIFF
--- a/src/core/json/parser.h
+++ b/src/core/json/parser.h
@@ -348,8 +348,11 @@ auto parse_number_exponent_rest(
         column += 1;
         break;
       default:
-        return parse_number_real_maybe_decimal(line, original_column,
-                                               result.str());
+        // As a heuristic, if a number has exponential notation, it is almost
+        // always a big number for which `double` is typically a poor
+        // representation. If an exponent is encountered, we just always parse
+        // as a high-precision decimal
+        return parse_number_decimal(line, original_column, result.str());
     }
   }
 

--- a/test/json/json_parse_test.cc
+++ b/test/json/json_parse_test.cc
@@ -404,8 +404,8 @@ TEST(JSON_parse, single_exponential_number_element) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 1);
-  EXPECT_TRUE(document.at(0).is_real());
-  EXPECT_EQ(document.at(0).to_real(), 300.0);
+  EXPECT_TRUE(document.at(0).is_decimal());
+  EXPECT_EQ(document.at(0).to_decimal(), sourcemeta::core::Decimal{"300"});
 }
 
 TEST(JSON_parse, object_equality) {
@@ -827,176 +827,176 @@ TEST(JSON_parse, leading_zero_real_number) {
 TEST(JSON_parse, zero_integer_with_exponent) {
   std::istringstream input{"0e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"0e2"});
 }
 
 TEST(JSON_parse, zero_real_with_exponent) {
   std::istringstream input{"0.0e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"0.0e2"});
 }
 
 TEST(JSON_parse, large_negative_exponential_number) {
   std::istringstream input{"-1.0e10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), -1e10);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-1.0e10"});
 }
 
 TEST(JSON_parse, large_positive_exponential_number_with_plus_exponent) {
   std::istringstream input{"1.0e+10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 1e10);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.0e+10"});
 }
 
 TEST(JSON_parse, large_negative_exponential_number_with_plus_exponent) {
   std::istringstream input{"-1.0e+10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), -1e10);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-1.0e+10"});
 }
 
 TEST(JSON_parse, number_exponential_notation_plus_after_e) {
   std::istringstream input{"3E+2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 300.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3E+2"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_1_upper) {
   std::istringstream input{"2E0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 2.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"2E0"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_2_upper) {
   std::istringstream input{"3E2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 300.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3E2"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_3_upper) {
   std::istringstream input{"4.321768E3"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 4321.768);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"4.321768E3"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_4_upper) {
   std::istringstream input{"-5.3E4"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), -53000);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-5.3E4"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_5_upper) {
   std::istringstream input{"6.72E9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 6720000000);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"6.72E9"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_6_upper) {
   std::istringstream input{"5E-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.5);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5E-1"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_7_upper) {
   std::istringstream input{"9.5E2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 950);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"9.5E2"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_8_upper) {
   std::istringstream input{"5E-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.5);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5E-1"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_1_lower) {
   std::istringstream input{"2e0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 2.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"2e0"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_2_lower) {
   std::istringstream input{"3e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 300.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3e2"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_3_lower) {
   std::istringstream input{"4.321768e3"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 4321.768);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"4.321768e3"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_4_lower) {
   std::istringstream input{"-5.3e4"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), -53000);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-5.3e4"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_5_lower) {
   std::istringstream input{"6.72e9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 6720000000);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"6.72e9"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_6_lower) {
   std::istringstream input{"5e-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.5);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5e-1"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_7_lower) {
   std::istringstream input{"9.5e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 950);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"9.5e2"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_8_lower) {
   std::istringstream input{"5e-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.5);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5e-1"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_1_real) {
   std::istringstream input{"2.0e0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 2.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"2.0e0"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_2_real) {
   std::istringstream input{"3.0e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 300.0);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3.0e2"});
 }
 
 TEST(JSON_parse, exponential_notation_integer_3_real) {
   std::istringstream input{"5.0e-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_EQ(document.to_real(), 0.5);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5.0e-1"});
 }
 
 TEST(JSON_parse, integer_equality) {
@@ -1459,15 +1459,36 @@ TEST(JSON_parse, big_real_in_object) {
 TEST(JSON_parse, big_number_with_exponent) {
   std::istringstream input{"1.5e10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_DOUBLE_EQ(document.to_real(), 1.5e10);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.5e10"});
 }
 
 TEST(JSON_parse, big_number_with_negative_exponent) {
   std::istringstream input{"1.5e-10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
-  EXPECT_TRUE(document.is_real());
-  EXPECT_DOUBLE_EQ(document.to_real(), 1.5e-10);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.5e-10"});
+}
+
+TEST(JSON_parse, scientific_constant_planck) {
+  std::istringstream input{"6.62607E-34"};
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"6.62607E-34"});
+}
+
+TEST(JSON_parse, scientific_constant_elementary_charge) {
+  std::istringstream input{"1.60218E-19"};
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.60218E-19"});
+}
+
+TEST(JSON_parse, scientific_constant_boltzmann) {
+  std::istringstream input{"1.38065E-23"};
+  const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
+  EXPECT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.38065E-23"});
 }
 
 TEST(JSON_parse, read_json_stub_bigint) {

--- a/test/json/json_stringify_test.cc
+++ b/test/json/json_stringify_test.cc
@@ -555,6 +555,30 @@ TEST(JSON_stringify, decimal_scientific_notation) {
   EXPECT_EQ(stream.str(), "12.3e+9");
 }
 
+TEST(JSON_stringify, scientific_constant_planck) {
+  const sourcemeta::core::Decimal value{"6.62607E-34"};
+  const sourcemeta::core::JSON document{value};
+  std::ostringstream stream;
+  sourcemeta::core::stringify(document, stream);
+  EXPECT_EQ(stream.str(), "662.607e-36");
+}
+
+TEST(JSON_stringify, scientific_constant_elementary_charge) {
+  const sourcemeta::core::Decimal value{"1.60218E-19"};
+  const sourcemeta::core::JSON document{value};
+  std::ostringstream stream;
+  sourcemeta::core::stringify(document, stream);
+  EXPECT_EQ(stream.str(), "160.218e-21");
+}
+
+TEST(JSON_stringify, scientific_constant_boltzmann) {
+  const sourcemeta::core::Decimal value{"1.38065E-23"};
+  const sourcemeta::core::JSON document{value};
+  std::ostringstream stream;
+  sourcemeta::core::stringify(document, stream);
+  EXPECT_EQ(stream.str(), "13.8065e-24");
+}
+
 TEST(JSON_stringify, decimal_in_array) {
   const sourcemeta::core::Decimal value1{100};
   const sourcemeta::core::Decimal value2{"999.999"};

--- a/test/yaml/yaml_parse_callback_test.cc
+++ b/test/yaml/yaml_parse_callback_test.cc
@@ -269,8 +269,9 @@ TEST(YAML_parse_callback, yaml_numbers_various_formats) {
   EXPECT_TRACE(4, Post, Real, 2, 10, sourcemeta::core::JSON{3.5});
   EXPECT_TRACE(5, Pre, Integer, 3, 1, sourcemeta::core::JSON{"negative"});
   EXPECT_TRACE(6, Post, Integer, 3, 13, sourcemeta::core::JSON{-10});
-  EXPECT_TRACE(7, Pre, Real, 4, 1, sourcemeta::core::JSON{"exponential"});
-  EXPECT_TRACE(8, Post, Real, 4, 17, sourcemeta::core::JSON{1e10});
+  EXPECT_TRACE(7, Pre, Decimal, 4, 1, sourcemeta::core::JSON{"exponential"});
+  EXPECT_TRACE(8, Post, Decimal, 4, 17,
+               sourcemeta::core::JSON{sourcemeta::core::Decimal{"1e10"}});
   EXPECT_TRACE(9, Post, Object, 5, 0, sourcemeta::core::parse_yaml(input));
 }
 

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -255,7 +255,7 @@ TEST(YAML_parse, decimal_high_precision_real) {
 TEST(YAML_parse, decimal_exponential_notation) {
   const std::string input{"1.234567890123456789012345678901e50"};
   const auto result{sourcemeta::core::parse_yaml(input)};
-  EXPECT_TRUE(result.is_real());
+  EXPECT_TRUE(result.is_decimal());
 }
 
 TEST(YAML_parse, decimal_in_object) {
@@ -281,5 +281,26 @@ TEST(YAML_parse, decimal_in_array) {
   EXPECT_TRUE(result.is_array());
   EXPECT_EQ(result.size(), 2);
   EXPECT_TRUE(result.at(0).is_decimal());
-  EXPECT_TRUE(result.at(1).is_real());
+  EXPECT_TRUE(result.at(1).is_decimal());
+}
+
+TEST(YAML_parse, scientific_constant_planck) {
+  const std::string input{"6.62607E-34"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  EXPECT_TRUE(result.is_decimal());
+  EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{"6.62607E-34"});
+}
+
+TEST(YAML_parse, scientific_constant_elementary_charge) {
+  const std::string input{"1.60218E-19"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  EXPECT_TRUE(result.is_decimal());
+  EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{"1.60218E-19"});
+}
+
+TEST(YAML_parse, scientific_constant_boltzmann) {
+  const std::string input{"1.38065E-23"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  EXPECT_TRUE(result.is_decimal());
+  EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{"1.38065E-23"});
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
