### PR TITLE
Consolidate schema exceptions on `::identifier()` vs `::id()`

### DIFF
--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -54,7 +54,7 @@ public:
     return this->message_;
   }
 
-  [[nodiscard]] auto id() const noexcept -> std::string_view {
+  [[nodiscard]] auto identifier() const noexcept -> std::string_view {
     return this->identifier_;
   }
 
@@ -120,7 +120,7 @@ public:
     return this->message_;
   }
 
-  [[nodiscard]] auto id() const noexcept -> std::string_view {
+  [[nodiscard]] auto identifier() const noexcept -> std::string_view {
     return this->identifier_;
   }
 

--- a/test/jsonschema/jsonschema_error_test.cc
+++ b/test/jsonschema/jsonschema_error_test.cc
@@ -23,5 +23,5 @@ TEST(JSONSchema, resolution_error_throw) {
       "https://sourcemeta.com/test", "My error")};
   EXPECT_THROW(throw exception, sourcemeta::core::SchemaResolutionError);
   EXPECT_EQ(std::string{exception.what()}, "My error");
-  EXPECT_EQ(exception.id(), "https://sourcemeta.com/test");
+  EXPECT_EQ(exception.identifier(), "https://sourcemeta.com/test");
 }

--- a/test/jsonschema/jsonschema_transformer_test.cc
+++ b/test/jsonschema/jsonschema_transformer_test.cc
@@ -1072,7 +1072,7 @@ TEST(JSONSchema_transformer, rereference_not_fixed_ref) {
                  transformer_callback_trace(entries));
     FAIL() << "The transformation was expected to throw";
   } catch (const sourcemeta::core::SchemaBrokenReferenceError &error) {
-    EXPECT_EQ(error.id(), "#/definitions/foo");
+    EXPECT_EQ(error.identifier(), "#/definitions/foo");
     EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/$ref");
     SUCCEED();
   } catch (const sourcemeta::core::SchemaReferenceError &) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
