### PR TITLE
Use a vector for `SchemaFrame::Paths`

### DIFF
--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -386,6 +386,8 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                           std::string_view default_dialect,
                           std::string_view default_id,
                           const SchemaFrame::Paths &paths) -> void {
+  assert(std::unordered_set<WeakPointer>(paths.cbegin(), paths.cend()).size() ==
+         paths.size());
   std::vector<InternalEntry> subschema_entries;
   std::unordered_map<Pointer, CacheSubschema> subschemas;
   std::unordered_map<sourcemeta::core::Pointer, std::vector<JSON::String>>

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
@@ -177,8 +177,8 @@ public:
       // point to different places.
       std::map<std::pair<SchemaReferenceType, JSON::String>, Location>;
 
-  /// A set of paths to frame within a schema wrapper
-  using Paths = std::set<WeakPointer>;
+  /// A list of paths to frame within a schema wrapper
+  using Paths = std::vector<WeakPointer>;
 
   /// Export the frame entries as JSON
   [[nodiscard]] auto to_json(


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
