### PR TITLE
Extend `jsonschema.json` to support an `extension` field

### DIFF
--- a/src/extension/schemaconfig/include/sourcemeta/core/schemaconfig.h
+++ b/src/extension/schemaconfig/include/sourcemeta/core/schemaconfig.h
@@ -23,6 +23,7 @@
 #include <filesystem>    // std::filesystem
 #include <optional>      // std::optional
 #include <unordered_map> // std::unordered_map
+#include <unordered_set> // std::unordered_set
 
 namespace sourcemeta::core {
 
@@ -44,6 +45,7 @@ struct SOURCEMETA_CORE_SCHEMACONFIG_EXPORT SchemaConfig {
   std::filesystem::path absolute_path;
   JSON::String base;
   std::optional<JSON::String> default_dialect;
+  std::unordered_set<JSON::String> extension;
   std::unordered_map<JSON::String, JSON::String> resolve;
   JSON extra = JSON::make_object();
 


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
