### PR TITLE
Fix several new ClangTidy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.24)
 project(core VERSION 0.0.0 LANGUAGES C CXX ASM_MASM DESCRIPTION "Sourcemeta Core")
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/cmake/FindGoogleTest.cmake
+++ b/cmake/FindGoogleTest.cmake
@@ -3,4 +3,13 @@ if(NOT GoogleTest_FOUND)
   set(INSTALL_GTEST OFF CACHE BOOL "disable installation")
   add_subdirectory("${PROJECT_SOURCE_DIR}/vendor/googletest")
   set(GoogleTest_FOUND ON)
+
+  # GoogleTest is vendored as-is and is not held to this project's strict
+  # warning policy, so do not let its own diagnostics fail the build
+  foreach(googletest_target gtest gtest_main gmock gmock_main)
+    if(TARGET ${googletest_target})
+      set_target_properties("${googletest_target}"
+        PROPERTIES COMPILE_WARNING_AS_ERROR OFF)
+    endif()
+  endforeach()
 endif()

--- a/src/core/markdown/markdown.cc
+++ b/src/core/markdown/markdown.cc
@@ -6,6 +6,7 @@
 
 #include <array>   // std::array
 #include <cstdlib> // std::free
+#include <mutex>   // std::mutex, std::lock_guard
 #include <string>  // std::string
 
 namespace sourcemeta::core {
@@ -14,6 +15,12 @@ auto markdown_to_html(const std::string_view input, const bool safe)
     -> std::string {
   [[maybe_unused]] static const bool cmark_initialized{
       (cmark_gfm_core_extensions_ensure_registered(), true)};
+
+  // cmark-gfm toggles process-global special-character tables when syntax
+  // extensions are attached and detached, so parser construction through
+  // teardown cannot run concurrently
+  static std::mutex cmark_mutex;
+  const std::lock_guard<std::mutex> lock{cmark_mutex};
 
   static constexpr auto base_options{
       CMARK_OPT_VALIDATE_UTF8 | CMARK_OPT_FOOTNOTES |

--- a/src/core/markdown/markdown.cc
+++ b/src/core/markdown/markdown.cc
@@ -6,7 +6,7 @@
 
 #include <array>   // std::array
 #include <cstdlib> // std::free
-#include <mutex>   // std::mutex, std::lock_guard
+#include <mutex>   // std::mutex, std::scoped_lock
 #include <string>  // std::string
 
 namespace sourcemeta::core {
@@ -20,7 +20,7 @@ auto markdown_to_html(const std::string_view input, const bool safe)
   // extensions are attached and detached, so parser construction through
   // teardown cannot run concurrently
   static std::mutex cmark_mutex;
-  const std::lock_guard<std::mutex> lock{cmark_mutex};
+  const std::scoped_lock lock{cmark_mutex};
 
   static constexpr auto base_options{
       CMARK_OPT_VALIDATE_UTF8 | CMARK_OPT_FOOTNOTES |

--- a/src/lang/process/spawn.cc
+++ b/src/lang/process/spawn.cc
@@ -168,8 +168,14 @@ auto spawn(const std::string &program,
       std::filesystem::current_path()};
   std::filesystem::current_path(directory);
 #else
+  // The standardized child-directory file action is not yet provided by every
+  // system and toolchain this builds on, so we keep using the long-standing
+  // platform extension and silence the deprecation that newer SDKs attach to it
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const int addchdir_result{
       posix_spawn_file_actions_addchdir_np(&file_actions, directory.c_str())};
+#pragma GCC diagnostic pop
   if (addchdir_result != 0) {
     posix_spawn_file_actions_destroy(&file_actions);
     posix_spawnattr_destroy(&attributes);

--- a/test/text/text_to_lowercase_test.cc
+++ b/test/text/text_to_lowercase_test.cc
@@ -450,6 +450,10 @@ TEST(Text_to_lowercase_basic_string, custom_allocator_wchar_t) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
+// This exercises the conversion over a string of a non-standard character
+// type, whose traits some standard libraries now mark deprecated
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST(Text_to_lowercase_basic_string, unsigned_char_string) {
   std::basic_string<unsigned char> value{
       reinterpret_cast<const unsigned char *>("Hello WORLD")};
@@ -457,6 +461,7 @@ TEST(Text_to_lowercase_basic_string, unsigned_char_string) {
   EXPECT_EQ(value, reinterpret_cast<const unsigned char *>("hello world"));
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
+#pragma GCC diagnostic pop
 
 TEST(Text_to_lowercase_path, empty) {
   std::filesystem::path value{""};

--- a/test/text/text_to_lowercase_test.cc
+++ b/test/text/text_to_lowercase_test.cc
@@ -452,8 +452,10 @@ TEST(Text_to_lowercase_basic_string, custom_allocator_wchar_t) {
 
 // This exercises the conversion over a string of a non-standard character
 // type, whose traits some standard libraries now mark deprecated
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 TEST(Text_to_lowercase_basic_string, unsigned_char_string) {
   std::basic_string<unsigned char> value{
       reinterpret_cast<const unsigned char *>("Hello WORLD")};
@@ -461,7 +463,9 @@ TEST(Text_to_lowercase_basic_string, unsigned_char_string) {
   EXPECT_EQ(value, reinterpret_cast<const unsigned char *>("hello world"));
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif
 
 TEST(Text_to_lowercase_path, empty) {
   std::filesystem::path value{""};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

