### PR TITLE
Optionally take the base path as a second argument on `describes()`

### DIFF
--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -124,9 +124,12 @@ public:
   /// registered routes, as a whole-segment prefix of one or more routes, as an
   /// exact route, or as a path captured by a route expansion. The fallback
   /// registered through the catch-all is never considered. Like matching, the
-  /// path is not normalized before evaluation
-  [[nodiscard]] auto describes(const std::string_view path) const noexcept
-      -> bool;
+  /// path is not normalized before evaluation. When a base path is given, it is
+  /// evaluated as if prepended to the path, avoiding a concatenation at the
+  /// call site
+  [[nodiscard]] auto
+  describes(const std::string_view path,
+            const std::string_view base_path = {}) const noexcept -> bool;
 
   /// Access the root node of the trie
   [[nodiscard]] auto root() const noexcept -> const Node &;
@@ -215,9 +218,12 @@ public:
   /// registered routes, as a whole-segment prefix of one or more routes, as an
   /// exact route, or as a path captured by a route expansion. The fallback
   /// registered through the catch-all is never considered. Like matching, the
-  /// path is not normalized before evaluation
-  [[nodiscard]] auto describes(const std::string_view path) const noexcept
-      -> bool;
+  /// path is not normalized before evaluation. When a base path is given, it is
+  /// evaluated as if prepended to the path, avoiding a concatenation at the
+  /// call site
+  [[nodiscard]] auto
+  describes(const std::string_view path,
+            const std::string_view base_path = {}) const noexcept -> bool;
 
   /// Access the stored arguments for a given route identifier
   auto arguments(const URITemplateRouter::Identifier identifier,

--- a/src/core/uritemplate/uritemplate_router.cc
+++ b/src/core/uritemplate/uritemplate_router.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm> // std::ranges::lower_bound, std::ranges::find_if
 #include <cassert>   // assert
+#include <cstdint>   // std::uint8_t
 #include <limits>    // std::numeric_limits
 #include <tuple>     // std::get, std::make_tuple
 
@@ -47,6 +48,62 @@ auto find_or_create_literal_child(std::vector<std::unique_ptr<Node>> &literals,
 
 inline auto is_expansion_type(const NodeType type) noexcept -> bool {
   return type == NodeType::Expansion || type == NodeType::OptionalExpansion;
+}
+
+enum class DescribeWalk : std::uint8_t { NoMatch, Captured, Reached };
+
+// Walk the segments of a rooted path fragment through the trie, starting from
+// the given node. A null node means the root. On a successful walk, the node is
+// advanced to where the fragment ends
+auto walk_describe_fragment(const Node *&current, const Node &root,
+                            const std::string_view fragment) noexcept
+    -> DescribeWalk {
+  if (fragment.empty()) {
+    return DescribeWalk::Reached;
+  }
+
+  if (fragment.front() != '/') {
+    return DescribeWalk::NoMatch;
+  }
+
+  const char *position = fragment.data() + 1;
+  const char *const fragment_end = fragment.data() + fragment.size();
+
+  if (position >= fragment_end) {
+    return DescribeWalk::Reached;
+  }
+
+  while (true) {
+    const char *segment_start = position;
+    while (position < fragment_end && *position != '/') {
+      ++position;
+    }
+    const std::string_view segment{
+        segment_start, static_cast<std::size_t>(position - segment_start)};
+
+    const auto &literal_children = current ? current->literals : root.literals;
+    const auto &variable_child = current ? current->variable : root.variable;
+
+    const Node *next = find_literal_child(literal_children, segment);
+    if (next == nullptr) {
+      if (segment.empty() || !variable_child) {
+        return DescribeWalk::NoMatch;
+      }
+      if (is_expansion_type(variable_child->type)) {
+        return DescribeWalk::Captured;
+      }
+      next = variable_child.get();
+    }
+
+    current = next;
+
+    if (position >= fragment_end) {
+      break;
+    }
+    ++position;
+  }
+
+  return DescribeWalk::Reached;
 }
 
 auto find_or_create_variable_child(std::unique_ptr<Node> &variable,
@@ -547,57 +604,34 @@ auto URITemplateRouter::root() const noexcept -> const Node & {
   return this->root_;
 }
 
-auto URITemplateRouter::describes(const std::string_view path) const noexcept
-    -> bool {
-  const bool root_describes = this->root_.identifier != 0 ||
-                              !this->root_.literals.empty() ||
-                              this->root_.variable != nullptr;
+auto URITemplateRouter::describes(
+    const std::string_view path,
+    const std::string_view base_path) const noexcept -> bool {
+  const Node *current = nullptr;
 
-  if (path.empty()) {
-    return root_describes;
-  }
-
-  if (path.front() != '/') {
-    return false;
-  }
-
-  const char *position = path.data() + 1;
-  const char *const path_end = path.data() + path.size();
-
-  if (position >= path_end) {
-    return root_describes;
-  }
-
-  const std::vector<std::unique_ptr<Node>> *literal_children =
-      &this->root_.literals;
-  const std::unique_ptr<Node> *variable_child = &this->root_.variable;
-
-  while (true) {
-    const char *segment_start = position;
-    while (position < path_end && *position != '/') {
-      ++position;
-    }
-    const std::string_view segment{
-        segment_start, static_cast<std::size_t>(position - segment_start)};
-
-    const Node *current = find_literal_child(*literal_children, segment);
-    if (current == nullptr) {
-      if (segment.empty() || !*variable_child) {
+  if (!base_path.empty()) {
+    switch (walk_describe_fragment(current, this->root_, base_path)) {
+      case DescribeWalk::NoMatch:
         return false;
-      }
-      if (is_expansion_type((*variable_child)->type)) {
+      case DescribeWalk::Captured:
         return true;
-      }
-      current = variable_child->get();
+      case DescribeWalk::Reached:
+        break;
     }
+  }
 
-    literal_children = &current->literals;
-    variable_child = &current->variable;
-
-    if (position >= path_end) {
+  switch (walk_describe_fragment(current, this->root_, path)) {
+    case DescribeWalk::NoMatch:
+      return false;
+    case DescribeWalk::Captured:
+      return true;
+    case DescribeWalk::Reached:
       break;
-    }
-    ++position;
+  }
+
+  if (current == nullptr) {
+    return this->root_.identifier != 0 || !this->root_.literals.empty() ||
+           this->root_.variable != nullptr;
   }
 
   return true;

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -162,6 +162,83 @@ inline auto binary_search_literal_children(
   return NO_CHILD;
 }
 
+enum class DescribeWalk : std::uint8_t { NoMatch, Captured, Reached };
+
+// Walk the segments of a rooted path fragment through the serialized trie,
+// starting from the given node index. On a successful walk, the node index is
+// advanced to where the fragment ends
+inline auto walk_describe_fragment(const SerializedNode *nodes,
+                                   const std::uint32_t node_count,
+                                   const char *string_table,
+                                   const std::size_t string_table_size,
+                                   std::uint32_t &current_node,
+                                   const std::string_view fragment) noexcept
+    -> DescribeWalk {
+  if (fragment.empty()) {
+    return DescribeWalk::Reached;
+  }
+
+  if (fragment.front() != '/') {
+    return DescribeWalk::NoMatch;
+  }
+
+  const char *position = fragment.data() + 1;
+  const char *const fragment_end = fragment.data() + fragment.size();
+
+  if (position >= fragment_end) {
+    return DescribeWalk::Reached;
+  }
+
+  while (true) {
+    const char *segment_start = position;
+    while (position < fragment_end && *position != '/') {
+      ++position;
+    }
+    const auto segment_length =
+        static_cast<std::uint32_t>(position - segment_start);
+
+    const auto &node = nodes[current_node];
+
+    std::uint32_t literal_match = NO_CHILD;
+    if (node.first_literal_child != NO_CHILD) {
+      if (node.first_literal_child >= node_count ||
+          node.literal_child_count > node_count - node.first_literal_child) {
+        return DescribeWalk::NoMatch;
+      }
+      literal_match = binary_search_literal_children(
+          nodes, string_table, string_table_size, node.first_literal_child,
+          node.literal_child_count, segment_start, segment_length);
+    }
+
+    if (literal_match != NO_CHILD) {
+      current_node = literal_match;
+    } else if (segment_length > 0 && node.variable_child != NO_CHILD) {
+      if (node.variable_child >= node_count) {
+        return DescribeWalk::NoMatch;
+      }
+      const auto &variable_node = nodes[node.variable_child];
+      if (variable_node.string_offset > string_table_size ||
+          variable_node.string_length >
+              string_table_size - variable_node.string_offset) {
+        return DescribeWalk::NoMatch;
+      }
+      if (is_expansion_type(variable_node.type)) {
+        return DescribeWalk::Captured;
+      }
+      current_node = node.variable_child;
+    } else {
+      return DescribeWalk::NoMatch;
+    }
+
+    if (position >= fragment_end) {
+      break;
+    }
+    ++position;
+  }
+
+  return DescribeWalk::Reached;
+}
+
 } // namespace
 
 auto URITemplateRouterView::save(const URITemplateRouter &router,
@@ -605,7 +682,8 @@ auto URITemplateRouterView::match(
 }
 
 auto URITemplateRouterView::describes(
-    const std::string_view path) const noexcept -> bool {
+    const std::string_view path,
+    const std::string_view base_path) const noexcept -> bool {
   if (this->size_ < sizeof(RouterHeader)) {
     return false;
   }
@@ -641,73 +719,35 @@ auto URITemplateRouterView::describes(
   const auto string_table_size =
       header->arguments_offset - header->string_table_offset;
 
-  const auto &root = nodes[0];
-  const bool root_describes = root.identifier != 0 ||
-                              root.first_literal_child != NO_CHILD ||
-                              root.variable_child != NO_CHILD;
-
-  if (path.empty()) {
-    return root_describes;
-  }
-
-  if (path.front() != '/') {
-    return false;
-  }
-
-  const char *position = path.data() + 1;
-  const char *const path_end = path.data() + path.size();
-
-  if (position >= path_end) {
-    return root_describes;
-  }
-
   std::uint32_t current_node = 0;
 
-  while (true) {
-    const char *segment_start = position;
-    while (position < path_end && *position != '/') {
-      ++position;
-    }
-    const auto segment_length =
-        static_cast<std::uint32_t>(position - segment_start);
-
-    const auto &node = nodes[current_node];
-
-    std::uint32_t literal_match = NO_CHILD;
-    if (node.first_literal_child != NO_CHILD) {
-      if (node.first_literal_child >= node_count ||
-          node.literal_child_count > node_count - node.first_literal_child) {
+  if (!base_path.empty()) {
+    switch (walk_describe_fragment(nodes, node_count, string_table,
+                                   string_table_size, current_node,
+                                   base_path)) {
+      case DescribeWalk::NoMatch:
         return false;
-      }
-      literal_match = binary_search_literal_children(
-          nodes, string_table, string_table_size, node.first_literal_child,
-          node.literal_child_count, segment_start, segment_length);
-    }
-
-    if (literal_match != NO_CHILD) {
-      current_node = literal_match;
-    } else if (segment_length > 0 && node.variable_child != NO_CHILD) {
-      if (node.variable_child >= node_count) {
-        return false;
-      }
-      const auto &variable_node = nodes[node.variable_child];
-      if (variable_node.string_offset > string_table_size ||
-          variable_node.string_length >
-              string_table_size - variable_node.string_offset) {
-        return false;
-      }
-      if (is_expansion_type(variable_node.type)) {
+      case DescribeWalk::Captured:
         return true;
-      }
-      current_node = node.variable_child;
-    } else {
-      return false;
+      case DescribeWalk::Reached:
+        break;
     }
+  }
 
-    if (position >= path_end) {
+  switch (walk_describe_fragment(nodes, node_count, string_table,
+                                 string_table_size, current_node, path)) {
+    case DescribeWalk::NoMatch:
+      return false;
+    case DescribeWalk::Captured:
+      return true;
+    case DescribeWalk::Reached:
       break;
-    }
-    ++position;
+  }
+
+  if (current_node == 0) {
+    const auto &root = nodes[0];
+    return root.identifier != 0 || root.first_literal_child != NO_CHILD ||
+           root.variable_child != NO_CHILD;
   }
 
   return true;

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -2958,3 +2958,66 @@ TEST(URITemplateRouter, describes_empty_template_root_route) {
   EXPECT_TRUE(router.describes("/"));
   EXPECT_FALSE(router.describes("/foo"));
 }
+
+TEST(URITemplateRouter, describes_with_base_argument_equivalent_to_concat) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/self/v1/api/{+any}", "op_832", 1);
+  router.add("/self/v1/mcp", "op_833", 2);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/api", "/self/v1"));
+  EXPECT_TRUE(router.describes("/self/v1/api"));
+  EXPECT_TRUE(router.describes("/api/foo", "/self/v1"));
+  EXPECT_TRUE(router.describes("/mcp", "/self/v1"));
+  EXPECT_FALSE(router.describes("/mpc", "/self/v1"));
+  EXPECT_FALSE(router.describes("/api", "/self/v2"));
+}
+
+TEST(URITemplateRouter, describes_with_base_argument_prefix_and_capture) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/files/{+path}", "op_834", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/files", ""));
+  EXPECT_TRUE(router.describes("/files/a/b", ""));
+  EXPECT_TRUE(router.describes("", "/files"));
+  EXPECT_TRUE(router.describes("/", "/files"));
+  EXPECT_TRUE(router.describes("/a/b", "/files"));
+  EXPECT_FALSE(router.describes("/a/b", "/file"));
+}
+
+TEST(URITemplateRouter, describes_with_base_argument_captured_in_base) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/files/{+path}", "op_835", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/anything", "/files/already"));
+}
+
+TEST(URITemplateRouter, describes_with_base_argument_base_mismatch) {
+  sourcemeta::core::URITemplateRouter router;
+  router.add("/self/v1/mcp", "op_836", 1);
+  router.otherwise(0);
+
+  EXPECT_FALSE(router.describes("/mcp", "/other"));
+  EXPECT_FALSE(router.describes("/mcp", "/self/v2"));
+}
+
+TEST(URITemplateRouter, describes_with_router_base_path_split_argument) {
+  sourcemeta::core::URITemplateRouter router{"/prefix"};
+  router.add("/foo", "op_837", 1);
+  router.otherwise(0);
+
+  EXPECT_TRUE(router.describes("/foo", "/prefix"));
+  EXPECT_TRUE(router.describes("/prefix/foo"));
+  EXPECT_TRUE(router.describes("", "/prefix"));
+  EXPECT_FALSE(router.describes("/bar", "/prefix"));
+}
+
+TEST(URITemplateRouter, describes_with_base_argument_empty_router) {
+  sourcemeta::core::URITemplateRouter router;
+  router.otherwise(0);
+
+  EXPECT_FALSE(router.describes("/foo", "/bar"));
+  EXPECT_FALSE(router.describes("", "/bar"));
+}

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -3897,3 +3897,94 @@ TEST_F(URITemplateRouterViewTest, describes_on_corrupt_buffer) {
   EXPECT_FALSE(view.describes("/anything"));
   EXPECT_FALSE(view.describes("/"));
 }
+
+TEST_F(URITemplateRouterViewTest,
+       describes_with_base_argument_equivalent_to_concat) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/self/v1/api/{+any}", "op_974", 1);
+    router.add("/self/v1/mcp", "op_975", 2);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/api", "/self/v1"));
+  EXPECT_TRUE(restored.describes("/self/v1/api"));
+  EXPECT_TRUE(restored.describes("/api/foo", "/self/v1"));
+  EXPECT_TRUE(restored.describes("/mcp", "/self/v1"));
+  EXPECT_FALSE(restored.describes("/mpc", "/self/v1"));
+  EXPECT_FALSE(restored.describes("/api", "/self/v2"));
+}
+
+TEST_F(URITemplateRouterViewTest,
+       describes_with_base_argument_prefix_and_capture) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/files/{+path}", "op_976", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/files", ""));
+  EXPECT_TRUE(restored.describes("/files/a/b", ""));
+  EXPECT_TRUE(restored.describes("", "/files"));
+  EXPECT_TRUE(restored.describes("/", "/files"));
+  EXPECT_TRUE(restored.describes("/a/b", "/files"));
+  EXPECT_FALSE(restored.describes("/a/b", "/file"));
+}
+
+TEST_F(URITemplateRouterViewTest,
+       describes_with_base_argument_captured_in_base) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/files/{+path}", "op_977", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/anything", "/files/already"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_with_base_argument_base_mismatch) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/self/v1/mcp", "op_978", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_FALSE(restored.describes("/mcp", "/other"));
+  EXPECT_FALSE(restored.describes("/mcp", "/self/v2"));
+}
+
+TEST_F(URITemplateRouterViewTest,
+       describes_with_router_base_path_split_argument) {
+  {
+    sourcemeta::core::URITemplateRouter router{"/prefix"};
+    router.add("/foo", "op_979", 1);
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_TRUE(restored.describes("/foo", "/prefix"));
+  EXPECT_TRUE(restored.describes("/prefix/foo"));
+  EXPECT_TRUE(restored.describes("", "/prefix"));
+  EXPECT_FALSE(restored.describes("/bar", "/prefix"));
+}
+
+TEST_F(URITemplateRouterViewTest, describes_with_base_argument_empty_router) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.otherwise(0);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  const sourcemeta::core::URITemplateRouterView restored{this->path};
+  EXPECT_FALSE(restored.describes("/foo", "/bar"));
+  EXPECT_FALSE(restored.describes("", "/bar"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

