### PR TITLE
Add a new `HTTPStatusError` exception class

### DIFF
--- a/src/core/http/include/sourcemeta/core/http_error.h
+++ b/src/core/http/include/sourcemeta/core/http_error.h
@@ -8,6 +8,7 @@
 #include <sourcemeta/core/http_method.h>
 #include <sourcemeta/core/http_status.h>
 
+#include <cstdint>   // std::uint16_t
 #include <stdexcept> // std::runtime_error
 #include <string>    // std::string
 #include <utility>   // std::move
@@ -57,7 +58,8 @@ private:
 };
 
 /// @ingroup http
-/// An error for a response with an unsuccessful status code. For example:
+/// An error for a response with an unsuccessful status code, owning a copy
+/// of the status data. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/http.h>
@@ -71,17 +73,20 @@ private:
 class SOURCEMETA_CORE_HTTP_EXPORT HTTPStatusError : public HTTPError {
 public:
   HTTPStatusError(const HTTPMethod method, std::string url,
-                  const HTTPStatus status)
+                  const HTTPStatus &status)
       : HTTPError{method, std::move(url), "Unsuccessful HTTP response"},
-        status_{status} {}
+        code_{status.code}, phrase_{status.phrase}, wire_{status.wire} {}
 
-  /// Get the response status that triggered the failure
-  [[nodiscard]] auto status() const noexcept -> const HTTPStatus & {
-    return this->status_;
+  /// Get the response status that triggered the failure. The contained
+  /// views borrow from this error and stay valid for its lifetime
+  [[nodiscard]] auto status() const noexcept -> HTTPStatus {
+    return {.code = this->code_, .phrase = this->phrase_, .wire = this->wire_};
   }
 
 private:
-  HTTPStatus status_;
+  std::uint16_t code_;
+  std::string phrase_;
+  std::string wire_;
 };
 
 #if defined(_MSC_VER)

--- a/src/core/http/include/sourcemeta/core/http_error.h
+++ b/src/core/http/include/sourcemeta/core/http_error.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <sourcemeta/core/http_method.h>
+#include <sourcemeta/core/http_status.h>
 
 #include <stdexcept> // std::runtime_error
 #include <string>    // std::string
@@ -53,6 +54,34 @@ public:
 private:
   HTTPMethod method_;
   std::string url_;
+};
+
+/// @ingroup http
+/// An error for a response with an unsuccessful status code. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const sourcemeta::core::HTTPStatusError error{
+///     sourcemeta::core::HTTPMethod::GET,
+///     "https://example.com", sourcemeta::core::HTTP_STATUS_NOT_FOUND};
+/// assert(error.status() == sourcemeta::core::HTTP_STATUS_NOT_FOUND);
+/// ```
+class SOURCEMETA_CORE_HTTP_EXPORT HTTPStatusError : public HTTPError {
+public:
+  HTTPStatusError(const HTTPMethod method, std::string url,
+                  const HTTPStatus status)
+      : HTTPError{method, std::move(url), "Unsuccessful HTTP response"},
+        status_{status} {}
+
+  /// Get the response status that triggered the failure
+  [[nodiscard]] auto status() const noexcept -> const HTTPStatus & {
+    return this->status_;
+  }
+
+private:
+  HTTPStatus status_;
 };
 
 #if defined(_MSC_VER)

--- a/test/http/http_error_test.cc
+++ b/test/http/http_error_test.cc
@@ -4,7 +4,9 @@
 #include <sourcemeta/core/http_method.h>
 #include <sourcemeta/core/http_status.h>
 
+#include <optional>  // std::optional
 #include <stdexcept> // std::runtime_error
+#include <string>    // std::string
 
 TEST(HTTP_error, message) {
   const sourcemeta::core::HTTPError error{sourcemeta::core::HTTPMethod::GET,
@@ -68,4 +70,20 @@ TEST(HTTP_error, status_error_catchable_as_http_error) {
                    sourcemeta::core::HTTPMethod::GET, "https://example.com",
                    sourcemeta::core::HTTP_STATUS_NOT_FOUND),
                sourcemeta::core::HTTPError);
+}
+
+TEST(HTTP_error, status_error_owns_status_data) {
+  std::optional<sourcemeta::core::HTTPStatusError> error;
+  {
+    const std::string phrase{"Custom Experimental Phrase"};
+    const std::string wire{"599 Custom Experimental Phrase"};
+    const sourcemeta::core::HTTPStatus status{
+        .code = 599, .phrase = phrase, .wire = wire};
+    error.emplace(sourcemeta::core::HTTPMethod::GET, "https://example.com",
+                  status);
+  }
+
+  EXPECT_EQ(error.value().status().code, 599);
+  EXPECT_EQ(error.value().status().phrase, "Custom Experimental Phrase");
+  EXPECT_EQ(error.value().status().wire, "599 Custom Experimental Phrase");
 }

--- a/test/http/http_error_test.cc
+++ b/test/http/http_error_test.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/http_error.h>
 #include <sourcemeta/core/http_method.h>
+#include <sourcemeta/core/http_status.h>
 
 #include <stdexcept> // std::runtime_error
 
@@ -31,4 +32,40 @@ TEST(HTTP_error, catchable_as_runtime_error) {
       throw sourcemeta::core::HTTPError(sourcemeta::core::HTTPMethod::GET,
                                         "https://example.com", "failure"),
       std::runtime_error);
+}
+
+TEST(HTTP_error, status_error_message) {
+  const sourcemeta::core::HTTPStatusError error{
+      sourcemeta::core::HTTPMethod::GET, "https://example.com",
+      sourcemeta::core::HTTP_STATUS_NOT_FOUND};
+  EXPECT_STREQ(error.what(), "Unsuccessful HTTP response");
+}
+
+TEST(HTTP_error, status_error_method) {
+  const sourcemeta::core::HTTPStatusError error{
+      sourcemeta::core::HTTPMethod::POST, "https://example.com",
+      sourcemeta::core::HTTP_STATUS_NOT_FOUND};
+  EXPECT_EQ(error.method(), sourcemeta::core::HTTPMethod::POST);
+}
+
+TEST(HTTP_error, status_error_url) {
+  const sourcemeta::core::HTTPStatusError error{
+      sourcemeta::core::HTTPMethod::GET, "https://example.com/schema.json",
+      sourcemeta::core::HTTP_STATUS_NOT_FOUND};
+  EXPECT_EQ(error.url(), "https://example.com/schema.json");
+}
+
+TEST(HTTP_error, status_error_status) {
+  const sourcemeta::core::HTTPStatusError error{
+      sourcemeta::core::HTTPMethod::GET, "https://example.com",
+      sourcemeta::core::HTTP_STATUS_SERVICE_UNAVAILABLE};
+  EXPECT_EQ(error.status(), sourcemeta::core::HTTP_STATUS_SERVICE_UNAVAILABLE);
+  EXPECT_EQ(error.status().code, 503);
+}
+
+TEST(HTTP_error, status_error_catchable_as_http_error) {
+  EXPECT_THROW(throw sourcemeta::core::HTTPStatusError(
+                   sourcemeta::core::HTTPMethod::GET, "https://example.com",
+                   sourcemeta::core::HTTP_STATUS_NOT_FOUND),
+               sourcemeta::core::HTTPError);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

