### PR TITLE
Support `{/path*}` segments in the URI Template router

### DIFF
--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -30,8 +30,18 @@ namespace sourcemeta::core {
 
 /// @ingroup uritemplate
 /// A URI Template path router. Keep in mind that the URI Template specification
-/// DOES NOT define expansion. So this is an opinionated non-standard adaptation
-/// of URI Template for path routing purposes
+/// DOES NOT define matching, only expansion. So this is an opinionated
+/// non-standard adaptation of URI Template for path routing purposes. The
+/// supported operators are:
+///
+/// - `{var}` for a single path segment (RFC 6570 Level 1 simple expansion)
+/// - `{+var}` for greedy capture to the end of the path, requiring at least
+///   one trailing segment (RFC 6570 Level 2 reserved expansion)
+/// - `{/var*}` for optional greedy capture to the end of the path, where
+///   zero trailing segments are also allowed (RFC 6570 Level 3 path-segment
+///   operator with Level 4 explode modifier). Must be the last component of
+///   the template. The captured value is empty when no trailing segments
+///   are present
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateRouter {
   friend class URITemplateRouterView;
 
@@ -51,12 +61,15 @@ public:
   using ArgumentCallback =
       std::function<void(std::string_view, const ArgumentValue &)>;
 
-  /// The type of a node in the router trie
+  /// The type of a node in the router trie. The numeric values of
+  /// `Expansion` and `OptionalExpansion` are deliberately adjacent so the
+  /// hot match path can test both with a single comparison
   enum class NodeType : std::uint8_t {
     Root = 0,
     Literal = 1,
     Variable = 2,
-    Expansion = 3
+    Expansion = 3,
+    OptionalExpansion = 4
   };
 
   /// A node in the router trie

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -61,9 +61,7 @@ public:
   using ArgumentCallback =
       std::function<void(std::string_view, const ArgumentValue &)>;
 
-  /// The type of a node in the router trie. The numeric values of
-  /// `Expansion` and `OptionalExpansion` are deliberately adjacent so the
-  /// hot match path can test both with a single comparison
+  /// The type of a node in the router trie
   enum class NodeType : std::uint8_t {
     Root = 0,
     Literal = 1,

--- a/src/core/uritemplate/uritemplate_router.cc
+++ b/src/core/uritemplate/uritemplate_router.cc
@@ -410,7 +410,7 @@ auto URITemplateRouter::add(const std::string_view uri_template,
 
       if (is_expansion_type(type) && position < end) {
         throw URITemplateRouterInvalidSegmentError{
-            "Reserved expansion must be the last segment", expression};
+            "Expansion operator must be the last segment", expression};
       }
 
       auto &variable = current ? current->variable : this->root_.variable;
@@ -569,7 +569,7 @@ auto URITemplateRouter::match(const std::string_view path,
     } else if (*variable_child) {
       assert(variable_index <=
              std::numeric_limits<URITemplateRouter::Index>::max());
-      if ((*variable_child)->type >= NodeType::Expansion) {
+      if (is_expansion_type((*variable_child)->type)) {
         const std::string_view remaining{
             segment_start, static_cast<std::size_t>(path_end - segment_start)};
         callback(static_cast<URITemplateRouter::Index>(variable_index),

--- a/src/core/uritemplate/uritemplate_router.cc
+++ b/src/core/uritemplate/uritemplate_router.cc
@@ -45,9 +45,15 @@ auto find_or_create_literal_child(std::vector<std::unique_ptr<Node>> &literals,
   return result;
 }
 
+inline auto is_expansion_type(const NodeType type) noexcept -> bool {
+  return type == NodeType::Expansion || type == NodeType::OptionalExpansion;
+}
+
 auto find_or_create_variable_child(std::unique_ptr<Node> &variable,
                                    const std::string_view name,
-                                   const NodeType type) -> Node * {
+                                   const NodeType type,
+                                   const std::string_view expression)
+    -> Node * {
   if (!variable) {
     variable = std::make_unique<Node>();
     variable->type = type;
@@ -59,12 +65,19 @@ auto find_or_create_variable_child(std::unique_ptr<Node> &variable,
     throw URITemplateRouterVariableMismatchError{variable->value, name};
   }
 
-  if (type == NodeType::Expansion) {
+  if (is_expansion_type(variable->type) && is_expansion_type(type) &&
+      variable->type != type) {
+    throw URITemplateRouterInvalidSegmentError{
+        "Conflicting expansion operators on the same path position",
+        expression};
+  }
+
+  if (is_expansion_type(type)) {
     if (variable->type == NodeType::Variable) {
-      variable->type = NodeType::Expansion;
+      variable->type = type;
       return variable.get();
     }
-  } else if (variable->type == NodeType::Expansion) {
+  } else if (is_expansion_type(variable->type)) {
     return nullptr;
   }
 
@@ -296,8 +309,16 @@ auto URITemplateRouter::add(const std::string_view uri_template,
       }
 
       NodeType type = NodeType::Variable;
+      bool path_segment_operator = false;
       if (*position == '+') {
         type = NodeType::Expansion;
+        ++position;
+        if (position >= end || *position == '}') {
+          throw URITemplateRouterInvalidSegmentError{"Empty variable name",
+                                                     expression};
+        }
+      } else if (*position == '/') {
+        path_segment_operator = true;
         ++position;
         if (position >= end || *position == '}') {
           throw URITemplateRouterInvalidSegmentError{"Empty variable name",
@@ -335,6 +356,8 @@ auto URITemplateRouter::add(const std::string_view uri_template,
                                                    expression};
       }
 
+      const char *const varname_end = position;
+
       if (*position == ' ') {
         throw URITemplateRouterInvalidSegmentError{
             "Space in variable expression", expression};
@@ -346,8 +369,25 @@ auto URITemplateRouter::add(const std::string_view uri_template,
       }
 
       if (*position == '*') {
+        if (!path_segment_operator) {
+          throw URITemplateRouterInvalidSegmentError{
+              "Explode modifier not supported", expression};
+        }
+        if (varname_end == varname_start) {
+          throw URITemplateRouterInvalidSegmentError{"Empty variable name",
+                                                     expression};
+        }
+        type = NodeType::OptionalExpansion;
+        ++position;
+        if (position >= end || *position != '}') {
+          throw URITemplateRouterInvalidSegmentError{
+              "Unexpected characters after explode modifier", expression};
+        }
+      } else if (path_segment_operator) {
         throw URITemplateRouterInvalidSegmentError{
-            "Explode modifier not supported", expression};
+            "Path-segment expansion without the explode modifier is not "
+            "supported",
+            expression};
       }
 
       if (*position == ',') {
@@ -356,23 +396,26 @@ auto URITemplateRouter::add(const std::string_view uri_template,
       }
 
       const std::string_view varname{
-          varname_start, static_cast<std::size_t>(position - varname_start)};
+          varname_start, static_cast<std::size_t>(varname_end - varname_start)};
 
       ++position; // skip '}'
 
       if (position < end && *position != '/') {
-        throw URITemplateRouterInvalidSegmentError{
-            "Path segment cannot mix literals and variables",
-            extract_segment(expression_start, end)};
+        if (*position != '{' || position + 1 >= end || *(position + 1) != '/') {
+          throw URITemplateRouterInvalidSegmentError{
+              "Path segment cannot mix literals and variables",
+              extract_segment(expression_start, end)};
+        }
       }
 
-      if (type == NodeType::Expansion && position < end) {
+      if (is_expansion_type(type) && position < end) {
         throw URITemplateRouterInvalidSegmentError{
             "Reserved expansion must be the last segment", expression};
       }
 
       auto &variable = current ? current->variable : this->root_.variable;
-      auto *result = find_or_create_variable_child(variable, varname, type);
+      auto *result =
+          find_or_create_variable_child(variable, varname, type, expression);
       if (result == nullptr) {
         absorbed = true;
       } else {
@@ -388,6 +431,14 @@ auto URITemplateRouter::add(const std::string_view uri_template,
       }
 
       if (position < end && *position == '{') {
+        if (position + 1 < end && *(position + 1) == '/') {
+          const std::string_view segment{
+              segment_start,
+              static_cast<std::size_t>(position - segment_start)};
+          auto &literals = current ? current->literals : this->root_.literals;
+          current = &find_or_create_literal_child(literals, segment);
+          continue;
+        }
         const char *expr_end = find_expression_end(position, end);
         const char *seg_end = expr_end;
         while (seg_end < end && *seg_end != '/') {
@@ -518,7 +569,7 @@ auto URITemplateRouter::match(const std::string_view path,
     } else if (*variable_child) {
       assert(variable_index <=
              std::numeric_limits<URITemplateRouter::Index>::max());
-      if ((*variable_child)->type == NodeType::Expansion) {
+      if ((*variable_child)->type >= NodeType::Expansion) {
         const std::string_view remaining{
             segment_start, static_cast<std::size_t>(path_end - segment_start)};
         callback(static_cast<URITemplateRouter::Index>(variable_index),
@@ -544,6 +595,16 @@ auto URITemplateRouter::match(const std::string_view path,
 
     // Skip the slash and continue to next segment
     ++position;
+  }
+
+  if (current && current->identifier == 0 && current->variable &&
+      current->variable->type == NodeType::OptionalExpansion) {
+    assert(variable_index <=
+           std::numeric_limits<URITemplateRouter::Index>::max());
+    callback(static_cast<URITemplateRouter::Index>(variable_index),
+             current->variable->value, std::string_view{});
+    return finalize_match(this->otherwise_, current->variable->identifier,
+                          current->variable->context);
   }
 
   return current ? finalize_match(this->otherwise_, current->identifier,

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -519,8 +519,8 @@ auto URITemplateRouterView::match(
       }
 
       // Check if this is an expansion (catch-all) or optional expansion.
-      // Both behave identically mid-path; the type ordering lets us use a
-      // single comparison on the hot path
+      // Both behave identically mid-path, and the type ordering lets us
+      // use a single comparison on the hot path
       if (variable_node.type >= URITemplateRouter::NodeType::Expansion) {
         const auto remaining_length =
             static_cast<std::uint32_t>(path_end - segment_start);

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -83,6 +83,12 @@ finalize_match(const URITemplateRouter::Identifier otherwise_context,
   return {identifier, context};
 }
 
+inline auto is_expansion_type(const URITemplateRouter::NodeType type) noexcept
+    -> bool {
+  return type == URITemplateRouter::NodeType::Expansion ||
+         type == URITemplateRouter::NodeType::OptionalExpansion;
+}
+
 // Binary search for a literal child matching the given segment
 inline auto binary_search_literal_children(
     const SerializedNode *nodes, const char *string_table,
@@ -518,10 +524,9 @@ auto URITemplateRouterView::match(
         return finalize_match(otherwise_context, 0, 0);
       }
 
-      // Check if this is an expansion (catch-all) or optional expansion.
-      // Both behave identically mid-path, and the type ordering lets us
-      // use a single comparison on the hot path
-      if (variable_node.type >= URITemplateRouter::NodeType::Expansion) {
+      // Both Expansion and OptionalExpansion consume the rest of the path
+      // verbatim
+      if (is_expansion_type(variable_node.type)) {
         const auto remaining_length =
             static_cast<std::uint32_t>(path_end - segment_start);
         callback(static_cast<URITemplateRouter::Index>(variable_index),

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -19,7 +19,7 @@ namespace sourcemeta::core {
 namespace {
 
 constexpr std::uint32_t ROUTER_MAGIC = 0x52544552; // "RTER"
-constexpr std::uint32_t ROUTER_VERSION = 6;
+constexpr std::uint32_t ROUTER_VERSION = 7;
 constexpr std::uint32_t NO_CHILD = std::numeric_limits<std::uint32_t>::max();
 
 // Type tags for argument value serialization
@@ -518,8 +518,10 @@ auto URITemplateRouterView::match(
         return finalize_match(otherwise_context, 0, 0);
       }
 
-      // Check if this is an expansion (catch-all)
-      if (variable_node.type == URITemplateRouter::NodeType::Expansion) {
+      // Check if this is an expansion (catch-all) or optional expansion.
+      // Both behave identically mid-path; the type ordering lets us use a
+      // single comparison on the hot path
+      if (variable_node.type >= URITemplateRouter::NodeType::Expansion) {
         const auto remaining_length =
             static_cast<std::uint32_t>(path_end - segment_start);
         callback(static_cast<URITemplateRouter::Index>(variable_index),
@@ -548,8 +550,27 @@ auto URITemplateRouterView::match(
     return finalize_match(otherwise_context, 0, 0);
   }
 
-  return finalize_match(otherwise_context, nodes[current_node].identifier,
-                        nodes[current_node].context);
+  const auto &final_node = nodes[current_node];
+  if (final_node.identifier == 0 && final_node.variable_child != NO_CHILD &&
+      final_node.variable_child < header->node_count) {
+    const auto &variable_node = nodes[final_node.variable_child];
+    if (variable_node.type == URITemplateRouter::NodeType::OptionalExpansion) {
+      if (variable_node.string_offset > string_table_size ||
+          variable_node.string_length >
+              string_table_size - variable_node.string_offset) {
+        return finalize_match(otherwise_context, 0, 0);
+      }
+      callback(static_cast<URITemplateRouter::Index>(variable_index),
+               {string_table + variable_node.string_offset,
+                variable_node.string_length},
+               std::string_view{});
+      return finalize_match(otherwise_context, variable_node.identifier,
+                            variable_node.context);
+    }
+  }
+
+  return finalize_match(otherwise_context, final_node.identifier,
+                        final_node.context);
 }
 
 auto URITemplateRouterView::arguments(

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -1830,3 +1830,576 @@ TEST(URITemplateRouter, operation_id_overwrite_removes_previous_mapping) {
   EXPECT_EQ(live.first, 2);
   EXPECT_EQ(live.second, 22);
 }
+
+// ----------------------------------------------------------------------------
+// {/var*} parser tests
+// ----------------------------------------------------------------------------
+
+TEST(URITemplateRouter, optional_expansion_accepted_simple) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/list{/path*}", "op_oex_1", 1);
+  EXPECT_EQ(router.size(), 1);
+}
+
+TEST(URITemplateRouter, optional_expansion_accepted_with_explicit_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list/{/path*}", "op_oex_2", 1);
+  EXPECT_EQ(router.size(), 1);
+}
+
+TEST(URITemplateRouter, optional_expansion_accepted_at_root) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/{/path*}", "op_oex_3", 1);
+  EXPECT_EQ(router.size(), 1);
+}
+
+TEST(URITemplateRouter, optional_expansion_accepted_with_deep_literal_prefix) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/v1/users/list{/path*}", "op_oex_4", 1);
+  EXPECT_EQ(router.size(), 1);
+}
+
+TEST(URITemplateRouter, optional_expansion_accepted_no_literal_prefix) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("{/path*}", "op_oex_5", 1);
+  EXPECT_EQ(router.size(), 1);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_no_explode) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path}", 1, "{/path}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_no_explode_at_root) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "{/path}", 1, "{/path}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_empty_name) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/}", 1, "{/}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_empty_name_with_explode) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/*}", 1, "{/*}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_unclosed) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*", 1, "{/path*");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_not_last_segment_literal) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*}/more", 1, "{/path*}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_not_last_segment_variable) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*}/{tail}", 1, "{/path*}");
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_reject_not_last_segment_trailing_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*}/", 1, "{/path*}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_extra_after_explode) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*abc}", 1, "{/path*abc}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_comma_after_explode) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*,more}", 1, "{/path*,more}");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_invalid_varname_char) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/pa-th*}", 1, "{/pa-th*}");
+}
+
+TEST(URITemplateRouter, simple_explode_still_rejected) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list/{var*}", 1, "{var*}");
+}
+
+TEST(URITemplateRouter, reserved_explode_still_rejected) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/list/{+var*}", 1, "{+var*}");
+}
+
+TEST(URITemplateRouter, optional_expansion_dotted_varname_accepted) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/list{/foo.bar*}", "op_oex_dot", 1);
+  EXPECT_ROUTER_MATCH(router, "/list/x", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "foo.bar", "x");
+}
+
+TEST(URITemplateRouter, literal_followed_by_path_segment_no_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_join", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST(URITemplateRouter, literal_followed_by_non_path_segment_still_throws) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{path}", 1, "list{path}");
+}
+
+TEST(URITemplateRouter, literal_followed_by_reserved_expansion_still_throws) {
+  sourcemeta::core::URITemplateRouter router;
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{+path}", 1, "list{+path}");
+}
+
+// ----------------------------------------------------------------------------
+// {/var*} matcher tests
+// ----------------------------------------------------------------------------
+
+TEST(URITemplateRouter, optional_expansion_match_empty_capture) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m1", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
+}
+
+TEST(URITemplateRouter, optional_expansion_match_single_segment) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m2", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST(URITemplateRouter, optional_expansion_match_two_segments) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m3", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo/bar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
+}
+
+TEST(URITemplateRouter, optional_expansion_match_many_segments) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m4", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo/bar/baz/qux", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/baz/qux");
+}
+
+TEST(URITemplateRouter, optional_expansion_match_percent_encoded_segment) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m5", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo%2Fbar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo%2Fbar");
+}
+
+TEST(URITemplateRouter, optional_expansion_match_dot_segment) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m6", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/.well-known/version", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", ".well-known/version");
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_trailing_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m7", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_double_trailing_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m8", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list//", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_internal_empty_segment) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m9", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list//foo", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_non_prefix) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m10", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/listing", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_unrelated_root) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m11", 1);
+  EXPECT_ROUTER_MATCH(router, "/other", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_empty_path) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m12", 1);
+  EXPECT_ROUTER_MATCH(router, "", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_reject_root_path) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_m13", 1);
+  EXPECT_ROUTER_MATCH(router, "/", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_root_template_does_not_match_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/{/path*}", "op_oex_m14", 1);
+  EXPECT_ROUTER_MATCH(router, "/", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_root_template_matches_segment) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/{/path*}", "op_oex_m15", 1);
+  EXPECT_ROUTER_MATCH(router, "/foo", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_root_template_matches_multiple_segments) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/{/path*}", "op_oex_m16", 1);
+  EXPECT_ROUTER_MATCH(router, "/foo/bar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
+}
+
+TEST(URITemplateRouter, optional_expansion_callback_index_zero) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_idx", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_EQ(std::get<0>(captures.at(0)), 0);
+}
+
+TEST(URITemplateRouter, optional_expansion_callback_index_after_variables) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/{namespace}/list{/path*}", "op_oex_idx2", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/users/list/foo/bar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "namespace", "users");
+  EXPECT_ROUTER_CAPTURE(captures, 1, "path", "foo/bar");
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_empty_callback_index_after_variables) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/{namespace}/list{/path*}", "op_oex_idx3", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/users/list", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "namespace", "users");
+  EXPECT_ROUTER_CAPTURE(captures, 1, "path", "");
+}
+
+TEST(URITemplateRouter, optional_expansion_with_context) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_ctx", 1, 42);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 42, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST(URITemplateRouter, optional_expansion_empty_with_context) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_ctx2", 1, 42);
+  EXPECT_ROUTER_MATCH(router, "/api/list", 1, 42, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
+}
+
+// ----------------------------------------------------------------------------
+// {/var*} sibling routes / precedence
+// ----------------------------------------------------------------------------
+
+TEST(URITemplateRouter, optional_expansion_literal_sibling_takes_priority) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_p1", 1);
+  router.add("/api/list/special", "op_oex_p2", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list/special", 2, 0, captures);
+  EXPECT_EQ(captures.size(), 0);
+}
+
+TEST(URITemplateRouter, optional_expansion_literal_sibling_fallback) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_p3", 1);
+  router.add("/api/list/special", "op_oex_p4", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list/other", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "other");
+}
+
+TEST(URITemplateRouter, optional_expansion_literal_sibling_fallback_multi) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_p5", 1);
+  router.add("/api/list/special", "op_oex_p6", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list/other/nested", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "other/nested");
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_literal_parent_route_takes_priority) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list", "op_oex_pp1", 1);
+  router.add("/api/list{/path*}", "op_oex_pp2", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 0);
+}
+
+TEST(URITemplateRouter, optional_expansion_literal_parent_route_other_order) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_pp3", 2);
+  router.add("/api/list", "op_oex_pp4", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 0);
+}
+
+TEST(URITemplateRouter, optional_expansion_with_literal_parent_match_nested) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list", "op_oex_pn1", 1);
+  router.add("/api/list{/path*}", "op_oex_pn2", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo/bar", 2, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
+}
+
+TEST(URITemplateRouter, optional_expansion_versus_simple_variable_upgrade) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list/{path}", "op_oex_v1", 1);
+  router.add("/api/list{/path*}", "op_oex_v2", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 2, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST(URITemplateRouter, optional_expansion_versus_simple_variable_absorbs) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_v3", 1);
+  router.add("/api/list/{path}", "op_oex_v4", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST(URITemplateRouter, optional_expansion_conflicts_with_reserved_expansion) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list/{+path}", "op_oex_c1", 1);
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{/path*}", 2, "{/path*}");
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_conflicts_with_reserved_expansion_other_order) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_c2", 1);
+  EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list/{+path}", 2, "{+path}");
+}
+
+TEST(URITemplateRouter, optional_expansion_variable_name_mismatch) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list/{id}", "op_oex_mm1", 1);
+  try {
+    router.add("/api/list{/path*}", "op_oex_mm2", 2);
+    FAIL();
+  } catch (
+      const sourcemeta::core::URITemplateRouterVariableMismatchError &error) {
+    EXPECT_EQ(error.left(), "id");
+    EXPECT_EQ(error.right(), "path");
+    SUCCEED();
+  }
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_variable_name_mismatch_with_expansion) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list/{+abc}", "op_oex_mm3", 1);
+  try {
+    router.add("/api/list{/xyz*}", "op_oex_mm4", 2);
+    FAIL();
+  } catch (
+      const sourcemeta::core::URITemplateRouterVariableMismatchError &error) {
+    EXPECT_EQ(error.left(), "abc");
+    EXPECT_EQ(error.right(), "xyz");
+    SUCCEED();
+  }
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_distinct_parents_independent_registration) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/a{/x*}", "op_oex_d1", 1);
+  router.add("/api/b{/y*}", "op_oex_d2", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/a/foo", 1, 0, captures_a);
+  EXPECT_EQ(captures_a.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_a, 0, "x", "foo");
+  EXPECT_ROUTER_MATCH(router, "/api/b/bar", 2, 0, captures_b);
+  EXPECT_EQ(captures_b.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "bar");
+}
+
+TEST(URITemplateRouter, optional_expansion_distinct_parents_both_empty) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/a{/x*}", "op_oex_d3", 1);
+  router.add("/api/b{/y*}", "op_oex_d4", 2);
+  EXPECT_ROUTER_MATCH(router, "/api/a", 1, 0, captures_a);
+  EXPECT_EQ(captures_a.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_a, 0, "x", "");
+  EXPECT_ROUTER_MATCH(router, "/api/b", 2, 0, captures_b);
+  EXPECT_EQ(captures_b.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "");
+}
+
+TEST(URITemplateRouter, optional_expansion_otherwise_fallback) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_o1", 1);
+  router.otherwise(99);
+  EXPECT_ROUTER_MATCH(router, "/api/list/", 0, 99, captures);
+  EXPECT_ROUTER_MATCH(router, "/api/listing", 0, 99, no_captures);
+}
+
+TEST(URITemplateRouter, optional_expansion_under_intermediate_variable) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/{tenant}{/path*}", "op_oex_iv1", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/acme", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "tenant", "acme");
+  EXPECT_ROUTER_CAPTURE(captures, 1, "path", "");
+}
+
+TEST(URITemplateRouter,
+     optional_expansion_under_intermediate_variable_with_payload) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/{tenant}{/path*}", "op_oex_iv2", 1);
+  EXPECT_ROUTER_MATCH(router, "/api/acme/foo/bar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "tenant", "acme");
+  EXPECT_ROUTER_CAPTURE(captures, 1, "path", "foo/bar");
+}
+
+TEST(URITemplateRouter, optional_expansion_path_method_round_trips) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_pth", 1);
+  EXPECT_EQ(router.path(1), "/api/list{/path*}");
+}
+
+TEST(URITemplateRouter, optional_expansion_operation_lookup) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "list_directory", 1, 42);
+  const auto result = router.operation("list_directory");
+  EXPECT_EQ(result.first, 1);
+  EXPECT_EQ(result.second, 42);
+}
+
+TEST(URITemplateRouter, optional_expansion_size_counts_one) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_sz", 1);
+  EXPECT_EQ(router.size(), 1);
+}
+
+TEST(URITemplateRouter, optional_expansion_size_counts_with_sibling_literal) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list", "op_oex_sz1", 1);
+  router.add("/api/list{/path*}", "op_oex_sz2", 2);
+  EXPECT_EQ(router.size(), 2);
+}
+
+TEST(URITemplateRouter, optional_expansion_with_arguments) {
+  sourcemeta::core::URITemplateRouter router;
+  const std::array<sourcemeta::core::URITemplateRouter::Argument, 2> arguments{
+      {{"max", std::int64_t{10}}, {"flag", true}}};
+  router.add("/api/list{/path*}", "op_oex_args", 1, 0, arguments);
+
+  std::vector<std::pair<std::string_view,
+                        sourcemeta::core::URITemplateRouter::ArgumentValue>>
+      collected;
+  router.arguments(
+      1, [&](const std::string_view name,
+             const sourcemeta::core::URITemplateRouter::ArgumentValue &value) {
+        collected.emplace_back(name, value);
+      });
+  EXPECT_EQ(collected.size(), 2);
+  EXPECT_EQ(collected[0].first, "max");
+  EXPECT_EQ(std::get<std::int64_t>(collected[0].second), 10);
+  EXPECT_EQ(collected[1].first, "flag");
+  EXPECT_EQ(std::get<bool>(collected[1].second), true);
+}
+
+TEST(URITemplateRouter, optional_expansion_with_base_path) {
+  sourcemeta::core::URITemplateRouter router{"/v1"};
+  router.add("/api/list{/path*}", "op_oex_bp", 1);
+  EXPECT_ROUTER_MATCH(router, "/v1/api/list", 1, 0, captures_empty);
+  EXPECT_EQ(captures_empty.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_empty, 0, "path", "");
+  EXPECT_ROUTER_MATCH(router, "/v1/api/list/foo", 1, 0, captures_one);
+  EXPECT_EQ(captures_one.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_one, 0, "path", "foo");
+  EXPECT_ROUTER_MATCH(router, "/v1/api/list/foo/bar", 1, 0, captures_two);
+  EXPECT_EQ(captures_two.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_two, 0, "path", "foo/bar");
+}
+
+TEST(URITemplateRouter, optional_expansion_matches_after_variable_segment) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users/{id}/files{/path*}", "op_oex_uf", 1);
+  EXPECT_ROUTER_MATCH(router, "/users/42/files", 1, 0, captures_empty);
+  EXPECT_EQ(captures_empty.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures_empty, 0, "id", "42");
+  EXPECT_ROUTER_CAPTURE(captures_empty, 1, "path", "");
+  EXPECT_ROUTER_MATCH(router, "/users/42/files/readme.md", 1, 0, captures_one);
+  EXPECT_EQ(captures_one.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures_one, 0, "id", "42");
+  EXPECT_ROUTER_CAPTURE(captures_one, 1, "path", "readme.md");
+}
+
+TEST(URITemplateRouter, optional_expansion_motivating_use_case) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/self/v1/api/list{/path*}", "list_directory", 1, 7);
+  EXPECT_ROUTER_MATCH(router, "/self/v1/api/list", 1, 7, captures_root);
+  EXPECT_EQ(captures_root.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_root, 0, "path", "");
+  EXPECT_ROUTER_MATCH(router, "/self/v1/api/list/foo", 1, 7, captures_one);
+  EXPECT_EQ(captures_one.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_one, 0, "path", "foo");
+  EXPECT_ROUTER_MATCH(router, "/self/v1/api/list/foo/bar/baz/qux", 1, 7,
+                      captures_deep);
+  EXPECT_EQ(captures_deep.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_deep, 0, "path", "foo/bar/baz/qux");
+  EXPECT_ROUTER_MATCH(router, "/self/v1/api/listing", 0, 0, captures_nope);
+  EXPECT_EQ(captures_nope.size(), 0);
+  EXPECT_ROUTER_MATCH(router, "/self/v1/api/list/", 0, 0, captures_trailing);
+}
+
+TEST(URITemplateRouter, optional_expansion_listing_does_not_count_node) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_oex_lc", 1);
+  EXPECT_EQ(router.size(), 1);
+  EXPECT_EQ(router.at(0), 1);
+  EXPECT_EQ(router.path(1), "/api/list{/path*}");
+  EXPECT_EQ(router.context(1), 0);
+}
+
+TEST(URITemplateRouter, optional_expansion_overwrite_replaces_identifier) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "first", 1, 11);
+  router.add("/api/list{/path*}", "second", 2, 22);
+
+  EXPECT_EQ(router.size(), 1);
+  EXPECT_ROUTER_MATCH(router, "/api/list/foo", 2, 22, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+
+  const auto stale = router.operation("first");
+  EXPECT_EQ(stale.first, 0);
+  const auto live = router.operation("second");
+  EXPECT_EQ(live.first, 2);
+  EXPECT_EQ(live.second, 22);
+}

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -1831,10 +1831,6 @@ TEST(URITemplateRouter, operation_id_overwrite_removes_previous_mapping) {
   EXPECT_EQ(live.second, 22);
 }
 
-// ----------------------------------------------------------------------------
-// {/var*} parser tests
-// ----------------------------------------------------------------------------
-
 TEST(URITemplateRouter, optional_expansion_accepted_simple) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/list{/path*}", "op_oex_1", 1);
@@ -1956,10 +1952,6 @@ TEST(URITemplateRouter, literal_followed_by_reserved_expansion_still_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{+path}", 1, "list{+path}");
 }
-
-// ----------------------------------------------------------------------------
-// {/var*} matcher tests
-// ----------------------------------------------------------------------------
 
 TEST(URITemplateRouter, optional_expansion_match_empty_capture) {
   sourcemeta::core::URITemplateRouter router;
@@ -2116,10 +2108,6 @@ TEST(URITemplateRouter, optional_expansion_empty_with_context) {
   EXPECT_EQ(captures.size(), 1);
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
 }
-
-// ----------------------------------------------------------------------------
-// {/var*} sibling routes / precedence
-// ----------------------------------------------------------------------------
 
 TEST(URITemplateRouter, optional_expansion_literal_sibling_takes_priority) {
   sourcemeta::core::URITemplateRouter router;

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -2391,3 +2391,36 @@ TEST(URITemplateRouter, optional_expansion_overwrite_replaces_identifier) {
   EXPECT_EQ(live.first, 2);
   EXPECT_EQ(live.second, 22);
 }
+
+TEST(URITemplateRouter, variable_does_not_consume_multiple_segments) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users/{id}", "var_no_consume_1", 1);
+  EXPECT_ROUTER_MATCH(router, "/users/42/extra", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, variable_does_not_consume_with_literal_suffix) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users/{id}/posts", "var_no_consume_2", 1);
+  EXPECT_ROUTER_MATCH(router, "/users/42/extra/posts", 0, 0, captures);
+}
+
+TEST(URITemplateRouter, variable_segment_does_not_match_empty_capture) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users/{id}", "var_no_empty", 1);
+  EXPECT_ROUTER_MATCH(router, "/users", 0, 0, captures);
+  EXPECT_EQ(captures.size(), 0);
+}
+
+TEST(URITemplateRouter, expansion_consumes_unlike_plain_variable) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/a/{x}", "plain_var", 1);
+  router.add("/b/{+y}", "reserved_exp", 2);
+  router.add("/c{/z*}", "optional_exp", 3);
+  EXPECT_ROUTER_MATCH(router, "/a/one/two", 0, 0, captures_a);
+  EXPECT_ROUTER_MATCH(router, "/b/one/two", 2, 0, captures_b);
+  EXPECT_EQ(captures_b.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "one/two");
+  EXPECT_ROUTER_MATCH(router, "/c/one/two", 3, 0, captures_c);
+  EXPECT_EQ(captures_c.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_c, 0, "z", "one/two");
+}

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -2738,10 +2738,6 @@ TEST_F(URITemplateRouterViewTest, operation_rejects_v6_blob) {
   EXPECT_EQ(result.second, 0);
 }
 
-// ----------------------------------------------------------------------------
-// {/var*} round-trip tests
-// ----------------------------------------------------------------------------
-
 TEST_F(URITemplateRouterViewTest, optional_expansion_empty_capture) {
   {
     sourcemeta::core::URITemplateRouter router;

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -2709,3 +2709,390 @@ TEST_F(URITemplateRouterViewTest, operation_rejects_v5_blob) {
   EXPECT_EQ(result.first, 0);
   EXPECT_EQ(result.second, 0);
 }
+
+TEST_F(URITemplateRouterViewTest, operation_rejects_v6_blob) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/a", "alpha", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  std::vector<std::uint8_t> blob;
+  {
+    std::ifstream file{this->path, std::ios::binary | std::ios::ate};
+    const auto size = static_cast<std::size_t>(file.tellg());
+    file.seekg(0, std::ios::beg);
+    blob.resize(size);
+    file.read(reinterpret_cast<char *>(blob.data()),
+              static_cast<std::streamsize>(size));
+  }
+
+  const std::uint32_t old_version = 6;
+  std::memcpy(blob.data() + sizeof(std::uint32_t), &old_version,
+              sizeof(old_version));
+
+  const sourcemeta::core::URITemplateRouterView restored{blob.data(),
+                                                         blob.size()};
+  const auto result = restored.operation("alpha");
+  EXPECT_EQ(result.first, 0);
+  EXPECT_EQ(result.second, 0);
+}
+
+// ----------------------------------------------------------------------------
+// {/var*} round-trip tests
+// ----------------------------------------------------------------------------
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_empty_capture) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_1", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_single_segment) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_2", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/foo", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_two_segments) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_3", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_many_segments) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_4", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar/baz/qux", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/baz/qux");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_percent_encoded_segment) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_5", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/foo%2Fbar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo%2Fbar");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_rejects_trailing_slash) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_6", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/", 0, 0, captures);
+}
+
+TEST_F(URITemplateRouterViewTest,
+       optional_expansion_rejects_internal_double_slash) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_7", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list//foo", 0, 0, captures);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_rejects_non_prefix) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_8", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/listing", 0, 0, captures);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_with_context) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_9", 1, 7);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list", 1, 7, captures_empty);
+  EXPECT_EQ(captures_empty.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_empty, 0, "path", "");
+  EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar", 1, 7, captures_two);
+  EXPECT_EQ(captures_two.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_two, 0, "path", "foo/bar");
+}
+
+TEST_F(URITemplateRouterViewTest,
+       optional_expansion_with_literal_sibling_priority) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_p1", 1);
+    router.add("/api/list/special", "op_v_oex_p2", 2);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/special", 2, 0, captures_special);
+  EXPECT_EQ(captures_special.size(), 0);
+  EXPECT_ROUTER_MATCH(restored, "/api/list/other", 1, 0, captures_other);
+  EXPECT_EQ(captures_other.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_other, 0, "path", "other");
+}
+
+TEST_F(URITemplateRouterViewTest,
+       optional_expansion_with_literal_parent_route_priority) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list", "op_v_oex_pp1", 1);
+    router.add("/api/list{/path*}", "op_v_oex_pp2", 2);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list", 1, 0, captures_root);
+  EXPECT_EQ(captures_root.size(), 0);
+  EXPECT_ROUTER_MATCH(restored, "/api/list/foo/bar", 2, 0, captures_nested);
+  EXPECT_EQ(captures_nested.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_nested, 0, "path", "foo/bar");
+}
+
+TEST_F(URITemplateRouterViewTest,
+       optional_expansion_callback_index_after_variables) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/{namespace}/list{/path*}", "op_v_oex_idx", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/users/list/foo/bar", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "namespace", "users");
+  EXPECT_ROUTER_CAPTURE(captures, 1, "path", "foo/bar");
+}
+
+TEST_F(URITemplateRouterViewTest,
+       optional_expansion_empty_callback_index_after_variables) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/{namespace}/list{/path*}", "op_v_oex_idx2", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/users/list", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "namespace", "users");
+  EXPECT_ROUTER_CAPTURE(captures, 1, "path", "");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_operation_lookup) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "list_directory", 1, 42);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  const auto result = restored.operation("list_directory");
+  EXPECT_EQ(result.first, 1);
+  EXPECT_EQ(result.second, 42);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_size) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_sz", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_EQ(restored.size(), 1);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_with_arguments) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    const std::array<sourcemeta::core::URITemplateRouter::Argument, 2>
+        arguments{
+            {{"max", std::int64_t{99}}, {"name", std::string_view{"hello"}}}};
+    router.add("/api/list{/path*}", "op_v_oex_args", 1, 0, arguments);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  std::vector<std::pair<std::string_view,
+                        sourcemeta::core::URITemplateRouter::ArgumentValue>>
+      collected;
+  restored.arguments(
+      1, [&](const std::string_view name,
+             const sourcemeta::core::URITemplateRouter::ArgumentValue &value) {
+        collected.emplace_back(name, value);
+      });
+  EXPECT_EQ(collected.size(), 2);
+  EXPECT_EQ(collected[0].first, "max");
+  EXPECT_EQ(std::get<std::int64_t>(collected[0].second), 99);
+  EXPECT_EQ(collected[1].first, "name");
+  EXPECT_EQ(std::get<std::string_view>(collected[1].second), "hello");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_with_base_path) {
+  {
+    sourcemeta::core::URITemplateRouter router{"/v1"};
+    router.add("/api/list{/path*}", "op_v_oex_bp", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_EQ(restored.base_path(), "/v1");
+  EXPECT_ROUTER_MATCH(restored, "/v1/api/list", 1, 0, captures_empty);
+  EXPECT_EQ(captures_empty.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_empty, 0, "path", "");
+  EXPECT_ROUTER_MATCH(restored, "/v1/api/list/foo/bar", 1, 0, captures_two);
+  EXPECT_EQ(captures_two.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_two, 0, "path", "foo/bar");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_otherwise_fallback) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/path*}", "op_v_oex_o1", 1);
+    router.otherwise(99);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/", 0, 99, captures_trailing);
+  EXPECT_ROUTER_MATCH(restored, "/api/listing", 0, 99, captures_other);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_root_template) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/{/path*}", "op_v_oex_root", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/foo", 1, 0, captures_one);
+  EXPECT_EQ(captures_one.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_one, 0, "path", "foo");
+  EXPECT_ROUTER_MATCH(restored, "/foo/bar", 1, 0, captures_two);
+  EXPECT_EQ(captures_two.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_two, 0, "path", "foo/bar");
+  EXPECT_ROUTER_MATCH(restored, "/", 0, 0, captures_slash);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_under_variable_segment) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/{tenant}{/path*}", "op_v_oex_uv", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/acme", 1, 0, captures_empty);
+  EXPECT_EQ(captures_empty.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures_empty, 0, "tenant", "acme");
+  EXPECT_ROUTER_CAPTURE(captures_empty, 1, "path", "");
+  EXPECT_ROUTER_MATCH(restored, "/api/acme/foo/bar", 1, 0, captures_payload);
+  EXPECT_EQ(captures_payload.size(), 2);
+  EXPECT_ROUTER_CAPTURE(captures_payload, 0, "tenant", "acme");
+  EXPECT_ROUTER_CAPTURE(captures_payload, 1, "path", "foo/bar");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_motivating_use_case) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/self/v1/api/list{/path*}", "list_directory", 1, 7);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/self/v1/api/list", 1, 7, captures_root);
+  EXPECT_EQ(captures_root.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_root, 0, "path", "");
+  EXPECT_ROUTER_MATCH(restored, "/self/v1/api/list/foo", 1, 7, captures_one);
+  EXPECT_EQ(captures_one.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_one, 0, "path", "foo");
+  EXPECT_ROUTER_MATCH(restored, "/self/v1/api/list/foo/bar/baz/qux", 1, 7,
+                      captures_deep);
+  EXPECT_EQ(captures_deep.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_deep, 0, "path", "foo/bar/baz/qux");
+  EXPECT_ROUTER_MATCH(restored, "/self/v1/api/list/", 0, 0, captures_trailing);
+  EXPECT_ROUTER_MATCH(restored, "/self/v1/api/listing", 0, 0, captures_nope);
+}
+
+TEST_F(URITemplateRouterViewTest,
+       optional_expansion_coexists_with_mandatory_expansion_sibling) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/a{/x*}", "op_v_coex_a", 1);
+    router.add("/api/b/{+y}", "op_v_coex_b", 2);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/a", 1, 0, captures_a_empty);
+  EXPECT_EQ(captures_a_empty.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_a_empty, 0, "x", "");
+  EXPECT_ROUTER_MATCH(restored, "/api/a/foo/bar", 1, 0, captures_a_payload);
+  EXPECT_EQ(captures_a_payload.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_a_payload, 0, "x", "foo/bar");
+  EXPECT_ROUTER_MATCH(restored, "/api/b/baz", 2, 0, captures_b);
+  EXPECT_EQ(captures_b.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "baz");
+  EXPECT_ROUTER_MATCH(restored, "/api/b", 0, 0, captures_b_empty);
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_path_method_round_trips) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/api/list{/path*}", "op_v_oex_pth", 1);
+  EXPECT_EQ(router.path(1), "/api/list{/path*}");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_dotted_varname) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/api/list{/foo.bar*}", "op_v_oex_dot", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/api/list/x/y", 1, 0, captures);
+  EXPECT_EQ(captures.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures, 0, "foo.bar", "x/y");
+}
+
+TEST_F(URITemplateRouterViewTest, optional_expansion_many_routes) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/a{/x*}", "op_v_many_a", 1);
+    router.add("/b{/y*}", "op_v_many_b", 2);
+    router.add("/c{/z*}", "op_v_many_c", 3);
+    router.add("/d{/w*}", "op_v_many_d", 4);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_EQ(restored.size(), 4);
+  EXPECT_ROUTER_MATCH(restored, "/a", 1, 0, captures_a);
+  EXPECT_ROUTER_CAPTURE(captures_a, 0, "x", "");
+  EXPECT_ROUTER_MATCH(restored, "/b/foo", 2, 0, captures_b);
+  EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "foo");
+  EXPECT_ROUTER_MATCH(restored, "/c/foo/bar", 3, 0, captures_c);
+  EXPECT_ROUTER_CAPTURE(captures_c, 0, "z", "foo/bar");
+  EXPECT_ROUTER_MATCH(restored, "/d", 4, 0, captures_d);
+  EXPECT_ROUTER_CAPTURE(captures_d, 0, "w", "");
+}

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -3092,3 +3092,32 @@ TEST_F(URITemplateRouterViewTest, optional_expansion_many_routes) {
   EXPECT_ROUTER_MATCH(restored, "/d", 4, 0, captures_d);
   EXPECT_ROUTER_CAPTURE(captures_d, 0, "w", "");
 }
+
+TEST_F(URITemplateRouterViewTest, variable_does_not_consume_multiple_segments) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/users/{id}", "v_var_no_consume_1", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/users/42/extra", 0, 0, captures);
+}
+
+TEST_F(URITemplateRouterViewTest,
+       expansion_types_distinct_from_plain_variable) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/a/{x}", "v_plain_var", 1);
+    router.add("/b/{+y}", "v_reserved_exp", 2);
+    router.add("/c{/z*}", "v_optional_exp", 3);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_ROUTER_MATCH(restored, "/a/one/two", 0, 0, captures_a);
+  EXPECT_ROUTER_MATCH(restored, "/b/one/two", 2, 0, captures_b);
+  EXPECT_EQ(captures_b.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "one/two");
+  EXPECT_ROUTER_MATCH(restored, "/c/one/two", 3, 0, captures_c);
+  EXPECT_EQ(captures_c.size(), 1);
+  EXPECT_ROUTER_CAPTURE(captures_c, 0, "z", "one/two");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
