### PR TITLE
Do not add `multipleOf: 1` when canonicalising real number schemas

### DIFF
--- a/src/extension/alterschema/canonicalizer/multiple_of_implicit.h
+++ b/src/extension/alterschema/canonicalizer/multiple_of_implicit.h
@@ -21,8 +21,8 @@ public:
                           Vocabularies::Known::JSON_Schema_Draft_4}) &&
                      schema.is_object() && schema.defines("type") &&
                      schema.at("type").is_string() &&
-                     (schema.at("type").to_string() == "integer" ||
-                      schema.at("type").to_string() == "number") &&
+                     // Applying this to numbers would be a semantic problem
+                     schema.at("type").to_string() == "integer" &&
                      !schema.defines("multipleOf"));
     return true;
   }

--- a/test/alterschema/alterschema_canonicalize_2019_09_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2019_09_test.cc
@@ -21,7 +21,7 @@ TEST(AlterSchema_canonicalize_2019_09, duplicate_allof_branches_2) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -45,7 +45,7 @@ TEST(AlterSchema_canonicalize_2019_09, duplicate_allof_branches_3) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -76,7 +76,7 @@ TEST(AlterSchema_canonicalize_2019_09, duplicate_allof_branches_4) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -217,7 +217,6 @@ TEST(AlterSchema_canonicalize_2019_09, exclusive_maximum_integer_to_maximum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMaximum": 1
   })JSON");
 
@@ -240,7 +239,7 @@ TEST(AlterSchema_canonicalize_2019_09, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "multipleOf": 1, "exclusiveMaximum": 1 },
+      { "type": "number", "exclusiveMaximum": 1 },
       { "multipleOf": 1, "maximum": 0, "type": "integer" }
     ]
   })JSON");
@@ -298,7 +297,6 @@ TEST(AlterSchema_canonicalize_2019_09, exclusive_minimum_integer_to_minimum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMinimum": 1
   })JSON");
 
@@ -321,7 +319,7 @@ TEST(AlterSchema_canonicalize_2019_09, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number", "exclusiveMinimum": 1 },
+      { "type": "number", "exclusiveMinimum": 1 },
       { "multipleOf": 1, "minimum": 2, "type": "integer" }
     ]
   })JSON");
@@ -355,7 +353,7 @@ TEST(AlterSchema_canonicalize_2019_09, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "multipleOf": 1, "type": "number" },
+              { "type": "number" },
               { "multipleOf": 1, "type": "integer" }
             ]
           }
@@ -363,7 +361,7 @@ TEST(AlterSchema_canonicalize_2019_09, boolean_true_1) {
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number" },
+      { "type": "number" },
       { "multipleOf": 1, "type": "integer" }
     ]
   })JSON");
@@ -420,7 +418,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -431,7 +429,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -463,7 +461,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -474,7 +472,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -507,7 +505,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -518,7 +516,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }

--- a/test/alterschema/alterschema_canonicalize_2020_12_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2020_12_test.cc
@@ -21,7 +21,7 @@ TEST(AlterSchema_canonicalize_2020_12, duplicate_allof_branches_2) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -45,7 +45,7 @@ TEST(AlterSchema_canonicalize_2020_12, duplicate_allof_branches_3) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -76,7 +76,7 @@ TEST(AlterSchema_canonicalize_2020_12, duplicate_allof_branches_4) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -139,7 +139,7 @@ TEST(AlterSchema_canonicalize_2020_12, dependent_required_tautology_3) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -150,7 +150,7 @@ TEST(AlterSchema_canonicalize_2020_12, dependent_required_tautology_3) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -161,7 +161,7 @@ TEST(AlterSchema_canonicalize_2020_12, dependent_required_tautology_3) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -305,7 +305,6 @@ TEST(AlterSchema_canonicalize_2020_12, exclusive_maximum_integer_to_maximum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMaximum": 1
   })JSON");
 
@@ -328,7 +327,7 @@ TEST(AlterSchema_canonicalize_2020_12, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "multipleOf": 1, "exclusiveMaximum": 1 },
+      { "type": "number", "exclusiveMaximum": 1 },
       { "multipleOf": 1, "maximum": 0, "type": "integer" }
     ]
   })JSON");
@@ -386,7 +385,6 @@ TEST(AlterSchema_canonicalize_2020_12, exclusive_minimum_integer_to_minimum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMinimum": 1
   })JSON");
 
@@ -409,7 +407,7 @@ TEST(AlterSchema_canonicalize_2020_12, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number", "exclusiveMinimum": 1 },
+      { "type": "number", "exclusiveMinimum": 1 },
       { "multipleOf": 1, "minimum": 2, "type": "integer" }
     ]
   })JSON");
@@ -443,7 +441,7 @@ TEST(AlterSchema_canonicalize_2020_12, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "multipleOf": 1, "type": "number" },
+              { "type": "number" },
               { "multipleOf": 1, "type": "integer" }
             ]
           }
@@ -451,7 +449,7 @@ TEST(AlterSchema_canonicalize_2020_12, boolean_true_1) {
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number" },
+      { "type": "number" },
       { "multipleOf": 1, "type": "integer" }
     ]
   })JSON");
@@ -476,7 +474,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_1) {
     "$anchor": "foo",
     "anyOf": [
       { "type": "integer", "minimum": 5, "multipleOf": 1 },
-      { "type": "number", "minimum": 5, "multipleOf": 1 },
+      { "type": "number", "minimum": 5 },
       { "type": "string", "minLength": 0 }
     ]
   })JSON");
@@ -500,7 +498,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_2) {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "anyOf": [
       { "type": "integer", "multipleOf": 1 },
-      { "type": "number", "multipleOf": 1 },
+      { "type": "number" },
       { "type": "string", "minLength": 0 }
     ],
     "allOf": [
@@ -614,7 +612,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_5) {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "anyOf": [
       { "type": "string", "minLength": 0 },
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ],
     "allOf": [
       {
@@ -626,7 +624,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_5) {
               { "type": "object", "minProperties": 0, "properties": {} },
               { "type": "array", "minItems": 0 },
               { "type": "string", "minLength": 1 },
-              { "type": "number", "multipleOf": 1 },
+              { "type": "number" },
               { "type": "integer", "multipleOf": 1 }
             ]
           },
@@ -637,7 +635,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_5) {
               { "type": "object", "minProperties": 0, "properties": {} },
               { "type": "array", "minItems": 0 },
               { "type": "string", "minLength": 0 },
-              { "type": "number", "minimum": 0, "multipleOf": 1 },
+              { "type": "number", "minimum": 0 },
               { "type": "integer", "minimum": 0, "multipleOf": 1 }
             ]
           }
@@ -698,7 +696,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -709,7 +707,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -741,7 +739,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -752,7 +750,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -785,7 +783,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -796,7 +794,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }

--- a/test/alterschema/alterschema_canonicalize_draft4_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft4_test.cc
@@ -21,7 +21,7 @@ TEST(AlterSchema_canonicalize_draft4, duplicate_allof_branches_2) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -45,7 +45,7 @@ TEST(AlterSchema_canonicalize_draft4, duplicate_allof_branches_3) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -76,7 +76,7 @@ TEST(AlterSchema_canonicalize_draft4, duplicate_allof_branches_4) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -177,7 +177,7 @@ TEST(AlterSchema_canonicalize_draft4, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "multipleOf": 1, "type": "number" },
+              { "type": "number" },
               { "multipleOf": 1, "type": "integer" }
             ]
           }
@@ -185,7 +185,7 @@ TEST(AlterSchema_canonicalize_draft4, boolean_true_1) {
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number" },
+      { "type": "number" },
       { "multipleOf": 1, "type": "integer" }
     ]
   })JSON");
@@ -216,7 +216,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -227,7 +227,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -259,7 +259,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -270,7 +270,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -303,7 +303,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -314,7 +314,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }

--- a/test/alterschema/alterschema_canonicalize_draft6_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft6_test.cc
@@ -21,7 +21,7 @@ TEST(AlterSchema_canonicalize_draft6, duplicate_allof_branches_2) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -45,7 +45,7 @@ TEST(AlterSchema_canonicalize_draft6, duplicate_allof_branches_3) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -76,7 +76,7 @@ TEST(AlterSchema_canonicalize_draft6, duplicate_allof_branches_4) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -217,7 +217,6 @@ TEST(AlterSchema_canonicalize_draft6, exclusive_maximum_integer_to_maximum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMaximum": 1
   })JSON");
 
@@ -240,7 +239,7 @@ TEST(AlterSchema_canonicalize_draft6, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "multipleOf": 1, "exclusiveMaximum": 1 },
+      { "type": "number", "exclusiveMaximum": 1 },
       { "multipleOf": 1, "maximum": 0, "type": "integer" }
     ]
   })JSON");
@@ -297,7 +296,6 @@ TEST(AlterSchema_canonicalize_draft6, exclusive_minimum_integer_to_minimum_3) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "multipleOf": 1,
     "type": "number",
     "exclusiveMinimum": 1
   })JSON");
@@ -321,7 +319,7 @@ TEST(AlterSchema_canonicalize_draft6, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number", "exclusiveMinimum": 1 },
+      { "type": "number", "exclusiveMinimum": 1 },
       { "multipleOf": 1, "minimum": 2, "type": "integer" }
     ]
   })JSON");
@@ -355,7 +353,7 @@ TEST(AlterSchema_canonicalize_draft6, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "multipleOf": 1, "type": "number" },
+              { "type": "number" },
               { "multipleOf": 1, "type": "integer" }
             ]
           }
@@ -363,7 +361,7 @@ TEST(AlterSchema_canonicalize_draft6, boolean_true_1) {
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number" },
+      { "type": "number" },
       { "multipleOf": 1, "type": "integer" }
     ]
   })JSON");
@@ -394,7 +392,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -405,7 +403,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -437,7 +435,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -448,7 +446,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -481,7 +479,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -492,7 +490,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }

--- a/test/alterschema/alterschema_canonicalize_draft7_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft7_test.cc
@@ -21,7 +21,7 @@ TEST(AlterSchema_canonicalize_draft7, duplicate_allof_branches_2) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -45,7 +45,7 @@ TEST(AlterSchema_canonicalize_draft7, duplicate_allof_branches_3) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -76,7 +76,7 @@ TEST(AlterSchema_canonicalize_draft7, duplicate_allof_branches_4) {
     "type": "string",
     "minLength": 0,
     "allOf": [
-      { "type": "number", "multipleOf": 1 }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -217,7 +217,6 @@ TEST(AlterSchema_canonicalize_draft7, exclusive_maximum_integer_to_maximum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMaximum": 1
   })JSON");
 
@@ -240,7 +239,7 @@ TEST(AlterSchema_canonicalize_draft7, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "multipleOf": 1, "exclusiveMaximum": 1 },
+      { "type": "number", "exclusiveMaximum": 1 },
       { "multipleOf": 1, "maximum": 0, "type": "integer" }
     ]
   })JSON");
@@ -298,7 +297,6 @@ TEST(AlterSchema_canonicalize_draft7, exclusive_minimum_integer_to_minimum_3) {
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "number",
-    "multipleOf": 1,
     "exclusiveMinimum": 1
   })JSON");
 
@@ -321,7 +319,7 @@ TEST(AlterSchema_canonicalize_draft7, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number", "exclusiveMinimum": 1 },
+      { "type": "number", "exclusiveMinimum": 1 },
       { "multipleOf": 1, "minimum": 2, "type": "integer" }
     ]
   })JSON");
@@ -435,7 +433,7 @@ TEST(AlterSchema_canonicalize_draft7, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "multipleOf": 1, "type": "number" },
+              { "type": "number" },
               { "multipleOf": 1, "type": "integer" }
             ]
           }
@@ -443,7 +441,7 @@ TEST(AlterSchema_canonicalize_draft7, boolean_true_1) {
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "multipleOf": 1, "type": "number" },
+      { "type": "number" },
       { "multipleOf": 1, "type": "integer" }
     ]
   })JSON");
@@ -474,7 +472,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -485,7 +483,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -517,7 +515,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -528,7 +526,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }
@@ -561,7 +559,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       },
@@ -572,7 +570,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number", "multipleOf": 1 },
+          { "type": "number" },
           { "type": "integer", "multipleOf": 1 }
         ]
       }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
