### PR TITLE
Implement a new `describes()` method in the URI Template router

### DIFF
--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -120,6 +120,14 @@ public:
                            const Callback &callback) const
       -> std::pair<Identifier, Identifier>;
 
+  /// Determine whether a path lies within the space described by the explicitly
+  /// registered routes, as a whole-segment prefix of one or more routes, as an
+  /// exact route, or as a path captured by a route expansion. The fallback
+  /// registered through the catch-all is never considered. Like matching, the
+  /// path is not normalized before evaluation
+  [[nodiscard]] auto describes(const std::string_view path) const noexcept
+      -> bool;
+
   /// Access the root node of the trie
   [[nodiscard]] auto root() const noexcept -> const Node &;
 
@@ -202,6 +210,14 @@ public:
                            const URITemplateRouter::Callback &callback) const
       -> std::pair<URITemplateRouter::Identifier,
                    URITemplateRouter::Identifier>;
+
+  /// Determine whether a path lies within the space described by the explicitly
+  /// registered routes, as a whole-segment prefix of one or more routes, as an
+  /// exact route, or as a path captured by a route expansion. The fallback
+  /// registered through the catch-all is never considered. Like matching, the
+  /// path is not normalized before evaluation
+  [[nodiscard]] auto describes(const std::string_view path) const noexcept
+      -> bool;
 
   /// Access the stored arguments for a given route identifier
   auto arguments(const URITemplateRouter::Identifier identifier,

--- a/src/core/uritemplate/uritemplate_router.cc
+++ b/src/core/uritemplate/uritemplate_router.cc
@@ -547,6 +547,62 @@ auto URITemplateRouter::root() const noexcept -> const Node & {
   return this->root_;
 }
 
+auto URITemplateRouter::describes(const std::string_view path) const noexcept
+    -> bool {
+  const bool root_describes = this->root_.identifier != 0 ||
+                              !this->root_.literals.empty() ||
+                              this->root_.variable != nullptr;
+
+  if (path.empty()) {
+    return root_describes;
+  }
+
+  if (path.front() != '/') {
+    return false;
+  }
+
+  const char *position = path.data() + 1;
+  const char *const path_end = path.data() + path.size();
+
+  if (position >= path_end) {
+    return root_describes;
+  }
+
+  const std::vector<std::unique_ptr<Node>> *literal_children =
+      &this->root_.literals;
+  const std::unique_ptr<Node> *variable_child = &this->root_.variable;
+
+  while (true) {
+    const char *segment_start = position;
+    while (position < path_end && *position != '/') {
+      ++position;
+    }
+    const std::string_view segment{
+        segment_start, static_cast<std::size_t>(position - segment_start)};
+
+    const Node *current = find_literal_child(*literal_children, segment);
+    if (current == nullptr) {
+      if (segment.empty() || !*variable_child) {
+        return false;
+      }
+      if (is_expansion_type((*variable_child)->type)) {
+        return true;
+      }
+      current = variable_child->get();
+    }
+
+    literal_children = &current->literals;
+    variable_child = &current->variable;
+
+    if (position >= path_end) {
+      break;
+    }
+    ++position;
+  }
+
+  return true;
+}
+
 auto URITemplateRouter::arguments(const Identifier identifier,
                                   const ArgumentCallback &callback) const
     -> void {

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -690,7 +690,13 @@ auto URITemplateRouterView::describes(
       if (node.variable_child >= node_count) {
         return false;
       }
-      if (is_expansion_type(nodes[node.variable_child].type)) {
+      const auto &variable_node = nodes[node.variable_child];
+      if (variable_node.string_offset > string_table_size ||
+          variable_node.string_length >
+              string_table_size - variable_node.string_offset) {
+        return false;
+      }
+      if (is_expansion_type(variable_node.type)) {
         return true;
       }
       current_node = node.variable_child;

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -604,6 +604,109 @@ auto URITemplateRouterView::match(
                         final_node.context);
 }
 
+auto URITemplateRouterView::describes(
+    const std::string_view path) const noexcept -> bool {
+  if (this->size_ < sizeof(RouterHeader)) {
+    return false;
+  }
+
+  const auto *header = reinterpret_cast<const RouterHeader *>(this->data_);
+  if (header->magic != ROUTER_MAGIC || header->version != ROUTER_VERSION) {
+    return false;
+  }
+
+  const auto node_count = header->node_count;
+  if (node_count == 0 || node_count > (this->size_ - sizeof(RouterHeader)) /
+                                          sizeof(SerializedNode)) {
+    return false;
+  }
+
+  const auto *nodes = reinterpret_cast<const SerializedNode *>(
+      this->data_ + sizeof(RouterHeader));
+  const auto nodes_size =
+      static_cast<std::size_t>(node_count) * sizeof(SerializedNode);
+  const auto expected_string_table_offset = sizeof(RouterHeader) + nodes_size;
+  if (header->string_table_offset < expected_string_table_offset ||
+      header->string_table_offset > this->size_) {
+    return false;
+  }
+
+  if (header->arguments_offset < header->string_table_offset ||
+      header->arguments_offset > this->size_) {
+    return false;
+  }
+
+  const auto *string_table =
+      reinterpret_cast<const char *>(this->data_ + header->string_table_offset);
+  const auto string_table_size =
+      header->arguments_offset - header->string_table_offset;
+
+  const auto &root = nodes[0];
+  const bool root_describes = root.identifier != 0 ||
+                              root.first_literal_child != NO_CHILD ||
+                              root.variable_child != NO_CHILD;
+
+  if (path.empty()) {
+    return root_describes;
+  }
+
+  if (path.front() != '/') {
+    return false;
+  }
+
+  const char *position = path.data() + 1;
+  const char *const path_end = path.data() + path.size();
+
+  if (position >= path_end) {
+    return root_describes;
+  }
+
+  std::uint32_t current_node = 0;
+
+  while (true) {
+    const char *segment_start = position;
+    while (position < path_end && *position != '/') {
+      ++position;
+    }
+    const auto segment_length =
+        static_cast<std::uint32_t>(position - segment_start);
+
+    const auto &node = nodes[current_node];
+
+    std::uint32_t literal_match = NO_CHILD;
+    if (node.first_literal_child != NO_CHILD) {
+      if (node.first_literal_child >= node_count ||
+          node.literal_child_count > node_count - node.first_literal_child) {
+        return false;
+      }
+      literal_match = binary_search_literal_children(
+          nodes, string_table, string_table_size, node.first_literal_child,
+          node.literal_child_count, segment_start, segment_length);
+    }
+
+    if (literal_match != NO_CHILD) {
+      current_node = literal_match;
+    } else if (segment_length > 0 && node.variable_child != NO_CHILD) {
+      if (node.variable_child >= node_count) {
+        return false;
+      }
+      if (is_expansion_type(nodes[node.variable_child].type)) {
+        return true;
+      }
+      current_node = node.variable_child;
+    } else {
+      return false;
+    }
+
+    if (position >= path_end) {
+      break;
+    }
+    ++position;
+  }
+
+  return true;
+}
+
 auto URITemplateRouterView::arguments(
     const URITemplateRouter::Identifier identifier,
     const URITemplateRouter::ArgumentCallback &callback) const -> void {

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -2806,3 +2806,155 @@ TEST(URITemplateRouter, strict_path_reconstruction_preserves_input) {
   EXPECT_EQ(router.path(1), "/foo//bar");
   EXPECT_EQ(router.path(2), "////");
 }
+
+TEST(URITemplateRouter, describes_worked_example_table) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/self/v1/api/schemas/health/{+schema}", "op_815", 1);
+  router.add("/self/v1/api/{+any}", "op_816", 2);
+  router.add("/self/v1/mcp", "op_817", 3);
+  router.add("/self/v1/health", "op_818", 4);
+  router.add("/self/v1/static/{+path}", "op_819", 5);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/self/v1/api"));
+  EXPECT_TRUE(router.describes("/self/v1/api/schemas/health"));
+  EXPECT_TRUE(router.describes("/self/v1/api/schemas/health/acme"));
+  EXPECT_TRUE(router.describes("/self/v1/mcp"));
+  EXPECT_TRUE(router.describes("/self/v1/static/css/app.css"));
+  EXPECT_TRUE(router.describes("/self/v1"));
+  EXPECT_FALSE(router.describes("/self/v1/mpc"));
+  EXPECT_FALSE(router.describes("/self/v1/healthz"));
+  EXPECT_FALSE(router.describes("/acme/foo"));
+  EXPECT_TRUE(router.describes("/"));
+}
+
+TEST(URITemplateRouter, describes_intermediate_prefixes) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/self/v1/mcp", "op_820", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/self"));
+  EXPECT_TRUE(router.describes("/self/v1"));
+  EXPECT_TRUE(router.describes("/self/v1/mcp"));
+  EXPECT_FALSE(router.describes("/self/v1/mcp/extra"));
+  EXPECT_FALSE(router.describes("/self/v2"));
+  EXPECT_FALSE(router.describes("/other"));
+}
+
+TEST(URITemplateRouter, describes_expansion_capture) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/files/{+path}", "op_821", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/files"));
+  EXPECT_TRUE(router.describes("/files/a"));
+  EXPECT_TRUE(router.describes("/files/a/b/c"));
+  EXPECT_FALSE(router.describes("/file"));
+  EXPECT_FALSE(router.describes("/filesx"));
+}
+
+TEST(URITemplateRouter, describes_optional_expansion_capture) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/docs/{/rest*}", "op_822", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/docs"));
+  EXPECT_TRUE(router.describes("/docs/a"));
+  EXPECT_TRUE(router.describes("/docs/a/b/c"));
+  EXPECT_FALSE(router.describes("/doc"));
+  EXPECT_FALSE(router.describes("/docsx"));
+}
+
+TEST(URITemplateRouter,
+     describes_single_segment_variable_does_not_over_absorb) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/foo/{bar}/baz", "op_823", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/foo"));
+  EXPECT_TRUE(router.describes("/foo/anything"));
+  EXPECT_TRUE(router.describes("/foo/anything/baz"));
+  EXPECT_FALSE(router.describes("/foo/anything/qux"));
+  EXPECT_FALSE(router.describes("/foo/anything/baz/extra"));
+}
+
+TEST(URITemplateRouter, describes_whole_segment_discipline) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/internalish", "op_824", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/internalish"));
+  EXPECT_FALSE(router.describes("/internal"));
+  EXPECT_FALSE(router.describes("/internalisher"));
+}
+
+TEST(URITemplateRouter, describes_excludes_otherwise_fallback) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/known", "op_825", 1);
+  router.otherwise(7);
+
+  EXPECT_TRUE(router.describes("/known"));
+  EXPECT_FALSE(router.describes("/unknown"));
+  EXPECT_FALSE(router.describes("/known/deeper"));
+}
+
+TEST(URITemplateRouter, describes_empty_router_describes_nothing) {
+  sourcemeta::core::URITemplateRouter router;
+  router.otherwise(3);
+
+  EXPECT_FALSE(router.describes("/"));
+  EXPECT_FALSE(router.describes(""));
+  EXPECT_FALSE(router.describes("/anything"));
+}
+
+TEST(URITemplateRouter, describes_root_and_empty_path) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users", "op_826", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/"));
+  EXPECT_TRUE(router.describes(""));
+}
+
+TEST(URITemplateRouter, describes_requires_leading_slash) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users", "op_827", 1);
+  router.otherwise(0);
+
+  EXPECT_FALSE(router.describes("users"));
+  EXPECT_FALSE(router.describes("users/list"));
+}
+
+TEST(URITemplateRouter, describes_with_base_path) {
+  sourcemeta::core::URITemplateRouter router{"/api"};
+  router.add("/foo", "op_828", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/api/foo"));
+  EXPECT_TRUE(router.describes("/api"));
+  EXPECT_FALSE(router.describes("/foo"));
+  EXPECT_FALSE(router.describes("/api/bar"));
+}
+
+TEST(URITemplateRouter, describes_literal_preferred_over_variable) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/users/me", "op_829", 1);
+  router.add("/users/{id}/posts", "op_830", 2);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/users/me"));
+  EXPECT_TRUE(router.describes("/users/42"));
+  EXPECT_TRUE(router.describes("/users/42/posts"));
+  EXPECT_FALSE(router.describes("/users/42/comments"));
+  EXPECT_FALSE(router.describes("/users/me/posts"));
+}
+
+TEST(URITemplateRouter, describes_empty_template_root_route) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("", "op_831", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes(""));
+  EXPECT_TRUE(router.describes("/"));
+  EXPECT_FALSE(router.describes("/foo"));
+}

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -3685,3 +3685,215 @@ TEST_F(URITemplateRouterViewTest, strict_root_template_still_works) {
   EXPECT_EQ(captures_match.size(), 0);
   EXPECT_ROUTER_MATCH(restored, "//", 0, 0, captures_double);
 }
+
+TEST_F(URITemplateRouterViewTest, describes_worked_example_table) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/self/v1/api/schemas/health/{+schema}", "op_957", 1);
+    router.add("/self/v1/api/{+any}", "op_958", 2);
+    router.add("/self/v1/mcp", "op_959", 3);
+    router.add("/self/v1/health", "op_960", 4);
+    router.add("/self/v1/static/{+path}", "op_961", 5);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/self/v1/api"));
+  EXPECT_TRUE(restored.describes("/self/v1/api/schemas/health"));
+  EXPECT_TRUE(restored.describes("/self/v1/api/schemas/health/acme"));
+  EXPECT_TRUE(restored.describes("/self/v1/mcp"));
+  EXPECT_TRUE(restored.describes("/self/v1/static/css/app.css"));
+  EXPECT_TRUE(restored.describes("/self/v1"));
+  EXPECT_FALSE(restored.describes("/self/v1/mpc"));
+  EXPECT_FALSE(restored.describes("/self/v1/healthz"));
+  EXPECT_FALSE(restored.describes("/acme/foo"));
+  EXPECT_TRUE(restored.describes("/"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_intermediate_prefixes) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/self/v1/mcp", "op_962", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/self"));
+  EXPECT_TRUE(restored.describes("/self/v1"));
+  EXPECT_TRUE(restored.describes("/self/v1/mcp"));
+  EXPECT_FALSE(restored.describes("/self/v1/mcp/extra"));
+  EXPECT_FALSE(restored.describes("/self/v2"));
+  EXPECT_FALSE(restored.describes("/other"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_expansion_capture) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/files/{+path}", "op_963", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/files"));
+  EXPECT_TRUE(restored.describes("/files/a"));
+  EXPECT_TRUE(restored.describes("/files/a/b/c"));
+  EXPECT_FALSE(restored.describes("/file"));
+  EXPECT_FALSE(restored.describes("/filesx"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_optional_expansion_capture) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/docs/{/rest*}", "op_964", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/docs"));
+  EXPECT_TRUE(restored.describes("/docs/a"));
+  EXPECT_TRUE(restored.describes("/docs/a/b/c"));
+  EXPECT_FALSE(restored.describes("/doc"));
+  EXPECT_FALSE(restored.describes("/docsx"));
+}
+
+TEST_F(URITemplateRouterViewTest,
+       describes_single_segment_variable_does_not_over_absorb) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/foo/{bar}/baz", "op_965", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/foo"));
+  EXPECT_TRUE(restored.describes("/foo/anything"));
+  EXPECT_TRUE(restored.describes("/foo/anything/baz"));
+  EXPECT_FALSE(restored.describes("/foo/anything/qux"));
+  EXPECT_FALSE(restored.describes("/foo/anything/baz/extra"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_whole_segment_discipline) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/internalish", "op_966", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/internalish"));
+  EXPECT_FALSE(restored.describes("/internal"));
+  EXPECT_FALSE(restored.describes("/internalisher"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_excludes_otherwise_fallback) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/known", "op_967", 1);
+    router.otherwise(7);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/known"));
+  EXPECT_FALSE(restored.describes("/unknown"));
+  EXPECT_FALSE(restored.describes("/known/deeper"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_empty_router_describes_nothing) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.otherwise(3);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_FALSE(restored.describes("/"));
+  EXPECT_FALSE(restored.describes(""));
+  EXPECT_FALSE(restored.describes("/anything"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_root_and_empty_path) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/users", "op_968", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/"));
+  EXPECT_TRUE(restored.describes(""));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_requires_leading_slash) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/users", "op_969", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_FALSE(restored.describes("users"));
+  EXPECT_FALSE(restored.describes("users/list"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_with_base_path) {
+  {
+    sourcemeta::core::URITemplateRouter router{"/api"};
+    router.add("/foo", "op_970", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/api/foo"));
+  EXPECT_TRUE(restored.describes("/api"));
+  EXPECT_FALSE(restored.describes("/foo"));
+  EXPECT_FALSE(restored.describes("/api/bar"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_literal_preferred_over_variable) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/users/me", "op_971", 1);
+    router.add("/users/{id}/posts", "op_972", 2);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/users/me"));
+  EXPECT_TRUE(restored.describes("/users/42"));
+  EXPECT_TRUE(restored.describes("/users/42/posts"));
+  EXPECT_FALSE(restored.describes("/users/42/comments"));
+  EXPECT_FALSE(restored.describes("/users/me/posts"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_empty_template_root_route) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("", "op_973", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes(""));
+  EXPECT_TRUE(restored.describes("/"));
+  EXPECT_FALSE(restored.describes("/foo"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_on_corrupt_buffer) {
+  std::array<std::uint8_t, 4> buffer{};
+  const sourcemeta::core::URITemplateRouterView view{buffer.data(),
+                                                     buffer.size()};
+  EXPECT_FALSE(view.describes("/anything"));
+  EXPECT_FALSE(view.describes("/"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

