### PR TITLE
Keep descriptions in the `mcp_make_resource_link` fallback

### DIFF
--- a/src/core/mcp/mcp.cc
+++ b/src/core/mcp/mcp.cc
@@ -88,21 +88,17 @@ auto mcp_make_resource_link(const MCPProtocolVersion version,
   if (!mcp_supports_resource_link_content(version)) {
     // Multi-line fallback is deliberate: the consumer is an LLM reading tool
     // output, not a human display surface, so a vertical layout keeps all three
-    // fields readable while sidestepping quoting issues, etc
+    // fields readable while sidestepping quoting issues, etc. The URI is the
+    // primary identifier and is always emitted, even when other fields are
+    // empty
     std::string text;
     if (!name.empty()) {
       text.append(name);
+      text.append("\n");
     }
-    if (!uri.empty()) {
-      if (!text.empty()) {
-        text.append("\n");
-      }
-      text.append(uri);
-    }
+    text.append(uri);
     if (!description.empty()) {
-      if (!text.empty()) {
-        text.append("\n");
-      }
+      text.append("\n");
       text.append(description);
     }
     return mcp_make_text_block(text);

--- a/src/core/mcp/mcp.cc
+++ b/src/core/mcp/mcp.cc
@@ -86,11 +86,24 @@ auto mcp_make_resource_link(const MCPProtocolVersion version,
                             const JSON::StringView description)
     -> sourcemeta::core::JSON {
   if (!mcp_supports_resource_link_content(version)) {
-    std::string text{uri};
+    // Multi-line fallback is deliberate: the consumer is an LLM reading tool
+    // output, not a human display surface, so a vertical layout keeps all three
+    // fields readable while sidestepping quoting issues, etc
+    std::string text;
     if (!name.empty()) {
-      text.append(" (");
       text.append(name);
-      text.append(")");
+    }
+    if (!uri.empty()) {
+      if (!text.empty()) {
+        text.append("\n");
+      }
+      text.append(uri);
+    }
+    if (!description.empty()) {
+      if (!text.empty()) {
+        text.append("\n");
+      }
+      text.append(description);
     }
     return mcp_make_text_block(text);
   }

--- a/test/mcp/mcp_test.cc
+++ b/test/mcp/mcp_test.cc
@@ -312,7 +312,7 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_with_name) {
       "text/plain", "My File", "A description")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "type": "text",
-    "text": "file:///foo (My File)"
+    "text": "My File\nfile:///foo\nA description"
   })JSON")};
   EXPECT_EQ(block, expected);
 }
@@ -323,7 +323,19 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_without_name) {
       "text/plain", {}, "A description")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "type": "text",
-    "text": "file:///foo"
+    "text": "file:///foo\nA description"
+  })JSON")};
+  EXPECT_EQ(block, expected);
+}
+
+TEST(MCP,
+     make_resource_link_2025_03_26_falls_back_to_text_without_description) {
+  const auto block{sourcemeta::core::mcp_make_resource_link(
+      sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "file:///foo",
+      "text/plain", "My File")};
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "type": "text",
+    "text": "My File\nfile:///foo"
   })JSON")};
   EXPECT_EQ(block, expected);
 }
@@ -335,6 +347,19 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_uri_only) {
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "type": "text",
     "text": "file:///foo"
+  })JSON")};
+  EXPECT_EQ(block, expected);
+}
+
+TEST(MCP,
+     make_resource_link_2025_03_26_falls_back_handles_parentheses_in_name) {
+  const auto block{sourcemeta::core::mcp_make_resource_link(
+      sourcemeta::core::MCPProtocolVersion::V_2025_03_26,
+      "https://example.com/schema", "application/schema+json",
+      "RFC 5322 Email Address (Addr-Spec)", "Validates email syntax")};
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "type": "text",
+    "text": "RFC 5322 Email Address (Addr-Spec)\nhttps://example.com/schema\nValidates email syntax"
   })JSON")};
   EXPECT_EQ(block, expected);
 }

--- a/test/mcp/mcp_test.cc
+++ b/test/mcp/mcp_test.cc
@@ -364,6 +364,41 @@ TEST(MCP,
   EXPECT_EQ(block, expected);
 }
 
+TEST(MCP,
+     make_resource_link_2025_03_26_falls_back_preserves_empty_uri_position) {
+  const auto block{sourcemeta::core::mcp_make_resource_link(
+      sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "", "text/plain",
+      "My File", "A description")};
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "type": "text",
+    "text": "My File\n\nA description"
+  })JSON")};
+  EXPECT_EQ(block, expected);
+}
+
+TEST(MCP,
+     make_resource_link_2025_03_26_falls_back_empty_uri_with_description_only) {
+  const auto block{sourcemeta::core::mcp_make_resource_link(
+      sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "", "text/plain", {},
+      "A description")};
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "type": "text",
+    "text": "\nA description"
+  })JSON")};
+  EXPECT_EQ(block, expected);
+}
+
+TEST(MCP, make_resource_link_2025_03_26_falls_back_empty_uri_with_name_only) {
+  const auto block{sourcemeta::core::mcp_make_resource_link(
+      sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "", "text/plain",
+      "My File")};
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "type": "text",
+    "text": "My File\n"
+  })JSON")};
+  EXPECT_EQ(block, expected);
+}
+
 TEST(MCP, tool_success_with_object_result) {
   const auto identifier{sourcemeta::core::JSON{1}};
   auto result{sourcemeta::core::JSON::make_object()};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
