### PR TITLE
Add a new `YAMLFileParseError` exception class

### DIFF
--- a/src/core/yaml/include/sourcemeta/core/yaml_error.h
+++ b/src/core/yaml/include/sourcemeta/core/yaml_error.h
@@ -7,8 +7,10 @@
 
 #include <cstdint>     // std::uint64_t
 #include <exception>   // std::exception
+#include <filesystem>  // std::filesystem::path
 #include <string>      // std::string
 #include <string_view> // std::string_view
+#include <utility>     // std::move
 
 namespace sourcemeta::core {
 
@@ -70,6 +72,34 @@ private:
   std::uint64_t line_;
   std::uint64_t column_;
   const char *message_;
+};
+
+/// @ingroup yaml
+/// An error that represents a YAML parse error occurring from parsing a file
+class SOURCEMETA_CORE_YAML_EXPORT YAMLFileParseError : public YAMLParseError {
+public:
+  YAMLFileParseError(std::filesystem::path path, const std::uint64_t line,
+                     const std::uint64_t column, const char *message)
+      : YAMLParseError{line, column, message}, path_{std::move(path)} {}
+  YAMLFileParseError(std::filesystem::path path, const std::uint64_t line,
+                     const std::uint64_t column, std::string message) = delete;
+  YAMLFileParseError(std::filesystem::path path, const std::uint64_t line,
+                     const std::uint64_t column,
+                     std::string &&message) = delete;
+  YAMLFileParseError(std::filesystem::path path, const std::uint64_t line,
+                     const std::uint64_t column,
+                     std::string_view message) = delete;
+
+  YAMLFileParseError(std::filesystem::path path, const YAMLParseError &parent)
+      : YAMLParseError{parent.line(), parent.column(), parent.what()},
+        path_{std::move(path)} {}
+
+  [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
+    return this->path_;
+  }
+
+private:
+  std::filesystem::path path_;
 };
 
 /// @ingroup yaml

--- a/src/core/yaml/yaml.cc
+++ b/src/core/yaml/yaml.cc
@@ -33,13 +33,18 @@ auto parse_yaml(const JSON::String &input) -> JSON {
 auto read_yaml(const std::filesystem::path &path) -> JSON {
   const auto input{read_file_to_string(path)};
 
-  yaml::Lexer lexer{input};
-  yaml::Parser parser{&lexer, nullptr};
-  auto result{parser.parse()};
+  try {
+    yaml::Lexer lexer{input};
+    yaml::Parser parser{&lexer, nullptr};
+    auto result{parser.parse()};
 
-  parser.validate_end_of_stream();
+    parser.validate_end_of_stream();
 
-  return result;
+    return result;
+  } catch (const YAMLParseError &error) {
+    // For producing better error messages
+    throw YAMLFileParseError(path, error);
+  }
 }
 
 auto parse_yaml(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
@@ -67,11 +72,16 @@ auto read_yaml(const std::filesystem::path &path, JSON &output,
                const JSON::ParseCallback &callback) -> void {
   const auto input{read_file_to_string(path)};
 
-  yaml::Lexer lexer{input};
-  yaml::Parser parser{&lexer, &callback};
-  output = parser.parse();
+  try {
+    yaml::Lexer lexer{input};
+    yaml::Parser parser{&lexer, &callback};
+    output = parser.parse();
 
-  parser.validate_end_of_stream();
+    parser.validate_end_of_stream();
+  } catch (const YAMLParseError &error) {
+    // For producing better error messages
+    throw YAMLFileParseError(path, error);
+  }
 }
 
 auto read_yaml_or_json(const std::filesystem::path &path) -> JSON {

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -216,6 +216,20 @@ TEST(YAML_parse, yaml_or_json_file_not_exists) {
                sourcemeta::core::IOFileNotFoundError);
 }
 
+TEST(YAML_parse, read_yaml_invalid_carries_path) {
+  try {
+    sourcemeta::core::read_yaml(std::filesystem::path{STUBS_PATH} /
+                                "invalid.yaml");
+    FAIL() << "Expected YAMLFileParseError to be thrown";
+  } catch (const sourcemeta::core::YAMLFileParseError &error) {
+    EXPECT_EQ(error.path(), std::filesystem::path{STUBS_PATH} / "invalid.yaml");
+    EXPECT_EQ(error.line(), 1);
+    EXPECT_EQ(error.column(), 15);
+  } catch (...) {
+    FAIL() << "The parse function was expected to throw a file parse error";
+  }
+}
+
 TEST(YAML_parse, istringstream) {
   std::istringstream stream{"hello: world\nfoo: 1\nbar: true"};
   const auto result{sourcemeta::core::parse_yaml(stream)};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

