### PR TITLE
Implement a `utf8_decode` helper

### DIFF
--- a/src/core/unicode/include/sourcemeta/core/unicode.h
+++ b/src/core/unicode/include/sourcemeta/core/unicode.h
@@ -14,6 +14,7 @@
 #include <ostream>     // std::ostream
 #include <string>      // std::string, std::u32string, std::wstring
 #include <string_view> // std::string_view, std::wstring_view
+#include <utility>     // std::pair, std::make_pair
 
 /// @defgroup unicode Unicode
 /// @brief Unicode encoding utilities.
@@ -569,6 +570,52 @@ utf8_codepoint_length(const std::string_view input,
   }
 
   return size;
+}
+
+/// @ingroup unicode
+/// Decode the single UTF-8 codepoint that begins at the given position within
+/// the input, returning the codepoint together with the number of bytes it
+/// occupies, or an empty result when the bytes at that position do not start a
+/// valid UTF-8 codepoint (RFC 3629 Section 4, excluding overlong encodings,
+/// surrogates, and code points above U+10FFFF). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/unicode.h>
+/// #include <cassert>
+///
+/// const auto result{sourcemeta::core::utf8_decode("\xCE\xB1", 0)};
+/// assert(result.has_value());
+/// assert(result.value().first == 0x03B1);
+/// assert(result.value().second == 2);
+/// assert(!sourcemeta::core::utf8_decode("\xED\xA0\x80", 0).has_value());
+/// ```
+inline constexpr auto utf8_decode(const std::string_view input,
+                                  const std::string_view::size_type position)
+    -> std::optional<std::pair<char32_t, std::size_t>> {
+  const auto size{utf8_codepoint_length(input, position)};
+  if (size == 0) {
+    return std::nullopt;
+  }
+
+  const auto lead{static_cast<unsigned char>(input[position])};
+  char32_t codepoint{0};
+  if (size == 1) {
+    codepoint = static_cast<char32_t>(lead);
+  } else if (size == 2) {
+    codepoint = static_cast<char32_t>(lead & 0x1FU);
+  } else if (size == 3) {
+    codepoint = static_cast<char32_t>(lead & 0x0FU);
+  } else {
+    codepoint = static_cast<char32_t>(lead & 0x07U);
+  }
+
+  for (std::size_t index{1}; index < size; ++index) {
+    const auto continuation{
+        static_cast<unsigned char>(input[position + index])};
+    codepoint = (codepoint << 6) | static_cast<char32_t>(continuation & 0x3FU);
+  }
+
+  return std::make_pair(codepoint, size);
 }
 
 } // namespace sourcemeta::core

--- a/test/unicode/CMakeLists.txt
+++ b/test/unicode/CMakeLists.txt
@@ -5,6 +5,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME unicode
     unicode_utf8_to_wide_test.cc
     unicode_wide_to_utf8_test.cc
     unicode_utf8_codepoint_length_test.cc
+    unicode_utf8_decode_test.cc
     unicode_utf8_lead_byte_size_test.cc
     unicode_utf8_codepoint_byte_count_test.cc
     unicode_is_utf8_continuation_test.cc

--- a/test/unicode/unicode_utf8_decode_test.cc
+++ b/test/unicode/unicode_utf8_decode_test.cc
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/unicode.h>
+
+TEST(Unicode_utf8_decode, ascii) {
+  const auto result{sourcemeta::core::utf8_decode("A", 0)};
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().first, 0x41U);
+  EXPECT_EQ(result.value().second, 1U);
+}
+
+TEST(Unicode_utf8_decode, two_byte) {
+  const auto result{sourcemeta::core::utf8_decode("\xCE\xB1", 0)};
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().first, 0x03B1U);
+  EXPECT_EQ(result.value().second, 2U);
+}
+
+TEST(Unicode_utf8_decode, three_byte) {
+  const auto result{sourcemeta::core::utf8_decode("\xE4\xB8\xAD", 0)};
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().first, 0x4E2DU);
+  EXPECT_EQ(result.value().second, 3U);
+}
+
+TEST(Unicode_utf8_decode, four_byte) {
+  const auto result{sourcemeta::core::utf8_decode("\xF0\x9F\x98\x80", 0)};
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().first, 0x1F600U);
+  EXPECT_EQ(result.value().second, 4U);
+}
+
+TEST(Unicode_utf8_decode, at_offset) {
+  const auto result{sourcemeta::core::utf8_decode("A\xCE\xB1", 1)};
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().first, 0x03B1U);
+  EXPECT_EQ(result.value().second, 2U);
+}
+
+TEST(Unicode_utf8_decode, max_codepoint) {
+  const auto result{sourcemeta::core::utf8_decode("\xF4\x8F\xBF\xBF", 0)};
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().first, 0x10FFFFU);
+  EXPECT_EQ(result.value().second, 4U);
+}
+
+TEST(Unicode_utf8_decode, empty) {
+  EXPECT_FALSE(sourcemeta::core::utf8_decode("", 0).has_value());
+}
+
+TEST(Unicode_utf8_decode, position_out_of_range) {
+  EXPECT_FALSE(sourcemeta::core::utf8_decode("A", 5).has_value());
+}
+
+TEST(Unicode_utf8_decode, truncated) {
+  EXPECT_FALSE(sourcemeta::core::utf8_decode("\xCE", 0).has_value());
+}
+
+TEST(Unicode_utf8_decode, lone_continuation) {
+  EXPECT_FALSE(sourcemeta::core::utf8_decode("\x80", 0).has_value());
+}
+
+TEST(Unicode_utf8_decode, overlong) {
+  EXPECT_FALSE(sourcemeta::core::utf8_decode("\xC0\xAF", 0).has_value());
+}
+
+TEST(Unicode_utf8_decode, surrogate) {
+  EXPECT_FALSE(sourcemeta::core::utf8_decode("\xED\xA0\x80", 0).has_value());
+}
+
+TEST(Unicode_utf8_decode, above_max) {
+  EXPECT_FALSE(
+      sourcemeta::core::utf8_decode("\xF4\x90\x80\x80", 0).has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

