### PR TITLE
Add a `Pointer::slice` overload for start/end indices

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -460,6 +460,37 @@ public:
     return result;
   }
 
+  /// Get a copy of the JSON Pointer starting from a given token index up to
+  /// (but not including) a given end index. This method is undefined if the
+  /// start index is greater than the end index or if the end index is greater
+  /// than the pointer size. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::Pointer pointer{"foo", "bar", "baz", "qux"};
+  /// const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
+  /// assert(result.size() == 2);
+  /// assert(result.at(0).is_property());
+  /// assert(result.at(0).to_property() == "bar");
+  /// assert(result.at(1).is_property());
+  /// assert(result.at(1).to_property() == "baz");
+  /// ```
+  [[nodiscard]] auto slice(const std::size_t start, const std::size_t end) const
+      -> GenericPointer<PropertyT, Hash> {
+    assert(start <= end);
+    assert(end <= this->size());
+    auto new_begin{this->data.cbegin()};
+    std::advance(new_begin, start);
+    auto new_end{this->data.cbegin()};
+    std::advance(new_end, end);
+    GenericPointer<PropertyT, Hash> result;
+    result.reserve(end - start);
+    std::copy(new_begin, new_end, std::back_inserter(result.data));
+    return result;
+  }
+
   /// Concatenate a JSON Pointer with another JSON Pointer, getting a new
   /// pointer as a result. For example:
   ///

--- a/test/jsonpointer/jsonpointer_slice_test.cc
+++ b/test/jsonpointer/jsonpointer_slice_test.cc
@@ -72,3 +72,77 @@ TEST(JSONPointer_slice, single_element_from_one) {
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
+
+TEST(JSONPointer_slice, range_middle) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz", "qux"};
+  const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_property());
+  EXPECT_EQ(result.at(0).to_property(), "bar");
+  EXPECT_TRUE(result.at(1).is_property());
+  EXPECT_EQ(result.at(1).to_property(), "baz");
+}
+
+TEST(JSONPointer_slice, range_from_start) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer result{pointer.slice(0, 2)};
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_property());
+  EXPECT_EQ(result.at(0).to_property(), "foo");
+  EXPECT_TRUE(result.at(1).is_property());
+  EXPECT_EQ(result.at(1).to_property(), "bar");
+}
+
+TEST(JSONPointer_slice, range_to_end) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_property());
+  EXPECT_EQ(result.at(0).to_property(), "bar");
+  EXPECT_TRUE(result.at(1).is_property());
+  EXPECT_EQ(result.at(1).to_property(), "baz");
+}
+
+TEST(JSONPointer_slice, range_full) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer result{pointer.slice(0, 3)};
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_TRUE(result.at(0).is_property());
+  EXPECT_EQ(result.at(0).to_property(), "foo");
+  EXPECT_TRUE(result.at(1).is_property());
+  EXPECT_EQ(result.at(1).to_property(), "bar");
+  EXPECT_TRUE(result.at(2).is_property());
+  EXPECT_EQ(result.at(2).to_property(), "baz");
+}
+
+TEST(JSONPointer_slice, range_empty_same_indices) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer result{pointer.slice(1, 1)};
+  EXPECT_EQ(result.size(), 0);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(JSONPointer_slice, range_single_element) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer result{pointer.slice(1, 2)};
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_TRUE(result.at(0).is_property());
+  EXPECT_EQ(result.at(0).to_property(), "bar");
+}
+
+TEST(JSONPointer_slice, range_empty_pointer) {
+  const sourcemeta::core::Pointer pointer;
+  const sourcemeta::core::Pointer result{pointer.slice(0, 0)};
+  EXPECT_EQ(result.size(), 0);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(JSONPointer_slice, range_with_indices) {
+  const sourcemeta::core::Pointer pointer{"foo", 1, "bar", 2};
+  const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result.at(0).is_index());
+  EXPECT_EQ(result.at(0).to_index(), 1);
+  EXPECT_TRUE(result.at(1).is_property());
+  EXPECT_EQ(result.at(1).to_property(), "bar");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
