### PR TITLE
Rename `AlterSchemaMode::Canonicalize` to `Canonicalizer`

### DIFF
--- a/src/extension/alterschema/alterschema.cc
+++ b/src/extension/alterschema/alterschema.cc
@@ -122,7 +122,7 @@ inline auto APPLIES_TO_POINTERS(std::vector<Pointer> &&keywords)
 namespace sourcemeta::core {
 
 auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
-  if (mode == AlterSchemaMode::Canonicalize) {
+  if (mode == AlterSchemaMode::Canonicalizer) {
     bundle.add<TypeUnionImplicit>();
     bundle.add<TypeArrayToAnyOf>();
   }
@@ -167,7 +167,7 @@ auto add(SchemaTransformer &bundle, const AlterSchemaMode mode) -> void {
   bundle.add<RequiredPropertiesInProperties>();
   bundle.add<OrphanDefinitions>();
 
-  if (mode == AlterSchemaMode::Canonicalize) {
+  if (mode == AlterSchemaMode::Canonicalizer) {
     bundle.add<BooleanTrue>();
     bundle.add<ConstAsEnum>();
     bundle.add<EqualNumericBoundsToConst>();

--- a/src/extension/alterschema/include/sourcemeta/core/alterschema.h
+++ b/src/extension/alterschema/include/sourcemeta/core/alterschema.h
@@ -30,7 +30,7 @@ enum class AlterSchemaMode : std::uint8_t {
   /// Rules that surface implicit constraints and simplifies keywords that
   /// are syntax sugar to other keywords, potentially decreasing human
   /// readability in favor of explicitness
-  Canonicalize,
+  Canonicalizer,
 };
 
 /// @ingroup alterschema

--- a/test/alterschema/alterschema_test_utils.h
+++ b/test/alterschema/alterschema_test_utils.h
@@ -53,7 +53,7 @@ static auto alterschema_test_resolver(std::string_view identifier)
 #define CANONICALIZE(document)                                                 \
   sourcemeta::core::SchemaTransformer bundle;                                  \
   sourcemeta::core::add(bundle,                                                \
-                        sourcemeta::core::AlterSchemaMode::Canonicalize);      \
+                        sourcemeta::core::AlterSchemaMode::Canonicalizer);     \
   bundle.apply(document, sourcemeta::core::schema_walker,                      \
                alterschema_test_resolver,                                      \
                [](const auto &, const auto &, const auto &, const auto &) {});


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
