### PR TITLE
feat(frame): Add PositionTracker for Uri Collision Errors

### DIFF
--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -266,18 +266,27 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
                                            "Schema identifier already exists");
 }
 
-auto store(sourcemeta::core::SchemaFrame::Locations &frame,
-           const sourcemeta::core::SchemaReferenceType type,
-           const sourcemeta::core::SchemaFrame::LocationType entry_type,
-           sourcemeta::core::JSON::String uri, const std::string_view base,
-           const sourcemeta::core::WeakPointer &pointer_from_root,
-           const std::size_t relative_pointer_offset,
-           const std::string_view dialect,
-           const sourcemeta::core::SchemaBaseDialect base_dialect,
-           const std::optional<sourcemeta::core::WeakPointer> &parent,
-           const bool property_name, const bool orphan,
-           const bool ignore_if_present = false,
-           const bool already_canonical = false) -> void {
+[[noreturn]]
+auto throw_already_exists(const sourcemeta::core::JSON::String &uri,
+                          const std::uint64_t line, const std::uint64_t column)
+    -> void {
+  throw sourcemeta::core::SchemaUriCollisionError(
+      uri, line, column, "Schema identifier already exists");
+}
+
+auto store(
+    sourcemeta::core::SchemaFrame::Locations &frame,
+    const sourcemeta::core::SchemaReferenceType type,
+    const sourcemeta::core::SchemaFrame::LocationType entry_type,
+    sourcemeta::core::JSON::String uri, const std::string_view base,
+    const sourcemeta::core::WeakPointer &pointer_from_root,
+    const std::size_t relative_pointer_offset, const std::string_view dialect,
+    const sourcemeta::core::SchemaBaseDialect base_dialect,
+    const std::optional<sourcemeta::core::WeakPointer> &parent,
+    const bool property_name, const bool orphan,
+    const std::optional<sourcemeta::core::PointerPositionTracker> &tracker,
+    const bool ignore_if_present = false, const bool already_canonical = false)
+    -> void {
   auto canonical{already_canonical ? std::move(uri)
                                    : sourcemeta::core::URI::canonicalize(uri)};
   auto [iterator, inserted] =
@@ -292,6 +301,14 @@ auto store(sourcemeta::core::SchemaFrame::Locations &frame,
                      .property_name = property_name,
                      .orphan = orphan}});
   if (!ignore_if_present && !inserted) {
+    if (tracker) {
+      const auto position =
+          tracker->get(sourcemeta::core::to_pointer(pointer_from_root));
+      throw_already_exists(iterator->first.second,
+                           std::get<0>(position.value()),
+                           std::get<1>(position.value()));
+    }
+
     throw_already_exists(iterator->first.second);
   }
 
@@ -430,6 +447,10 @@ auto SchemaFrame::to_json(
   return root;
 }
 
+auto SchemaFrame::add_tracker(const PointerPositionTracker &tracker) -> void {
+  this->position_tracker_ = tracker;
+}
+
 auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                           const SchemaResolver &resolver,
                           std::string_view default_dialect,
@@ -499,7 +520,8 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
       store(this->locations_, SchemaReferenceType::Static,
             SchemaFrame::LocationType::Resource, default_id_canonical,
             this->root_, path, path.size(), root_dialect,
-            root_base_dialect.value(), std::nullopt, false, false);
+            root_base_dialect.value(), std::nullopt, false, false,
+            this->position_tracker_);
 
       base_uris.insert({path, {root_id.value(), default_id_canonical}});
     }
@@ -606,6 +628,12 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                 this->locations_.find({SchemaReferenceType::Static, new_id})};
             if (maybe_match != this->locations_.cend() &&
                 maybe_match->second.pointer != common_pointer_weak) {
+              if (this->position_tracker_) {
+                const auto position =
+                    position_tracker_->get(to_pointer(common_pointer_weak));
+                throw_already_exists(new_id, std::get<0>(position.value()),
+                                     std::get<1>(position.value()));
+              }
               throw_already_exists(new_id);
             }
 
@@ -618,7 +646,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, common_pointer_weak.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan);
+                    entry.common.orphan, this->position_tracker_);
             }
 
             auto base_uri_match{base_uris.find(common_pointer_weak)};
@@ -687,7 +715,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   common_pointer_weak, bases.second.size(),
                   entry.common.dialect, entry.common.base_dialect.value(),
                   common_parent, entry.common.property_name,
-                  entry.common.orphan);
+                  entry.common.orphan, this->position_tracker_);
           }
 
           if (type == AnchorType::Dynamic || type == AnchorType::All) {
@@ -696,7 +724,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   common_pointer_weak, bases.second.size(),
                   entry.common.dialect, entry.common.base_dialect.value(),
                   common_parent, entry.common.property_name,
-                  entry.common.orphan);
+                  entry.common.orphan, this->position_tracker_);
 
             // Register a dynamic anchor as a static anchor if possible too
             if (entry.common.vocabularies.contains(
@@ -706,7 +734,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan, true);
+                    entry.common.orphan, this->position_tracker_, true);
             }
           }
         } else {
@@ -737,7 +765,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan);
+                    entry.common.orphan, this->position_tracker_);
             }
 
             if (type == AnchorType::Dynamic || type == AnchorType::All) {
@@ -747,7 +775,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan);
+                    entry.common.orphan, this->position_tracker_);
 
               if (entry.common.vocabularies.contains(
                       Vocabularies::Known::JSON_Schema_2020_12_Core)) {
@@ -757,7 +785,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                       common_pointer_weak, bases.second.size(),
                       entry.common.dialect, entry.common.base_dialect.value(),
                       common_parent, entry.common.property_name,
-                      entry.common.orphan, true);
+                      entry.common.orphan, this->position_tracker_, true);
               }
             }
 
@@ -861,7 +889,8 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   dialect_for_pointer, current_base_dialect,
                   subschema_it->second.parent,
                   subschema_it->second.property_name,
-                  subschema_it->second.orphan, false, true);
+                  subschema_it->second.orphan, this->position_tracker_, false,
+                  true);
           } else {
             const auto &parent_pointer{combined.dialect_match.has_value()
                                            ? combined.dialect_match->second
@@ -877,7 +906,8 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   SchemaFrame::LocationType::Pointer, std::move(result),
                   base_view, pointer_weak, nearest_base_depth,
                   dialect_for_pointer, current_base_dialect, parent_pointer,
-                  parent_property_name, parent_orphan, false, true);
+                  parent_property_name, parent_orphan, this->position_tracker_,
+                  false, true);
           }
         }
       }

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -267,13 +267,12 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
 }
 
 [[noreturn]]
-auto throw_already_exists_anchor(
+inline auto throw_already_exists_anchor(
     const sourcemeta::core::JSON::String &uri,
     const sourcemeta::core::WeakPointer &collided_anchor,
     const sourcemeta::core::WeakPointer &other_anchor) -> void {
   throw sourcemeta::core::SchemaAnchorCollisionError(
-      uri, "Schema identifier already exists",
-      sourcemeta::core::to_pointer(collided_anchor),
+      uri, sourcemeta::core::to_pointer(collided_anchor),
       sourcemeta::core::to_pointer(other_anchor));
 }
 

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -304,7 +304,7 @@ auto store(sourcemeta::core::SchemaFrame::Locations &frame,
                      .orphan = orphan}});
   if (!ignore_if_present && !inserted) {
     if (entry_type == sourcemeta::core::SchemaFrame::LocationType::Anchor) {
-      throw_already_exists_anchor(uri, pointer_from_root,
+      throw_already_exists_anchor(iterator->first.second, pointer_from_root,
                                   iterator->second.pointer);
     }
     throw_already_exists(iterator->first.second);

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -294,7 +294,7 @@ auto store(sourcemeta::core::SchemaFrame::Locations &frame,
                      .orphan = orphan}});
   if (!ignore_if_present && !inserted) {
     if (entry_type == sourcemeta::core::SchemaFrame::LocationType::Anchor) {
-       throw sourcemeta::core::SchemaAnchorCollisionError(uri, sourcemeta::core::to_pointer(pointer_from_root),
+       throw sourcemeta::core::SchemaAnchorCollisionError(iterator->first.second, sourcemeta::core::to_pointer(pointer_from_root),
       sourcemeta::core::to_pointer(iterator->second.pointer));
     }
     throw_already_exists(iterator->first.second);

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -267,26 +267,28 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
 }
 
 [[noreturn]]
-auto throw_already_exists(const sourcemeta::core::JSON::String &uri,
-                          const std::uint64_t line, const std::uint64_t column)
-    -> void {
-  throw sourcemeta::core::SchemaUriCollisionError(
-      uri, line, column, "Schema identifier already exists");
+auto throw_already_exists_anchor(
+    const sourcemeta::core::JSON::String &uri,
+    const sourcemeta::core::WeakPointer &collided_anchor,
+    const sourcemeta::core::WeakPointer &other_anchor) -> void {
+  throw sourcemeta::core::SchemaAnchorCollisionError(
+      uri, "Schema identifier already exists",
+      sourcemeta::core::to_pointer(collided_anchor),
+      sourcemeta::core::to_pointer(other_anchor));
 }
 
-auto store(
-    sourcemeta::core::SchemaFrame::Locations &frame,
-    const sourcemeta::core::SchemaReferenceType type,
-    const sourcemeta::core::SchemaFrame::LocationType entry_type,
-    sourcemeta::core::JSON::String uri, const std::string_view base,
-    const sourcemeta::core::WeakPointer &pointer_from_root,
-    const std::size_t relative_pointer_offset, const std::string_view dialect,
-    const sourcemeta::core::SchemaBaseDialect base_dialect,
-    const std::optional<sourcemeta::core::WeakPointer> &parent,
-    const bool property_name, const bool orphan,
-    const std::optional<sourcemeta::core::PointerPositionTracker> &tracker,
-    const bool ignore_if_present = false, const bool already_canonical = false)
-    -> void {
+auto store(sourcemeta::core::SchemaFrame::Locations &frame,
+           const sourcemeta::core::SchemaReferenceType type,
+           const sourcemeta::core::SchemaFrame::LocationType entry_type,
+           sourcemeta::core::JSON::String uri, const std::string_view base,
+           const sourcemeta::core::WeakPointer &pointer_from_root,
+           const std::size_t relative_pointer_offset,
+           const std::string_view dialect,
+           const sourcemeta::core::SchemaBaseDialect base_dialect,
+           const std::optional<sourcemeta::core::WeakPointer> &parent,
+           const bool property_name, const bool orphan,
+           const bool ignore_if_present = false,
+           const bool already_canonical = false) -> void {
   auto canonical{already_canonical ? std::move(uri)
                                    : sourcemeta::core::URI::canonicalize(uri)};
   auto [iterator, inserted] =
@@ -301,14 +303,10 @@ auto store(
                      .property_name = property_name,
                      .orphan = orphan}});
   if (!ignore_if_present && !inserted) {
-    if (tracker) {
-      const auto position =
-          tracker->get(sourcemeta::core::to_pointer(pointer_from_root));
-      throw_already_exists(iterator->first.second,
-                           std::get<0>(position.value()),
-                           std::get<1>(position.value()));
+    if (entry_type == sourcemeta::core::SchemaFrame::LocationType::Anchor) {
+      throw_already_exists_anchor(uri, pointer_from_root,
+                                  iterator->second.pointer);
     }
-
     throw_already_exists(iterator->first.second);
   }
 
@@ -447,10 +445,6 @@ auto SchemaFrame::to_json(
   return root;
 }
 
-auto SchemaFrame::add_tracker(const PointerPositionTracker &tracker) -> void {
-  this->position_tracker_ = tracker;
-}
-
 auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                           const SchemaResolver &resolver,
                           std::string_view default_dialect,
@@ -520,8 +514,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
       store(this->locations_, SchemaReferenceType::Static,
             SchemaFrame::LocationType::Resource, default_id_canonical,
             this->root_, path, path.size(), root_dialect,
-            root_base_dialect.value(), std::nullopt, false, false,
-            this->position_tracker_);
+            root_base_dialect.value(), std::nullopt, false, false);
 
       base_uris.insert({path, {root_id.value(), default_id_canonical}});
     }
@@ -628,12 +621,6 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                 this->locations_.find({SchemaReferenceType::Static, new_id})};
             if (maybe_match != this->locations_.cend() &&
                 maybe_match->second.pointer != common_pointer_weak) {
-              if (this->position_tracker_) {
-                const auto position =
-                    position_tracker_->get(to_pointer(common_pointer_weak));
-                throw_already_exists(new_id, std::get<0>(position.value()),
-                                     std::get<1>(position.value()));
-              }
               throw_already_exists(new_id);
             }
 
@@ -646,7 +633,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, common_pointer_weak.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan, this->position_tracker_);
+                    entry.common.orphan);
             }
 
             auto base_uri_match{base_uris.find(common_pointer_weak)};
@@ -715,7 +702,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   common_pointer_weak, bases.second.size(),
                   entry.common.dialect, entry.common.base_dialect.value(),
                   common_parent, entry.common.property_name,
-                  entry.common.orphan, this->position_tracker_);
+                  entry.common.orphan);
           }
 
           if (type == AnchorType::Dynamic || type == AnchorType::All) {
@@ -724,7 +711,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   common_pointer_weak, bases.second.size(),
                   entry.common.dialect, entry.common.base_dialect.value(),
                   common_parent, entry.common.property_name,
-                  entry.common.orphan, this->position_tracker_);
+                  entry.common.orphan);
 
             // Register a dynamic anchor as a static anchor if possible too
             if (entry.common.vocabularies.contains(
@@ -734,7 +721,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan, this->position_tracker_, true);
+                    entry.common.orphan, true);
             }
           }
         } else {
@@ -765,7 +752,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan, this->position_tracker_);
+                    entry.common.orphan);
             }
 
             if (type == AnchorType::Dynamic || type == AnchorType::All) {
@@ -775,7 +762,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                     common_pointer_weak, bases.second.size(),
                     entry.common.dialect, entry.common.base_dialect.value(),
                     common_parent, entry.common.property_name,
-                    entry.common.orphan, this->position_tracker_);
+                    entry.common.orphan);
 
               if (entry.common.vocabularies.contains(
                       Vocabularies::Known::JSON_Schema_2020_12_Core)) {
@@ -785,7 +772,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                       common_pointer_weak, bases.second.size(),
                       entry.common.dialect, entry.common.base_dialect.value(),
                       common_parent, entry.common.property_name,
-                      entry.common.orphan, this->position_tracker_, true);
+                      entry.common.orphan, true);
               }
             }
 
@@ -889,8 +876,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   dialect_for_pointer, current_base_dialect,
                   subschema_it->second.parent,
                   subschema_it->second.property_name,
-                  subschema_it->second.orphan, this->position_tracker_, false,
-                  true);
+                  subschema_it->second.orphan, false, true);
           } else {
             const auto &parent_pointer{combined.dialect_match.has_value()
                                            ? combined.dialect_match->second
@@ -906,8 +892,7 @@ auto SchemaFrame::analyse(const JSON &root, const SchemaWalker &walker,
                   SchemaFrame::LocationType::Pointer, std::move(result),
                   base_view, pointer_weak, nearest_base_depth,
                   dialect_for_pointer, current_base_dialect, parent_pointer,
-                  parent_property_name, parent_orphan, this->position_tracker_,
-                  false, true);
+                  parent_property_name, parent_orphan, false, true);
           }
         }
       }

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -266,15 +266,6 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
                                            "Schema identifier already exists");
 }
 
-[[noreturn]]
-inline auto throw_already_exists_anchor(
-    const sourcemeta::core::JSON::String &uri,
-    const sourcemeta::core::WeakPointer &collided_anchor,
-    const sourcemeta::core::WeakPointer &other_anchor) -> void {
-  throw sourcemeta::core::SchemaAnchorCollisionError(
-      uri, sourcemeta::core::to_pointer(collided_anchor),
-      sourcemeta::core::to_pointer(other_anchor));
-}
 
 auto store(sourcemeta::core::SchemaFrame::Locations &frame,
            const sourcemeta::core::SchemaReferenceType type,
@@ -303,8 +294,8 @@ auto store(sourcemeta::core::SchemaFrame::Locations &frame,
                      .orphan = orphan}});
   if (!ignore_if_present && !inserted) {
     if (entry_type == sourcemeta::core::SchemaFrame::LocationType::Anchor) {
-      throw_already_exists_anchor(iterator->first.second, pointer_from_root,
-                                  iterator->second.pointer);
+       throw sourcemeta::core::SchemaAnchorCollisionError(uri, sourcemeta::core::to_pointer(pointer_from_root),
+      sourcemeta::core::to_pointer(iterator->second.pointer));
     }
     throw_already_exists(iterator->first.second);
   }

--- a/src/core/jsonschema/frame.cc
+++ b/src/core/jsonschema/frame.cc
@@ -266,7 +266,6 @@ auto throw_already_exists(const sourcemeta::core::JSON::String &uri) -> void {
                                            "Schema identifier already exists");
 }
 
-
 auto store(sourcemeta::core::SchemaFrame::Locations &frame,
            const sourcemeta::core::SchemaReferenceType type,
            const sourcemeta::core::SchemaFrame::LocationType entry_type,
@@ -294,8 +293,10 @@ auto store(sourcemeta::core::SchemaFrame::Locations &frame,
                      .orphan = orphan}});
   if (!ignore_if_present && !inserted) {
     if (entry_type == sourcemeta::core::SchemaFrame::LocationType::Anchor) {
-       throw sourcemeta::core::SchemaAnchorCollisionError(iterator->first.second, sourcemeta::core::to_pointer(pointer_from_root),
-      sourcemeta::core::to_pointer(iterator->second.pointer));
+      throw sourcemeta::core::SchemaAnchorCollisionError(
+          iterator->first.second,
+          sourcemeta::core::to_pointer(pointer_from_root),
+          sourcemeta::core::to_pointer(iterator->second.pointer));
     }
     throw_already_exists(iterator->first.second);
   }

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -237,6 +237,40 @@ private:
   const char *message_;
 };
 
+/// @ingroup jsonschema
+/// An error that represents a schema Uri Collision error
+class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaUriCollisionError
+    : public std::exception {
+public:
+  SchemaUriCollisionError(const std::string_view identifier,
+                          const std::uint64_t line, const std::uint64_t column,
+                          const char *message)
+      : identifier_{identifier}, message_{message}, line_{line},
+        column_{column} {}
+
+  [[nodiscard]] auto what() const noexcept -> const char * override {
+    return this->message_;
+  }
+
+  [[nodiscard]] auto identifier() const noexcept -> std::string_view {
+    return this->identifier_;
+  }
+
+  [[nodiscard]] auto line() const noexcept -> std::uint64_t {
+    return this->line_;
+  }
+
+  [[nodiscard]] auto column() const noexcept -> std::uint64_t {
+    return this->column_;
+  }
+
+private:
+  std::string identifier_;
+  const char *message_;
+  std::uint64_t line_;
+  std::uint64_t column_;
+};
+
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -248,7 +248,7 @@ public:
         other_(std::move(other)) {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
-    return "Schema identifier already exists";
+    return "Schema anchor already exists";
   }
 
   [[nodiscard]] auto identifier() const noexcept -> std::string_view {

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -238,19 +238,17 @@ private:
 };
 
 /// @ingroup jsonschema
-/// An error that represents a schema Uri Collision error
+/// An error that represents a schema anchor collision error
 class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaAnchorCollisionError
     : public std::exception {
 public:
   SchemaAnchorCollisionError(const std::string_view identifier,
-                             const char *message, Pointer collision_location,
-                             Pointer other)
-      : identifier_{identifier}, message_{message},
-        collision_location_(std::move(collision_location)),
+                             Pointer location, Pointer other)
+      : identifier_{identifier}, location_(std::move(location)),
         other_(std::move(other)) {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
-    return this->message_;
+    return "Schema identifier already exists";
   }
 
   [[nodiscard]] auto identifier() const noexcept -> std::string_view {
@@ -258,18 +256,17 @@ public:
   }
 
   [[nodiscard]] auto location() const noexcept -> const Pointer & {
-    return collision_location_;
+    return this->location_;
   }
 
   [[nodiscard]] auto other() const noexcept -> const Pointer & {
-    return other_;
+    return this->other_;
   }
 
 private:
   std::string identifier_;
-  const char *message_;
-  Pointer collision_location_;
-  Pointer other_; // where the first anchor appeared
+  Pointer location_;
+  Pointer other_;
 };
 
 #if defined(_MSC_VER)

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_error.h
@@ -239,14 +239,15 @@ private:
 
 /// @ingroup jsonschema
 /// An error that represents a schema Uri Collision error
-class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaUriCollisionError
+class SOURCEMETA_CORE_JSONSCHEMA_EXPORT SchemaAnchorCollisionError
     : public std::exception {
 public:
-  SchemaUriCollisionError(const std::string_view identifier,
-                          const std::uint64_t line, const std::uint64_t column,
-                          const char *message)
-      : identifier_{identifier}, message_{message}, line_{line},
-        column_{column} {}
+  SchemaAnchorCollisionError(const std::string_view identifier,
+                             const char *message, Pointer collision_location,
+                             Pointer other)
+      : identifier_{identifier}, message_{message},
+        collision_location_(std::move(collision_location)),
+        other_(std::move(other)) {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return this->message_;
@@ -256,19 +257,19 @@ public:
     return this->identifier_;
   }
 
-  [[nodiscard]] auto line() const noexcept -> std::uint64_t {
-    return this->line_;
+  [[nodiscard]] auto location() const noexcept -> const Pointer & {
+    return collision_location_;
   }
 
-  [[nodiscard]] auto column() const noexcept -> std::uint64_t {
-    return this->column_;
+  [[nodiscard]] auto other() const noexcept -> const Pointer & {
+    return other_;
   }
 
 private:
   std::string identifier_;
   const char *message_;
-  std::uint64_t line_;
-  std::uint64_t column_;
+  Pointer collision_location_;
+  Pointer other_; // where the first anchor appeared
 };
 
 #if defined(_MSC_VER)

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
@@ -154,6 +154,8 @@ public:
                std::string_view default_id = "",
                const Paths &paths = {empty_weak_pointer}) -> void;
 
+  auto add_tracker(const PointerPositionTracker &tracker) -> void;
+
   /// Access the analysed schema locations
   [[nodiscard]] auto locations() const noexcept -> const Locations &;
 
@@ -272,6 +274,7 @@ private:
   JSON::String root_;
   Locations locations_;
   References references_;
+  std::optional<PointerPositionTracker> position_tracker_;
   mutable std::unordered_map<std::reference_wrapper<const WeakPointer>,
                              std::vector<const Location *>, WeakPointer::Hasher,
                              WeakPointer::Comparator>

--- a/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
+++ b/src/core/jsonschema/include/sourcemeta/core/jsonschema_frame.h
@@ -154,8 +154,6 @@ public:
                std::string_view default_id = "",
                const Paths &paths = {empty_weak_pointer}) -> void;
 
-  auto add_tracker(const PointerPositionTracker &tracker) -> void;
-
   /// Access the analysed schema locations
   [[nodiscard]] auto locations() const noexcept -> const Locations &;
 
@@ -274,7 +272,6 @@ private:
   JSON::String root_;
   Locations locations_;
   References references_;
-  std::optional<PointerPositionTracker> position_tracker_;
   mutable std::unordered_map<std::reference_wrapper<const WeakPointer>,
                              std::vector<const Location *>, WeakPointer::Hasher,
                              WeakPointer::Comparator>

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -815,7 +815,7 @@ TEST(JSONSchema_frame_2019_09, static_anchor_override) {
       sourcemeta::core::SchemaFrame::Mode::References};
   EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
                              sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaFrameError);
+               sourcemeta::core::SchemaAnchorCollisionError);
 }
 
 TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
@@ -2233,7 +2233,7 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_conflict) {
       sourcemeta::core::SchemaFrame::Mode::References};
   EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
                              sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaFrameError);
+               sourcemeta::core::SchemaAnchorCollisionError);
 }
 
 TEST(JSONSchema_frame_2019_09, invalid_recursive_ref) {

--- a/test/jsonschema/jsonschema_frame_2019_09_test.cc
+++ b/test/jsonschema/jsonschema_frame_2019_09_test.cc
@@ -813,9 +813,17 @@ TEST(JSONSchema_frame_2019_09, static_anchor_override) {
 
   sourcemeta::core::SchemaFrame frame{
       sourcemeta::core::SchemaFrame::Mode::References};
-  EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
-                             sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaAnchorCollisionError);
+  try {
+    frame.analyse(document, sourcemeta::core::schema_walker,
+                  sourcemeta::core::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::core::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/items");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST(JSONSchema_frame_2019_09, explicit_argument_id_same) {
@@ -2231,9 +2239,17 @@ TEST(JSONSchema_frame_2019_09, recursive_anchor_conflict) {
 
   sourcemeta::core::SchemaFrame frame{
       sourcemeta::core::SchemaFrame::Mode::References};
-  EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
-                             sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaAnchorCollisionError);
+  try {
+    frame.analyse(document, sourcemeta::core::schema_walker,
+                  sourcemeta::core::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::core::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/items");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST(JSONSchema_frame_2019_09, invalid_recursive_ref) {

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -851,7 +851,7 @@ TEST(JSONSchema_frame_2020_12, static_anchor_override) {
       sourcemeta::core::SchemaFrame::Mode::References};
   EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
                              sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaFrameError);
+               sourcemeta::core::SchemaAnchorCollisionError);
 }
 
 TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
@@ -2707,7 +2707,7 @@ TEST(JSONSchema_frame_2020_12, dynamic_anchor_same_on_schema_resource) {
       sourcemeta::core::SchemaFrame::Mode::References};
   EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
                              sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaFrameError);
+               sourcemeta::core::SchemaAnchorCollisionError);
 }
 
 TEST(JSONSchema_frame_2020_12, no_id_recursive_empty_pointer) {
@@ -4826,7 +4826,7 @@ TEST(JSONSchema_frame_2020_12, multiple_nested_same_anonymous_anchors) {
                              "https://json-schema.org/draft/2020-12/schema", "",
                              {sourcemeta::core::to_weak_pointer(path1),
                               sourcemeta::core::to_weak_pointer(path2)}),
-               sourcemeta::core::SchemaFrameError);
+               sourcemeta::core::SchemaAnchorCollisionError);
 }
 
 TEST(JSONSchema_frame_2020_12, multiple_nested_with_default_id) {

--- a/test/jsonschema/jsonschema_frame_2020_12_test.cc
+++ b/test/jsonschema/jsonschema_frame_2020_12_test.cc
@@ -849,9 +849,17 @@ TEST(JSONSchema_frame_2020_12, static_anchor_override) {
 
   sourcemeta::core::SchemaFrame frame{
       sourcemeta::core::SchemaFrame::Mode::References};
-  EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
-                             sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaAnchorCollisionError);
+  try {
+    frame.analyse(document, sourcemeta::core::schema_walker,
+                  sourcemeta::core::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::core::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/items");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST(JSONSchema_frame_2020_12, explicit_argument_id_same) {
@@ -2705,9 +2713,17 @@ TEST(JSONSchema_frame_2020_12, dynamic_anchor_same_on_schema_resource) {
 
   sourcemeta::core::SchemaFrame frame{
       sourcemeta::core::SchemaFrame::Mode::References};
-  EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
-                             sourcemeta::core::schema_resolver),
-               sourcemeta::core::SchemaAnchorCollisionError);
+  try {
+    frame.analyse(document, sourcemeta::core::schema_walker,
+                  sourcemeta::core::schema_resolver);
+    FAIL();
+  } catch (sourcemeta::core::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "https://www.sourcemeta.com/schema#foo");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/items");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST(JSONSchema_frame_2020_12, no_id_recursive_empty_pointer) {
@@ -4821,12 +4837,20 @@ TEST(JSONSchema_frame_2020_12, multiple_nested_same_anonymous_anchors) {
   const sourcemeta::core::Pointer path1{"common", "foo"};
   const sourcemeta::core::Pointer path2{"common", "bar"};
 
-  EXPECT_THROW(frame.analyse(document, sourcemeta::core::schema_walker,
-                             sourcemeta::core::schema_resolver,
-                             "https://json-schema.org/draft/2020-12/schema", "",
-                             {sourcemeta::core::to_weak_pointer(path1),
-                              sourcemeta::core::to_weak_pointer(path2)}),
-               sourcemeta::core::SchemaAnchorCollisionError);
+  try {
+    frame.analyse(document, sourcemeta::core::schema_walker,
+                  sourcemeta::core::schema_resolver,
+                  "https://json-schema.org/draft/2020-12/schema", "",
+                  {sourcemeta::core::to_weak_pointer(path1),
+                   sourcemeta::core::to_weak_pointer(path2)});
+    FAIL();
+  } catch (sourcemeta::core::SchemaAnchorCollisionError &error) {
+    EXPECT_EQ(error.identifier(), "#test");
+    EXPECT_EQ(sourcemeta::core::to_string(error.location()), "/common/bar");
+    EXPECT_EQ(sourcemeta::core::to_string(error.other()), "/common/foo");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST(JSONSchema_frame_2020_12, multiple_nested_with_default_id) {


### PR DESCRIPTION
this helps to solve https://github.com/sourcemeta/jsonschema/issues/321
i have used the `PositionTracker` to get the line and column, Im not sure if there is another way to do the same thing
i think (if thats the right direction to solve this) that we might need to refactor the `to_json` so it uses the internal `PositionTracker` instead  
i will start writing some unit tests just want to make sure that this is the right direction 
