### PR TITLE
test(dns): extend idn-hostname coverage for Bidi, A-label and ContextJ rules

### DIFF
--- a/test/dns/idn_hostname_test.cc
+++ b/test/dns/idn_hostname_test.cc
@@ -593,3 +593,63 @@ TEST(DNS_idn_hostname, label_with_out_of_order_combining_marks_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a\xcc\x81\xcc\x96"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xcc\x81\xcc\x96"));
 }
+
+// --- additional coverage: subtle cases (whole-name Bidi, A-label
+// re-validation, non-canonical Punycode, per-occurrence ContextJ) ---
+
+// RFC 5893 sec 2: a digit-first label is invalid in a Bidi domain name
+// (whole-name rule)
+TEST(DNS_idn_hostname, invalid_bidi_digit_first_in_bidi_domain) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x30\x61\x2e\xd7\x90"));
+}
+
+// RFC 5893 sec 2 cond 1: label must start with L, R or AL
+TEST(DNS_idn_hostname, invalid_bidi_single_label_digit_then_rtl) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x30\xd8\xa7"));
+}
+
+// RFC 5893 sec 2 cond 5: an LTR label may not contain an RTL letter
+TEST(DNS_idn_hostname, invalid_bidi_ltr_label_with_rtl_letter) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x61\xd7\x90"));
+}
+
+// RFC 5890 sec 2.3.2.1 + 5892 sec 2.6: decodes to U+00A1 (DISALLOWED)
+TEST(DNS_idn_hostname, invalid_a_label_decodes_to_disallowed) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x78\x6e\x2d\x2d\x37\x61"));
+}
+
+// RFC 5890 sec 2.3.2.1: A-label decodes to the all-ASCII label example
+TEST(DNS_idn_hostname, invalid_a_label_decodes_to_ascii_only) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
+      "\x78\x6e\x2d\x2d\x65\x78\x61\x6d\x70\x6c\x65\x2d"));
+}
+
+// RFC 5890 sec 2.3.2.1 + 5893: decodes to a-grave + Hebrew aleph
+TEST(DNS_idn_hostname, invalid_a_label_decodes_to_bidi_violation) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
+      "\x78\x6e\x2d\x2d\x30\x63\x61\x32\x34\x77"));
+}
+
+// RFC 5891 sec 5.4: non-canonical Punycode; canonical form is xn--9uc
+TEST(DNS_idn_hostname, invalid_noncanonical_punycode) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_idn_hostname("\x78\x6e\x2d\x2d\x2d\x39\x75\x63"));
+}
+
+// RFC 5892 sec 2.6: fullwidth digits U+FF11..U+FF13 are DISALLOWED
+TEST(DNS_idn_hostname, invalid_fullwidth_digits) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
+      "\xef\xbc\x91\xef\xbc\x92\xef\xbc\x93"));
+}
+
+// RFC 5892 sec 2.6: U+200B (ZERO WIDTH SPACE) is DISALLOWED
+TEST(DNS_idn_hostname, invalid_zero_width_space) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x61\xe2\x80\x8b\x62"));
+}
+
+// RFC 5892 appendix A.1 (errata 3312): the ZWNJ rule must hold at every
+// occurrence
+TEST(DNS_idn_hostname, invalid_zwnj_failing_at_one_occurrence) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
+      "\xe0\xa4\x95\xe0\xa5\x8d\xe2\x80\x8c\xe0\xa4\xb7\x78\xe2\x80\x8c\x79"));
+}

--- a/test/dns/idn_hostname_test.cc
+++ b/test/dns/idn_hostname_test.cc
@@ -594,9 +594,6 @@ TEST(DNS_idn_hostname, label_with_out_of_order_combining_marks_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xcc\x81\xcc\x96"));
 }
 
-// --- additional coverage: subtle cases (whole-name Bidi, A-label
-// re-validation, non-canonical Punycode, per-occurrence ContextJ) ---
-
 // RFC 5893 sec 2: a digit-first label is invalid in a Bidi domain name
 // (whole-name rule)
 TEST(DNS_idn_hostname, invalid_bidi_digit_first_in_bidi_domain) {


### PR DESCRIPTION
`is_idn_hostname` already handles these cases correctly. This adds 10 tests that pin that behaviour explicitly so regressions are caught early. Each case targets a rule that at least one other production library misses, confirmed by running the same inputs across 9 validators.

## Changes

- `invalid_bidi_digit_first_in_bidi_domain` - whole-name Bidi check: `0a.א` is invalid because the LTR label `0a` violates RFC 5893 §2 condition 1 when paired with an RTL label (python-jsonschema misses this)
- `invalid_bidi_single_label_digit_then_rtl` - RTL label starting with a digit is invalid (RFC 5893 §2 cond 1)
- `invalid_bidi_ltr_label_with_rtl_letter` - LTR label containing an RTL letter violates RFC 5893 §2 cond 5
- `invalid_a_label_decodes_to_disallowed` - `xn--7a` decodes to U+00A1, which is DISALLOWED under RFC 5892 §2.6; an A-label is only valid if it decodes to a valid U-label (RFC 5890 §2.3.2.1)
- `invalid_a_label_decodes_to_ascii_only` - `xn--example-` decodes to `example` (all ASCII); a U-label must contain at least one non-ASCII character (RFC 5890 §2.3.2.1)
- `invalid_a_label_decodes_to_bidi_violation` - A-label whose decoded U-label itself violates the Bidi rule
- `invalid_noncanonical_punycode` - `xn---9uc` decodes to a codepoint whose canonical A-label is `xn--9uc`; round-trip must match (RFC 5891 §5.4)
- `invalid_fullwidth_digits` - U+FF11..U+FF13 are DISALLOWED under RFC 5892 §2.6; UTS46 processors silently map them to ASCII and accept
- `invalid_zero_width_space` - U+200B is DISALLOWED under RFC 5892 §2.6; several UTS46 libraries strip it silently
- `invalid_zwnj_failing_at_one_occurrence` - ZWNJ rule (RFC 5892 appendix A.1, erratum 3312) must pass at every occurrence; Node and PHP accept a label where one ZWNJ is valid and a second is not

## Ecosystem Impact

1. Bidi whole-name rule: python `idna` 3.10 FAILS (per-label check misses cross-label condition); Go `x/net/idna` PASSES
2. A-label decodes to DISALLOWED: Go, Node, PHP, Rust, Java, ICU4J, Guava all ACCEPT; python idna REJECTS (7/9 wrong)
3. A-label decodes to ASCII only: Go `x/net/idna` and Node ACCEPT; python idna REJECTS - same class as CVE-2024-12224 (Rust idna), CVE-2026-39821 (Go x/net), CVE-2026-46644 (PHP polyfill)
4. Non-canonical Punycode: python idna and Node ACCEPT; Go, PHP, Rust, ICU4J REJECT
5. Fullwidth digits / zero-width space: 8/9 validators ACCEPT (all but python idna); GNU libidn2 GitLab issue #136
6. ZWNJ per-occurrence: Node and PHP ACCEPT the mixed case; Go and python idna REJECT

## RFC References

- [RFC 5890 §2.3.2.1](https://www.rfc-editor.org/rfc/rfc5890#section-2.3.2.1) - A-label/U-label relationship
- [RFC 5891 §5.4](https://www.rfc-editor.org/rfc/rfc5891#section-5.4) - Punycode round-trip requirement
- [RFC 5892 §2.6](https://www.rfc-editor.org/rfc/rfc5892#section-2.6) - DISALLOWED code points
- [RFC 5892 appendix A.1](https://www.rfc-editor.org/rfc/rfc5892#appendix-A.1) - ZWNJ rule + erratum 3312
- [RFC 5893 §2](https://www.rfc-editor.org/rfc/rfc5893#section-2) - Bidi rule (all 6 conditions)

Cross-implementation evidence: https://github.com/vtushar06/JSON-Schema-format-test-Evidence/blob/main/idn-hostname.md
