### PR TITLE
Implement a `http_parse_bearer` helper

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -2,7 +2,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
   PRIVATE_HEADERS problem.h status.h method.h message.h error.h
   SOURCES helpers.h problem.cc match_accept.cc match_accept_language.cc
           negotiate_encoding.cc from_date.cc format_link.cc field_list.cc
-          accept_includes_all.cc content_type_matches.cc)
+          accept_includes_all.cc content_type_matches.cc parse_bearer.cc)
 
 if(SOURCEMETA_CORE_INSTALL)
   sourcemeta_library_install(NAMESPACE sourcemeta PROJECT core NAME http)

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -250,6 +250,24 @@ auto http_field_list_contains_any(
     const std::string_view header_value,
     std::initializer_list<std::string_view> tokens) noexcept -> bool;
 
+/// @ingroup http
+/// Extract the credential from an `Authorization` header that uses the Bearer
+/// scheme per RFC 6750 §2.1, matching the scheme case-insensitively per RFC
+/// 9110 §11.1 and tolerating optional whitespace around the token. Returns an
+/// empty view when the header is absent, uses another scheme, or carries no
+/// token. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_parse_bearer("Bearer abc123") == "abc123");
+/// assert(sourcemeta::core::http_parse_bearer("Basic abc123").empty());
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_parse_bearer(const std::string_view authorization) noexcept
+    -> std::string_view;
+
 } // namespace sourcemeta::core
 
 #endif

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -254,8 +254,8 @@ auto http_field_list_contains_any(
 /// Extract the credential from an `Authorization` header that uses the Bearer
 /// scheme per RFC 6750 §2.1, matching the scheme case-insensitively per RFC
 /// 9110 §11.1 and tolerating optional whitespace around the token. Returns an
-/// empty view when the header is absent, uses another scheme, or carries no
-/// token. For example:
+/// empty view when the header is absent, uses another scheme, or does not carry
+/// a well-formed `b64token` credential. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/http.h>

--- a/src/core/http/parse_bearer.cc
+++ b/src/core/http/parse_bearer.cc
@@ -1,0 +1,27 @@
+#include <sourcemeta/core/http.h>
+
+#include "helpers.h"
+
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto http_parse_bearer(const std::string_view authorization) noexcept
+    -> std::string_view {
+  constexpr std::string_view scheme{"bearer"};
+  if (authorization.size() <= scheme.size() ||
+      authorization[scheme.size()] != ' ') {
+    return {};
+  }
+
+  if (!http_iequals_ascii(http_subview(authorization, 0, scheme.size()),
+                          scheme)) {
+    return {};
+  }
+
+  const auto token{http_subview(authorization, scheme.size() + 1,
+                                authorization.size() - scheme.size() - 1)};
+  return http_trim_trailing_ows(http_trim_leading_ows(token));
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/parse_bearer.cc
+++ b/src/core/http/parse_bearer.cc
@@ -2,7 +2,43 @@
 
 #include "helpers.h"
 
+#include <cstddef>     // std::size_t
 #include <string_view> // std::string_view
+
+namespace {
+
+auto is_b64token_character(const char character) noexcept -> bool {
+  return (character >= 'A' && character <= 'Z') ||
+         (character >= 'a' && character <= 'z') ||
+         (character >= '0' && character <= '9') || character == '-' ||
+         character == '.' || character == '_' || character == '~' ||
+         character == '+' || character == '/';
+}
+
+// RFC 6750 §2.1: b64token = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" /
+// "/" ) *"=". At least one character from the alphabet, followed by optional
+// trailing padding.
+auto is_b64token(const std::string_view token) noexcept -> bool {
+  std::size_t position{0};
+  while (position < token.size() && is_b64token_character(token[position])) {
+    ++position;
+  }
+
+  if (position == 0) {
+    return false;
+  }
+
+  while (position < token.size()) {
+    if (token[position] != '=') {
+      return false;
+    }
+    ++position;
+  }
+
+  return true;
+}
+
+} // namespace
 
 namespace sourcemeta::core {
 
@@ -19,9 +55,14 @@ auto http_parse_bearer(const std::string_view authorization) noexcept
     return {};
   }
 
-  const auto token{http_subview(authorization, scheme.size() + 1,
-                                authorization.size() - scheme.size() - 1)};
-  return http_trim_trailing_ows(http_trim_leading_ows(token));
+  const auto token{http_trim_trailing_ows(http_trim_leading_ows(
+      http_subview(authorization, scheme.size() + 1,
+                   authorization.size() - scheme.size() - 1)))};
+  if (!is_b64token(token)) {
+    return {};
+  }
+
+  return token;
 }
 
 } // namespace sourcemeta::core

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -7,7 +7,8 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME http
           http_method_test.cc http_status_from_code_test.cc
           http_is_status_line_test.cc http_accumulate_header_line_test.cc
           http_parse_headers_test.cc http_serialize_headers_test.cc
-          http_header_find_test.cc http_error_test.cc)
+          http_header_find_test.cc http_error_test.cc
+          http_parse_bearer_test.cc)
 
 target_link_libraries(sourcemeta_core_http_unit
   PRIVATE sourcemeta::core::http)

--- a/test/http/http_parse_bearer_test.cc
+++ b/test/http/http_parse_bearer_test.cc
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/http.h>
+
+TEST(HTTP_parse_bearer, plain_token) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer abc123"), "abc123");
+}
+
+TEST(HTTP_parse_bearer, scheme_lowercase) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("bearer abc123"), "abc123");
+}
+
+TEST(HTTP_parse_bearer, scheme_uppercase) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("BEARER abc123"), "abc123");
+}
+
+TEST(HTTP_parse_bearer, scheme_mixed_case) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("BeArEr abc123"), "abc123");
+}
+
+TEST(HTTP_parse_bearer, trailing_whitespace_trimmed) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer abc123   "), "abc123");
+}
+
+TEST(HTTP_parse_bearer, leading_whitespace_trimmed) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer    abc123"), "abc123");
+}
+
+TEST(HTTP_parse_bearer, surrounding_whitespace_trimmed) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer   abc123   "),
+            "abc123");
+}
+
+TEST(HTTP_parse_bearer, tab_whitespace_trimmed) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer \tabc123\t"), "abc123");
+}
+
+TEST(HTTP_parse_bearer, empty_header) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("").empty());
+}
+
+TEST(HTTP_parse_bearer, other_scheme) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Basic abc123").empty());
+}
+
+TEST(HTTP_parse_bearer, scheme_only) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer").empty());
+}
+
+TEST(HTTP_parse_bearer, scheme_with_space_but_no_token) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer ").empty());
+}
+
+TEST(HTTP_parse_bearer, scheme_with_only_whitespace) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer   ").empty());
+}
+
+TEST(HTTP_parse_bearer, scheme_without_separating_space) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearerabc123").empty());
+}

--- a/test/http/http_parse_bearer_test.cc
+++ b/test/http/http_parse_bearer_test.cc
@@ -58,3 +58,44 @@ TEST(HTTP_parse_bearer, scheme_with_only_whitespace) {
 TEST(HTTP_parse_bearer, scheme_without_separating_space) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearerabc123").empty());
 }
+
+TEST(HTTP_parse_bearer, internal_space_rejected) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer abc def").empty());
+}
+
+TEST(HTTP_parse_bearer, internal_tab_rejected) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer abc\tdef").empty());
+}
+
+TEST(HTTP_parse_bearer, invalid_character_rejected) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer abc@def").empty());
+}
+
+TEST(HTTP_parse_bearer, control_character_rejected) {
+  EXPECT_TRUE(
+      sourcemeta::core::http_parse_bearer("Bearer abc\x01zdef").empty());
+}
+
+TEST(HTTP_parse_bearer, b64token_alphabet_accepted) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer aZ09-._~+/"),
+            "aZ09-._~+/");
+}
+
+TEST(HTTP_parse_bearer, base64_padding_accepted) {
+  EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer YWJjMTIz=="),
+            "YWJjMTIz==");
+}
+
+TEST(HTTP_parse_bearer, jwt_like_accepted) {
+  EXPECT_EQ(
+      sourcemeta::core::http_parse_bearer("Bearer eyJhbGc.eyJzdWIi.SflKxwRJ"),
+      "eyJhbGc.eyJzdWIi.SflKxwRJ");
+}
+
+TEST(HTTP_parse_bearer, only_padding_rejected) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer ===").empty());
+}
+
+TEST(HTTP_parse_bearer, padding_before_alphabet_rejected) {
+  EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer ab=cd").empty());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

