### PR TITLE
Remove `std::optional` in `ReferencesEntry::base`

### DIFF
--- a/src/core/jsonschema/bundle.cc
+++ b/src/core/jsonschema/bundle.cc
@@ -46,27 +46,27 @@ auto dependencies_internal(const sourcemeta::core::JSON &schema,
       continue;
     }
 
-    if (!reference.base.has_value()) {
+    if (reference.base.empty()) {
       throw sourcemeta::core::SchemaReferenceError(
           reference.destination, key.second,
           "Could not resolve schema reference");
     }
 
     // To not infinitely loop on circular references
-    if (visited.contains(reference.base.value())) {
+    if (visited.contains(reference.base)) {
       continue;
     }
 
     // If we can't find the destination but there is a base and we can
     // find the base, then we are facing an unresolved fragment
-    if (frame.traverse(reference.base.value()).has_value()) {
+    if (frame.traverse(reference.base).has_value()) {
       throw sourcemeta::core::SchemaReferenceError(
           reference.destination, key.second,
           "Could not resolve schema reference");
     }
 
-    assert(reference.base.has_value());
-    const auto &identifier{reference.base.value()};
+    assert(!reference.base.empty());
+    const auto &identifier{reference.base};
     auto remote{resolver(identifier)};
     if (!remote.has_value()) {
       throw sourcemeta::core::SchemaResolutionError(
@@ -165,21 +165,20 @@ auto bundle_schema(sourcemeta::core::JSON &root,
 
     // If we can't find the destination but there is a base and we can
     // find base, then we are facing an unresolved fragment
-    if (reference.base.has_value() &&
-        frame.traverse(reference.base.value()).has_value()) {
+    if (!reference.base.empty() && frame.traverse(reference.base).has_value()) {
       throw sourcemeta::core::SchemaReferenceError(
           reference.destination, key.second,
           "Could not resolve schema reference");
     }
 
-    if (!reference.base.has_value()) {
+    if (reference.base.empty()) {
       throw sourcemeta::core::SchemaReferenceError(
           reference.destination, key.second,
           "Could not resolve schema reference");
     }
 
-    assert(reference.base.has_value());
-    const sourcemeta::core::JSON::String identifier{reference.base.value()};
+    assert(!reference.base.empty());
+    const sourcemeta::core::JSON::String identifier{reference.base};
 
     // Skip if already bundled to avoid infinite loops on circular references
     if (bundled.contains(identifier)) {

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
@@ -116,8 +116,8 @@ public:
     JSON::String original;
     // TODO: Make this a string view over the locations map
     JSON::String destination;
-    // TODO: This can be empty to signify no base?
-    std::optional<std::string_view> base;
+    // Empty means no base
+    std::string_view base;
     std::optional<std::string_view> fragment;
   };
 

--- a/src/extension/alterschema/common/unknown_local_ref.h
+++ b/src/extension/alterschema/common/unknown_local_ref.h
@@ -43,9 +43,9 @@ public:
     // If there is a base beyond the fragment, the base must exist.
     // Otherwise it is likely an external reference?
     const auto &reference_base{reference_entry->second.base};
-    if (reference_base.has_value()) {
+    if (!reference_base.empty()) {
       const auto base_location{frame.locations().find(
-          {SchemaReferenceType::Static, JSON::String{reference_base.value()}})};
+          {SchemaReferenceType::Static, JSON::String{reference_base}})};
       ONLY_CONTINUE_IF(base_location != frame.locations().end());
     }
 

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -1118,8 +1118,8 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_no_recursive_anchor_anonymous) {
       frame, "/$schema", "https://json-schema.org/draft/2019-09/schema",
       "https://json-schema.org/draft/2019-09/schema", std::nullopt,
       "https://json-schema.org/draft/2019-09/schema");
-  EXPECT_STATIC_REFERENCE(frame, "/additionalItems/$recursiveRef", "",
-                          std::nullopt, std::nullopt, "#");
+  EXPECT_STATIC_REFERENCE(frame, "/additionalItems/$recursiveRef", "", "",
+                          std::nullopt, "#");
 }
 
 TEST(JSONSchema_frame_2019_09, recursive_ref_no_recursive_anchor) {
@@ -1217,8 +1217,8 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_false_anonymous) {
       frame, "/$schema", "https://json-schema.org/draft/2019-09/schema",
       "https://json-schema.org/draft/2019-09/schema", std::nullopt,
       "https://json-schema.org/draft/2019-09/schema");
-  EXPECT_STATIC_REFERENCE(frame, "/additionalItems/$recursiveRef", "",
-                          std::nullopt, std::nullopt, "#");
+  EXPECT_STATIC_REFERENCE(frame, "/additionalItems/$recursiveRef", "", "",
+                          std::nullopt, "#");
 }
 
 TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_false) {
@@ -1327,8 +1327,8 @@ TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_true_anonymous) {
       frame, "/$schema", "https://json-schema.org/draft/2019-09/schema",
       "https://json-schema.org/draft/2019-09/schema", std::nullopt,
       "https://json-schema.org/draft/2019-09/schema");
-  EXPECT_DYNAMIC_REFERENCE(frame, "/additionalItems/$recursiveRef", "",
-                           std::nullopt, std::nullopt, "#");
+  EXPECT_DYNAMIC_REFERENCE(frame, "/additionalItems/$recursiveRef", "", "",
+                           std::nullopt, "#");
 }
 
 TEST(JSONSchema_frame_2019_09, recursive_ref_recursive_anchor_true) {
@@ -2169,13 +2169,13 @@ TEST(JSONSchema_frame_2019_09,
       "https://json-schema.org/draft/2019-09/schema", std::nullopt,
       "https://json-schema.org/draft/2019-09/schema");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
-                          "#/definitions/enabled", std::nullopt,
-                          "/definitions/enabled", "#/definitions/enabled");
+                          "#/definitions/enabled", "", "/definitions/enabled",
+                          "#/definitions/enabled");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/properties/bar/$ref",
-                          "#/definitions/config", std::nullopt,
-                          "/definitions/config", "#/definitions/config");
+                          "#/definitions/config", "", "/definitions/config",
+                          "#/definitions/config");
   EXPECT_STATIC_REFERENCE(
       frame, "/properties/foo/properties/bar/additionalProperties/$ref",
-      "#/definitions/threshold", std::nullopt, "/definitions/threshold",
+      "#/definitions/threshold", "", "/definitions/threshold",
       "#/definitions/threshold");
 }

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -920,18 +920,18 @@ TEST(JSONSchema_frame_2020_12, dynamic_refs_with_no_id) {
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
 
-  EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$dynamicRef", "",
-                          std::nullopt, std::nullopt, "#");
+  EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$dynamicRef", "", "",
+                          std::nullopt, "#");
   EXPECT_STATIC_REFERENCE(frame, "/properties/bar/$dynamicRef",
-                          "#/properties/baz", std::nullopt, "/properties/baz",
+                          "#/properties/baz", "", "/properties/baz",
                           "#/properties/baz");
   EXPECT_STATIC_REFERENCE(frame, "/properties/qux/$dynamicRef",
                           "https://www.example.com", "https://www.example.com",
                           std::nullopt, "#");
-  EXPECT_STATIC_REFERENCE(frame, "/properties/anchor/$dynamicRef", "#baz",
-                          std::nullopt, "baz", "#baz");
+  EXPECT_STATIC_REFERENCE(frame, "/properties/anchor/$dynamicRef", "#baz", "",
+                          "baz", "#baz");
   EXPECT_DYNAMIC_REFERENCE(frame, "/properties/extra/$dynamicRef", "#dynamic",
-                           std::nullopt, "dynamic", "#dynamic");
+                           "", "dynamic", "#dynamic");
   EXPECT_DYNAMIC_REFERENCE(frame, "/properties/unknown/$dynamicRef",
                            "https://www.example.com/foo#xxx",
                            "https://www.example.com/foo", "xxx",
@@ -1287,8 +1287,7 @@ TEST(JSONSchema_frame_2020_12,
       frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_STATIC_REFERENCE(frame, "/$dynamicRef", "#test", std::nullopt, "test",
-                          "#test");
+  EXPECT_STATIC_REFERENCE(frame, "/$dynamicRef", "#test", "", "test", "#test");
 }
 
 TEST(JSONSchema_frame_2020_12, dynamic_ref_to_single_dynamic_anchor_external) {
@@ -1358,8 +1357,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_ref_to_single_dynamic_anchor_external) {
       frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_DYNAMIC_REFERENCE(frame, "/$dynamicRef", "#test", std::nullopt, "test",
-                           "#test");
+  EXPECT_DYNAMIC_REFERENCE(frame, "/$dynamicRef", "#test", "", "test", "#test");
   EXPECT_STATIC_REFERENCE(frame, "/$defs/foo/$ref", "https://sourcemeta.com",
                           "https://sourcemeta.com", std::nullopt,
                           "https://sourcemeta.com");
@@ -1424,8 +1422,8 @@ TEST(JSONSchema_frame_2020_12, no_id_recursive_empty_pointer) {
       frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref", "", std::nullopt,
-                          std::nullopt, "#");
+  EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref", "", "", std::nullopt,
+                          "#");
 }
 
 TEST(JSONSchema_frame_2020_12, ref_metaschema) {
@@ -2360,7 +2358,7 @@ TEST(JSONSchema_frame_2020_12, cross_id_anonymous_nested) {
       frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/$defs/schema/items", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/$defs/schema/items", "",
                           "/$defs/schema/items", "#/$defs/schema/items");
   EXPECT_STATIC_REFERENCE(frame, "/$defs/schema/$schema",
                           "https://json-schema.org/draft/2020-12/schema",
@@ -2529,8 +2527,8 @@ TEST(JSONSchema_frame_2020_12,
   EXPECT_EQ(frame.references().size(), 1);
 
   // Without an identifier, the reference goes from the root
-  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/wrapper", std::nullopt,
-                          "/wrapper", "#/wrapper");
+  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/wrapper", "", "/wrapper",
+                          "#/wrapper");
 }
 
 TEST(JSONSchema_frame_2020_12, single_nested_anonymous_with_nested_resource) {
@@ -2719,10 +2717,10 @@ TEST(JSONSchema_frame_2020_12, multiple_nested_cross_ref) {
 
   EXPECT_EQ(frame.references().size(), 3);
 
-  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/common/test", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/common/test", "",
                           "/common/test", "#/common/test");
-  EXPECT_STATIC_REFERENCE(frame, "/common/test/$ref", "#/common/with-id",
-                          std::nullopt, "/common/with-id", "#/common/with-id");
+  EXPECT_STATIC_REFERENCE(frame, "/common/test/$ref", "#/common/with-id", "",
+                          "/common/with-id", "#/common/with-id");
   EXPECT_STATIC_REFERENCE(frame, "/common/with-id/$schema",
                           "https://json-schema.org/draft/2020-12/schema",
                           "https://json-schema.org/draft/2020-12/schema",
@@ -2781,10 +2779,10 @@ TEST(JSONSchema_frame_2020_12, multiple_nested_cross_ref_missing_target) {
 
   EXPECT_EQ(frame.references().size(), 2);
 
-  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/common/test", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/common/test", "",
                           "/common/test", "#/common/test");
-  EXPECT_STATIC_REFERENCE(frame, "/common/test/$ref", "#/common/with-id",
-                          std::nullopt, "/common/with-id", "#/common/with-id");
+  EXPECT_STATIC_REFERENCE(frame, "/common/test/$ref", "#/common/with-id", "",
+                          "/common/with-id", "#/common/with-id");
 }
 
 TEST(JSONSchema_frame_2020_12, multiple_nested_no_base_dialect) {
@@ -2923,10 +2921,10 @@ TEST(JSONSchema_frame_2020_12, multiple_nested_with_default_id) {
 
   EXPECT_EQ(frame.references().size(), 2);
 
-  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/common/test", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/wrapper/$ref", "#/common/test", "",
                           "/common/test", "#/common/test");
-  EXPECT_STATIC_REFERENCE(frame, "/common/test/$ref", "#/common/with-id",
-                          std::nullopt, "/common/with-id", "#/common/with-id");
+  EXPECT_STATIC_REFERENCE(frame, "/common/test/$ref", "#/common/with-id", "",
+                          "/common/with-id", "#/common/with-id");
 }
 
 TEST(JSONSchema_frame_2020_12, anchor_with_invalid_type) {
@@ -3090,14 +3088,14 @@ TEST(JSONSchema_frame_2020_12,
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
-                          "#/definitions/enabled", std::nullopt,
-                          "/definitions/enabled", "#/definitions/enabled");
+                          "#/definitions/enabled", "", "/definitions/enabled",
+                          "#/definitions/enabled");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/properties/bar/$ref",
-                          "#/definitions/config", std::nullopt,
-                          "/definitions/config", "#/definitions/config");
+                          "#/definitions/config", "", "/definitions/config",
+                          "#/definitions/config");
   EXPECT_STATIC_REFERENCE(
       frame, "/properties/foo/properties/bar/additionalProperties/$ref",
-      "#/definitions/threshold", std::nullopt, "/definitions/threshold",
+      "#/definitions/threshold", "", "/definitions/threshold",
       "#/definitions/threshold");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft3_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft3_test.cc
@@ -568,7 +568,7 @@ TEST(JSONSchema_frame_draft3, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-03/schema",
       "http://json-schema.org/draft-03/schema", std::nullopt,
       "http://json-schema.org/draft-03/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", "",
                           "/definitions/string", "#/definitions/string");
 }
 

--- a/test/jsonschema/jsonschema_frame_draft4_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft4_test.cc
@@ -596,8 +596,8 @@ TEST(JSONSchema_frame_draft4, location_independent_identifier_anonymous) {
       frame, "/$schema", "http://json-schema.org/draft-04/schema",
       "http://json-schema.org/draft-04/schema", std::nullopt,
       "http://json-schema.org/draft-04/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/definitions/bar/$ref", "#foo", std::nullopt,
-                          "foo", "#foo");
+  EXPECT_STATIC_REFERENCE(frame, "/definitions/bar/$ref", "#foo", "", "foo",
+                          "#foo");
 }
 
 TEST(JSONSchema_frame_draft4, ref_with_id) {
@@ -654,7 +654,7 @@ TEST(JSONSchema_frame_draft4, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-04/schema",
       "http://json-schema.org/draft-04/schema", std::nullopt,
       "http://json-schema.org/draft-04/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", "",
                           "/definitions/string", "#/definitions/string");
 }
 
@@ -919,8 +919,8 @@ TEST(JSONSchema_frame_draft4, ref_invalidates_sibling_subschemas_and_refs) {
       "http://json-schema.org/draft-04/schema", std::nullopt,
       "http://json-schema.org/draft-04/schema#");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
-                          "#/definitions/enabled", std::nullopt,
-                          "/definitions/enabled", "#/definitions/enabled");
+                          "#/definitions/enabled", "", "/definitions/enabled",
+                          "#/definitions/enabled");
 }
 
 TEST(JSONSchema_frame_draft4, top_level_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_frame_draft6_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft6_test.cc
@@ -596,8 +596,8 @@ TEST(JSONSchema_frame_draft6, location_independent_identifier_anonymous) {
       frame, "/$schema", "http://json-schema.org/draft-06/schema",
       "http://json-schema.org/draft-06/schema", std::nullopt,
       "http://json-schema.org/draft-06/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/definitions/bar/$ref", "#foo", std::nullopt,
-                          "foo", "#foo");
+  EXPECT_STATIC_REFERENCE(frame, "/definitions/bar/$ref", "#foo", "", "foo",
+                          "#foo");
 }
 
 TEST(JSONSchema_frame_draft6, ref_with_id) {
@@ -654,7 +654,7 @@ TEST(JSONSchema_frame_draft6, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-06/schema",
       "http://json-schema.org/draft-06/schema", std::nullopt,
       "http://json-schema.org/draft-06/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", "",
                           "/definitions/string", "#/definitions/string");
 }
 
@@ -826,8 +826,8 @@ TEST(JSONSchema_frame_draft6, ref_invalidates_sibling_subschemas_and_refs) {
       "http://json-schema.org/draft-06/schema", std::nullopt,
       "http://json-schema.org/draft-06/schema#");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
-                          "#/definitions/enabled", std::nullopt,
-                          "/definitions/enabled", "#/definitions/enabled");
+                          "#/definitions/enabled", "", "/definitions/enabled",
+                          "#/definitions/enabled");
 }
 
 TEST(JSONSchema_frame_draft6, top_level_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_frame_draft7_test.cc
+++ b/test/jsonschema/jsonschema_frame_draft7_test.cc
@@ -596,8 +596,8 @@ TEST(JSONSchema_frame_draft7, location_independent_identifier_anonymous) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/definitions/bar/$ref", "#foo", std::nullopt,
-                          "foo", "#foo");
+  EXPECT_STATIC_REFERENCE(frame, "/definitions/bar/$ref", "#foo", "", "foo",
+                          "#foo");
 }
 
 TEST(JSONSchema_frame_draft7, ref_with_id) {
@@ -654,7 +654,7 @@ TEST(JSONSchema_frame_draft7, ref_with_id) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", "",
                           "/definitions/string", "#/definitions/string");
 }
 
@@ -706,7 +706,7 @@ TEST(JSONSchema_frame_draft7, ref_with_definitions) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/definitions/string", "",
                           "/definitions/string", "#/definitions/string");
 }
 
@@ -755,7 +755,7 @@ TEST(JSONSchema_frame_draft7, ref_with_properties) {
       frame, "/$schema", "http://json-schema.org/draft-07/schema",
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
-  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/properties/string", std::nullopt,
+  EXPECT_STATIC_REFERENCE(frame, "/$ref", "#/properties/string", "",
                           "/properties/string", "#/properties/string");
 }
 
@@ -927,8 +927,8 @@ TEST(JSONSchema_frame_draft7, ref_invalidates_sibling_subschemas_and_refs) {
       "http://json-schema.org/draft-07/schema", std::nullopt,
       "http://json-schema.org/draft-07/schema#");
   EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref",
-                          "#/definitions/enabled", std::nullopt,
-                          "/definitions/enabled", "#/definitions/enabled");
+                          "#/definitions/enabled", "", "/definitions/enabled",
+                          "#/definitions/enabled");
 }
 
 TEST(JSONSchema_frame_draft7, top_level_relative_ref_with_id) {

--- a/test/jsonschema/jsonschema_frame_test.cc
+++ b/test/jsonschema/jsonschema_frame_test.cc
@@ -1272,15 +1272,15 @@ TEST(JSONSchema_frame, refs_with_no_id) {
       frame, "/$schema", "https://json-schema.org/draft/2020-12/schema",
       "https://json-schema.org/draft/2020-12/schema", std::nullopt,
       "https://json-schema.org/draft/2020-12/schema");
-  EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref", "", std::nullopt,
-                          std::nullopt, "#");
-  EXPECT_STATIC_REFERENCE(frame, "/properties/bar/$ref", "#/properties/baz",
-                          std::nullopt, "/properties/baz", "#/properties/baz");
+  EXPECT_STATIC_REFERENCE(frame, "/properties/foo/$ref", "", "", std::nullopt,
+                          "#");
+  EXPECT_STATIC_REFERENCE(frame, "/properties/bar/$ref", "#/properties/baz", "",
+                          "/properties/baz", "#/properties/baz");
   EXPECT_STATIC_REFERENCE(frame, "/properties/qux/$ref",
                           "https://www.example.com", "https://www.example.com",
                           std::nullopt, "#");
-  EXPECT_STATIC_REFERENCE(frame, "/properties/anchor/$ref", "#baz",
-                          std::nullopt, "baz", "#baz");
+  EXPECT_STATIC_REFERENCE(frame, "/properties/anchor/$ref", "#baz", "", "baz",
+                          "#baz");
 }
 
 TEST(JSONSchema_frame, no_dynamic_ref_on_old_drafts) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
