### PR TITLE
Implement a non-throwing JSON parsing function

### DIFF
--- a/src/core/json/include/sourcemeta/core/json.h
+++ b/src/core/json/include/sourcemeta/core/json.h
@@ -19,6 +19,7 @@
 #include <fstream>          // std::basic_ifstream
 #include <initializer_list> // std::initializer_list
 #include <istream>          // std::basic_istream
+#include <optional>         // std::optional
 #include <ostream>          // std::basic_ostream
 #include <sstream>          // std::ostringstream
 #include <string>           // std::basic_string
@@ -74,6 +75,25 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream)
 SOURCEMETA_CORE_JSON_EXPORT
 auto parse_json(
     const std::basic_string_view<JSON::Char, JSON::CharTraits> input) -> JSON;
+
+/// @ingroup json
+///
+/// Create a JSON document from a JSON string, returning no value instead of
+/// throwing when the input is not valid JSON. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+///
+/// const auto document{sourcemeta::core::try_parse_json("[ 1, 2, 3 ]")};
+/// assert(document.has_value());
+/// assert(document.value().is_array());
+/// assert(!sourcemeta::core::try_parse_json("[ 1, 2,").has_value());
+/// ```
+SOURCEMETA_CORE_JSON_EXPORT
+auto try_parse_json(
+    const std::basic_string_view<JSON::Char, JSON::CharTraits> input)
+    -> std::optional<JSON>;
 
 /// @ingroup json
 ///

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -8,54 +8,76 @@
 #include "parser.h"
 #include "stringify.h"
 
-#include <cassert>    // assert
-#include <cstdint>    // std::uint64_t
-#include <filesystem> // std::filesystem
-#include <istream>    // std::basic_istream
-#include <limits>     // std::numeric_limits
-#include <ostream>    // std::basic_ostream
-#include <utility>    // std::cmp_greater
-#include <vector>     // std::vector
+#include <cassert>     // assert
+#include <cstdint>     // std::uint64_t
+#include <filesystem>  // std::filesystem
+#include <istream>     // std::basic_istream
+#include <limits>      // std::numeric_limits
+#include <optional>    // std::optional, std::nullopt
+#include <ostream>     // std::basic_ostream
+#include <type_traits> // std::conditional_t
+#include <utility>     // std::cmp_greater
+#include <vector>      // std::vector
 
 namespace sourcemeta::core {
 
+template <bool should_throw>
 static auto internal_parse_json(const char *&cursor, const char *end,
                                 std::uint64_t &line, std::uint64_t &column,
                                 const JSON::ParseCallback &callback,
                                 const bool track_positions, JSON &output)
-    -> void {
+    -> std::conditional_t<should_throw, void, bool> {
   const char *buffer_start{cursor};
   // Tape entries address the input with 32-bit offsets and lengths, so a larger
   // input cannot be represented without truncation
   if (std::cmp_greater(end - cursor,
                        std::numeric_limits<std::uint32_t>::max())) {
-    throw JSONParseError(line, column);
+    if constexpr (should_throw) {
+      throw JSONParseError(line, column);
+    } else {
+      return false;
+    }
   }
 
   std::vector<TapeEntry> tape;
   tape.reserve(static_cast<std::size_t>(end - cursor) / 8);
   if (callback || track_positions) {
-    scan_json<true>(cursor, end, buffer_start, line, column, tape);
+    if constexpr (should_throw) {
+      scan_json<true>(cursor, end, buffer_start, line, column, tape);
+    } else {
+      try {
+        scan_json<true>(cursor, end, buffer_start, line, column, tape);
+      } catch (const JSONParseError &) {
+        return false;
+      }
+    }
   } else {
     try {
       scan_json<false>(cursor, end, buffer_start, line, column, tape);
     } catch (const JSONParseError &) {
-      cursor = buffer_start;
-      tape.clear();
-      line = 1;
-      column = 0;
-      scan_json<true>(cursor, end, buffer_start, line, column, tape);
+      if constexpr (should_throw) {
+        cursor = buffer_start;
+        tape.clear();
+        line = 1;
+        column = 0;
+        scan_json<true>(cursor, end, buffer_start, line, column, tape);
+      } else {
+        return false;
+      }
     }
   }
   construct_json(buffer_start, tape, callback, output);
+  if constexpr (!should_throw) {
+    return true;
+  }
 }
 
 static auto internal_parse_json(const char *&cursor, const char *end,
                                 std::uint64_t &line, std::uint64_t &column,
                                 const bool track_positions) -> JSON {
   JSON output{nullptr};
-  internal_parse_json(cursor, end, line, column, nullptr, track_positions,
-                      output);
+  internal_parse_json<true>(cursor, end, line, column, nullptr, track_positions,
+                            output);
   return output;
 }
 
@@ -110,6 +132,21 @@ auto parse_json(
                              false);
 }
 
+auto try_parse_json(
+    const std::basic_string_view<JSON::Char, JSON::CharTraits> input)
+    -> std::optional<JSON> {
+  std::uint64_t line{1};
+  std::uint64_t column{0};
+  const char *cursor{input.empty() ? "" : input.data()};
+  JSON output{nullptr};
+  if (internal_parse_json<false>(cursor, cursor + input.size(), line, column,
+                                 nullptr, false, output)) {
+    return output;
+  }
+
+  return std::nullopt;
+}
+
 auto read_json(const std::filesystem::path &path) -> JSON {
   try {
     return parse_json(read_file_to_string(path));
@@ -127,7 +164,7 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
   const auto input{read_to_string(stream)};
   const char *cursor{input.data()};
   const char *end{input.data() + input.size()};
-  internal_parse_json(cursor, end, line, column, callback, true, output);
+  internal_parse_json<true>(cursor, end, line, column, callback, true, output);
   if (start_position != static_cast<std::streampos>(-1)) {
     const auto consumed{static_cast<std::streamoff>(cursor - input.data())};
     stream.clear();
@@ -140,8 +177,8 @@ auto parse_json(
     std::uint64_t &line, std::uint64_t &column, JSON &output,
     const JSON::ParseCallback &callback) -> void {
   const char *cursor{input.empty() ? "" : input.data()};
-  internal_parse_json(cursor, cursor + input.size(), line, column, callback,
-                      true, output);
+  internal_parse_json<true>(cursor, cursor + input.size(), line, column,
+                            callback, true, output);
 }
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -153,7 +190,7 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
   const char *end{input.data() + input.size()};
   std::uint64_t line{1};
   std::uint64_t column{0};
-  internal_parse_json(cursor, end, line, column, callback, false, output);
+  internal_parse_json<true>(cursor, end, line, column, callback, false, output);
   if (start_position != static_cast<std::streampos>(-1)) {
     const auto consumed{static_cast<std::streamoff>(cursor - input.data())};
     stream.clear();
@@ -167,8 +204,8 @@ auto parse_json(
   std::uint64_t line{1};
   std::uint64_t column{0};
   const char *cursor{input.empty() ? "" : input.data()};
-  internal_parse_json(cursor, cursor + input.size(), line, column, callback,
-                      false, output);
+  internal_parse_json<true>(cursor, cursor + input.size(), line, column,
+                            callback, false, output);
 }
 
 auto read_json(const std::filesystem::path &path, JSON &output,

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -41,33 +41,36 @@ static auto internal_parse_json(const char *&cursor, const char *end,
 
   std::vector<TapeEntry> tape;
   tape.reserve(static_cast<std::size_t>(end - cursor) / 8);
-  if (callback || track_positions) {
-    if constexpr (should_throw) {
+
+  if constexpr (should_throw) {
+    if (callback || track_positions) {
       scan_json<true>(cursor, end, buffer_start, line, column, tape);
     } else {
+      // Re-scan with position tracking on failure for a precise error message
       try {
-        scan_json<true>(cursor, end, buffer_start, line, column, tape);
+        scan_json<false>(cursor, end, buffer_start, line, column, tape);
       } catch (const JSONParseError &) {
-        return false;
-      }
-    }
-  } else {
-    try {
-      scan_json<false>(cursor, end, buffer_start, line, column, tape);
-    } catch (const JSONParseError &) {
-      if constexpr (should_throw) {
         cursor = buffer_start;
         tape.clear();
         line = 1;
         column = 0;
         scan_json<true>(cursor, end, buffer_start, line, column, tape);
-      } else {
-        return false;
       }
     }
-  }
-  construct_json(buffer_start, tape, callback, output);
-  if constexpr (!should_throw) {
+    construct_json(buffer_start, tape, callback, output);
+  } else {
+    // Both the scanning and the construction phases signal failure by throwing,
+    // so a single boundary around them reports either as no value
+    try {
+      if (callback || track_positions) {
+        scan_json<true>(cursor, end, buffer_start, line, column, tape);
+      } else {
+        scan_json<false>(cursor, end, buffer_start, line, column, tape);
+      }
+      construct_json(buffer_start, tape, callback, output);
+    } catch (const JSONParseError &) {
+      return false;
+    }
     return true;
   }
 }

--- a/test/json/CMakeLists.txt
+++ b/test/json/CMakeLists.txt
@@ -12,6 +12,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME json
     json_parse_callback_test.cc
     json_parse_error_test.cc
     json_parse_test.cc
+    json_try_parse_test.cc
     json_parse_roundtrip_test.cc
     json_prettify_test.cc
     json_real_test.cc

--- a/test/json/json_try_parse_test.cc
+++ b/test/json/json_try_parse_test.cc
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/json.h>
+
+TEST(JSON_try_parse, valid_object) {
+  const auto document{sourcemeta::core::try_parse_json("{ \"foo\": 1 }")};
+  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.value().is_object());
+  EXPECT_EQ(document.value().size(), 1);
+}
+
+TEST(JSON_try_parse, valid_array) {
+  const auto document{sourcemeta::core::try_parse_json("[ 1, 2, 3 ]")};
+  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.value().is_array());
+  EXPECT_EQ(document.value().size(), 3);
+}
+
+TEST(JSON_try_parse, valid_string) {
+  const auto document{sourcemeta::core::try_parse_json("\"hello\"")};
+  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.value().is_string());
+  EXPECT_EQ(document.value().to_string(), "hello");
+}
+
+TEST(JSON_try_parse, valid_integer) {
+  const auto document{sourcemeta::core::try_parse_json("42")};
+  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.value().is_integer());
+  EXPECT_EQ(document.value().to_integer(), 42);
+}
+
+TEST(JSON_try_parse, valid_null) {
+  const auto document{sourcemeta::core::try_parse_json("null")};
+  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.value().is_null());
+}
+
+TEST(JSON_try_parse, matches_throwing_parse) {
+  const auto via_try{sourcemeta::core::try_parse_json("[ 1, 2, 3 ]")};
+  const auto via_throw{sourcemeta::core::parse_json("[ 1, 2, 3 ]")};
+  ASSERT_TRUE(via_try.has_value());
+  EXPECT_EQ(via_try.value(), via_throw);
+}
+
+TEST(JSON_try_parse, rejects_empty) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("").has_value());
+}
+
+TEST(JSON_try_parse, rejects_garbage) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("not json").has_value());
+}
+
+TEST(JSON_try_parse, rejects_truncated_array) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("[ 1, 2,").has_value());
+}
+
+TEST(JSON_try_parse, rejects_unclosed_object) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("{ \"foo\":").has_value());
+}
+
+TEST(JSON_try_parse, rejects_invalid_number) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("01").has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

