### PR TITLE
Simplify `type_union_implicit` to not add the `integer` part

### DIFF
--- a/src/extension/alterschema/canonicalizer/type_union_implicit.h
+++ b/src/extension/alterschema/canonicalizer/type_union_implicit.h
@@ -76,16 +76,14 @@ public:
   auto transform(JSON &schema, const Result &) const -> void override {
     auto types{sourcemeta::core::JSON::make_array()};
 
-    // All possible JSON Schema types
-    // See
-    // https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.6.1.1
     types.push_back(sourcemeta::core::JSON{"null"});
     types.push_back(sourcemeta::core::JSON{"boolean"});
     types.push_back(sourcemeta::core::JSON{"object"});
     types.push_back(sourcemeta::core::JSON{"array"});
     types.push_back(sourcemeta::core::JSON{"string"});
+
+    // Note we don't add `integer`, as its covered by `number`
     types.push_back(sourcemeta::core::JSON{"number"});
-    types.push_back(sourcemeta::core::JSON{"integer"});
 
     schema.assign("type", std::move(types));
   }

--- a/test/alterschema/alterschema_canonicalize_2019_09_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2019_09_test.cc
@@ -239,8 +239,7 @@ TEST(AlterSchema_canonicalize_2019_09, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMaximum": 1 },
-      { "multipleOf": 1, "maximum": 0, "type": "integer" }
+      { "type": "number", "exclusiveMaximum": 1 }
     ]
   })JSON");
 
@@ -319,8 +318,7 @@ TEST(AlterSchema_canonicalize_2019_09, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMinimum": 1 },
-      { "multipleOf": 1, "minimum": 2, "type": "integer" }
+      { "type": "number", "exclusiveMinimum": 1 }
     ]
   })JSON");
 
@@ -353,16 +351,14 @@ TEST(AlterSchema_canonicalize_2019_09, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "type": "number" },
-              { "multipleOf": 1, "type": "integer" }
+              { "type": "number" }
             ]
           }
         }
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number" },
-      { "multipleOf": 1, "type": "integer" }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -418,8 +414,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -429,8 +424,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -461,8 +455,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -472,8 +465,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -505,8 +497,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -516,8 +507,7 @@ TEST(AlterSchema_canonicalize_2019_09, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }

--- a/test/alterschema/alterschema_canonicalize_2020_12_test.cc
+++ b/test/alterschema/alterschema_canonicalize_2020_12_test.cc
@@ -104,8 +104,7 @@ TEST(AlterSchema_canonicalize_2020_12, duplicate_allof_branches_5) {
       { "type": "object", "minProperties": 0, "properties": {} },
       { "type": "array", "minItems": 0 },
       { "type": "string", "minLength": 0 },
-      { "type": "number", "multipleOf": 1 },
-      { "type": "integer", "multipleOf": 1 }
+      { "type": "number", "multipleOf": 1 }
     ]
   })JSON");
 
@@ -139,8 +138,7 @@ TEST(AlterSchema_canonicalize_2020_12, dependent_required_tautology_3) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -150,8 +148,7 @@ TEST(AlterSchema_canonicalize_2020_12, dependent_required_tautology_3) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "baz": {
@@ -161,8 +158,7 @@ TEST(AlterSchema_canonicalize_2020_12, dependent_required_tautology_3) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -327,8 +323,7 @@ TEST(AlterSchema_canonicalize_2020_12, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMaximum": 1 },
-      { "multipleOf": 1, "maximum": 0, "type": "integer" }
+      { "type": "number", "exclusiveMaximum": 1 }
     ]
   })JSON");
 
@@ -407,8 +402,7 @@ TEST(AlterSchema_canonicalize_2020_12, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMinimum": 1 },
-      { "multipleOf": 1, "minimum": 2, "type": "integer" }
+      { "type": "number", "exclusiveMinimum": 1 }
     ]
   })JSON");
 
@@ -441,16 +435,14 @@ TEST(AlterSchema_canonicalize_2020_12, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "type": "number" },
-              { "multipleOf": 1, "type": "integer" }
+              { "type": "number" }
             ]
           }
         }
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number" },
-      { "multipleOf": 1, "type": "integer" }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -624,8 +616,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_5) {
               { "type": "object", "minProperties": 0, "properties": {} },
               { "type": "array", "minItems": 0 },
               { "type": "string", "minLength": 1 },
-              { "type": "number" },
-              { "type": "integer", "multipleOf": 1 }
+              { "type": "number" }
             ]
           },
           {
@@ -635,8 +626,7 @@ TEST(AlterSchema_canonicalize_2020_12, type_array_to_any_of_5) {
               { "type": "object", "minProperties": 0, "properties": {} },
               { "type": "array", "minItems": 0 },
               { "type": "string", "minLength": 0 },
-              { "type": "number", "minimum": 0 },
-              { "type": "integer", "minimum": 0, "multipleOf": 1 }
+              { "type": "number", "minimum": 0 }
             ]
           }
         ]
@@ -696,8 +686,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -707,8 +696,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -739,8 +727,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -750,8 +737,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -783,8 +769,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -794,8 +779,7 @@ TEST(AlterSchema_canonicalize_2020_12, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -1191,8 +1175,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_required_branches_1) {
               { "type": "object", "minProperties": 0, "properties": {} },
               { "type": "array", "minItems": 0 },
               { "type": "string", "minLength": 0 },
-              { "type": "number" },
-              { "type": "integer", "multipleOf": 1 }
+              { "type": "number" }
             ]
           }
         },
@@ -1200,8 +1183,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_required_branches_1) {
       },
       { "type": "array", "minItems": 0 },
       { "type": "string", "minLength": 0 },
-      { "type": "number" },
-      { "type": "integer", "multipleOf": 1 }
+      { "type": "number" }
     ],
     "minProperties": 1,
     "properties": {
@@ -1212,8 +1194,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_required_branches_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -1272,8 +1253,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_properties_branches_1) {
               { "type": "object", "minProperties": 0, "properties": {} },
               { "type": "array", "minItems": 0 },
               { "type": "string", "minLength": 0 },
-              { "type": "number" },
-              { "type": "integer", "multipleOf": 1 }
+              { "type": "number" }
             ]
           }
         },
@@ -1281,8 +1261,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_properties_branches_1) {
       },
       { "type": "array", "minItems": 0 },
       { "type": "string", "minLength": 0 },
-      { "type": "number" },
-      { "type": "integer", "multipleOf": 1 }
+      { "type": "number" }
     ],
     "allOf": [
       {
@@ -1299,8 +1278,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_properties_branches_1) {
                   { "type": "object", "minProperties": 0, "properties": {} },
                   { "type": "array", "minItems": 0 },
                   { "type": "string", "minLength": 0 },
-                  { "type": "number" },
-                  { "type": "integer", "multipleOf": 1 }
+                  { "type": "number" }
                 ]
               }
             },
@@ -1308,8 +1286,7 @@ TEST(AlterSchema_canonicalize_2020_12, allof_two_properties_branches_1) {
           },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     ],

--- a/test/alterschema/alterschema_canonicalize_draft0_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft0_test.cc
@@ -16,10 +16,10 @@ TEST(AlterSchema_canonicalize_draft0, boolean_true_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-00/schema#",
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ],
+    "type": [ "null", "boolean", "object", "array", "string", "number" ],
     "properties": {
       "foo": {
-        "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+        "type": [ "null", "boolean", "object", "array", "string", "number" ]
       }
     }
   })JSON");

--- a/test/alterschema/alterschema_canonicalize_draft1_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft1_test.cc
@@ -84,10 +84,10 @@ TEST(AlterSchema_canonicalize_draft1, boolean_true_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-01/schema#",
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ],
+    "type": [ "null", "boolean", "object", "array", "string", "number" ],
     "properties": {
       "foo": {
-        "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+        "type": [ "null", "boolean", "object", "array", "string", "number" ]
       }
     }
   })JSON");

--- a/test/alterschema/alterschema_canonicalize_draft2_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft2_test.cc
@@ -84,10 +84,10 @@ TEST(AlterSchema_canonicalize_draft2, boolean_true_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-02/schema#",
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ],
+    "type": [ "null", "boolean", "object", "array", "string", "number" ],
     "properties": {
       "foo": {
-        "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+        "type": [ "null", "boolean", "object", "array", "string", "number" ]
       }
     }
   })JSON");

--- a/test/alterschema/alterschema_canonicalize_draft3_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft3_test.cc
@@ -84,10 +84,10 @@ TEST(AlterSchema_canonicalize_draft3, boolean_true_1) {
 
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
     "$schema": "http://json-schema.org/draft-03/schema#",
-    "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ],
+    "type": [ "null", "boolean", "object", "array", "string", "number" ],
     "properties": {
       "foo": {
-        "type": [ "null", "boolean", "object", "array", "string", "number", "integer" ]
+        "type": [ "null", "boolean", "object", "array", "string", "number" ]
       }
     }
   })JSON");

--- a/test/alterschema/alterschema_canonicalize_draft4_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft4_test.cc
@@ -177,16 +177,14 @@ TEST(AlterSchema_canonicalize_draft4, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "type": "number" },
-              { "multipleOf": 1, "type": "integer" }
+              { "type": "number" }
             ]
           }
         }
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number" },
-      { "multipleOf": 1, "type": "integer" }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -216,8 +214,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -227,8 +224,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -259,8 +255,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -270,8 +265,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -303,8 +297,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -314,8 +307,7 @@ TEST(AlterSchema_canonicalize_draft4, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }

--- a/test/alterschema/alterschema_canonicalize_draft6_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft6_test.cc
@@ -239,8 +239,7 @@ TEST(AlterSchema_canonicalize_draft6, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMaximum": 1 },
-      { "multipleOf": 1, "maximum": 0, "type": "integer" }
+      { "type": "number", "exclusiveMaximum": 1 }
     ]
   })JSON");
 
@@ -319,8 +318,7 @@ TEST(AlterSchema_canonicalize_draft6, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMinimum": 1 },
-      { "multipleOf": 1, "minimum": 2, "type": "integer" }
+      { "type": "number", "exclusiveMinimum": 1 }
     ]
   })JSON");
 
@@ -353,16 +351,14 @@ TEST(AlterSchema_canonicalize_draft6, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "type": "number" },
-              { "multipleOf": 1, "type": "integer" }
+              { "type": "number" }
             ]
           }
         }
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number" },
-      { "multipleOf": 1, "type": "integer" }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -392,8 +388,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -403,8 +398,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -435,8 +429,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -446,8 +439,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -479,8 +471,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -490,8 +481,7 @@ TEST(AlterSchema_canonicalize_draft6, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }

--- a/test/alterschema/alterschema_canonicalize_draft7_test.cc
+++ b/test/alterschema/alterschema_canonicalize_draft7_test.cc
@@ -239,8 +239,7 @@ TEST(AlterSchema_canonicalize_draft7, exclusive_maximum_integer_to_maximum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMaximum": 1 },
-      { "multipleOf": 1, "maximum": 0, "type": "integer" }
+      { "type": "number", "exclusiveMaximum": 1 }
     ]
   })JSON");
 
@@ -319,8 +318,7 @@ TEST(AlterSchema_canonicalize_draft7, exclusive_minimum_integer_to_minimum_5) {
       { "properties": {}, "minProperties": 0, "type": "object" },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number", "exclusiveMinimum": 1 },
-      { "multipleOf": 1, "minimum": 2, "type": "integer" }
+      { "type": "number", "exclusiveMinimum": 1 }
     ]
   })JSON");
 
@@ -433,16 +431,14 @@ TEST(AlterSchema_canonicalize_draft7, boolean_true_1) {
               { "properties": {}, "minProperties": 0, "type": "object" },
               { "minItems": 0, "type": "array" },
               { "minLength": 0, "type": "string" },
-              { "type": "number" },
-              { "multipleOf": 1, "type": "integer" }
+              { "type": "number" }
             ]
           }
         }
       },
       { "minItems": 0, "type": "array" },
       { "minLength": 0, "type": "string" },
-      { "type": "number" },
-      { "multipleOf": 1, "type": "integer" }
+      { "type": "number" }
     ]
   })JSON");
 
@@ -472,8 +468,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -483,8 +478,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_covered_by_required_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -515,8 +509,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -526,8 +519,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_1) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }
@@ -559,8 +551,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       },
       "bar": {
@@ -570,8 +561,7 @@ TEST(AlterSchema_canonicalize_draft7, min_properties_implicit_2) {
           { "type": "object", "minProperties": 0, "properties": {} },
           { "type": "array", "minItems": 0 },
           { "type": "string", "minLength": 0 },
-          { "type": "number" },
-          { "type": "integer", "multipleOf": 1 }
+          { "type": "number" }
         ]
       }
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
