### PR TITLE
Implement a JSON-LD `materialize` custom utility

### DIFF
--- a/src/core/jsonld/CMakeLists.txt
+++ b/src/core/jsonld/CMakeLists.txt
@@ -1,5 +1,5 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME jsonld
-  PRIVATE_HEADERS error.h
+  PRIVATE_HEADERS error.h materialize.h
   SOURCES jsonld.cc
     jsonld_iri_expansion.cc jsonld_create_term_definition.cc
     jsonld_context_processing.cc jsonld_value_expansion.cc jsonld_expansion.cc
@@ -7,6 +7,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME jsonld
     jsonld_inverse_context.cc jsonld_iri_compaction.cc
     jsonld_value_compaction.cc jsonld_compaction.cc
     jsonld_node_map.cc jsonld_flatten.cc
+    jsonld_materialize.cc
     jsonld_algorithms.h jsonld_keywords.h)
 
 if(SOURCEMETA_CORE_INSTALL)

--- a/src/core/jsonld/include/sourcemeta/core/jsonld.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld.h
@@ -7,6 +7,7 @@
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld_error.h>
+#include <sourcemeta/core/jsonld_materialize.h>
 
 #include <cstdint>    // std::uint8_t
 #include <functional> // std::function

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
@@ -1,0 +1,115 @@
+#ifndef SOURCEMETA_CORE_JSONLD_MATERIALIZE_H_
+#define SOURCEMETA_CORE_JSONLD_MATERIALIZE_H_
+
+#ifndef SOURCEMETA_CORE_JSONLD_EXPORT
+#include <sourcemeta/core/jsonld_export.h>
+#endif
+
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/jsonpointer.h>
+
+#include <cstdint>       // std::uint8_t
+#include <optional>      // std::optional
+#include <unordered_map> // std::unordered_map
+#include <variant>       // std::variant
+#include <vector>        // std::vector
+
+namespace sourcemeta::core {
+
+/// @ingroup jsonld
+/// How a position connects to its parent. The position is the object of the
+/// edge, asserted in reverse when the flag is set.
+struct JSONLDEdge {
+  JSON::String predicate{};
+  bool reverse{false};
+};
+
+/// @ingroup jsonld
+/// The base direction of a language-tagged string
+enum class JSONLDDirection : std::uint8_t { LTR, RTL };
+
+/// @ingroup jsonld
+/// A position that is an object. An absent identifier means a fresh blank node,
+/// and the graph flag asserts the node's descendants in the named graph the
+/// identifier denotes.
+struct JSONLDNode {
+  std::optional<JSON::String> id{};
+  std::vector<JSON::String> types{};
+  bool graph{false};
+};
+
+/// @ingroup jsonld
+/// A position that is a value. The datatype defaults to the native type of the
+/// JSON value, a language may carry a direction, and the JSON flag preserves an
+/// opaque JSON literal verbatim.
+struct JSONLDLiteral {
+  std::optional<JSON::String> datatype{};
+  std::optional<JSON::String> language{};
+  std::optional<JSONLDDirection> direction{};
+  bool json{false};
+};
+
+/// @ingroup jsonld
+/// A scalar promoted to an identified node
+struct JSONLDReference {
+  JSON::String id{};
+  std::vector<JSON::String> types{};
+};
+
+/// @ingroup jsonld
+/// A position that is an array, asserted as an RDF list when ordered and as a
+/// set otherwise
+struct JSONLDCollection {
+  bool ordered{false};
+};
+
+/// @ingroup jsonld
+/// The semantics of a single instance position: how it connects to its parent
+/// and what it is
+struct JSONLDDescriptor {
+  std::vector<JSONLDEdge> edges{};
+  std::variant<JSONLDNode, JSONLDLiteral, JSONLDReference, JSONLDCollection>
+      value{};
+};
+
+/// @ingroup jsonld
+/// A resolved mapping of instance positions to their JSON-LD semantics, keyed
+/// by JSON Pointer
+using JSONLDAnnotationMap =
+    std::unordered_map<Pointer, JSONLDDescriptor, Pointer::Hasher>;
+
+/// @ingroup jsonld
+///
+/// Materialize an instance into expanded JSON-LD using an annotation map that
+/// assigns JSON-LD semantics to instance positions. The result is always a JSON
+/// array. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/json.h>
+/// #include <sourcemeta/core/jsonld.h>
+/// #include <iostream>
+///
+/// const auto instance{sourcemeta::core::parse_json(
+///     R"({ "name": "Sourcemeta" })")};
+///
+/// sourcemeta::core::JSONLDAnnotationMap map;
+/// map.emplace(sourcemeta::core::Pointer{},
+///             sourcemeta::core::JSONLDDescriptor{
+///                 {}, sourcemeta::core::JSONLDNode{
+///                         "https://example.com/org", {}, false }});
+/// map.emplace(sourcemeta::core::Pointer{"name"},
+///             sourcemeta::core::JSONLDDescriptor{
+///                 { { "https://schema.org/name", false } },
+///                 sourcemeta::core::JSONLDLiteral{}});
+///
+/// const auto expanded{sourcemeta::core::jsonld_materialize(instance, map)};
+/// sourcemeta::core::prettify(expanded, std::cout);
+/// std::cout << std::endl;
+/// ```
+SOURCEMETA_CORE_JSONLD_EXPORT
+auto jsonld_materialize(const JSON &instance, const JSONLDAnnotationMap &map)
+    -> JSON;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/jsonld/jsonld_materialize.cc
+++ b/src/core/jsonld/jsonld_materialize.cc
@@ -73,6 +73,11 @@ auto reverse_target(JSON &node, const JSON::StringView predicate) -> JSON & {
 // Attach a value under a single edge. A set, represented as a bare array,
 // spreads its members into the property array.
 auto attach_one(JSON &node, const JSONLDEdge &edge, JSON value) -> void {
+  // An empty set carries no values, so it asserts no property.
+  if (value.is_array() && value.empty()) {
+    return;
+  }
+
   auto &target{edge.reverse ? reverse_target(node, edge.predicate)
                             : property_target(node, edge.predicate)};
   if (value.is_array()) {

--- a/src/core/jsonld/jsonld_materialize.cc
+++ b/src/core/jsonld/jsonld_materialize.cc
@@ -304,14 +304,18 @@ auto jsonld_materialize(const JSON &instance, const JSONLDAnnotationMap &map)
 
   auto result{JSON::make_array()};
   if (root.has_value()) {
+    // The default graph may only hold node objects. A top-level value or list
+    // object, whether the root itself or an element of a root set, carries no
+    // triples and is dropped.
     if (root->is_array()) {
       for (auto &element : root->as_array()) {
-        result.push_back(std::move(element));
+        if (is_node_object(element)) {
+          result.push_back(std::move(element));
+        }
       }
     } else if (is_node_object(root.value())) {
       result.push_back(std::move(root.value()));
     }
-    // A top-level value or list object carries no triples and is dropped.
   }
 
   for (auto &node : standalone) {

--- a/src/core/jsonld/jsonld_materialize.cc
+++ b/src/core/jsonld/jsonld_materialize.cc
@@ -1,0 +1,319 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/jsonpointer.h>
+
+#include "jsonld_keywords.h"
+
+#include <algorithm> // std::ranges::sort
+#include <cstddef>   // std::size_t
+#include <optional>  // std::optional, std::nullopt
+#include <utility>   // std::move, std::unreachable
+#include <variant>   // std::holds_alternative, std::get
+#include <vector>    // std::vector
+
+namespace sourcemeta::core {
+
+namespace {
+
+auto materialize_value(const JSON &value, Pointer &pointer,
+                       const JSONLDAnnotationMap &map,
+                       std::vector<JSON> &standalone) -> std::optional<JSON>;
+
+auto fill_node(JSON &node, const JSON &instance_object, Pointer &pointer,
+               const JSONLDAnnotationMap &map, std::vector<JSON> &standalone)
+    -> void;
+
+// A node object is any map that is neither a value object nor a list object.
+auto is_node_object(const JSON &value) -> bool {
+  return value.is_object() &&
+         !value.defines(KEYWORD_VALUE, KEYWORD_VALUE_HASH) &&
+         !value.defines(KEYWORD_LIST, KEYWORD_LIST_HASH);
+}
+
+auto direction_to_string(const JSONLDDirection direction) -> JSON::StringView {
+  switch (direction) {
+    case JSONLDDirection::LTR:
+      return "ltr";
+    case JSONLDDirection::RTL:
+      return "rtl";
+  }
+
+  std::unreachable();
+}
+
+auto types_to_array(const std::vector<JSON::String> &types) -> JSON {
+  auto result{JSON::make_array()};
+  for (const auto &type : types) {
+    result.push_back(JSON{type});
+  }
+  return result;
+}
+
+// The property array of node under the given predicate, creating it as needed.
+auto property_target(JSON &node, const JSON::StringView predicate) -> JSON & {
+  if (!node.defines(predicate)) {
+    node.assign_assume_new(JSON::String{predicate}, JSON::make_array());
+  }
+  return node.at(predicate);
+}
+
+// The property array nested under @reverse and the given predicate.
+auto reverse_target(JSON &node, const JSON::StringView predicate) -> JSON & {
+  if (!node.defines(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)) {
+    node.assign_assume_new(JSON::String{KEYWORD_REVERSE}, JSON::make_object(),
+                           KEYWORD_REVERSE_HASH);
+  }
+  auto &reverse{node.at(KEYWORD_REVERSE, KEYWORD_REVERSE_HASH)};
+  if (!reverse.defines(predicate)) {
+    reverse.assign_assume_new(JSON::String{predicate}, JSON::make_array());
+  }
+  return reverse.at(predicate);
+}
+
+// Attach a value under a single edge. A set, represented as a bare array,
+// spreads its members into the property array.
+auto attach_one(JSON &node, const JSONLDEdge &edge, JSON value) -> void {
+  auto &target{edge.reverse ? reverse_target(node, edge.predicate)
+                            : property_target(node, edge.predicate)};
+  if (value.is_array()) {
+    for (auto &element : value.as_array()) {
+      target.push_back(std::move(element));
+    }
+  } else {
+    target.push_back(std::move(value));
+  }
+}
+
+auto attach(JSON &node, const std::vector<JSONLDEdge> &edges, JSON value)
+    -> void {
+  for (std::size_t index = 0; index + 1 < edges.size(); index += 1) {
+    attach_one(node, edges[index], value);
+  }
+  attach_one(node, edges.back(), std::move(value));
+}
+
+auto materialize_literal(const JSONLDLiteral &descriptor, const JSON &value)
+    -> JSON {
+  auto result{JSON::make_object()};
+  result.assign_assume_new(JSON::String{KEYWORD_VALUE}, JSON{value},
+                           KEYWORD_VALUE_HASH);
+  if (descriptor.json) {
+    result.assign_assume_new(JSON::String{KEYWORD_TYPE}, JSON{KEYWORD_JSON},
+                             KEYWORD_TYPE_HASH);
+    return result;
+  }
+
+  if (descriptor.datatype.has_value()) {
+    result.assign_assume_new(JSON::String{KEYWORD_TYPE},
+                             JSON{descriptor.datatype.value()},
+                             KEYWORD_TYPE_HASH);
+  }
+  if (descriptor.language.has_value()) {
+    result.assign_assume_new(JSON::String{KEYWORD_LANGUAGE},
+                             JSON{descriptor.language.value()},
+                             KEYWORD_LANGUAGE_HASH);
+  }
+  if (descriptor.direction.has_value()) {
+    result.assign_assume_new(
+        JSON::String{KEYWORD_DIRECTION},
+        JSON{direction_to_string(descriptor.direction.value())},
+        KEYWORD_DIRECTION_HASH);
+  }
+  return result;
+}
+
+auto materialize_reference(const JSONLDReference &descriptor) -> JSON {
+  auto result{JSON::make_object()};
+  result.assign_assume_new(JSON::String{KEYWORD_ID}, JSON{descriptor.id},
+                           KEYWORD_ID_HASH);
+  if (!descriptor.types.empty()) {
+    result.assign_assume_new(JSON::String{KEYWORD_TYPE},
+                             types_to_array(descriptor.types),
+                             KEYWORD_TYPE_HASH);
+  }
+  return result;
+}
+
+auto build_collection(const JSON &value, Pointer &pointer,
+                      const JSONLDAnnotationMap &map,
+                      std::vector<JSON> &standalone, const bool ordered)
+    -> JSON {
+  auto elements{JSON::make_array()};
+  for (std::size_t index = 0; index < value.size(); index += 1) {
+    pointer.push_back(index);
+    auto element{materialize_value(value.at(index), pointer, map, standalone)};
+    pointer.pop_back();
+    if (!element.has_value()) {
+      continue;
+    }
+
+    // A nested set flattens into the enclosing collection.
+    if (element->is_array()) {
+      for (auto &nested : element->as_array()) {
+        elements.push_back(std::move(nested));
+      }
+    } else {
+      elements.push_back(std::move(element.value()));
+    }
+  }
+
+  if (!ordered) {
+    return elements;
+  }
+
+  auto result{JSON::make_object()};
+  result.assign_assume_new(JSON::String{KEYWORD_LIST}, std::move(elements),
+                           KEYWORD_LIST_HASH);
+  return result;
+}
+
+auto materialize_node(const JSONLDNode &descriptor, const JSON &value,
+                      Pointer &pointer, const JSONLDAnnotationMap &map,
+                      std::vector<JSON> &standalone) -> JSON {
+  auto node{JSON::make_object()};
+  if (descriptor.id.has_value()) {
+    node.assign_assume_new(JSON::String{KEYWORD_ID},
+                           JSON{descriptor.id.value()}, KEYWORD_ID_HASH);
+  }
+  if (!descriptor.types.empty()) {
+    node.assign_assume_new(JSON::String{KEYWORD_TYPE},
+                           types_to_array(descriptor.types), KEYWORD_TYPE_HASH);
+  }
+
+  if (!value.is_object()) {
+    return node;
+  }
+
+  // A graph node asserts its members in the named graph it identifies, with the
+  // members carried by a subject node that shares its identifier.
+  if (descriptor.graph) {
+    auto inner{JSON::make_object()};
+    if (descriptor.id.has_value()) {
+      inner.assign_assume_new(JSON::String{KEYWORD_ID},
+                              JSON{descriptor.id.value()}, KEYWORD_ID_HASH);
+    }
+    std::vector<JSON> graph_nodes;
+    fill_node(inner, value, pointer, map, graph_nodes);
+    auto graph{JSON::make_array()};
+    if (inner.object_size() > (descriptor.id.has_value() ? 1 : 0)) {
+      graph.push_back(std::move(inner));
+    }
+    for (auto &extra : graph_nodes) {
+      graph.push_back(std::move(extra));
+    }
+    node.assign_assume_new(JSON::String{KEYWORD_GRAPH}, std::move(graph),
+                           KEYWORD_GRAPH_HASH);
+    return node;
+  }
+
+  fill_node(node, value, pointer, map, standalone);
+  return node;
+}
+
+auto materialize_value(const JSON &value, Pointer &pointer,
+                       const JSONLDAnnotationMap &map,
+                       std::vector<JSON> &standalone) -> std::optional<JSON> {
+  if (value.is_null()) {
+    return std::nullopt;
+  }
+
+  const auto iterator{map.find(pointer)};
+  if (iterator == map.cend()) {
+    // An undescribed object with described descendants becomes an anonymous
+    // blank node so its children have a subject. Anything else is not
+    // annotated.
+    if (value.is_object()) {
+      auto node{JSON::make_object()};
+      fill_node(node, value, pointer, map, standalone);
+      if (node.empty()) {
+        return std::nullopt;
+      }
+      return node;
+    }
+    return std::nullopt;
+  }
+
+  const auto &descriptor{iterator->second};
+  if (std::holds_alternative<JSONLDNode>(descriptor.value)) {
+    return materialize_node(std::get<JSONLDNode>(descriptor.value), value,
+                            pointer, map, standalone);
+  }
+  if (std::holds_alternative<JSONLDLiteral>(descriptor.value)) {
+    return materialize_literal(std::get<JSONLDLiteral>(descriptor.value),
+                               value);
+  }
+  if (std::holds_alternative<JSONLDReference>(descriptor.value)) {
+    return materialize_reference(std::get<JSONLDReference>(descriptor.value));
+  }
+
+  const auto &collection{std::get<JSONLDCollection>(descriptor.value)};
+  if (!value.is_array()) {
+    return std::nullopt;
+  }
+  return build_collection(value, pointer, map, standalone, collection.ordered);
+}
+
+auto fill_node(JSON &node, const JSON &instance_object, Pointer &pointer,
+               const JSONLDAnnotationMap &map, std::vector<JSON> &standalone)
+    -> void {
+  std::vector<JSON::StringView> keys;
+  keys.reserve(instance_object.object_size());
+  for (const auto &entry : instance_object.as_object()) {
+    keys.push_back(entry.first);
+  }
+  std::ranges::sort(keys);
+
+  for (const auto key : keys) {
+    pointer.push_back(JSON::String{key});
+    const auto child_iterator{map.find(pointer)};
+    auto child_value{
+        materialize_value(instance_object.at(key), pointer, map, standalone)};
+    pointer.pop_back();
+    if (!child_value.has_value()) {
+      continue;
+    }
+
+    const std::vector<JSONLDEdge> *edges{
+        child_iterator == map.cend() ? nullptr : &child_iterator->second.edges};
+    if (edges == nullptr || edges->empty()) {
+      // Without an edge a node cannot attach to its parent, so it is asserted
+      // as a standalone node in the current graph. A non-node cannot be
+      // asserted.
+      if (is_node_object(child_value.value())) {
+        standalone.push_back(std::move(child_value.value()));
+      }
+      continue;
+    }
+
+    attach(node, *edges, std::move(child_value.value()));
+  }
+}
+
+} // namespace
+
+auto jsonld_materialize(const JSON &instance, const JSONLDAnnotationMap &map)
+    -> JSON {
+  std::vector<JSON> standalone;
+  Pointer pointer;
+  auto root{materialize_value(instance, pointer, map, standalone)};
+
+  auto result{JSON::make_array()};
+  if (root.has_value()) {
+    if (root->is_array()) {
+      for (auto &element : root->as_array()) {
+        result.push_back(std::move(element));
+      }
+    } else if (is_node_object(root.value())) {
+      result.push_back(std::move(root.value()));
+    }
+    // A top-level value or list object carries no triples and is dropped.
+  }
+
+  for (auto &node : standalone) {
+    result.push_back(std::move(node));
+  }
+
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/test/jsonld/CMakeLists.txt
+++ b/test/jsonld/CMakeLists.txt
@@ -1,6 +1,7 @@
 sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsonld
   SOURCES jsonld_expand_test.cc jsonld_expand_error_test.cc
-    jsonld_is_expanded_test.cc jsonld_compact_test.cc jsonld_flatten_test.cc)
+    jsonld_is_expanded_test.cc jsonld_compact_test.cc jsonld_flatten_test.cc
+    jsonld_materialize_test.cc)
 
 target_link_libraries(sourcemeta_core_jsonld_unit
   PRIVATE sourcemeta::core::jsonld)

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -1004,6 +1004,64 @@ TEST(JSONLD_materialize, array_root_spreads_into_default_graph) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
+TEST(JSONLD_materialize, root_collection_of_literals_is_dropped) {
+  const auto instance = sourcemeta::core::parse_json(R"([ "a", "b" ])");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(sourcemeta::core::Pointer{0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{1},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json("[]");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, root_collection_keeps_only_node_elements) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"([ { "name": "A" }, "loose" ])");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(
+      sourcemeta::core::Pointer{0},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/a"}});
+  map.emplace(sourcemeta::core::Pointer{0, "name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{1},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/a",
+      "https://schema.org/name": [ { "@value": "A" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
 TEST(JSONLD_materialize, scalar_root_literal_is_dropped) {
   const auto instance = sourcemeta::core::parse_json(R"("hello")");
 

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -1,0 +1,548 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/jsonpointer.h>
+
+TEST(JSONLD_materialize, node_with_literal_property) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "name": "Sourcemeta" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/org"}});
+  map.emplace(sourcemeta::core::Pointer{"name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/org",
+      "https://schema.org/name": [ { "@value": "Sourcemeta" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, literal_with_datatype) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "isbn": "978-0131103627" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "urn:isbn:978-0131103627"}});
+  map.emplace(sourcemeta::core::Pointer{"isbn"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/isbn", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .datatype = "http://www.w3.org/2001/XMLSchema#string"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "urn:isbn:978-0131103627",
+      "https://schema.org/isbn": [
+        {
+          "@value": "978-0131103627",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, literal_with_language_and_direction) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "title": "مرحبا" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"title"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .language = "ar",
+                      .direction = sourcemeta::core::JSONLDDirection::RTL}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://schema.org/name": [
+        { "@value": "مرحبا", "@language": "ar", "@direction": "rtl" }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, reference_property) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "currency": "USD" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "urn:isbn:978-0131103627"}});
+  map.emplace(sourcemeta::core::Pointer{"currency"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/priceCurrency", false}},
+                  .value = sourcemeta::core::JSONLDReference{
+                      .id = "https://www.iso.org/iso-4217/USD",
+                      .types = {"https://schema.org/Currency"}}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "urn:isbn:978-0131103627",
+      "https://schema.org/priceCurrency": [
+        {
+          "@id": "https://www.iso.org/iso-4217/USD",
+          "@type": [ "https://schema.org/Currency" ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, ordered_collection_becomes_list) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "authors": [ "Ada", "Alan" ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/book"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"authors"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/author", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+  map.emplace(sourcemeta::core::Pointer{"authors", 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .datatype = "http://www.w3.org/2001/XMLSchema#string"}});
+  map.emplace(sourcemeta::core::Pointer{"authors", 1},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .datatype = "http://www.w3.org/2001/XMLSchema#string"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/book",
+      "https://schema.org/author": [
+        {
+          "@list": [
+            { "@value": "Ada", "@type": "http://www.w3.org/2001/XMLSchema#string" },
+            { "@value": "Alan", "@type": "http://www.w3.org/2001/XMLSchema#string" }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, unordered_collection_spreads_into_property) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "tags": [ "a", "b" ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"tags"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/keywords", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(sourcemeta::core::Pointer{"tags", 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"tags", 1},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://schema.org/keywords": [ { "@value": "a" }, { "@value": "b" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, field_with_multiple_predicates) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "label": "Hi" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"label"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/name", false},
+                    {"http://www.w3.org/2000/01/rdf-schema#label", false}},
+          .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://schema.org/name": [ { "@value": "Hi" } ],
+      "http://www.w3.org/2000/01/rdf-schema#label": [ { "@value": "Hi" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, reverse_edge) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "series": { "name": "Trilogy" } })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/book"}});
+  map.emplace(sourcemeta::core::Pointer{"series"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/hasPart", true}},
+                  .value = sourcemeta::core::JSONLDNode{}});
+  map.emplace(sourcemeta::core::Pointer{"series", "name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/book",
+      "@reverse": {
+        "https://schema.org/hasPart": [
+          { "https://schema.org/name": [ { "@value": "Trilogy" } ] }
+        ]
+      }
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, shared_blank_node_identifier_co_refers) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "billing": {}, "shipping": {} })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/order"}});
+  map.emplace(sourcemeta::core::Pointer{"billing"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/billing", false}},
+                  .value = sourcemeta::core::JSONLDNode{.id = "_:address"}});
+  map.emplace(sourcemeta::core::Pointer{"shipping"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/shipping", false}},
+                  .value = sourcemeta::core::JSONLDNode{.id = "_:address"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/order",
+      "https://example.com/billing": [ { "@id": "_:address" } ],
+      "https://example.com/shipping": [ { "@id": "_:address" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, json_literal_preserved_verbatim) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "payload": { "a": [ 1, 2 ] } })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"payload"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/raw", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{.json = true}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/raw": [
+        { "@value": { "a": [ 1, 2 ] }, "@type": "@json" }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, nested_ordered_collection_is_list_of_lists) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "matrix": [ [ 5 ] ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"matrix"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/rows", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+  map.emplace(
+      sourcemeta::core::Pointer{"matrix", 0},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+  map.emplace(sourcemeta::core::Pointer{"matrix", 0, 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .datatype = "http://www.w3.org/2001/XMLSchema#integer"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/rows": [
+        {
+          "@list": [
+            {
+              "@list": [
+                {
+                  "@value": 5,
+                  "@type": "http://www.w3.org/2001/XMLSchema#integer"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, undescribed_object_with_described_child) {
+  const auto instance = sourcemeta::core::parse_json(
+      R"({ "name": "Doc", "meta": { "title": "T" } })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"meta", "title"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/title", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://schema.org/name": [ { "@value": "Doc" } ]
+    },
+    { "https://example.com/title": [ { "@value": "T" } ] }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, described_node_without_edge_is_standalone) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "extra": { "x": "v" } })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"extra"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/other"}});
+  map.emplace(sourcemeta::core::Pointer{"extra", "x"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/x", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    { "@id": "https://example.com/doc" },
+    {
+      "@id": "https://example.com/other",
+      "https://example.com/x": [ { "@value": "v" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, null_value_produces_no_triple) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "maybe": null })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"maybe"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    { "@id": "https://example.com/doc" }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, named_graph) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "prov": { "who": "X" } })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"prov"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/statedIn", false}},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/graph", .graph = true}});
+  map.emplace(sourcemeta::core::Pointer{"prov", "who"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/statedIn": [
+        {
+          "@id": "https://example.com/graph",
+          "@graph": [
+            {
+              "@id": "https://example.com/graph",
+              "https://schema.org/name": [ { "@value": "X" } ]
+            }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, scalar_root_reference) {
+  const auto instance = sourcemeta::core::parse_json(R"("USD")");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDReference{
+                      .id = "https://www.iso.org/iso-4217/USD",
+                      .types = {"https://schema.org/Currency"}}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://www.iso.org/iso-4217/USD",
+      "@type": [ "https://schema.org/Currency" ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, empty_map_yields_empty_array) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "a": 1 })");
+  const sourcemeta::core::JSONLDAnnotationMap map;
+
+  const auto expected = sourcemeta::core::parse_json("[]");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -546,3 +546,568 @@ TEST(JSONLD_materialize, empty_map_yields_empty_array) {
   EXPECT_EQ(result, expected);
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
+
+TEST(JSONLD_materialize, node_with_type) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "name": "Ada" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/ada",
+                      .types = {"https://schema.org/Person"}}});
+  map.emplace(sourcemeta::core::Pointer{"name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/ada",
+      "@type": [ "https://schema.org/Person" ],
+      "https://schema.org/name": [ { "@value": "Ada" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, node_with_multiple_types) {
+  const auto instance = sourcemeta::core::parse_json(R"({})");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/thing",
+                      .types = {"https://schema.org/Person",
+                                "https://schema.org/Author"}}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/thing",
+      "@type": [ "https://schema.org/Person", "https://schema.org/Author" ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, reference_without_types) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "currency": "USD" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/book"}});
+  map.emplace(sourcemeta::core::Pointer{"currency"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/priceCurrency", false}},
+                  .value = sourcemeta::core::JSONLDReference{
+                      .id = "https://www.iso.org/iso-4217/USD"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/book",
+      "https://schema.org/priceCurrency": [
+        { "@id": "https://www.iso.org/iso-4217/USD" }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, literal_with_language_only) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "title": "Hello" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"title"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{.language = "en"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://schema.org/name": [ { "@value": "Hello", "@language": "en" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, literal_with_ltr_direction) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "title": "Hello" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"title"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .language = "en",
+                      .direction = sourcemeta::core::JSONLDDirection::LTR}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://schema.org/name": [
+        { "@value": "Hello", "@language": "en", "@direction": "ltr" }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, boolean_literal) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "active": true })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"active"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/active", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/active": [ { "@value": true } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, integer_literal_without_datatype) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "count": 42 })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"count"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/count", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/count": [ { "@value": 42 } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, ordered_collection_of_nodes) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "authors": [ { "name": "Ada" } ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/book"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"authors"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/author", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+  map.emplace(sourcemeta::core::Pointer{"authors", 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDNode{}});
+  map.emplace(sourcemeta::core::Pointer{"authors", 0, "name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/book",
+      "https://schema.org/author": [
+        {
+          "@list": [
+            { "https://schema.org/name": [ { "@value": "Ada" } ] }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, unordered_collection_of_nodes) {
+  const auto instance = sourcemeta::core::parse_json(
+      R"({ "items": [ { "sku": "1" }, { "sku": "2" } ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/order"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"items"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/item", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(sourcemeta::core::Pointer{"items", 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDNode{}});
+  map.emplace(sourcemeta::core::Pointer{"items", 0, "sku"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/sku", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"items", 1},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDNode{}});
+  map.emplace(sourcemeta::core::Pointer{"items", 1, "sku"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/sku", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/order",
+      "https://example.com/item": [
+        { "https://example.com/sku": [ { "@value": "1" } ] },
+        { "https://example.com/sku": [ { "@value": "2" } ] }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, empty_ordered_collection_is_rdf_nil) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "authors": [] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/book"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"authors"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/author", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/book",
+      "https://schema.org/author": [ { "@list": [] } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, empty_unordered_collection_adds_no_property) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "tags": [] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"tags"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/keywords", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    { "@id": "https://example.com/doc" }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, collection_with_undescribed_elements_skips_them) {
+  const auto instance = sourcemeta::core::parse_json(
+      R"({ "authors": [ "Ada", "Unknown", "Alan" ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/book"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"authors"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/author", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+  map.emplace(sourcemeta::core::Pointer{"authors", 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"authors", 2},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/book",
+      "https://schema.org/author": [
+        { "@list": [ { "@value": "Ada" }, { "@value": "Alan" } ] }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, nested_unordered_collection_flattens) {
+  const auto instance = sourcemeta::core::parse_json(
+      R"({ "groups": [ [ "a", "b" ], [ "c" ] ] })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"groups"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/member", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(
+      sourcemeta::core::Pointer{"groups", 0},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(
+      sourcemeta::core::Pointer{"groups", 1},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(sourcemeta::core::Pointer{"groups", 0, 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"groups", 0, 1},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"groups", 1, 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/member": [
+        { "@value": "a" }, { "@value": "b" }, { "@value": "c" }
+      ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, array_root_spreads_into_default_graph) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"([ { "name": "A" }, { "name": "B" } ])");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = false}});
+  map.emplace(
+      sourcemeta::core::Pointer{0},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/a"}});
+  map.emplace(sourcemeta::core::Pointer{0, "name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(
+      sourcemeta::core::Pointer{1},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/b"}});
+  map.emplace(sourcemeta::core::Pointer{1, "name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/a",
+      "https://schema.org/name": [ { "@value": "A" } ]
+    },
+    {
+      "@id": "https://example.com/b",
+      "https://schema.org/name": [ { "@value": "B" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, scalar_root_literal_is_dropped) {
+  const auto instance = sourcemeta::core::parse_json(R"("hello")");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {}, .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json("[]");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, collection_descriptor_on_non_array_is_dropped) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "x": "scalar" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"x"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/x", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    { "@id": "https://example.com/doc" }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(JSONLD_materialize, output_is_a_fixed_point_of_expansion) {
+  const auto instance = sourcemeta::core::parse_json(R"({
+    "name": "Ada",
+    "homepage": "https://ada.example",
+    "books": [ "Notes" ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(sourcemeta::core::Pointer{},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/ada",
+                      .types = {"https://schema.org/Person"}}});
+  map.emplace(sourcemeta::core::Pointer{"name"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/name", false}},
+                  .value = sourcemeta::core::JSONLDLiteral{}});
+  map.emplace(sourcemeta::core::Pointer{"homepage"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://schema.org/url", false}},
+                  .value = sourcemeta::core::JSONLDReference{
+                      .id = "https://ada.example"}});
+  map.emplace(
+      sourcemeta::core::Pointer{"books"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://schema.org/author", false}},
+          .value = sourcemeta::core::JSONLDCollection{.ordered = true}});
+  map.emplace(sourcemeta::core::Pointer{"books", 0},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {},
+                  .value = sourcemeta::core::JSONLDLiteral{
+                      .datatype = "http://www.w3.org/2001/XMLSchema#string"}});
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+
+  // Expanded form is a fixed point of expansion, so re-expanding the output of
+  // materialization must leave it unchanged.
+  EXPECT_EQ(sourcemeta::core::jsonld_expand(result), result);
+}
+
+TEST(JSONLD_materialize, node_descriptor_on_scalar_ignores_value) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "x": "scalar" })");
+
+  sourcemeta::core::JSONLDAnnotationMap map;
+  map.emplace(
+      sourcemeta::core::Pointer{},
+      sourcemeta::core::JSONLDDescriptor{.edges = {},
+                                         .value = sourcemeta::core::JSONLDNode{
+                                             .id = "https://example.com/doc"}});
+  map.emplace(sourcemeta::core::Pointer{"x"},
+              sourcemeta::core::JSONLDDescriptor{
+                  .edges = {{"https://example.com/x", false}},
+                  .value = sourcemeta::core::JSONLDNode{
+                      .id = "https://example.com/other"}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/doc",
+      "https://example.com/x": [ { "@id": "https://example.com/other" } ]
+    }
+  ])");
+
+  const auto result{sourcemeta::core::jsonld_materialize(instance, map)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

