### PR TITLE
Implement `std::hash` for `PointerTemplate`

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -659,6 +659,41 @@ struct hash<sourcemeta::core::GenericPointer<
                 : last.to_index());
   }
 };
+
+template <typename PointerT>
+struct hash<sourcemeta::core::GenericPointerTemplate<PointerT>> {
+  auto operator()(const sourcemeta::core::GenericPointerTemplate<PointerT>
+                      &pointer) const noexcept -> std::size_t {
+    const auto size{pointer.size()};
+    if (size == 0) {
+      return size;
+    }
+
+    auto hash_element =
+        [](const typename sourcemeta::core::GenericPointerTemplate<
+            PointerT>::value_type &element) -> std::size_t {
+      using Template = sourcemeta::core::GenericPointerTemplate<PointerT>;
+      const auto *token{std::get_if<typename Template::Token>(&element)};
+      if (token) {
+        return token->is_property()
+                   ? static_cast<std::size_t>(token->property_hash().a)
+                   : token->to_index();
+      } else {
+        return element.index();
+      }
+    };
+
+    const auto &first{*pointer.cbegin()};
+    const auto &middle{
+        *(pointer.cbegin() +
+          static_cast<typename sourcemeta::core::GenericPointerTemplate<
+              PointerT>::difference_type>(size / 2))};
+    const auto &last{*(pointer.cend() - 1)};
+
+    return size + hash_element(first) + hash_element(middle) +
+           hash_element(last);
+  }
+};
 } // namespace std
 
 #endif

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_template.h
@@ -207,6 +207,20 @@ public:
     return this->data.empty();
   }
 
+  /// Get the size of the JSON Pointer template. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::Pointer base{"foo", "bar"};
+  /// const sourcemeta::core::PointerTemplate pointer{base};
+  /// assert(pointer.size() == 2);
+  /// ```
+  [[nodiscard]] auto size() const noexcept -> size_type {
+    return this->data.size();
+  }
+
   /// Check if a JSON Pointer template only consists in normal non-templated
   /// tokens. For example:
   ///


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
