### PR TITLE
Cover decimals in `JSON::fast_hash`

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -733,6 +733,8 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
                                return accumulator + 1 + pair.first.size() +
                                       pair.second.fast_hash();
                              });
+    case Type::Decimal:
+      return 8;
     default:
       assert(false);
       return 0;

--- a/test/json/json_decimal_test.cc
+++ b/test/json/json_decimal_test.cc
@@ -877,3 +877,24 @@ TEST(JSON_decimal, divisible_by_mixed_scale_decimal_real_divisible_true) {
   const sourcemeta::core::JSON divisor{0.5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
+
+TEST(JSON_decimal, fast_hash_positive) {
+  const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"3.14"}};
+  EXPECT_EQ(document.fast_hash(), 8);
+}
+
+TEST(JSON_decimal, fast_hash_negative) {
+  const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"-3.14"}};
+  EXPECT_EQ(document.fast_hash(), 8);
+}
+
+TEST(JSON_decimal, fast_hash_zero) {
+  const sourcemeta::core::JSON document{sourcemeta::core::Decimal{0}};
+  EXPECT_EQ(document.fast_hash(), 8);
+}
+
+TEST(JSON_decimal, fast_hash_large) {
+  const sourcemeta::core::JSON document{
+      sourcemeta::core::Decimal{"123456789012345678901234567890"}};
+  EXPECT_EQ(document.fast_hash(), 8);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
