### PR TITLE
Do not apply LTO on GoogleTest executables

### DIFF
--- a/cmake/common/targets/googletest.cmake
+++ b/cmake/common/targets/googletest.cmake
@@ -18,6 +18,14 @@ function(sourcemeta_googletest)
 
   target_link_libraries("${TARGET_NAME}"
     PRIVATE GTest::gtest GTest::gmock GTest::gtest_main)
+
+  # Test executables are not shipped, so LTO buys nothing and significantly
+  # slows the link step (GCC's LTRANS phase serializes per executable)
+  if(SOURCEMETA_COMPILER_LLVM OR SOURCEMETA_COMPILER_GCC)
+    target_compile_options("${TARGET_NAME}" PRIVATE -fno-lto)
+    target_link_options("${TARGET_NAME}" PRIVATE -fno-lto)
+  endif()
+
   add_test(NAME "${SOURCEMETA_GOOGLETEST_PROJECT}.${SOURCEMETA_GOOGLETEST_NAME}"
     COMMAND "${TARGET_NAME}" --gtest_brief=1)
 endfunction()


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
