### PR TITLE
Make use of `JSONObject::Entry::key_equals` in `src/core/jsonld`

### DIFF
--- a/src/core/jsonld/include/sourcemeta/core/jsonld.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld.h
@@ -49,6 +49,7 @@ enum class JSONLDVersion : std::uint8_t { V1_0, V1_1 };
 ///   "@context": { "name": "https://schema.org/name" },
 ///   "name": "Sourcemeta"
 /// })")};
+///
 /// const auto expanded{sourcemeta::core::jsonld_expand(document)};
 /// sourcemeta::core::prettify(expanded, std::cout);
 /// std::cout << std::endl;
@@ -73,6 +74,7 @@ auto jsonld_expand(const JSON &input, const JSON::StringView base_iri = "",
 ///     R"({ "name": "Sourcemeta" })")};
 /// const auto context{sourcemeta::core::parse_json(
 ///     R"({ "name": "https://schema.org/name" })")};
+///
 /// const auto expanded{sourcemeta::core::jsonld_expand(document, context)};
 /// sourcemeta::core::prettify(expanded, std::cout);
 /// std::cout << std::endl;

--- a/src/core/jsonld/jsonld_context_processing.cc
+++ b/src/core/jsonld/jsonld_context_processing.cc
@@ -174,7 +174,7 @@ auto process_context(ExpansionState &state, ActiveContext &active_context,
       // overriding, and process the result as a single context.
       auto merged{JSON{*imported_context}};
       for (const auto &entry : context.as_object()) {
-        if (JSON::StringView{entry.first} != KEYWORD_IMPORT) {
+        if (!entry.key_equals(KEYWORD_IMPORT, KEYWORD_IMPORT_HASH)) {
           merged.assign(entry.first, entry.second);
         }
       }
@@ -261,10 +261,14 @@ auto process_context(ExpansionState &state, ActiveContext &active_context,
     DefinedTerms defined;
     for (const auto &entry : context.as_object()) {
       const auto &name{entry.first};
-      if (name == KEYWORD_BASE || name == KEYWORD_VOCAB ||
-          name == KEYWORD_LANGUAGE || name == KEYWORD_VERSION ||
-          name == KEYWORD_DIRECTION || name == KEYWORD_IMPORT ||
-          name == KEYWORD_PROPAGATE || name == KEYWORD_PROTECTED) {
+      if (entry.key_equals(KEYWORD_BASE, KEYWORD_BASE_HASH) ||
+          entry.key_equals(KEYWORD_VOCAB, KEYWORD_VOCAB_HASH) ||
+          entry.key_equals(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH) ||
+          entry.key_equals(KEYWORD_VERSION, KEYWORD_VERSION_HASH) ||
+          entry.key_equals(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH) ||
+          entry.key_equals(KEYWORD_IMPORT, KEYWORD_IMPORT_HASH) ||
+          entry.key_equals(KEYWORD_PROPAGATE, KEYWORD_PROPAGATE_HASH) ||
+          entry.key_equals(KEYWORD_PROTECTED, KEYWORD_PROTECTED_HASH)) {
         continue;
       }
       create_term_definition(state, active_context, context, name, defined,

--- a/src/core/jsonld/jsonld_create_term_definition.cc
+++ b/src/core/jsonld/jsonld_create_term_definition.cc
@@ -84,14 +84,15 @@ auto create_term_definition(ExpansionState &state,
       bool has_container{false};
       bool invalid_entry{false};
       for (const auto &entry : value.as_object()) {
-        const auto &name{entry.first};
-        if (name == KEYWORD_PROTECTED) {
+        if (entry.key_equals(KEYWORD_PROTECTED, KEYWORD_PROTECTED_HASH)) {
           if (!entry.second.is_boolean()) {
             throw JSONLDError("Invalid @protected value", term_pointer,
                               {KEYWORD_PROTECTED});
           }
           type_definition.is_protected = entry.second.to_boolean();
-        } else if (name == KEYWORD_CONTAINER && entry.second.is_string()) {
+        } else if (entry.key_equals(KEYWORD_CONTAINER,
+                                    KEYWORD_CONTAINER_HASH) &&
+                   entry.second.is_string()) {
           const auto &container{entry.second.to_string()};
           if (container == KEYWORD_SET) {
             type_definition.container.push_back(container);
@@ -579,13 +580,17 @@ auto create_term_definition(ExpansionState &state,
     // A term definition may not contain any entry other than the keywords
     // recognised above.
     for (const auto &entry : value.as_object()) {
-      const JSON::StringView key{entry.first};
-      if (key != KEYWORD_ID && key != KEYWORD_REVERSE &&
-          key != KEYWORD_CONTAINER && key != KEYWORD_CONTEXT &&
-          key != KEYWORD_DIRECTION && key != KEYWORD_INDEX &&
-          key != KEYWORD_LANGUAGE && key != KEYWORD_NEST &&
-          key != KEYWORD_PREFIX && key != KEYWORD_PROTECTED &&
-          key != KEYWORD_TYPE) {
+      if (!entry.key_equals(KEYWORD_ID, KEYWORD_ID_HASH) &&
+          !entry.key_equals(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH) &&
+          !entry.key_equals(KEYWORD_CONTAINER, KEYWORD_CONTAINER_HASH) &&
+          !entry.key_equals(KEYWORD_CONTEXT, KEYWORD_CONTEXT_HASH) &&
+          !entry.key_equals(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH) &&
+          !entry.key_equals(KEYWORD_INDEX, KEYWORD_INDEX_HASH) &&
+          !entry.key_equals(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH) &&
+          !entry.key_equals(KEYWORD_NEST, KEYWORD_NEST_HASH) &&
+          !entry.key_equals(KEYWORD_PREFIX, KEYWORD_PREFIX_HASH) &&
+          !entry.key_equals(KEYWORD_PROTECTED, KEYWORD_PROTECTED_HASH) &&
+          !entry.key_equals(KEYWORD_TYPE, KEYWORD_TYPE_HASH)) {
         throw JSONLDError("Invalid term definition", term_pointer);
       }
     }

--- a/src/core/jsonld/jsonld_expansion.cc
+++ b/src/core/jsonld/jsonld_expansion.cc
@@ -142,13 +142,16 @@ auto expand_object(ExpansionState &state, ActiveContext active_context,
         type != nullptr && type->is_string() ? &type->to_string() : nullptr};
     const bool is_json{type_string != nullptr && *type_string == KEYWORD_JSON};
     for (const auto &entry : result.as_object()) {
-      const auto &name{entry.first};
-      if (name != KEYWORD_VALUE && name != KEYWORD_TYPE &&
-          name != KEYWORD_LANGUAGE && name != KEYWORD_INDEX &&
-          name != KEYWORD_DIRECTION) {
+      if (!entry.key_equals(KEYWORD_VALUE, KEYWORD_VALUE_HASH) &&
+          !entry.key_equals(KEYWORD_TYPE, KEYWORD_TYPE_HASH) &&
+          !entry.key_equals(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH) &&
+          !entry.key_equals(KEYWORD_INDEX, KEYWORD_INDEX_HASH) &&
+          !entry.key_equals(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH)) {
         throw JSONLDError("Invalid value object", pointer);
       }
-      if ((name == KEYWORD_LANGUAGE || name == KEYWORD_DIRECTION) && has_type) {
+      if ((entry.key_equals(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH) ||
+           entry.key_equals(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH)) &&
+          has_type) {
         throw JSONLDError("Invalid value object", pointer);
       }
     }
@@ -180,9 +183,9 @@ auto expand_object(ExpansionState &state, ActiveContext active_context,
   if (result.defines(KEYWORD_LIST, KEYWORD_LIST_HASH) ||
       result.defines(KEYWORD_SET, KEYWORD_SET_HASH)) {
     for (const auto &entry : result.as_object()) {
-      const auto &name{entry.first};
-      if (name != KEYWORD_LIST && name != KEYWORD_SET &&
-          name != KEYWORD_INDEX) {
+      if (!entry.key_equals(KEYWORD_LIST, KEYWORD_LIST_HASH) &&
+          !entry.key_equals(KEYWORD_SET, KEYWORD_SET_HASH) &&
+          !entry.key_equals(KEYWORD_INDEX, KEYWORD_INDEX_HASH)) {
         throw JSONLDError("Invalid set or list object", pointer);
       }
     }
@@ -200,9 +203,9 @@ auto expand_object(ExpansionState &state, ActiveContext active_context,
        result.defines(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH))) {
     bool only_value_keys{true};
     for (const auto &entry : result.as_object()) {
-      const auto &name{entry.first};
-      if (name != KEYWORD_LANGUAGE && name != KEYWORD_DIRECTION &&
-          name != KEYWORD_INDEX) {
+      if (!entry.key_equals(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH) &&
+          !entry.key_equals(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH) &&
+          !entry.key_equals(KEYWORD_INDEX, KEYWORD_INDEX_HASH)) {
         only_value_keys = false;
       }
     }
@@ -459,7 +462,7 @@ auto expand_entries(ExpansionState &state, ActiveContext &active_context,
                                                      : JSON::make_object()};
         for (const auto &reverse_entry : reversed.as_object()) {
           const auto &reverse_property{reverse_entry.first};
-          if (reverse_entry.hash == KEYWORD_REVERSE_HASH) {
+          if (reverse_entry.key_equals(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)) {
             for (auto &forward : reverse_entry.second.as_object()) {
               merge(result, JSON::StringView{forward.first},
                     into_array(JSON{forward.second}));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

