### PR TITLE
Use `hex_to_bytes` in `pyca_cryptography_*` tests

### DIFF
--- a/test/crypto/CMakeLists.txt
+++ b/test/crypto/CMakeLists.txt
@@ -11,7 +11,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME crypto
     crypto_base64url_test.cc)
 
 target_link_libraries(sourcemeta_core_crypto_unit
-  PRIVATE sourcemeta::core::crypto)
+  PRIVATE sourcemeta::core::crypto sourcemeta::core::text)
 
 # pyca/cryptography SHA-256 Test Vectors
 # See https://github.com/pyca/cryptography
@@ -20,7 +20,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME pyca_cryptography_s
 target_compile_definitions(sourcemeta_core_pyca_cryptography_sha256_unit
   PRIVATE PYCA_CRYPTOGRAPHY_PATH="${PROJECT_SOURCE_DIR}/vendor/pyca-cryptography/vectors/cryptography_vectors")
 target_link_libraries(sourcemeta_core_pyca_cryptography_sha256_unit
-  PRIVATE sourcemeta::core::crypto sourcemeta::core::io)
+  PRIVATE sourcemeta::core::crypto sourcemeta::core::io sourcemeta::core::text)
 
 # pyca/cryptography SHA-384 Test Vectors
 # See https://github.com/pyca/cryptography
@@ -29,7 +29,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME pyca_cryptography_s
 target_compile_definitions(sourcemeta_core_pyca_cryptography_sha384_unit
   PRIVATE PYCA_CRYPTOGRAPHY_PATH="${PROJECT_SOURCE_DIR}/vendor/pyca-cryptography/vectors/cryptography_vectors")
 target_link_libraries(sourcemeta_core_pyca_cryptography_sha384_unit
-  PRIVATE sourcemeta::core::crypto sourcemeta::core::io)
+  PRIVATE sourcemeta::core::crypto sourcemeta::core::io sourcemeta::core::text)
 
 # pyca/cryptography SHA-512 Test Vectors
 # See https://github.com/pyca/cryptography
@@ -38,7 +38,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME pyca_cryptography_s
 target_compile_definitions(sourcemeta_core_pyca_cryptography_sha512_unit
   PRIVATE PYCA_CRYPTOGRAPHY_PATH="${PROJECT_SOURCE_DIR}/vendor/pyca-cryptography/vectors/cryptography_vectors")
 target_link_libraries(sourcemeta_core_pyca_cryptography_sha512_unit
-  PRIVATE sourcemeta::core::crypto sourcemeta::core::io)
+  PRIVATE sourcemeta::core::crypto sourcemeta::core::io sourcemeta::core::text)
 
 # pyca/cryptography SHA-1 Test Vectors
 # See https://github.com/pyca/cryptography
@@ -47,4 +47,4 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME pyca_cryptography_s
 target_compile_definitions(sourcemeta_core_pyca_cryptography_sha1_unit
   PRIVATE PYCA_CRYPTOGRAPHY_PATH="${PROJECT_SOURCE_DIR}/vendor/pyca-cryptography/vectors/cryptography_vectors")
 target_link_libraries(sourcemeta_core_pyca_cryptography_sha1_unit
-  PRIVATE sourcemeta::core::crypto sourcemeta::core::io)
+  PRIVATE sourcemeta::core::crypto sourcemeta::core::io sourcemeta::core::text)

--- a/test/crypto/pyca_cryptography_sha1_test.cc
+++ b/test/crypto/pyca_cryptography_sha1_test.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/text.h>
 
 #include <cstdint>    // std::uint64_t
 #include <filesystem> // std::filesystem
@@ -12,17 +13,6 @@ static auto strip_cr(std::string &value) -> void {
   if (!value.empty() && value.back() == '\r') {
     value.pop_back();
   }
-}
-
-static auto hex_to_bytes(const std::string &hex) -> std::string {
-  std::string result;
-  result.reserve(hex.size() / 2);
-  for (std::string::size_type index = 0; index + 1 < hex.size(); index += 2) {
-    result.push_back(static_cast<char>(static_cast<unsigned char>(
-        std::stoi(hex.substr(index, 2), nullptr, 16))));
-  }
-
-  return result;
 }
 
 static auto sha1_hex(const std::string &input) -> std::string {
@@ -67,8 +57,9 @@ public:
     auto md_1 = this->seed;
     auto md_2 = this->seed;
     for (std::uint64_t iteration = 3; iteration <= 1002; ++iteration) {
-      const auto message =
-          hex_to_bytes(md_0) + hex_to_bytes(md_1) + hex_to_bytes(md_2);
+      const auto message = sourcemeta::core::hex_to_bytes(md_0).value() +
+                           sourcemeta::core::hex_to_bytes(md_1).value() +
+                           sourcemeta::core::hex_to_bytes(md_2).value();
       const auto digest = sha1_hex(message);
       md_0 = md_1;
       md_1 = md_2;
@@ -104,9 +95,10 @@ static auto register_msg_tests(const std::filesystem::path &file_path,
       current_message_hex = line.substr(6);
     } else if (line.starts_with("MD = ")) {
       const auto expected_digest{line.substr(5)};
-      const auto message{current_length_bits == 0
-                             ? std::string{}
-                             : hex_to_bytes(current_message_hex)};
+      const auto message{
+          current_length_bits == 0
+              ? std::string{}
+              : sourcemeta::core::hex_to_bytes(current_message_hex).value()};
 
       const auto test_name{"len_" + std::to_string(current_length_bits)};
       testing::RegisterTest(

--- a/test/crypto/pyca_cryptography_sha256_test.cc
+++ b/test/crypto/pyca_cryptography_sha256_test.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/text.h>
 
 #include <cstdint>    // std::uint64_t
 #include <filesystem> // std::filesystem
@@ -12,17 +13,6 @@ static auto strip_cr(std::string &value) -> void {
   if (!value.empty() && value.back() == '\r') {
     value.pop_back();
   }
-}
-
-static auto hex_to_bytes(const std::string &hex) -> std::string {
-  std::string result;
-  result.reserve(hex.size() / 2);
-  for (std::string::size_type index = 0; index + 1 < hex.size(); index += 2) {
-    result.push_back(static_cast<char>(static_cast<unsigned char>(
-        std::stoi(hex.substr(index, 2), nullptr, 16))));
-  }
-
-  return result;
 }
 
 static auto sha256_hex(const std::string &input) -> std::string {
@@ -67,8 +57,9 @@ public:
     auto md_1 = this->seed;
     auto md_2 = this->seed;
     for (std::uint64_t iteration = 3; iteration <= 1002; ++iteration) {
-      const auto message =
-          hex_to_bytes(md_0) + hex_to_bytes(md_1) + hex_to_bytes(md_2);
+      const auto message = sourcemeta::core::hex_to_bytes(md_0).value() +
+                           sourcemeta::core::hex_to_bytes(md_1).value() +
+                           sourcemeta::core::hex_to_bytes(md_2).value();
       const auto digest = sha256_hex(message);
       md_0 = md_1;
       md_1 = md_2;
@@ -104,9 +95,10 @@ static auto register_msg_tests(const std::filesystem::path &file_path,
       current_message_hex = line.substr(6);
     } else if (line.starts_with("MD = ")) {
       const auto expected_digest{line.substr(5)};
-      const auto message{current_length_bits == 0
-                             ? std::string{}
-                             : hex_to_bytes(current_message_hex)};
+      const auto message{
+          current_length_bits == 0
+              ? std::string{}
+              : sourcemeta::core::hex_to_bytes(current_message_hex).value()};
 
       const auto test_name{"len_" + std::to_string(current_length_bits)};
       testing::RegisterTest(

--- a/test/crypto/pyca_cryptography_sha384_test.cc
+++ b/test/crypto/pyca_cryptography_sha384_test.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/text.h>
 
 #include <cstdint>    // std::uint64_t
 #include <filesystem> // std::filesystem
@@ -12,17 +13,6 @@ static auto strip_cr(std::string &value) -> void {
   if (!value.empty() && value.back() == '\r') {
     value.pop_back();
   }
-}
-
-static auto hex_to_bytes(const std::string &hex) -> std::string {
-  std::string result;
-  result.reserve(hex.size() / 2);
-  for (std::string::size_type index = 0; index + 1 < hex.size(); index += 2) {
-    result.push_back(static_cast<char>(static_cast<unsigned char>(
-        std::stoi(hex.substr(index, 2), nullptr, 16))));
-  }
-
-  return result;
 }
 
 static auto sha384_hex(const std::string &input) -> std::string {
@@ -67,8 +57,9 @@ public:
     auto md_1 = this->seed;
     auto md_2 = this->seed;
     for (std::uint64_t iteration = 3; iteration <= 1002; ++iteration) {
-      const auto message =
-          hex_to_bytes(md_0) + hex_to_bytes(md_1) + hex_to_bytes(md_2);
+      const auto message = sourcemeta::core::hex_to_bytes(md_0).value() +
+                           sourcemeta::core::hex_to_bytes(md_1).value() +
+                           sourcemeta::core::hex_to_bytes(md_2).value();
       const auto digest = sha384_hex(message);
       md_0 = md_1;
       md_1 = md_2;
@@ -104,9 +95,10 @@ static auto register_msg_tests(const std::filesystem::path &file_path,
       current_message_hex = line.substr(6);
     } else if (line.starts_with("MD = ")) {
       const auto expected_digest{line.substr(5)};
-      const auto message{current_length_bits == 0
-                             ? std::string{}
-                             : hex_to_bytes(current_message_hex)};
+      const auto message{
+          current_length_bits == 0
+              ? std::string{}
+              : sourcemeta::core::hex_to_bytes(current_message_hex).value()};
 
       const auto test_name{"len_" + std::to_string(current_length_bits)};
       testing::RegisterTest(

--- a/test/crypto/pyca_cryptography_sha512_test.cc
+++ b/test/crypto/pyca_cryptography_sha512_test.cc
@@ -2,6 +2,7 @@
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/text.h>
 
 #include <cstdint>    // std::uint64_t
 #include <filesystem> // std::filesystem
@@ -12,17 +13,6 @@ static auto strip_cr(std::string &value) -> void {
   if (!value.empty() && value.back() == '\r') {
     value.pop_back();
   }
-}
-
-static auto hex_to_bytes(const std::string &hex) -> std::string {
-  std::string result;
-  result.reserve(hex.size() / 2);
-  for (std::string::size_type index = 0; index + 1 < hex.size(); index += 2) {
-    result.push_back(static_cast<char>(static_cast<unsigned char>(
-        std::stoi(hex.substr(index, 2), nullptr, 16))));
-  }
-
-  return result;
 }
 
 static auto sha512_hex(const std::string &input) -> std::string {
@@ -67,8 +57,9 @@ public:
     auto md_1 = this->seed;
     auto md_2 = this->seed;
     for (std::uint64_t iteration = 3; iteration <= 1002; ++iteration) {
-      const auto message =
-          hex_to_bytes(md_0) + hex_to_bytes(md_1) + hex_to_bytes(md_2);
+      const auto message = sourcemeta::core::hex_to_bytes(md_0).value() +
+                           sourcemeta::core::hex_to_bytes(md_1).value() +
+                           sourcemeta::core::hex_to_bytes(md_2).value();
       const auto digest = sha512_hex(message);
       md_0 = md_1;
       md_1 = md_2;
@@ -104,9 +95,10 @@ static auto register_msg_tests(const std::filesystem::path &file_path,
       current_message_hex = line.substr(6);
     } else if (line.starts_with("MD = ")) {
       const auto expected_digest{line.substr(5)};
-      const auto message{current_length_bits == 0
-                             ? std::string{}
-                             : hex_to_bytes(current_message_hex)};
+      const auto message{
+          current_length_bits == 0
+              ? std::string{}
+              : sourcemeta::core::hex_to_bytes(current_message_hex).value()};
 
       const auto test_name{"len_" + std::to_string(current_length_bits)};
       testing::RegisterTest(


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

