### PR TITLE
Increase `mpdecimal` precision to its maximum

### DIFF
--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -70,8 +70,6 @@ thread_local mpd_context_t decimal_context = []() {
   mpd_context_t context;
   mpd_defaultcontext(&context);
   mpd_qsetprec(&context, 16);
-  context.emax = 999999;
-  context.emin = -999999;
   context.round = MPD_ROUND_HALF_EVEN;
   context.traps =
       MPD_IEEE_Invalid_operation | MPD_Division_by_zero | MPD_Overflow;

--- a/test/numeric/decimal_ibm_dectest.cc
+++ b/test/numeric/decimal_ibm_dectest.cc
@@ -97,30 +97,6 @@ static auto count_significant_digits(const std::string &value) -> std::size_t {
   return count;
 }
 
-// TODO: Our Decimal context uses emax/emin = +/-999999, which is smaller
-// than the extreme exponents used in some tests (e.g. 1e999999999).
-// These tests would overflow/underflow in our context.
-static auto has_extreme_exponent(const std::string &value) -> bool {
-  const auto stripped{strip_quotes(value)};
-  const auto lower{to_lower(stripped)};
-  if (lower.find("nan") != std::string::npos ||
-      lower.find("inf") != std::string::npos) {
-    return false;
-  }
-
-  auto exponent_position{lower.find('e')};
-  if (exponent_position == std::string::npos) {
-    return false;
-  }
-
-  try {
-    const auto exponent{std::stol(stripped.substr(exponent_position + 1))};
-    return exponent > 999999 || exponent < -999999;
-  } catch (...) {
-    return false;
-  }
-}
-
 static auto make_decimal(const std::string &raw) -> sourcemeta::core::Decimal {
   const auto value{strip_quotes(raw)};
   const auto lower{to_lower(value)};
@@ -438,12 +414,6 @@ static auto should_skip_test(const DecTestCase &test_case,
   if (test_case.operand1.find('#') != std::string::npos ||
       test_case.operand2.find('#') != std::string::npos ||
       test_case.expected.find('#') != std::string::npos) {
-    return true;
-  }
-
-  if (has_extreme_exponent(test_case.operand1) ||
-      has_extreme_exponent(test_case.operand2) ||
-      has_extreme_exponent(test_case.expected)) {
     return true;
   }
 

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -1483,7 +1483,7 @@ TEST(Numeric_decimal, exception_invalid_operation_zero_modulo_zero) {
 }
 
 TEST(Numeric_decimal, exception_overflow_multiplication) {
-  const sourcemeta::core::Decimal large{"9e999999"};
+  const sourcemeta::core::Decimal large{"9e999999999999999999"};
   const sourcemeta::core::Decimal multiplier{10};
   EXPECT_THROW(
       { const auto result = large * multiplier; },
@@ -1491,8 +1491,8 @@ TEST(Numeric_decimal, exception_overflow_multiplication) {
 }
 
 TEST(Numeric_decimal, exception_overflow_addition) {
-  const sourcemeta::core::Decimal large{"9e999999"};
-  const sourcemeta::core::Decimal addend{"9e999999"};
+  const sourcemeta::core::Decimal large{"9e999999999999999999"};
+  const sourcemeta::core::Decimal addend{"9e999999999999999999"};
   EXPECT_THROW(
       { const auto result = large + addend; },
       sourcemeta::core::NumericOverflowError);


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
