### PR TITLE
test(uri): expand is_iri coverage for ucschar boundaries, iprivate positions, and host forms

### DIFF
--- a/test/uri/uri_is_iri_test.cc
+++ b/test/uri/uri_is_iri_test.cc
@@ -283,3 +283,251 @@ TEST(URI_is_iri, fragment_with_backslash_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
+
+TEST(URI_is_iri, ucschar_before_surrogate_gap_in_path) {
+  const std::string input{"https://example.com/\xED\x9F\xBF"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ucschar_after_private_use_gap_in_path) {
+  const std::string input{"https://example.com/\xEF\xA4\x80"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ucschar_before_noncharacter_block_in_path) {
+  const std::string input{"https://example.com/\xEF\xB7\x8F"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, noncharacter_fdd0_in_path_rejected) {
+  const std::string input{"https://example.com/\xEF\xB7\x90"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, noncharacter_fdef_in_path_rejected) {
+  const std::string input{"https://example.com/\xEF\xB7\xAF"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ucschar_after_noncharacter_block_in_path) {
+  const std::string input{"https://example.com/\xEF\xB7\xB0"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ucschar_upper_bmp_bound_in_path) {
+  const std::string input{"https://example.com/\xEF\xBF\xAF"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, replacement_character_in_path_rejected) {
+  const std::string input{"https://example.com/\xEF\xBF\xBD"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, noncharacter_fffe_in_path_rejected) {
+  const std::string input{"https://example.com/\xEF\xBF\xBE"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, noncharacter_ffff_in_path_rejected) {
+  const std::string input{"https://example.com/\xEF\xBF\xBF"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, plane_fourteen_below_ucschar_in_path_rejected) {
+  const std::string input{"https://example.com/\xF3\xA0\xBF\xBF"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, plane_fourteen_ucschar_in_path) {
+  const std::string input{"https://example.com/\xF3\xA1\x80\x80"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, astral_ucschar_in_path) {
+  const std::string input{"https://example.com/\xF0\x90\x80\x80"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, astral_ucschar_upper_bound_in_path) {
+  const std::string input{"https://example.com/\xF0\x9F\xBF\xBD"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, astral_noncharacter_in_path_rejected) {
+  const std::string input{"https://example.com/\xF0\x9F\xBF\xBE"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, astral_plane_two_ucschar_in_path) {
+  const std::string input{"https://example.com/\xF0\xA0\x80\x80"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, userinfo_with_iprivate_rejected) {
+  const std::string input{"https://u\xEE\x80\x80@example.com/"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, port_with_iprivate_rejected) {
+  const std::string input{"https://example.com:\xEE\x80\x80/"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, supplementary_iprivate_in_query) {
+  const std::string input{"https://example.com/?q=\xF3\xB0\x80\x80"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, supplementary_iprivate_in_path_rejected) {
+  const std::string input{"https://example.com/\xF3\xB0\x80\x80"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, plane_sixteen_iprivate_in_query) {
+  const std::string input{"https://example.com/?q=\xF4\x80\x80\x80"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, iprivate_upper_bound_in_query) {
+  const std::string input{"https://example.com/?q=\xF4\x8F\xBF\xBD"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ipv4_host) {
+  const std::string input{"http://192.168.0.1/p"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ipvfuture_host_lowercase) {
+  const std::string input{"http://[v1.fe]/"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ipvfuture_host_uppercase) {
+  const std::string input{"http://[V1.fe]/"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, ipvfuture_host_non_hex_version_rejected) {
+  const std::string input{"http://[vG.fe]/"};
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, opaque_path_with_scheme) {
+  const std::string input{"urn:example:resource"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, absolute_path_with_scheme) {
+  const std::string input{"file:/etc/hosts"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, explicit_port) {
+  const std::string input{"http://example.com:8080/p"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, scheme_with_empty_path) {
+  const std::string input{"http:"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}
+
+TEST(URI_is_iri, scheme_with_empty_authority) {
+  const std::string input{"http://"};
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri(input));
+  EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
+}


### PR DESCRIPTION
I added 31 tests to `test/uri/uri_is_iri_test.cc` for parts of the RFC 3987 grammar the existing `is_iri` tests do not reach. Core already passes all of them, so this is coverage, not a fix.

What is new:

- ucschar range edges the current tests skip - the points just before and after the surrogate gap (U+D7FF) and the private-use gap (U+F900), the upper BMP bound (U+FFEF), the noncharacter blocks (U+FDD0-FDEF, U+FFFE, U+FFFF), the replacement character U+FFFD, and the plane-14 cutover at U+E0FFF / U+E1000.
- astral (non-BMP) ucschar, which the file did not cover at all - U+10000, U+1FFFD, U+20000, and the astral noncharacter U+1FFFE.
- the iprivate positional rule finished off - the existing tests have iprivate in query, path, fragment and host, so I added userinfo and port (both rejected) and the two supplementary private-use planes (U+F0000 and U+100000, valid only in the query).
- host and path forms the file was missing - an IPv4 host, IPvFuture in lower and upper case plus a non-hex version that is rejected, an opaque scheme (urn:), an absolute-path scheme (file:/), an explicit port, and the empty-hierarchy forms http: and http://.

Every test keeps the existing four-way checks - is_iri / is_iri_reference / is_uri / is_uri_reference - so each input also records the URI vs IRI split (a non-ASCII IRI is not a URI) and the absolute vs reference split.

How I checked the expected values: I ran each input through the four functions with a small driver linked against the library, confirmed each verdict against the RFC 3987 grammar, and wrote the tests from that. The uri test target builds and all 65 URI_is_iri tests pass.

RFC references:

- ucschar and iprivate ranges, and iprivate being allowed only in iquery - RFC 3987 section 2.2.
- IPvFuture and the case-insensitive host - RFC 3986 section 3.2.2, carried into RFC 3987 section 2.2 unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

