### PR TITLE
Simplify URI `relative_to` results

### DIFF
--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -156,6 +156,18 @@ auto URI::relative_to(const URI &base) -> URI & {
     return *this;
   }
 
+  // Both URIs share the same path and differ only in their query or fragment,
+  // so the relative reference needs no path, just the differing query and
+  // fragment.
+  if (this->path_ == base.path_) {
+    this->scheme_.reset();
+    this->userinfo_.reset();
+    this->host_.reset();
+    this->port_.reset();
+    this->path_.reset();
+    return *this;
+  }
+
   // If this URI doesn't have a path, we can't make it relative
   if (!this->path_.has_value()) {
     return *this;

--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -158,8 +158,11 @@ auto URI::relative_to(const URI &base) -> URI & {
 
   // Both URIs share the same path and differ only in their query or fragment,
   // so the relative reference needs no path, just the differing query and
-  // fragment.
-  if (this->path_ == base.path_) {
+  // fragment. An empty path inherits the base's query on resolution, so this is
+  // only safe when this URI carries its own query or the base has none.
+  // Otherwise a trailing path segment is needed to override the base's query.
+  if (this->path_ == base.path_ &&
+      (this->query_.has_value() || !base.query_.has_value())) {
     this->scheme_.reset();
     this->userinfo_.reset();
     this->host_.reset();

--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -156,18 +156,26 @@ auto URI::relative_to(const URI &base) -> URI & {
     return *this;
   }
 
-  // Both URIs share the same path and differ only in their query or fragment,
-  // so the relative reference needs no path, just the differing query and
-  // fragment. An empty path inherits the base's query on resolution, so this is
-  // only safe when this URI carries its own query or the base has none.
-  // Otherwise a trailing path segment is needed to override the base's query.
-  if (this->path_ == base.path_ &&
-      (this->query_.has_value() || !base.query_.has_value())) {
+  // Both URIs share the same path and differ only in their query or fragment.
+  if (this->path_ == base.path_ && this->path_.has_value()) {
     this->scheme_.reset();
     this->userinfo_.reset();
     this->host_.reset();
     this->port_.reset();
-    this->path_.reset();
+    if (this->query_.has_value() || !base.query_.has_value()) {
+      // An empty relative path is safe here: it will not inherit a base query
+      // on resolution, because this URI either carries its own query or the
+      // base has none.
+      this->path_.reset();
+    } else {
+      // Dropping the base's query requires a non-empty path so that resolution
+      // does not re-inherit it. Use the last path segment, or "./" when the
+      // path has no final segment (it ends in a slash).
+      const auto &path{this->path_.value()};
+      const auto slash{path.rfind('/')};
+      auto segment{slash == std::string::npos ? path : path.substr(slash + 1)};
+      this->path_ = segment.empty() ? std::string{"./"} : std::move(segment);
+    }
     return *this;
   }
 

--- a/src/core/uri/resolution.cc
+++ b/src/core/uri/resolution.cc
@@ -157,26 +157,31 @@ auto URI::relative_to(const URI &base) -> URI & {
   }
 
   // Both URIs share the same path and differ only in their query or fragment.
-  if (this->path_ == base.path_ && this->path_.has_value()) {
-    this->scheme_.reset();
-    this->userinfo_.reset();
-    this->host_.reset();
-    this->port_.reset();
-    if (this->query_.has_value() || !base.query_.has_value()) {
-      // An empty relative path is safe here: it will not inherit a base query
-      // on resolution, because this URI either carries its own query or the
-      // base has none.
-      this->path_.reset();
-    } else {
-      // Dropping the base's query requires a non-empty path so that resolution
-      // does not re-inherit it. Use the last path segment, or "./" when the
-      // path has no final segment (it ends in a slash).
-      const auto &path{this->path_.value()};
-      const auto slash{path.rfind('/')};
-      auto segment{slash == std::string::npos ? path : path.substr(slash + 1)};
-      this->path_ = segment.empty() ? std::string{"./"} : std::move(segment);
+  // An empty relative path is safe when this URI carries its own query or the
+  // base has none, since resolution then will not re-inherit the base's query.
+  // Otherwise a non-empty path is required to reset the query, which is only
+  // possible when there is a path to express.
+  if (this->path_ == base.path_) {
+    const bool empty_path_safe{this->query_.has_value() ||
+                               !base.query_.has_value()};
+    if (empty_path_safe || this->path_.has_value()) {
+      this->scheme_.reset();
+      this->userinfo_.reset();
+      this->host_.reset();
+      this->port_.reset();
+      if (empty_path_safe) {
+        this->path_.reset();
+      } else {
+        // Use the last path segment, or "./" when the path has no final segment
+        // (it ends in a slash).
+        const auto &path{this->path_.value()};
+        const auto slash{path.rfind('/')};
+        auto segment{slash == std::string::npos ? path
+                                                : path.substr(slash + 1)};
+        this->path_ = segment.empty() ? std::string{"./"} : std::move(segment);
+      }
+      return *this;
     }
-    return *this;
   }
 
   // If this URI doesn't have a path, we can't make it relative

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -287,3 +287,24 @@ TEST(URI_relative_to, iri_preserves_ucschar) {
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "caf\xC3\xA9");
 }
+
+TEST(URI_relative_to, same_path_only_query_differs) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=1"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "?q=1");
+}
+
+TEST(URI_relative_to, same_path_only_fragment_differs) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/bar#baz"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "#baz");
+}
+
+TEST(URI_relative_to, same_path_query_and_fragment_differ) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=1#baz"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "?q=1#baz");
+}

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -308,3 +308,24 @@ TEST(URI_relative_to, same_path_query_and_fragment_differ) {
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=1#baz");
 }
+
+TEST(URI_relative_to, same_path_base_query_target_none) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/bar?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/bar"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "bar");
+}
+
+TEST(URI_relative_to, same_path_base_query_target_fragment_only) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/bar?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/bar#baz"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "bar#baz");
+}
+
+TEST(URI_relative_to, same_path_base_query_target_other_query) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/bar?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=2"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "?q=2");
+}

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -329,3 +329,24 @@ TEST(URI_relative_to, same_path_base_query_target_other_query) {
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=2");
 }
+
+TEST(URI_relative_to, same_directory_path_base_query_target_none) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./");
+}
+
+TEST(URI_relative_to, same_directory_path_base_query_target_fragment) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/#baz"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "./#baz");
+}
+
+TEST(URI_relative_to, same_directory_path_target_query) {
+  const sourcemeta::core::URI base{"https://www.example.com/foo/?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com/foo/?q=2"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "?q=2");
+}

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -350,3 +350,24 @@ TEST(URI_relative_to, same_directory_path_target_query) {
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=2");
 }
+
+TEST(URI_relative_to, authority_no_path_only_fragment_differs) {
+  const sourcemeta::core::URI base{"https://www.example.com"};
+  sourcemeta::core::URI uri{"https://www.example.com#baz"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "#baz");
+}
+
+TEST(URI_relative_to, authority_no_path_only_query_differs) {
+  const sourcemeta::core::URI base{"https://www.example.com?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com?q=2"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "?q=2");
+}
+
+TEST(URI_relative_to, authority_no_path_base_query_target_none) {
+  const sourcemeta::core::URI base{"https://www.example.com?q=1"};
+  sourcemeta::core::URI uri{"https://www.example.com"};
+  uri.relative_to(base);
+  EXPECT_EQ(uri.recompose(), "https://www.example.com");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

