### PR TITLE
Perform shared GCC macOS builds only on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           - os: ubuntu-latest
             cc: clang
             cxx: clang++
-            type: static
+            type: shared
             shell: sh
             benchmark: linux/llvm
           - os: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
