### PR TITLE
Fix LibDeflate sudden ARM issues on GitHub Actions

### DIFF
--- a/cmake/FindLibDeflate.cmake
+++ b/cmake/FindLibDeflate.cmake
@@ -26,6 +26,29 @@ if(NOT LibDeflate_FOUND)
   add_library(libdeflate STATIC ${LIBDEFLATE_SOURCES})
   sourcemeta_add_default_options(PRIVATE libdeflate)
 
+  # Check if the assembler supports ARM dot-product (udot) instructions.
+  # GCC 14+ assumes binutils is new enough, but some CI environments
+  # pair GCC 14 with older binutils that lack udot support
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+    include(CheckCSourceCompiles)
+    set(CMAKE_REQUIRED_FLAGS "-march=armv8.2-a+dotprod")
+    check_c_source_compiles("
+      #include <arm_neon.h>
+      int main(void) {
+        uint32x4_t a = vdupq_n_u32(0);
+        uint8x16_t b = vdupq_n_u8(0);
+        uint8x16_t c = vdupq_n_u8(0);
+        a = vdotq_u32(a, b, c);
+        return 0;
+      }
+    " LIBDEFLATE_HAS_DOTPROD_ASSEMBLER)
+    unset(CMAKE_REQUIRED_FLAGS)
+    if(NOT LIBDEFLATE_HAS_DOTPROD_ASSEMBLER)
+      target_compile_definitions(libdeflate PRIVATE
+        LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_DOTPROD)
+    endif()
+  endif()
+
   target_include_directories(libdeflate PUBLIC
     "$<BUILD_INTERFACE:${LIBDEFLATE_DIR}>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")

--- a/cmake/FindLibDeflate.cmake
+++ b/cmake/FindLibDeflate.cmake
@@ -31,7 +31,8 @@ if(NOT LibDeflate_FOUND)
   # pair GCC 14 with older binutils that lack udot support
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
     include(CheckCSourceCompiles)
-    set(CMAKE_REQUIRED_FLAGS "-march=armv8.2-a+dotprod")
+    set(LIBDEFLATE_SAVED_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -march=armv8.2-a+dotprod")
     check_c_source_compiles("
       #include <arm_neon.h>
       int main(void) {
@@ -42,7 +43,7 @@ if(NOT LibDeflate_FOUND)
         return 0;
       }
     " LIBDEFLATE_HAS_DOTPROD_ASSEMBLER)
-    unset(CMAKE_REQUIRED_FLAGS)
+    set(CMAKE_REQUIRED_FLAGS "${LIBDEFLATE_SAVED_CMAKE_REQUIRED_FLAGS}")
     if(NOT LIBDEFLATE_HAS_DOTPROD_ASSEMBLER)
       target_compile_definitions(libdeflate PRIVATE
         LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_DOTPROD)


### PR DESCRIPTION
```
/tmp/ccXubsJM.s: Assembler messages:
/tmp/ccXubsJM.s:1253: Error: selected processor does not support `udot v18.4s,v25.16b,v23.16b'
/tmp/ccXubsJM.s:1254: Error: selected processor does not support `udot v30.4s,v25.16b,v19.16b'
/tmp/ccXubsJM.s:1255: Error: selected processor does not support `udot v17.4s,v26.16b,v23.16b'
/tmp/ccXubsJM.s:1256: Error: selected processor does not support `udot v24.4s,v26.16b,v20.16b'
/tmp/ccXubsJM.s:1261: Error: selected processor does not support `udot v6.4s,v0.16b,v23.16b'
/tmp/ccXubsJM.s:1262: Error: selected processor does not support `udot v7.4s,v16.16b,v23.16b'
/tmp/ccXubsJM.s:1263: Error: selected processor does not support `udot v25.4s,v0.16b,v21.16b'
/tmp/ccXubsJM.s:1264: Error: selected processor does not support `udot v26.4s,v16.16b,v22.16b'
/tmp/ccXubsJM.s:1267: Error: selected processor does not support `udot v30.4s,v3.16b,v19.16b'
/tmp/ccXubsJM.s:1268: Error: selected processor does not support `udot v24.4s,v4.16b,v20.16b'
/tmp/ccXubsJM.s:1270: Error: selected processor does not support `udot v25.4s,v5.16b,v21.16b'
/tmp/ccXubsJM.s:1271: Error: selected processor does not support `udot v26.4s,v1.16b,v22.16b'
/tmp/ccXubsJM.s:1274: Error: selected processor does not support `udot v18.4s,v3.16b,v23.16b'
/tmp/ccXubsJM.s:1276: Error: selected processor does not support `udot v17.4s,v4.16b,v23.16b'
/tmp/ccXubsJM.s:1278: Error: selected processor does not support `udot v6.4s,v5.16b,v23.16b'
/tmp/ccXubsJM.s:1280: Error: selected processor does not support `udot v7.4s,v1.16b,v23.16b'
/tmp/ccXubsJM.s:1283: Error: selected processor does not support `udot v30.4s,v2.16b,v19.16b'
/tmp/ccXubsJM.s:1284: Error: selected processor does not support `udot v24.4s,v0.16b,v20.16b'
/tmp/ccXubsJM.s:1286: Error: selected processor does not support `udot v25.4s,v3.16b,v21.16b'
/tmp/ccXubsJM.s:1287: Error: selected processor does not support `udot v26.4s,v16.16b,v22.16b'
/tmp/ccXubsJM.s:1290: Error: selected processor does not support `udot v18.4s,v2.16b,v23.16b'
/tmp/ccXubsJM.s:1292: Error: selected processor does not support `udot v17.4s,v0.16b,v23.16b'
/tmp/ccXubsJM.s:1294: Error: selected processor does not support `udot v6.4s,v3.16b,v23.16b'
/tmp/ccXubsJM.s:1296: Error: selected processor does not support `udot v7.4s,v16.16b,v23.16b'
/tmp/ccXubsJM.s:1309: Error: selected processor does not support `udot v18.4s,v4.16b,v23.16b'
/tmp/ccXubsJM.s:1310: Error: selected processor does not support `udot v17.4s,v5.16b,v23.16b'
/tmp/ccXubsJM.s:1311: Error: selected processor does not support `udot v24.4s,v5.16b,v20.16b'
/tmp/ccXubsJM.s:1312: Error: selected processor does not support `udot v30.4s,v4.16b,v19.16b'
/tmp/ccXubsJM.s:1314: Error: selected processor does not support `udot v7.4s,v28.16b,v23.16b'
/tmp/ccXubsJM.s:1315: Error: selected processor does not support `udot v25.4s,v3.16b,v21.16b'
/tmp/ccXubsJM.s:1316: Error: selected processor does not support `udot v16.4s,v3.16b,v23.16b'
/tmp/ccXubsJM.s:1317: Error: selected processor does not support `udot v26.4s,v28.16b,v22.16b'
/tmp/ccXubsJM.s:1326: Error: selected processor does not support `udot v17.4s,v7.16b,v23.16b'
/tmp/ccXubsJM.s:1327: Error: selected processor does not support `udot v24.4s,v7.16b,v20.16b'
/tmp/ccXubsJM.s:1328: Error: selected processor does not support `udot v16.4s,v2.16b,v23.16b'
/tmp/ccXubsJM.s:1329: Error: selected processor does not support `udot v25.4s,v2.16b,v21.16b'
/tmp/ccXubsJM.s:1331: Error: selected processor does not support `udot v29.4s,v18.16b,v23.16b'
/tmp/ccXubsJM.s:1332: Error: selected processor does not support `udot v30.4s,v18.16b,v19.16b'
/tmp/ccXubsJM.s:1335: Error: selected processor does not support `udot v24.4s,v6.16b,v20.16b'
/tmp/ccXubsJM.s:1336: Error: selected processor does not support `udot v25.4s,v7.16b,v21.16b'
/tmp/ccXubsJM.s:1338: Error: selected processor does not support `udot v17.4s,v6.16b,v23.16b'
/tmp/ccXubsJM.s:1340: Error: selected processor does not support `udot v16.4s,v7.16b,v23.16b'
/tmp/ccXubsJM.s:1343: Error: selected processor does not support `udot v3.4s,v0.16b,v23.16b'
/tmp/ccXubsJM.s:1344: Error: selected processor does not support `udot v26.4s,v0.16b,v22.16b'
/tmp/ccXubsJM.s:1345: Error: selected processor does not support `udot v29.4s,v4.16b,v23.16b'
/tmp/ccXubsJM.s:1346: Error: selected processor does not support `udot v30.4s,v4.16b,v19.16b'
/tmp/ccXubsJM.s:1348: Error: selected processor does not support `udot v25.4s,v18.16b,v21.16b'
/tmp/ccXubsJM.s:1349: Error: selected processor does not support `udot v24.4s,v0.16b,v20.16b'
/tmp/ccXubsJM.s:1350: Error: selected processor does not support `udot v6.4s,v18.16b,v23.16b'
/tmp/ccXubsJM.s:1353: Error: selected processor does not support `udot v17.4s,v0.16b,v23.16b'
/tmp/ccXubsJM.s:1357: Error: selected processor does not support `udot v3.4s,v16.16b,v23.16b'
/tmp/ccXubsJM.s:1358: Error: selected processor does not support `udot v26.4s,v16.16b,v22.16b'
/tmp/ccXubsJM.s:1361: Error: selected processor does not support `udot v30.4s,v1.16b,v19.16b'
/tmp/ccXubsJM.s:1362: Error: selected processor does not support `udot v18.4s,v1.16b,v23.16b'
/tmp/ccXubsJM.s:1365: Error: selected processor does not support `udot v7.4s,v3.16b,v23.16b'
/tmp/ccXubsJM.s:1366: Error: selected processor does not support `udot v26.4s,v3.16b,v22.16b'
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
