### PR TITLE
Implement `is_ucschar` and `is_iprivate` helpers for IRI

### DIFF
--- a/src/core/unicode/include/sourcemeta/core/unicode.h
+++ b/src/core/unicode/include/sourcemeta/core/unicode.h
@@ -190,6 +190,70 @@ inline constexpr auto is_valid_codepoint(const char32_t codepoint) -> bool {
 }
 
 /// @ingroup unicode
+/// Check whether the given codepoint matches the `ucschar` production of
+/// RFC 3987 Section 2.2, the set of non-ASCII characters that an IRI may
+/// carry in components other than the scheme, host, and percent-encoded
+/// octets. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/unicode.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::is_ucschar(0x00A0));
+/// assert(sourcemeta::core::is_ucschar(0x4E2D));
+/// assert(!sourcemeta::core::is_ucschar(0x0041));
+/// assert(!sourcemeta::core::is_ucschar(0xE000));
+/// ```
+inline constexpr auto is_ucschar(const char32_t codepoint) -> bool {
+  if (codepoint >= 0xA0 && codepoint <= 0xD7FF) {
+    return true;
+  }
+  if (codepoint >= 0xF900 && codepoint <= 0xFDCF) {
+    return true;
+  }
+  if (codepoint >= 0xFDF0 && codepoint <= 0xFFEF) {
+    return true;
+  }
+  // Supplementary planes 1 through 14. Each plane allows 0..FFFD;
+  // FFFE and FFFF are noncharacters. Plane 14 starts at offset 0x1000
+  // rather than 0x0000.
+  if (codepoint < 0x10000 || codepoint > 0xEFFFD) {
+    return false;
+  }
+  if (codepoint >= 0xE0000 && codepoint < 0xE1000) {
+    return false;
+  }
+  return (codepoint & 0xFFFFU) <= 0xFFFDU;
+}
+
+/// @ingroup unicode
+/// Check whether the given codepoint matches the `iprivate` production of
+/// RFC 3987 Section 2.2, the set of private-use characters that an IRI
+/// may carry in the query component. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/unicode.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::is_iprivate(0xE000));
+/// assert(sourcemeta::core::is_iprivate(0xF0000));
+/// assert(!sourcemeta::core::is_iprivate(0x0041));
+/// assert(!sourcemeta::core::is_iprivate(0xF8FF + 1));
+/// ```
+inline constexpr auto is_iprivate(const char32_t codepoint) -> bool {
+  if (codepoint >= 0xE000 && codepoint <= 0xF8FF) {
+    return true;
+  }
+  if (codepoint >= 0xF0000 && codepoint <= 0xFFFFD) {
+    return true;
+  }
+  if (codepoint >= 0x100000 && codepoint <= 0x10FFFD) {
+    return true;
+  }
+  return false;
+}
+
+/// @ingroup unicode
 /// Determine the number of UTF-8 bytes that a codepoint encodes to per
 /// RFC 3629: 1 byte for U+0000-U+007F, 2 bytes for U+0080-U+07FF, 3 bytes
 /// for U+0800-U+FFFF, and 4 bytes for U+10000 and above. The caller is

--- a/test/unicode/CMakeLists.txt
+++ b/test/unicode/CMakeLists.txt
@@ -17,7 +17,9 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME unicode
     unicode_canonical_decomposition_test.cc
     unicode_canonical_composition_test.cc
     unicode_nfc_test.cc
-    unicode_is_nfc_test.cc)
+    unicode_is_nfc_test.cc
+    unicode_is_ucschar_test.cc
+    unicode_is_iprivate_test.cc)
 
 target_link_libraries(sourcemeta_core_unicode_unit
   PRIVATE sourcemeta::core::unicode)

--- a/test/unicode/unicode_is_iprivate_test.cc
+++ b/test/unicode/unicode_is_iprivate_test.cc
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/unicode.h>
+
+TEST(Unicode_is_iprivate, ascii_letter_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(U'A'));
+}
+
+TEST(Unicode_is_iprivate, before_bmp_private_use_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0xDFFF));
+}
+
+// BMP private use area: U+E000..U+F8FF
+TEST(Unicode_is_iprivate, bmp_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xE000));
+}
+
+TEST(Unicode_is_iprivate, bmp_middle) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xE800));
+}
+
+TEST(Unicode_is_iprivate, bmp_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF8FF));
+}
+
+TEST(Unicode_is_iprivate, just_above_bmp_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0xF900));
+}
+
+// Plane 15 supplementary private use: U+F0000..U+FFFFD
+TEST(Unicode_is_iprivate, plane15_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF0000));
+}
+
+TEST(Unicode_is_iprivate, plane15_middle) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF8000));
+}
+
+TEST(Unicode_is_iprivate, plane15_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xFFFFD));
+}
+
+TEST(Unicode_is_iprivate, plane15_fffe_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0xFFFFE));
+}
+
+TEST(Unicode_is_iprivate, plane15_ffff_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0xFFFFF));
+}
+
+// Plane 16 supplementary private use: U+100000..U+10FFFD
+TEST(Unicode_is_iprivate, plane16_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0x100000));
+}
+
+TEST(Unicode_is_iprivate, plane16_middle) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0x108000));
+}
+
+TEST(Unicode_is_iprivate, plane16_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_iprivate(0x10FFFD));
+}
+
+TEST(Unicode_is_iprivate, plane16_fffe_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0x10FFFE));
+}
+
+TEST(Unicode_is_iprivate, beyond_max_codepoint) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0x110000));
+}
+
+// Plane 14 (ucschar) is not iprivate
+TEST(Unicode_is_iprivate, plane14_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0xE1000));
+}
+
+// BMP non-ASCII letters are not iprivate
+TEST(Unicode_is_iprivate, latin_extended_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0x00C0));
+}
+
+TEST(Unicode_is_iprivate, han_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_iprivate(0x4E2D));
+}

--- a/test/unicode/unicode_is_ucschar_test.cc
+++ b/test/unicode/unicode_is_ucschar_test.cc
@@ -49,11 +49,13 @@ TEST(Unicode_is_ucschar, before_surrogates) {
 }
 
 // Surrogates are excluded
-TEST(Unicode_is_ucschar, surrogate_low_excluded) {
+TEST(Unicode_is_ucschar, surrogate_high_excluded) {
+  // U+D800 is a high (leading) surrogate
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xD800));
 }
 
-TEST(Unicode_is_ucschar, surrogate_high_excluded) {
+TEST(Unicode_is_ucschar, surrogate_low_excluded) {
+  // U+DFFF is a low (trailing) surrogate
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xDFFF));
 }
 

--- a/test/unicode/unicode_is_ucschar_test.cc
+++ b/test/unicode/unicode_is_ucschar_test.cc
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/unicode.h>
+
+// ASCII range is excluded from ucschar (those are in the URI ASCII set)
+TEST(Unicode_is_ucschar, ascii_letter_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(U'A'));
+}
+
+TEST(Unicode_is_ucschar, ascii_digit_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(U'0'));
+}
+
+TEST(Unicode_is_ucschar, null_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x0000));
+}
+
+TEST(Unicode_is_ucschar, c0_control_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x001F));
+}
+
+TEST(Unicode_is_ucschar, latin1_below_a0_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x009F));
+}
+
+// BMP non-ASCII letters are in ucschar
+TEST(Unicode_is_ucschar, nbsp_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x00A0));
+}
+
+TEST(Unicode_is_ucschar, latin_extended) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x00C0));
+}
+
+TEST(Unicode_is_ucschar, greek_alpha) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x03B1));
+}
+
+TEST(Unicode_is_ucschar, hebrew_alef) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x05D0));
+}
+
+TEST(Unicode_is_ucschar, han_zhong) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x4E2D));
+}
+
+TEST(Unicode_is_ucschar, before_surrogates) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xD7FF));
+}
+
+// Surrogates are excluded
+TEST(Unicode_is_ucschar, surrogate_low_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xD800));
+}
+
+TEST(Unicode_is_ucschar, surrogate_high_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xDFFF));
+}
+
+// BMP private use area is iprivate, not ucschar
+TEST(Unicode_is_ucschar, bmp_private_use_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xE000));
+}
+
+TEST(Unicode_is_ucschar, bmp_private_use_top_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF8FF));
+}
+
+// Compatibility ideographs gap
+TEST(Unicode_is_ucschar, before_compatibility_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF8FF));
+}
+
+TEST(Unicode_is_ucschar, compatibility_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xF900));
+}
+
+TEST(Unicode_is_ucschar, compatibility_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFDCF));
+}
+
+// Arabic presentation forms-A noncharacters gap
+TEST(Unicode_is_ucschar, fdd0_noncharacter_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFDD0));
+}
+
+TEST(Unicode_is_ucschar, fdef_noncharacter_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFDEF));
+}
+
+TEST(Unicode_is_ucschar, after_fdef_gap) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFDF0));
+}
+
+TEST(Unicode_is_ucschar, ffef_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFFEF));
+}
+
+// End-of-plane-0 noncharacters
+TEST(Unicode_is_ucschar, fff0_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFF0));
+}
+
+TEST(Unicode_is_ucschar, fffe_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFFE));
+}
+
+TEST(Unicode_is_ucschar, ffff_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFFF));
+}
+
+// Supplementary planes 1..13 each allow 0..FFFD
+TEST(Unicode_is_ucschar, plane1_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x10000));
+}
+
+TEST(Unicode_is_ucschar, plane1_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x1FFFD));
+}
+
+TEST(Unicode_is_ucschar, plane1_fffe_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x1FFFE));
+}
+
+TEST(Unicode_is_ucschar, plane1_ffff_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x1FFFF));
+}
+
+TEST(Unicode_is_ucschar, plane2) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x20000));
+}
+
+TEST(Unicode_is_ucschar, plane13_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xDFFFD));
+}
+
+// Plane 14 starts at offset 0x1000 (E1000), not E0000
+TEST(Unicode_is_ucschar, plane14_e0000_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xE0000));
+}
+
+TEST(Unicode_is_ucschar, plane14_e0fff_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xE0FFF));
+}
+
+TEST(Unicode_is_ucschar, plane14_lower_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xE1000));
+}
+
+TEST(Unicode_is_ucschar, plane14_upper_bound) {
+  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xEFFFD));
+}
+
+// Planes 15 and 16 are iprivate, not ucschar
+TEST(Unicode_is_ucschar, plane15_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF0000));
+}
+
+TEST(Unicode_is_ucschar, plane16_excluded) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x100000));
+}
+
+TEST(Unicode_is_ucschar, beyond_max_codepoint) {
+  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x110000));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
