### PR TITLE
Fix a GCC 15 debug test crash

### DIFF
--- a/src/core/regex/preprocess.h
+++ b/src/core/regex/preprocess.h
@@ -561,6 +561,10 @@ inline auto expand_set_ops(const std::string &content, std::bitset<128> &result)
 
     result =
         op_char == '-' ? (result & ~operand_chars) : (result & operand_chars);
+    if (next == std::string::npos) {
+      break;
+    }
+
     position = next;
   }
 


### PR DESCRIPTION
```
[ RUN      ] Regex_matches.ecma262_v_flag_set_subtraction
  /usr/include/c++/15/bits/basic_string.h:1349: constexpr std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::const_reference std::__cxx11::basic_string<_CharT, _Traits,
  _Alloc>::operator[](size_type) const [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; const_reference = const char&; size_type = long unsigned
  int]: Assertion '__pos <= size()' failed.
  Aborted
```

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
