### PR TITLE
Fix leap seconds in `is_rfc3339_datetime`

### DIFF
--- a/src/core/time/rfc3339_datetime.cc
+++ b/src/core/time/rfc3339_datetime.cc
@@ -205,17 +205,55 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
     return false;
   }
 
-  // --- Validate leap second (§5.6) ---
-  // The value 60 is only legal at the end of a UTC day, i.e. when the
-  // UTC equivalent of the local time is 23:59
+  // --- Validate leap second (§5.7) ---
+  // The value 60 is only legal at the end of months in which a leap second
+  // occurs: June (XXXX-06-30T23:59:60Z) or December (XXXX-12-31T23:59:60Z),
+  // evaluated in UTC after applying the time offset
   if (second == 60) {
     const auto local_minute_of_day{hour * 60 + minute};
     const auto offset_total_minutes{offset_hour * 60 + offset_minute};
-    const auto utc_minute_of_day{
-        offset_sign == '+'
-            ? (local_minute_of_day + 1440 - offset_total_minutes) % 1440
-            : (local_minute_of_day + offset_total_minutes) % 1440};
+
+    unsigned int utc_minute_of_day{0};
+    bool previous_utc_day{false};
+
+    if (offset_sign == '+') {
+      if (local_minute_of_day >= offset_total_minutes) {
+        utc_minute_of_day = local_minute_of_day - offset_total_minutes;
+      } else {
+        utc_minute_of_day = local_minute_of_day + 1440 - offset_total_minutes;
+        previous_utc_day = true;
+      }
+    } else {
+      utc_minute_of_day = (local_minute_of_day + offset_total_minutes) % 1440;
+    }
+
     if (utc_minute_of_day != 23 * 60 + 59) {
+      return false;
+    }
+
+    // A "next UTC day" shift cannot coexist with UTC time 23:59, since
+    // max(local) + max(offset) = 1439 + 1439 = 2878 < 1440 + 1439
+
+    unsigned int utc_month{month};
+    unsigned int utc_day{day};
+    if (previous_utc_day) {
+      if (utc_day > 1) {
+        utc_day -= 1;
+      } else if (utc_month > 1) {
+        utc_month -= 1;
+        utc_day = max_day_in_month(utc_month, year);
+      } else {
+        // Going back from year 0000 January 1 would yield year -1
+        if (year == 0) {
+          return false;
+        }
+        utc_month = 12;
+        utc_day = 31;
+      }
+    }
+
+    if (!((utc_month == 6 && utc_day == 30) ||
+          (utc_month == 12 && utc_day == 31))) {
       return false;
     }
   }

--- a/src/core/time/rfc3339_datetime.cc
+++ b/src/core/time/rfc3339_datetime.cc
@@ -148,9 +148,14 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
     return false;
   }
 
+  char offset_sign{'+'};
+  unsigned int offset_hour{0};
+  unsigned int offset_minute{0};
+
   if (value[position] == 'Z' || value[position] == 'z') {
     position += 1;
   } else if (value[position] == '+' || value[position] == '-') {
+    offset_sign = value[position];
     position += 1;
 
     // time-numoffset = ("+" / "-") time-hour ":" time-minute
@@ -162,9 +167,8 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
     if (!is_digit(value[position]) || !is_digit(value[position + 1])) {
       return false;
     }
-    const auto offset_hour{
-        static_cast<unsigned int>(value[position] - '0') * 10 +
-        static_cast<unsigned int>(value[position + 1] - '0')};
+    offset_hour = static_cast<unsigned int>(value[position] - '0') * 10 +
+                  static_cast<unsigned int>(value[position + 1] - '0');
     if (offset_hour > 23) {
       return false;
     }
@@ -180,9 +184,8 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
     if (!is_digit(value[position]) || !is_digit(value[position + 1])) {
       return false;
     }
-    const auto offset_minute{
-        static_cast<unsigned int>(value[position] - '0') * 10 +
-        static_cast<unsigned int>(value[position + 1] - '0')};
+    offset_minute = static_cast<unsigned int>(value[position] - '0') * 10 +
+                    static_cast<unsigned int>(value[position + 1] - '0');
     if (offset_minute > 59) {
       return false;
     }
@@ -200,6 +203,21 @@ auto is_rfc3339_datetime(const std::string_view value) -> bool {
   // --- Validate date-mday against month/year (§5.7) ---
   if (day < 1 || day > max_day_in_month(month, year)) {
     return false;
+  }
+
+  // --- Validate leap second (§5.6) ---
+  // The value 60 is only legal at the end of a UTC day, i.e. when the
+  // UTC equivalent of the local time is 23:59
+  if (second == 60) {
+    const auto local_minute_of_day{hour * 60 + minute};
+    const auto offset_total_minutes{offset_hour * 60 + offset_minute};
+    const auto utc_minute_of_day{
+        offset_sign == '+'
+            ? (local_minute_of_day + 1440 - offset_total_minutes) % 1440
+            : (local_minute_of_day + offset_total_minutes) % 1440};
+    if (utc_minute_of_day != 23 * 60 + 59) {
+      return false;
+    }
   }
 
   return true;

--- a/test/time/rfc3339_datetime_test.cc
+++ b/test/time/rfc3339_datetime_test.cc
@@ -208,3 +208,52 @@ TEST(Time_rfc3339_datetime, valid_leap_second_unknown_offset) {
 TEST(Time_rfc3339_datetime, invalid_leap_second_zero_hour_utc) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T00:00:60Z"));
 }
+
+TEST(Time_rfc3339_datetime, valid_leap_second_june_30) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2012-06-30T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, valid_leap_second_december_31) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2008-12-31T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, valid_leap_second_june_30_negative_offset) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2012-06-30T15:59:60-08:00"));
+}
+
+TEST(Time_rfc3339_datetime,
+     valid_leap_second_june_30_positive_offset_rollover) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2012-07-01T03:59:60+04:00"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_december_30) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-30T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_march_31) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-03-31T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_september_30) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-09-30T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_june_29) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-06-29T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_july_1) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-07-01T23:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_january_1_utc_shifts_to_jan_1) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2024-01-01T23:59:60-00:00"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_year_zero_jan_1_underflow) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("0000-01-01T00:59:60+01:00"));
+}

--- a/test/time/rfc3339_datetime_test.cc
+++ b/test/time/rfc3339_datetime_test.cc
@@ -171,3 +171,40 @@ TEST(Time_rfc3339_datetime, invalid_empty_secfrac) {
 TEST(Time_rfc3339_datetime, invalid_feb29_year_2300) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2300-02-29T00:00:00Z"));
 }
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_minute_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T23:58:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_hour_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T22:59:60Z"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_local_negative_offset) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("1998-12-31T22:59:60-08:00"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_local_positive_offset) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("1998-12-31T04:59:60+04:00"));
+}
+
+TEST(Time_rfc3339_datetime, valid_leap_second_positive_offset_rollover) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("1999-01-01T03:59:60+04:00"));
+}
+
+TEST(Time_rfc3339_datetime, valid_leap_second_negative_offset_rollover) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("1998-12-31T07:59:60-16:00"));
+}
+
+TEST(Time_rfc3339_datetime, valid_leap_second_unknown_offset) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("1998-12-31T23:59:60-00:00"));
+}
+
+TEST(Time_rfc3339_datetime, invalid_leap_second_zero_hour_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T00:00:60Z"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
