### PR TITLE
Extend `JSON::as_real()` to support `Decimal` if possible

### DIFF
--- a/src/core/jose/jose_jwt.cc
+++ b/src/core/jose/jose_jwt.cc
@@ -45,22 +45,14 @@ auto date_claim(const sourcemeta::core::JSON &object,
   }
 
   // A NumericDate is the number of seconds since the Unix epoch, possibly
-  // non-integer (RFC 7519 Section 2). A number can be backed by an integer, a
-  // real, or a decimal (such as the exponent form "1e9"), each of which must
-  // be read through its own accessor
+  // non-integer (RFC 7519 Section 2). A decimal-backed number (such as the
+  // exponent form "1e9") whose magnitude exceeds the range of a double cannot
+  // stand for a usable timestamp, and untrusted input must not abort
   double seconds{0};
-  if (member->is_integer()) {
-    seconds = static_cast<double>(member->to_integer());
-  } else if (member->is_real()) {
-    seconds = member->to_real();
-  } else {
-    // A decimal whose magnitude exceeds the range of a double cannot stand for
-    // a usable timestamp
-    try {
-      seconds = member->to_decimal().to_double();
-    } catch (const std::out_of_range &) {
-      return std::nullopt;
-    }
+  try {
+    seconds = member->as_real();
+  } catch (const std::out_of_range &) {
+    return std::nullopt;
   }
 
   return sourcemeta::core::from_unix_timestamp(

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -774,7 +774,9 @@ public:
   }
 
   /// Get the JSON numeric document as a real number if it is not one already.
-  /// For example:
+  /// A decimal whose magnitude does not fit in a double throws
+  /// `std::out_of_range`, matching the behaviour of converting that decimal
+  /// directly. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/json.h>
@@ -783,11 +785,15 @@ public:
   /// const sourcemeta::core::JSON document{5};
   /// assert(document.as_real() == 5.0);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_real() const noexcept
-      -> Real {
+  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_real() const -> Real {
     assert(this->is_number());
-    return this->is_real() ? this->to_real()
-                           : static_cast<Real>(this->to_integer());
+    if (this->is_real()) {
+      return this->to_real();
+    } else if (this->is_integer()) {
+      return static_cast<Real>(this->to_integer());
+    } else {
+      return this->to_decimal().to_double();
+    }
   }
 
   /// Get the JSON numeric document as an integer number if it is not one

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -812,8 +812,10 @@ public:
     assert(this->is_number());
     if (this->is_integer()) {
       return this->to_integer();
-    } else {
+    } else if (this->is_real()) {
       return static_cast<Integer>(std::trunc(this->to_real()));
+    } else {
+      return this->to_decimal().to_integral().to_int64();
     }
   }
 

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -21,9 +21,11 @@
 #include <cstdint>          // std::int64_t, std::uint8_t
 #include <functional>       // std::less, std::reference_wrapper, std::function
 #include <initializer_list> // std::initializer_list
+#include <limits>           // std::numeric_limits
 #include <memory>           // std::allocator
 #include <set>              // std::set
 #include <sstream>          // std::basic_istringstream
+#include <stdexcept>        // std::out_of_range
 #include <string>           // std::basic_string, std::char_traits
 #include <string_view>      // std::basic_string_view
 #include <type_traits>      // std::is_same_v, std::remove_cvref_t
@@ -797,8 +799,9 @@ public:
   }
 
   /// Get the JSON numeric document as an integer number if it is not one
-  /// already. If the number is a real number, truncation will take place. For
-  /// example:
+  /// already. If the number is a real number, truncation will take place. A
+  /// value whose magnitude does not fit in a 64-bit integer throws
+  /// `std::out_of_range`. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/json.h>
@@ -807,15 +810,28 @@ public:
   /// const sourcemeta::core::JSON document{5.3};
   /// assert(document.as_integer() == 5);
   /// ```
-  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_integer() const noexcept
+  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto as_integer() const
       -> Integer {
     assert(this->is_number());
     if (this->is_integer()) {
       return this->to_integer();
     } else if (this->is_real()) {
-      return static_cast<Integer>(std::trunc(this->to_real()));
+      const auto truncated{std::trunc(this->to_real())};
+      if (truncated < static_cast<Real>(std::numeric_limits<Integer>::min()) ||
+          truncated >= static_cast<Real>(std::numeric_limits<Integer>::max())) {
+        throw std::out_of_range{
+            "The real number does not fit in a 64-bit integer"};
+      }
+
+      return static_cast<Integer>(truncated);
     } else {
-      return this->to_decimal().to_integral().to_int64();
+      const auto integral{this->to_decimal().to_integral()};
+      if (!integral.is_int64()) {
+        throw std::out_of_range{
+            "The decimal number does not fit in a 64-bit integer"};
+      }
+
+      return integral.to_int64();
     }
   }
 

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -432,6 +432,9 @@ auto JSON::size(const String &value) noexcept -> std::size_t {
   return result;
 }
 
+// `as_real` is reached only for integer and real operands here, never a
+// decimal, so it cannot throw even though it is no longer noexcept
+// NOLINTNEXTLINE(bugprone-exception-escape)
 auto JSON::operator<(const JSON &other) const noexcept -> bool {
   if ((this->type() == Type::Integer && other.type() == Type::Real) ||
       (this->type() == Type::Real && other.type() == Type::Integer)) {
@@ -489,6 +492,9 @@ auto JSON::operator>=(const JSON &other) const noexcept -> bool {
   return *this > other || *this == other;
 }
 
+// `as_real` is reached only for integer and real operands here, never a
+// decimal, so it cannot throw even though it is no longer noexcept
+// NOLINTNEXTLINE(bugprone-exception-escape)
 auto JSON::operator==(const JSON &other) const noexcept -> bool {
   if ((this->type() == Type::Integer && other.type() == Type::Real) ||
       (this->type() == Type::Real && other.type() == Type::Integer)) {

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -2,6 +2,8 @@
 
 #include <sourcemeta/core/json.h>
 
+#include <stdexcept> // std::out_of_range
+
 TEST(JSON_number, is_number_zero) {
   const sourcemeta::core::JSON document{0};
   EXPECT_TRUE(document.is_number());
@@ -586,7 +588,20 @@ TEST(JSON_number, as_real_integer) {
   EXPECT_DOUBLE_EQ(document.as_real(), 4.0);
 }
 
-TEST(JSON_value, compare_int_real_equal) {
+TEST(JSON_number, as_real_decimal) {
+  const auto document{sourcemeta::core::parse_json("1e9")};
+  ASSERT_TRUE(document.is_decimal());
+  EXPECT_DOUBLE_EQ(document.as_real(), 1e9);
+}
+
+TEST(JSON_number, as_real_decimal_out_of_range_throws) {
+  const auto document{sourcemeta::core::parse_json("1e400")};
+  ASSERT_TRUE(document.is_decimal());
+  EXPECT_THROW([[maybe_unused]] const auto value = document.as_real(),
+               std::out_of_range);
+}
+
+TEST(JSON_number, compare_int_real_equal) {
   const sourcemeta::core::JSON left{300};
   const sourcemeta::core::JSON right{300.0};
   EXPECT_TRUE(left.is_integer());

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -655,6 +655,18 @@ TEST(JSON_number, as_integer_non_integer_real) {
   EXPECT_EQ(document.as_integer(), 5);
 }
 
+TEST(JSON_number, as_integer_decimal) {
+  const auto document{sourcemeta::core::parse_json("1e9")};
+  ASSERT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.as_integer(), 1000000000);
+}
+
+TEST(JSON_number, as_integer_decimal_fractional) {
+  const auto document{sourcemeta::core::parse_json("1700000000.000000001")};
+  ASSERT_TRUE(document.is_decimal());
+  EXPECT_EQ(document.as_integer(), 1700000000);
+}
+
 TEST(JSON_number, is_integer_int_storage) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_integer());

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -667,6 +667,20 @@ TEST(JSON_number, as_integer_decimal_fractional) {
   EXPECT_EQ(document.as_integer(), 1700000000);
 }
 
+TEST(JSON_number, as_integer_decimal_out_of_range_throws) {
+  const auto document{sourcemeta::core::parse_json("10000000000000000000")};
+  ASSERT_TRUE(document.is_decimal());
+  EXPECT_THROW([[maybe_unused]] const auto value = document.as_integer(),
+               std::out_of_range);
+}
+
+TEST(JSON_number, as_integer_real_out_of_range_throws) {
+  const sourcemeta::core::JSON document{1e300};
+  ASSERT_TRUE(document.is_real());
+  EXPECT_THROW([[maybe_unused]] const auto value = document.as_integer(),
+               std::out_of_range);
+}
+
 TEST(JSON_number, is_integer_int_storage) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_integer());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

