### PR TITLE
Implement an HTTP `cache-control` parsing utility

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -13,6 +13,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
   SOURCES helpers.h problem.cc match_accept.cc match_accept_language.cc
           negotiate_encoding.cc from_date.cc format_link.cc field_list.cc
           accept_includes_all.cc content_type_matches.cc parse_bearer.cc
+          cache_control_max_age.cc
           ${SOURCEMETA_CORE_HTTP_CLIENT_SOURCE})
 
 if(SOURCEMETA_CORE_INSTALL)

--- a/src/core/http/cache_control_max_age.cc
+++ b/src/core/http/cache_control_max_age.cc
@@ -1,0 +1,56 @@
+#include <sourcemeta/core/http.h>
+
+#include "helpers.h"
+
+#include <chrono>      // std::chrono::seconds
+#include <optional>    // std::optional, std::nullopt
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto http_cache_control_max_age(const std::string_view cache_control) noexcept
+    -> std::optional<std::chrono::seconds> {
+  // RFC 9111 §1.2.2: a delta-seconds value larger than the cache can
+  // represent, or any subsequent overflow, must be treated as 2^31
+  constexpr std::chrono::seconds::rep overflow_seconds{2147483648};
+  std::optional<std::chrono::seconds> result;
+  bool found{false};
+  http_for_each_list_entry(
+      cache_control, [&](const std::string_view directive) -> void {
+        if (found) {
+          return;
+        }
+
+        const auto separator{directive.find('=')};
+        if (separator == std::string_view::npos ||
+            !http_iequals_ascii(http_subview(directive, 0, separator),
+                                "max-age")) {
+          return;
+        }
+
+        found = true;
+        const auto digits{http_subview(directive, separator + 1,
+                                       directive.size() - separator - 1)};
+        if (digits.empty()) {
+          return;
+        }
+
+        std::chrono::seconds::rep seconds{0};
+        for (const char character : digits) {
+          if (character < '0' || character > '9') {
+            return;
+          }
+
+          seconds = (seconds * 10) + (character - '0');
+          if (seconds > overflow_seconds) {
+            seconds = overflow_seconds;
+          }
+        }
+
+        result = std::chrono::seconds{seconds};
+      });
+
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/cache_control_max_age.cc
+++ b/src/core/http/cache_control_max_age.cc
@@ -29,8 +29,15 @@ auto http_cache_control_max_age(const std::string_view cache_control) noexcept
         }
 
         found = true;
-        const auto digits{http_subview(directive, separator + 1,
-                                       directive.size() - separator - 1)};
+        auto digits{http_subview(directive, separator + 1,
+                                 directive.size() - separator - 1)};
+        // RFC 9111 §5.2.4: a sender must not generate the quoted-string form
+        // for a delta-seconds argument, but recipients ought to accept it
+        if (digits.size() >= 2 && digits.front() == '"' &&
+            digits.back() == '"') {
+          digits = http_subview(digits, 1, digits.size() - 2);
+        }
+
         if (digits.empty()) {
           return;
         }

--- a/src/core/http/cache_control_max_age.cc
+++ b/src/core/http/cache_control_max_age.cc
@@ -3,6 +3,7 @@
 #include "helpers.h"
 
 #include <chrono>      // std::chrono::seconds
+#include <cstddef>     // std::size_t
 #include <optional>    // std::optional, std::nullopt
 #include <string_view> // std::string_view
 
@@ -10,8 +11,8 @@ namespace sourcemeta::core {
 
 auto http_cache_control_max_age(const std::string_view cache_control) noexcept
     -> std::optional<std::chrono::seconds> {
-  // RFC 9111 §1.2.2: a delta-seconds value larger than the cache can
-  // represent, or any subsequent overflow, must be treated as 2^31
+  // RFC 9111 §1.2.2: a delta-seconds value larger than the cache can represent
+  // is treated as 2^31
   constexpr std::chrono::seconds::rep overflow_seconds{2147483648};
   std::optional<std::chrono::seconds> result;
   bool found{false};
@@ -29,29 +30,51 @@ auto http_cache_control_max_age(const std::string_view cache_control) noexcept
         }
 
         found = true;
-        auto digits{http_subview(directive, separator + 1,
-                                 directive.size() - separator - 1)};
-        // RFC 9111 §5.2.4: a sender must not generate the quoted-string form
-        // for a delta-seconds argument, but recipients ought to accept it
-        if (digits.size() >= 2 && digits.front() == '"' &&
-            digits.back() == '"') {
-          digits = http_subview(digits, 1, digits.size() - 2);
+        auto value{http_subview(directive, separator + 1,
+                                directive.size() - separator - 1)};
+        // RFC 9111 §5.2.2.1 forbids a sender from generating the quoted-string
+        // form for delta-seconds, but RFC 9111 §5.2.4 asks recipients to accept
+        // it regardless
+        const bool quoted{value.size() >= 2 && value.front() == '"' &&
+                          value.back() == '"'};
+        if (quoted) {
+          value = http_subview(value, 1, value.size() - 2);
         }
 
-        if (digits.empty()) {
+        if (value.empty()) {
           return;
         }
 
         std::chrono::seconds::rep seconds{0};
-        for (const char character : digits) {
+        for (std::size_t index{0}; index < value.size(); ++index) {
+          char character{value[index]};
+          // RFC 9110 §5.6.4: within a quoted-string a backslash escapes the
+          // octet that follows it
+          if (quoted && character == '\\') {
+            index += 1;
+            if (index >= value.size()) {
+              return;
+            }
+
+            character = value[index];
+          }
+
           if (character < '0' || character > '9') {
             return;
           }
 
-          seconds = (seconds * 10) + (character - '0');
-          if (seconds > overflow_seconds) {
+          // Clamp before multiplying so the running total cannot itself
+          // overflow on a hostile number of digits
+          if (seconds > overflow_seconds / 10) {
             seconds = overflow_seconds;
+            continue;
           }
+
+          seconds = (seconds * 10) + (character - '0');
+        }
+
+        if (seconds > overflow_seconds) {
+          seconds = overflow_seconds;
         }
 
         result = std::chrono::seconds{seconds};

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -155,6 +155,26 @@ auto http_from_date(const std::string_view value) noexcept
     -> std::optional<std::chrono::system_clock::time_point>;
 
 /// @ingroup http
+/// Read the `max-age` response directive from a `Cache-Control` header value
+/// per RFC 9111 §5.2.2.1. Returns an empty value when the directive is absent
+/// or malformed. A value larger than the cache can represent saturates to
+/// `2147483648` seconds as mandated by RFC 9111 §1.2.2. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+/// #include <chrono>
+///
+/// const auto max_age{sourcemeta::core::http_cache_control_max_age(
+///     "public, max-age=600")};
+/// assert(max_age.has_value());
+/// assert(max_age.value() == std::chrono::seconds{600});
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_cache_control_max_age(const std::string_view cache_control) noexcept
+    -> std::optional<std::chrono::seconds>;
+
+/// @ingroup http
 /// A typed RFC 8288 §3 link-value. The caller owns the backing storage for
 /// every field, must URI-escape `target`, and must ensure parameter values are
 /// valid `quoted-string` content.

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -8,7 +8,7 @@ sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME http
           http_is_status_line_test.cc http_accumulate_header_line_test.cc
           http_parse_headers_test.cc http_serialize_headers_test.cc
           http_header_find_test.cc http_error_test.cc
-          http_parse_bearer_test.cc)
+          http_parse_bearer_test.cc http_cache_control_max_age_test.cc)
 
 target_link_libraries(sourcemeta_core_http_unit
   PRIVATE sourcemeta::core::http)

--- a/test/http/http_cache_control_max_age_test.cc
+++ b/test/http/http_cache_control_max_age_test.cc
@@ -80,6 +80,35 @@ TEST(HTTP_cache_control_max_age, prefix_only_directive_ignored) {
   EXPECT_EQ(result.value(), std::chrono::seconds{7});
 }
 
+TEST(HTTP_cache_control_max_age, quoted_string_value) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("max-age=\"600\"")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{600});
+}
+
+TEST(HTTP_cache_control_max_age, quoted_string_value_among_directives) {
+  const auto result{sourcemeta::core::http_cache_control_max_age(
+      "public, max-age=\"42\", must-revalidate")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{42});
+}
+
+TEST(HTTP_cache_control_max_age, empty_quoted_string_value) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_cache_control_max_age("max-age=\"\"").has_value());
+}
+
+TEST(HTTP_cache_control_max_age, unterminated_quote_rejected) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"600")
+                   .has_value());
+}
+
+TEST(HTTP_cache_control_max_age, non_numeric_quoted_value_rejected) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"abc\"")
+                   .has_value());
+}
+
 TEST(HTTP_cache_control_max_age, overflow_saturates) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "max-age=999999999999999999999999")};

--- a/test/http/http_cache_control_max_age_test.cc
+++ b/test/http/http_cache_control_max_age_test.cc
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <sourcemeta/core/http.h>
+
+#include <chrono> // std::chrono::seconds
+
+TEST(HTTP_cache_control_max_age, single_directive) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("max-age=600")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{600});
+}
+
+TEST(HTTP_cache_control_max_age, zero) {
+  const auto result{sourcemeta::core::http_cache_control_max_age("max-age=0")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{0});
+}
+
+TEST(HTTP_cache_control_max_age, among_other_directives) {
+  const auto result{sourcemeta::core::http_cache_control_max_age(
+      "public, max-age=3600, must-revalidate")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{3600});
+}
+
+TEST(HTTP_cache_control_max_age, leading_other_directive) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("no-cache, max-age=120")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{120});
+}
+
+TEST(HTTP_cache_control_max_age, case_insensitive_directive_name) {
+  const auto result{sourcemeta::core::http_cache_control_max_age("Max-Age=42")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{42});
+}
+
+TEST(HTTP_cache_control_max_age, surrounding_whitespace_trimmed) {
+  const auto result{sourcemeta::core::http_cache_control_max_age(
+      "  public ,  max-age=90  , no-store ")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{90});
+}
+
+TEST(HTTP_cache_control_max_age, absent) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("public, no-store")
+                   .has_value());
+}
+
+TEST(HTTP_cache_control_max_age, empty_header) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("").has_value());
+}
+
+TEST(HTTP_cache_control_max_age, no_value) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_cache_control_max_age("max-age").has_value());
+}
+
+TEST(HTTP_cache_control_max_age, empty_value) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_cache_control_max_age("max-age=").has_value());
+}
+
+TEST(HTTP_cache_control_max_age, non_numeric_value) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_cache_control_max_age("max-age=abc").has_value());
+}
+
+TEST(HTTP_cache_control_max_age, partly_numeric_value) {
+  EXPECT_FALSE(
+      sourcemeta::core::http_cache_control_max_age("max-age=12x").has_value());
+}
+
+TEST(HTTP_cache_control_max_age, prefix_only_directive_ignored) {
+  const auto result{sourcemeta::core::http_cache_control_max_age(
+      "max-age-extension=5, max-age=7")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{7});
+}
+
+TEST(HTTP_cache_control_max_age, overflow_saturates) {
+  const auto result{sourcemeta::core::http_cache_control_max_age(
+      "max-age=999999999999999999999999")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{2147483648});
+}
+
+TEST(HTTP_cache_control_max_age, at_overflow_boundary) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("max-age=2147483648")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{2147483648});
+}
+
+TEST(HTTP_cache_control_max_age, just_below_overflow_boundary) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("max-age=2147483647")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{2147483647});
+}

--- a/test/http/http_cache_control_max_age_test.cc
+++ b/test/http/http_cache_control_max_age_test.cc
@@ -109,6 +109,35 @@ TEST(HTTP_cache_control_max_age, non_numeric_quoted_value_rejected) {
                    .has_value());
 }
 
+TEST(HTTP_cache_control_max_age, quoted_pair_escaped_digits) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("max-age=\"6\\0\\0\"")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{600});
+}
+
+TEST(HTTP_cache_control_max_age, quoted_pair_escaped_non_digit_rejected) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"6\\a0\"")
+                   .has_value());
+}
+
+TEST(HTTP_cache_control_max_age, dangling_escape_rejected) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"60\\\"")
+                   .has_value());
+}
+
+TEST(HTTP_cache_control_max_age, backslash_in_token_form_rejected) {
+  EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=6\\00")
+                   .has_value());
+}
+
+TEST(HTTP_cache_control_max_age, far_above_overflow_boundary) {
+  const auto result{
+      sourcemeta::core::http_cache_control_max_age("max-age=4294967296")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), std::chrono::seconds{2147483648});
+}
+
 TEST(HTTP_cache_control_max_age, overflow_saturates) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "max-age=999999999999999999999999")};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

