### PR TITLE
Use `uint128_t` on Crypto big num

### DIFF
--- a/src/core/crypto/crypto_bignum.h
+++ b/src/core/crypto/crypto_bignum.h
@@ -6,6 +6,8 @@
 // and their double-width products. Performance and constant-time
 // execution are non-goals, verification consumes only public inputs
 
+#include <sourcemeta/core/numeric.h>
+
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint8_t, std::uint64_t
@@ -14,10 +16,7 @@
 
 namespace sourcemeta::core {
 
-// The double-width word is a compiler extension, though one that every
-// compiler this backend ever compiles under provides. The extension marker
-// keeps pedantic diagnostics quiet about it
-__extension__ typedef unsigned __int128 BignumDoubleWord;
+using BignumDoubleWord = uint128_t;
 
 struct Bignum {
   // Enough words for an 8192-bit product plus shifting headroom


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

