### PR TITLE
Implement `std::wstring` conversion utilities

### DIFF
--- a/src/core/unicode/include/sourcemeta/core/unicode.h
+++ b/src/core/unicode/include/sourcemeta/core/unicode.h
@@ -12,8 +12,8 @@
 #include <istream>     // std::istream
 #include <optional>    // std::optional
 #include <ostream>     // std::ostream
-#include <string>      // std::string, std::u32string
-#include <string_view> // std::string_view
+#include <string>      // std::string, std::u32string, std::wstring
+#include <string_view> // std::string_view, std::wstring_view
 
 /// @defgroup unicode Unicode
 /// @brief Unicode encoding utilities.
@@ -105,6 +105,33 @@ auto utf8_to_utf32(std::istream &input) -> std::optional<std::u32string>;
 SOURCEMETA_CORE_UNICODE_EXPORT
 auto utf8_to_utf32(const std::string_view input)
     -> std::optional<std::u32string>;
+
+/// @ingroup unicode
+/// Convert a UTF-8 string into its wide character form without validation.
+/// The input must be valid UTF-8, otherwise the result is undefined.
+/// For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/unicode.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::utf8_to_wide("hello") == L"hello");
+/// ```
+SOURCEMETA_CORE_UNICODE_EXPORT
+auto utf8_to_wide(const std::string_view input) -> std::wstring;
+
+/// @ingroup unicode
+/// Convert a wide string into its UTF-8 form without validation. The input
+/// must be valid, otherwise the result is undefined. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/unicode.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::wide_to_utf8(L"hello") == "hello");
+/// ```
+SOURCEMETA_CORE_UNICODE_EXPORT
+auto wide_to_utf8(const std::wstring_view input) -> std::string;
 
 /// @ingroup unicode
 /// Determine the byte length encoded by a UTF-8 lead byte. Returns 1 for an

--- a/src/core/unicode/unicode.cc
+++ b/src/core/unicode/unicode.cc
@@ -1,10 +1,17 @@
 #include <sourcemeta/core/unicode.h>
 
-#include <array>    // std::array
-#include <cassert>  // assert
-#include <cstddef>  // std::size_t
-#include <cstdint>  // std::uint8_t
-#include <optional> // std::optional, std::nullopt
+#include <array>       // std::array
+#include <cassert>     // assert
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string, std::wstring
+#include <string_view> // std::string_view, std::wstring_view
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h> // MultiByteToWideChar, WideCharToMultiByte, CP_UTF8
+#endif
 
 #include "unicode_data.h"
 
@@ -164,6 +171,84 @@ auto utf8_to_utf32(const std::string_view input)
   }
 
   return result;
+}
+
+auto utf8_to_wide(const std::string_view input) -> std::wstring {
+  if (input.empty()) {
+    return L"";
+  }
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+  const auto size{MultiByteToWideChar(
+      CP_UTF8, 0, input.data(), static_cast<int>(input.size()), nullptr, 0)};
+  std::wstring result(static_cast<std::size_t>(size), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, input.data(), static_cast<int>(input.size()),
+                      result.data(), size);
+  return result;
+#else
+  // Outside of Windows, a wide character holds an entire codepoint, so the
+  // result never has more characters than the input has bytes
+  std::wstring result(input.size(), L'\0');
+  std::size_t write{0};
+  std::size_t read{0};
+  while (read < input.size()) {
+    const auto lead{static_cast<std::uint8_t>(input[read])};
+    if (lead < 0x80) {
+      result[write++] = static_cast<wchar_t>(lead);
+      read += 1;
+    } else if (lead < 0xE0) {
+      result[write++] = static_cast<wchar_t>(
+          ((lead & 0x1FU) << 6U) |
+          (static_cast<std::uint8_t>(input[read + 1]) & 0x3FU));
+      read += 2;
+    } else if (lead < 0xF0) {
+      result[write++] = static_cast<wchar_t>(
+          ((lead & 0x0FU) << 12U) |
+          ((static_cast<std::uint8_t>(input[read + 1]) & 0x3FU) << 6U) |
+          (static_cast<std::uint8_t>(input[read + 2]) & 0x3FU));
+      read += 3;
+    } else {
+      result[write++] = static_cast<wchar_t>(
+          ((lead & 0x07U) << 18U) |
+          ((static_cast<std::uint8_t>(input[read + 1]) & 0x3FU) << 12U) |
+          ((static_cast<std::uint8_t>(input[read + 2]) & 0x3FU) << 6U) |
+          (static_cast<std::uint8_t>(input[read + 3]) & 0x3FU));
+      read += 4;
+    }
+  }
+
+  result.resize(write);
+  return result;
+#endif
+}
+
+auto wide_to_utf8(const std::wstring_view input) -> std::string {
+  if (input.empty()) {
+    return "";
+  }
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+  const auto size{WideCharToMultiByte(CP_UTF8, 0, input.data(),
+                                      static_cast<int>(input.size()), nullptr,
+                                      0, nullptr, nullptr)};
+  std::string result(static_cast<std::size_t>(size), '\0');
+  WideCharToMultiByte(CP_UTF8, 0, input.data(), static_cast<int>(input.size()),
+                      result.data(), size, nullptr, nullptr);
+  return result;
+#else
+  std::size_t size{0};
+  for (const auto character : input) {
+    size += utf8_codepoint_byte_count(static_cast<char32_t>(character));
+  }
+
+  std::string result;
+  result.reserve(size);
+  for (const auto character : input) {
+    codepoint_to_utf8(static_cast<char32_t>(character), result);
+  }
+
+  return result;
+#endif
 }
 
 auto combining_class(const char32_t codepoint) noexcept -> std::uint8_t {

--- a/src/core/unicode/unicode.cc
+++ b/src/core/unicode/unicode.cc
@@ -10,6 +10,7 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define WIN32_LEAN_AND_MEAN
+#include <limits>    // std::numeric_limits
 #include <windows.h> // MultiByteToWideChar, WideCharToMultiByte, CP_UTF8
 #endif
 
@@ -179,6 +180,8 @@ auto utf8_to_wide(const std::string_view input) -> std::wstring {
   }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+  assert(input.size() <=
+         static_cast<std::size_t>(std::numeric_limits<int>::max()));
   const auto size{MultiByteToWideChar(
       CP_UTF8, 0, input.data(), static_cast<int>(input.size()), nullptr, 0)};
   std::wstring result(static_cast<std::size_t>(size), L'\0');
@@ -188,6 +191,8 @@ auto utf8_to_wide(const std::string_view input) -> std::wstring {
 #else
   // Outside of Windows, a wide character holds an entire codepoint, so the
   // result never has more characters than the input has bytes
+  static_assert(sizeof(wchar_t) >= 4,
+                "a wide character must hold an entire codepoint");
   std::wstring result(input.size(), L'\0');
   std::size_t write{0};
   std::size_t read{0};
@@ -228,6 +233,8 @@ auto wide_to_utf8(const std::wstring_view input) -> std::string {
   }
 
 #if defined(_WIN32) || defined(__CYGWIN__)
+  assert(input.size() <=
+         static_cast<std::size_t>(std::numeric_limits<int>::max()));
   const auto size{WideCharToMultiByte(CP_UTF8, 0, input.data(),
                                       static_cast<int>(input.size()), nullptr,
                                       0, nullptr, nullptr)};
@@ -236,6 +243,8 @@ auto wide_to_utf8(const std::wstring_view input) -> std::string {
                       result.data(), size, nullptr, nullptr);
   return result;
 #else
+  static_assert(sizeof(wchar_t) >= 4,
+                "a wide character must hold an entire codepoint");
   std::size_t size{0};
   for (const auto character : input) {
     size += utf8_codepoint_byte_count(static_cast<char32_t>(character));

--- a/src/core/unicode/unicode.cc
+++ b/src/core/unicode/unicode.cc
@@ -10,6 +10,7 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <limits>    // std::numeric_limits
 #include <windows.h> // MultiByteToWideChar, WideCharToMultiByte, CP_UTF8
 #endif

--- a/test/unicode/CMakeLists.txt
+++ b/test/unicode/CMakeLists.txt
@@ -2,6 +2,8 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME unicode
   SOURCES
     unicode_codepoint_to_utf8_test.cc
     unicode_utf8_to_utf32_test.cc
+    unicode_utf8_to_wide_test.cc
+    unicode_wide_to_utf8_test.cc
     unicode_utf8_codepoint_length_test.cc
     unicode_utf8_lead_byte_size_test.cc
     unicode_utf8_codepoint_byte_count_test.cc

--- a/test/unicode/unicode_utf8_to_wide_test.cc
+++ b/test/unicode/unicode_utf8_to_wide_test.cc
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/unicode.h>
+
+#include <string>      // std::wstring
+#include <string_view> // std::string_view
+
+TEST(Unicode_utf8_to_wide, empty_string) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide(""), L"");
+}
+
+TEST(Unicode_utf8_to_wide, single_ascii_character) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("a"), L"a");
+}
+
+TEST(Unicode_utf8_to_wide, ascii_word) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("hello"), L"hello");
+}
+
+TEST(Unicode_utf8_to_wide, ascii_sentence_with_punctuation) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("Hello, World! 123"),
+            L"Hello, World! 123");
+}
+
+TEST(Unicode_utf8_to_wide, ascii_url) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("https://example.com/foo?bar=baz"),
+            L"https://example.com/foo?bar=baz");
+}
+
+TEST(Unicode_utf8_to_wide, two_byte_latin_small_letter_e_with_acute) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xc3\xa9"), L"\x00e9");
+}
+
+TEST(Unicode_utf8_to_wide, two_byte_word) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("caf\xc3\xa9"), L"caf\x00e9");
+}
+
+TEST(Unicode_utf8_to_wide, two_byte_greek_word) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xce\xb1\xce\xb2\xce\xb3"),
+            L"\x03b1\x03b2\x03b3");
+}
+
+TEST(Unicode_utf8_to_wide, two_byte_cyrillic_word) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide(
+                "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"),
+            L"\x041f\x0440\x0438\x0432\x0435\x0442");
+}
+
+TEST(Unicode_utf8_to_wide, three_byte_euro_sign) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xe2\x82\xac"), L"\x20ac");
+}
+
+TEST(Unicode_utf8_to_wide, three_byte_cjk_word) {
+  EXPECT_EQ(
+      sourcemeta::core::utf8_to_wide("\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"),
+      L"\x65e5\x672c\x8a9e");
+}
+
+TEST(Unicode_utf8_to_wide, four_byte_grinning_face_emoji) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x9f\x98\x80"), L"\U0001f600");
+}
+
+TEST(Unicode_utf8_to_wide, four_byte_musical_symbol_g_clef) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x9d\x84\x9e"), L"\U0001d11e");
+}
+
+TEST(Unicode_utf8_to_wide, consecutive_four_byte_code_points) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x9f\x98\x80\xf0\x9f\x98\x81"),
+            L"\U0001f600\U0001f601");
+}
+
+TEST(Unicode_utf8_to_wide, mixed_sequence_lengths) {
+  EXPECT_EQ(
+      sourcemeta::core::utf8_to_wide("a\xc3\xa9\xe2\x82\xac\xf0\x9f\x98\x80"),
+      L"a\x00e9\x20ac\U0001f600");
+}
+
+TEST(Unicode_utf8_to_wide, multibyte_at_start) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xe2\x82\xacxyz"), L"\x20acxyz");
+}
+
+TEST(Unicode_utf8_to_wide, multibyte_at_end) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("xyz\xe2\x82\xac"), L"xyz\x20ac");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_last_one_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\x7f"), L"\x007f");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_first_two_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xc2\x80"), L"\x0080");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_last_two_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xdf\xbf"), L"\x07ff");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_first_three_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xe0\xa0\x80"), L"\x0800");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_last_three_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xef\xbf\xbf"), L"\xffff");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_first_four_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x90\x80\x80"), L"\U00010000");
+}
+
+TEST(Unicode_utf8_to_wide, boundary_last_four_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf4\x8f\xbf\xbf"), L"\U0010ffff");
+}
+
+TEST(Unicode_utf8_to_wide, embedded_null_byte) {
+  const std::string_view input{"a\0b", 3};
+  const std::wstring expected{L"a\0b", 3};
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide(input), expected);
+}

--- a/test/unicode/unicode_wide_to_utf8_test.cc
+++ b/test/unicode/unicode_wide_to_utf8_test.cc
@@ -1,0 +1,128 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/unicode.h>
+
+#include <string>      // std::string
+#include <string_view> // std::wstring_view
+
+TEST(Unicode_wide_to_utf8, empty_string) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L""), "");
+}
+
+TEST(Unicode_wide_to_utf8, single_ascii_character) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"a"), "a");
+}
+
+TEST(Unicode_wide_to_utf8, ascii_word) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"hello"), "hello");
+}
+
+TEST(Unicode_wide_to_utf8, ascii_sentence_with_punctuation) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"Hello, World! 123"),
+            "Hello, World! 123");
+}
+
+TEST(Unicode_wide_to_utf8, ascii_url) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"https://example.com/foo?bar=baz"),
+            "https://example.com/foo?bar=baz");
+}
+
+TEST(Unicode_wide_to_utf8, two_byte_latin_small_letter_e_with_acute) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x00e9"), "\xc3\xa9");
+}
+
+TEST(Unicode_wide_to_utf8, two_byte_word) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"caf\x00e9"), "caf\xc3\xa9");
+}
+
+TEST(Unicode_wide_to_utf8, two_byte_greek_word) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x03b1\x03b2\x03b3"),
+            "\xce\xb1\xce\xb2\xce\xb3");
+}
+
+TEST(Unicode_wide_to_utf8, two_byte_cyrillic_word) {
+  EXPECT_EQ(
+      sourcemeta::core::wide_to_utf8(L"\x041f\x0440\x0438\x0432\x0435\x0442"),
+      "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82");
+}
+
+TEST(Unicode_wide_to_utf8, three_byte_euro_sign) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x20ac"), "\xe2\x82\xac");
+}
+
+TEST(Unicode_wide_to_utf8, three_byte_cjk_word) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x65e5\x672c\x8a9e"),
+            "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e");
+}
+
+TEST(Unicode_wide_to_utf8, four_byte_grinning_face_emoji) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0001f600"), "\xf0\x9f\x98\x80");
+}
+
+TEST(Unicode_wide_to_utf8, four_byte_musical_symbol_g_clef) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0001d11e"), "\xf0\x9d\x84\x9e");
+}
+
+TEST(Unicode_wide_to_utf8, consecutive_four_byte_code_points) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0001f600\U0001f601"),
+            "\xf0\x9f\x98\x80\xf0\x9f\x98\x81");
+}
+
+TEST(Unicode_wide_to_utf8, mixed_sequence_lengths) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"a\x00e9\x20ac\U0001f600"),
+            "a\xc3\xa9\xe2\x82\xac\xf0\x9f\x98\x80");
+}
+
+TEST(Unicode_wide_to_utf8, multibyte_at_start) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x20acxyz"), "\xe2\x82\xacxyz");
+}
+
+TEST(Unicode_wide_to_utf8, multibyte_at_end) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"xyz\x20ac"), "xyz\xe2\x82\xac");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_last_one_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x007f"), "\x7f");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_first_two_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x0080"), "\xc2\x80");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_last_two_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x07ff"), "\xdf\xbf");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_first_three_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x0800"), "\xe0\xa0\x80");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_last_three_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\xffff"), "\xef\xbf\xbf");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_first_four_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U00010000"), "\xf0\x90\x80\x80");
+}
+
+TEST(Unicode_wide_to_utf8, boundary_last_four_byte_code_point) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0010ffff"), "\xf4\x8f\xbf\xbf");
+}
+
+TEST(Unicode_wide_to_utf8, embedded_null_character) {
+  const std::wstring_view input{L"a\0b", 3};
+  const std::string expected{"a\0b", 3};
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(input), expected);
+}
+
+TEST(Unicode_wide_to_utf8, round_trip_from_utf8) {
+  EXPECT_EQ(sourcemeta::core::wide_to_utf8(sourcemeta::core::utf8_to_wide(
+                "caf\xc3\xa9 \xe2\x82\xac \xf0\x9f\x98\x80")),
+            "caf\xc3\xa9 \xe2\x82\xac \xf0\x9f\x98\x80");
+}
+
+TEST(Unicode_wide_to_utf8, round_trip_from_wide) {
+  EXPECT_EQ(sourcemeta::core::utf8_to_wide(
+                sourcemeta::core::wide_to_utf8(L"caf\x00e9 \x20ac \U0001f600")),
+            L"caf\x00e9 \x20ac \U0001f600");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

