### PR TITLE
test(email): cover internationalized idn-email edge cases

### DIFF
--- a/test/email/idn_email_test.cc
+++ b/test/email/idn_email_test.cc
@@ -397,3 +397,135 @@ TEST(IdnEmail, invalid_domain_total_too_long) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@" + domain));
   EXPECT_FALSE(sourcemeta::core::is_email("a@" + domain));
 }
+
+// RFC 6531 §3.3 extends the local-part with UTF8-non-ascii but, unlike the
+// domain U-label (RFC 5890 §2.3.2.1), imposes no NFC requirement on it. So
+// "cafe" + U+0301 COMBINING ACUTE (NFD, bytes 63 61 66 65 CC 81) is a valid
+// local-part even though it is not in NFC.
+TEST(IdnEmail, valid_local_non_nfc) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("cafe\xcc\x81@example.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("cafe\xcc\x81@example.com"));
+}
+
+// RFC 5890 §2.3.2.1: a domain U-label MUST be in NFC. The same "cafe" +
+// U+0301 (NFD) sequence that is valid in the local-part is invalid as a
+// domain label.
+TEST(IdnEmail, invalid_domain_non_nfc) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@cafe\xcc\x81.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@cafe\xcc\x81.com"));
+}
+
+// RFC 5321 §4.1.2: SP is not atext and is only allowed inside a quoted
+// string, so an unquoted space in the local-part is invalid.
+TEST(IdnEmail, invalid_local_unquoted_space) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("a b@example.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("a b@example.com"));
+}
+
+// RFC 5321 §4.1.2: quoted-pairSMTP = %d92 %d32-126, so the octet after a
+// backslash must be ASCII. A backslash followed by UTF8-non-ascii (U+03B1,
+// bytes CE B1) is invalid even under RFC 6531.
+TEST(IdnEmail, invalid_quoted_pair_non_ascii) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\\\xce\xb1\"@example.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("\"\\\xce\xb1\"@example.com"));
+}
+
+// RFC 6531 §3.3 delegates the domain to IDNA (is_idn_hostname). Fullwidth
+// digits U+FF11 U+FF12 U+FF13 (bytes EF BC 91 EF BC 92 EF BC 93) are
+// DISALLOWED by RFC 5892 §2.6, so the domain - and the whole address - is
+// invalid.
+TEST(IdnEmail, invalid_domain_idna_disallowed_codepoint) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email(
+      "user@\xef\xbc\x91\xef\xbc\x92\xef\xbc\x93.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email(
+      "user@\xef\xbc\x91\xef\xbc\x92\xef\xbc\x93.com"));
+}
+
+// RFC 5321 §4.1.2: Quoted-string = DQUOTE *QcontentSMTP DQUOTE, so zero quoted
+// content is permitted - an empty quoted string is a valid local-part.
+TEST(IdnEmail, valid_quoted_empty) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\"@example.com"));
+  EXPECT_TRUE(sourcemeta::core::is_email("\"\"@example.com"));
+}
+
+// RFC 5321 §4.1.2: "@" (%d64) is qtextSMTP, so it is ordinary content inside a
+// quoted string and does not start the domain - the address has one @
+// separator.
+TEST(IdnEmail, valid_quoted_local_with_at) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a@b\"@example.com"));
+  EXPECT_TRUE(sourcemeta::core::is_email("\"a@b\"@example.com"));
+}
+
+// RFC 5321 §4.1.2: "." (%d46) is qtextSMTP, so the Dot-string rules (no
+// leading, trailing, or consecutive dots) do not apply inside a quoted string.
+TEST(IdnEmail, valid_quoted_local_consecutive_dots) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a..b\"@example.com"));
+  EXPECT_TRUE(sourcemeta::core::is_email("\"a..b\"@example.com"));
+}
+
+// RFC 6531 §3.3: atext =/ UTF8-non-ascii puts no IDNA codepoint restriction on
+// the local-part, so U+2665 BLACK HEART (bytes E2 99 A5) is a valid local atom
+// even though it is DISALLOWED (RFC 5892 §2.6) in a domain U-label.
+TEST(IdnEmail, valid_local_symbol_codepoint) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\xe2\x99\xa5@example.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("\xe2\x99\xa5@example.com"));
+}
+
+// RFC 6531 §3.3: the local-part has no Bidi constraint (unlike a domain
+// U-label, RFC 5893), so a right-to-left character U+05D0 HEBREW ALEF (bytes D7
+// 90) is a valid local atom.
+TEST(IdnEmail, valid_local_rtl_codepoint) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\xd7\x90@example.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("\xd7\x90@example.com"));
+}
+
+// RFC 6531 §3.3: the local-part has no leading-combining-mark rule (unlike a
+// domain U-label, RFC 5891 §4.2.3.2), so a lone U+0301 COMBINING ACUTE (bytes
+// CC 81) is a valid local atom.
+TEST(IdnEmail, valid_local_combining_mark) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\xcc\x81@example.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("\xcc\x81@example.com"));
+}
+
+// RFC 5893 §2: in a domain that has a right-to-left label, every label must
+// satisfy the Bidi rule. The LTR label "0a" (starts with EN digit U+0030) in a
+// name that also has the RTL label U+05D0 (bytes D7 90) violates it.
+TEST(IdnEmail, invalid_domain_bidi_rule) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@0a.\xd7\x90"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@0a.\xd7\x90"));
+}
+
+// RFC 5892 §2.6: U+200B ZERO WIDTH SPACE (bytes E2 80 8B) is DISALLOWED, so a
+// domain label containing it is invalid (lenient processors silently strip it).
+TEST(IdnEmail, invalid_domain_zero_width) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@a\xe2\x80\x8b"
+                                              "b.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@a\xe2\x80\x8b"
+                                          "b.com"));
+}
+
+// RFC 5891 §4.2.3.2: a domain U-label MUST NOT begin with a combining mark. A
+// leading U+0301 COMBINING ACUTE (bytes CC 81) is invalid in the domain - the
+// mirror of valid_local_combining_mark, where the same mark is fine in the
+// local.
+TEST(IdnEmail, invalid_domain_leading_combining_mark) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@\xcc\x81"
+                                              "a.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("user@\xcc\x81"
+                                          "a.com"));
+}
+
+// RFC 6531 §3.3: a quoted non-ASCII local-part with a U-label domain. Local
+// U+03B1 GREEK ALPHA (CE B1) inside quotes; domain "m" + U+00FC (C3 BC) +
+// "nchen.de".
+TEST(IdnEmail, valid_quoted_local_and_ulabel_domain) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\xce\xb1\"@m\xc3\xbcnchen.de"));
+  EXPECT_FALSE(sourcemeta::core::is_email("\"\xce\xb1\"@m\xc3\xbcnchen.de"));
+}
+
+// RFC 6531 §3.3 + RFC 5890 §2.3.2.1: a U-label local-part (U+03B1 GREEK ALPHA,
+// CE B1) combined with a valid A-label domain (xn--nxasmq6b).
+TEST(IdnEmail, valid_ulabel_local_and_alabel_domain) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("\xce\xb1@xn--nxasmq6b.com"));
+  EXPECT_FALSE(sourcemeta::core::is_email("\xce\xb1@xn--nxasmq6b.com"));
+}


### PR DESCRIPTION
Core's `is_idn_email` already has good coverage, but a handful of RFC 6531 and RFC 5321 edge cases around the local-part and the domain delegation are not exercised yet. This adds them to `test/email/idn_email_test.cc`. I ran every input through `is_idn_email` (and `is_email`) on the current build before adding it, so each assertion matches the behavior as it stands.

The cases:

- The local-part vs domain normalization difference. RFC 6531 puts no NFC requirement on the local-part, while RFC 5890 section 2.3.2.1 requires a domain U-label to be in NFC. So the same decomposed "cafe" + U+0301 is a valid local-part but an invalid domain. The same split shows up for a leading combining mark, and for codepoints that are fine in a local-part but DISALLOWED in a domain (a symbol, a right-to-left character).
- Quoted-string local-parts: an empty quoted string, an "@" inside the quotes (ordinary content, not a second separator), and consecutive dots inside the quotes (the Dot-string rules do not apply there).
- The domain delegation to `is_idn_hostname`: a Bidi-rule violation, a DISALLOWED zero-width codepoint, and a leading combining mark are all rejected through the email path.
- Two mixed forms: a quoted non-ASCII local-part with a U-label domain, and a U-label local-part with an A-label domain.

Each test asserts both `is_idn_email` and `is_email`, which keeps the RFC 5321 vs RFC 6531 difference visible - a non-ASCII local-part is valid under `is_idn_email` but not `is_email`. Inputs are byte-escaped with the codepoints noted in a comment, and every test cites the governing RFC rule.

These are per-variant cases - the kind that fit in Core rather than the JSON Schema Test Suite, where one representative per mechanism is enough.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

