### PR TITLE
Avoid `mpdecimal` warning log on multithreaded `Decimal` construction

### DIFF
--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -52,11 +52,24 @@ auto Decimal::data() const -> const Data * {
 
 namespace {
 
+// One-time global initialization of MPD_MINALLOC
+// This must happen before any thread-local contexts are initialized
+[[maybe_unused]] static const bool minalloc_initialized = []() {
+  constexpr mpd_ssize_t precision{16};
+  const mpd_ssize_t ideal_minalloc =
+      2 * ((precision + MPD_RDIGITS - 1) / MPD_RDIGITS);
+  mpd_setminalloc(ideal_minalloc);
+  return true;
+}();
+
 // Thread-local context for decimal arithmetic operations
 // Matches the C++ wrapper context_template settings (16 digit precision)
+// Note: We use mpd_defaultcontext + mpd_qsetprec instead of mpd_init
+// to avoid calling mpd_setminalloc multiple times (once per thread)
 thread_local mpd_context_t decimal_context = []() {
   mpd_context_t context;
-  mpd_init(&context, 16);
+  mpd_defaultcontext(&context);
+  mpd_qsetprec(&context, 16);
   context.emax = 999999;
   context.emin = -999999;
   context.round = MPD_ROUND_HALF_EVEN;

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -4,6 +4,8 @@
 
 #include <cmath>  // std::isnan, std::isinf
 #include <string> // std::string
+#include <thread> // std::thread
+#include <vector> // std::vector
 
 TEST(Numeric_decimal, add_small_integers) {
   const sourcemeta::core::Decimal left{2};
@@ -1742,4 +1744,23 @@ TEST(Numeric_decimal, construct_from_float_high_precision) {
   const sourcemeta::core::Decimal decimal{value};
   const float roundtrip{decimal.to_float()};
   EXPECT_EQ(roundtrip, value);
+}
+
+TEST(Numeric_decimal, multithreaded_construction) {
+  constexpr int number_of_threads{4};
+  std::vector<std::thread> threads;
+  threads.reserve(number_of_threads);
+
+  for (int index = 0; index < number_of_threads; index++) {
+    threads.emplace_back([]() {
+      const sourcemeta::core::Decimal value{42};
+      const sourcemeta::core::Decimal result{value +
+                                             sourcemeta::core::Decimal{1}};
+      EXPECT_EQ(result, sourcemeta::core::Decimal{43});
+    });
+  }
+
+  for (auto &thread : threads) {
+    thread.join();
+  }
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
