### PR TITLE
Refactor `orphan_definitions` to not rely on instance locations

### DIFF
--- a/benchmark/jsonschema.cc
+++ b/benchmark/jsonschema.cc
@@ -8,28 +8,14 @@
 #include <sourcemeta/core/jsonschema.h>
 #include <sourcemeta/core/uri.h>
 
-static void Schema_Frame_WoT_Instances(benchmark::State &state) {
+static void Schema_Frame_WoT_References(benchmark::State &state) {
   const auto schema{
       sourcemeta::core::read_json(std::filesystem::path{CURRENT_DIRECTORY} /
                                   "schemas" / "draft7_w3c_wot_td_v1_1.json")};
 
   for (auto _ : state) {
     sourcemeta::core::SchemaFrame frame{
-        sourcemeta::core::SchemaFrame::Mode::Instances};
-    frame.analyse(schema, sourcemeta::core::schema_walker,
-                  sourcemeta::core::schema_resolver);
-    benchmark::DoNotOptimize(frame);
-  }
-}
-
-static void Schema_Frame_OMC_Instances(benchmark::State &state) {
-  const auto schema{
-      sourcemeta::core::read_json(std::filesystem::path{CURRENT_DIRECTORY} /
-                                  "schemas" / "2019_09_omc_json_v2.json")};
-
-  for (auto _ : state) {
-    sourcemeta::core::SchemaFrame frame{
-        sourcemeta::core::SchemaFrame::Mode::Instances};
+        sourcemeta::core::SchemaFrame::Mode::References};
     frame.analyse(schema, sourcemeta::core::schema_walker,
                   sourcemeta::core::schema_resolver);
     benchmark::DoNotOptimize(frame);
@@ -178,8 +164,7 @@ static void Schema_Bundle_Meta_2020_12(benchmark::State &state) {
   }
 }
 
-BENCHMARK(Schema_Frame_WoT_Instances);
-BENCHMARK(Schema_Frame_OMC_Instances);
+BENCHMARK(Schema_Frame_WoT_References);
 BENCHMARK(Schema_Frame_OMC_References);
 BENCHMARK(Schema_Frame_OMC_Locations);
 BENCHMARK(Schema_Frame_ISO_Language_Locations);

--- a/src/core/jsonschema/transformer.cc
+++ b/src/core/jsonschema/transformer.cc
@@ -107,7 +107,7 @@ auto SchemaTransformer::check(
     const std::optional<JSON::String> &default_dialect,
     const std::optional<JSON::String> &default_id) const
     -> std::pair<bool, std::uint8_t> {
-  SchemaFrame frame{SchemaFrame::Mode::Instances};
+  SchemaFrame frame{SchemaFrame::Mode::References};
 
   // If we use the default id when there is already one, framing will duplicate
   // the locations leading to duplicate check reports
@@ -173,7 +173,7 @@ auto SchemaTransformer::apply(
   std::size_t subschema_count{0};
   std::size_t subschema_failures{0};
   while (true) {
-    SchemaFrame frame{SchemaFrame::Mode::Instances};
+    SchemaFrame frame{SchemaFrame::Mode::References};
     frame.analyse(schema, walker, resolver, default_dialect, default_id);
     std::unordered_set<Pointer> visited;
 

--- a/test/jsonpointer/jsonpointer_starts_with_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_test.cc
@@ -130,3 +130,75 @@ TEST(JSONPointer_starts_with, tail_empty_prefix) {
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix, tail));
 }
+
+TEST(JSONPointer_starts_with, property_tail_true) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_TRUE(pointer.starts_with(prefix, "$defs"));
+}
+
+TEST(JSONPointer_starts_with, property_tail_false_wrong_tail) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "other"));
+}
+
+TEST(JSONPointer_starts_with, property_tail_false_wrong_prefix) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar"};
+  const sourcemeta::core::Pointer prefix{"baz"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "$defs"));
+}
+
+TEST(JSONPointer_starts_with, property_tail_pointer_too_short) {
+  const sourcemeta::core::Pointer pointer{"foo"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "$defs"));
+}
+
+TEST(JSONPointer_starts_with, property_tail_empty_prefix) {
+  const sourcemeta::core::Pointer pointer{"$defs", "bar"};
+  const sourcemeta::core::Pointer prefix;
+  EXPECT_TRUE(pointer.starts_with(prefix, "$defs"));
+}
+
+TEST(JSONPointer_starts_with, property_tail_index_token) {
+  const sourcemeta::core::Pointer pointer{"foo", 0, "bar"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "0"));
+}
+
+TEST(JSONPointer_starts_with, property_two_tails_true) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_TRUE(pointer.starts_with(prefix, "$defs", "bar"));
+}
+
+TEST(JSONPointer_starts_with, property_two_tails_false_wrong_left) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "other", "bar"));
+}
+
+TEST(JSONPointer_starts_with, property_two_tails_false_wrong_right) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "$defs", "other"));
+}
+
+TEST(JSONPointer_starts_with, property_two_tails_pointer_too_short) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "$defs", "bar"));
+}
+
+TEST(JSONPointer_starts_with, property_two_tails_empty_prefix) {
+  const sourcemeta::core::Pointer pointer{"$defs", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix;
+  EXPECT_TRUE(pointer.starts_with(prefix, "$defs", "bar"));
+}
+
+TEST(JSONPointer_starts_with, property_two_tails_index_in_right) {
+  const sourcemeta::core::Pointer pointer{"foo", "$defs", 0, "baz"};
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with(prefix, "$defs", "0"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
