### PR TITLE
Use the new test runner when possible

### DIFF
--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -174,16 +174,30 @@ inline auto test_c_string_label(const char *const value) -> std::string_view {
                           : std::string_view{value};
 }
 
-// The operands are taken as function arguments so that any temporaries they
-// produce live through the whole comparison, which a separate reference binding
-// inside the macro would let dangle
+// References, rather than values, so that the operands bind without copying and
+// without rejecting comparisons of non-copyable types. This aggregate only ever
+// lives for the duration of a single comparison call, so the usual hazards of
+// reference members do not apply here.
+template <typename Left, typename Right> struct test_operands {
+  // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+  const Left &left;
+  const Right &right;
+  // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
+};
+
+// Collecting both operands through a single braced initializer keeps their
+// temporaries alive for the whole comparison and pins their evaluation to
+// left-to-right order. Binding each operand to its own reference inside the
+// macro guarantees neither
 template <typename Left, typename Right, typename Comparator>
 auto test_expect_comparison(std::string_view file, int line,
-                            std::string_view expression, const Left &left,
-                            const Right &right, Comparator comparator) -> void {
-  if (!comparator(left, right)) {
-    test_report_failure(file, line,
-                        test_describe_mismatch(expression, left, right));
+                            std::string_view expression,
+                            const test_operands<Left, Right> &operands,
+                            Comparator comparator) -> void {
+  if (!comparator(operands.left, operands.right)) {
+    test_report_failure(
+        file, line,
+        test_describe_mismatch(expression, operands.left, operands.right));
   }
 }
 
@@ -201,8 +215,8 @@ auto test_expect_comparison(std::string_view file, int line,
 
 #define SOURCEMETA_CORE_TEST_COMPARE(actual, expected, comparator, operation)  \
   ::sourcemeta::core::test_expect_comparison(                                  \
-      __FILE__, __LINE__, #actual " " operation " " #expected, (actual),       \
-      (expected),                                                              \
+      __FILE__, __LINE__, #actual " " operation " " #expected,                 \
+      ::sourcemeta::core::test_operands{(actual), (expected)},                 \
       [](const auto &sourcemeta_test_left,                                     \
          const auto &sourcemeta_test_right) {                                  \
         return ::sourcemeta::core::comparator(sourcemeta_test_left,            \

--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -174,6 +174,19 @@ inline auto test_c_string_label(const char *const value) -> std::string_view {
                           : std::string_view{value};
 }
 
+// The operands are taken as function arguments so that any temporaries they
+// produce live through the whole comparison, which a separate reference binding
+// inside the macro would let dangle
+template <typename Left, typename Right, typename Comparator>
+auto test_expect_comparison(std::string_view file, int line,
+                            std::string_view expression, const Left &left,
+                            const Right &right, Comparator comparator) -> void {
+  if (!comparator(left, right)) {
+    test_report_failure(file, line,
+                        test_describe_mismatch(expression, left, right));
+  }
+}
+
 } // namespace sourcemeta::core
 
 #define SOURCEMETA_CORE_TEST_REGISTER(name)                                    \
@@ -187,18 +200,14 @@ inline auto test_c_string_label(const char *const value) -> std::string_view {
 #define TEST(name) SOURCEMETA_CORE_TEST_REGISTER(name)
 
 #define SOURCEMETA_CORE_TEST_COMPARE(actual, expected, comparator, operation)  \
-  do {                                                                         \
-    const auto &sourcemeta_test_actual{(actual)};                              \
-    const auto &sourcemeta_test_expected{(expected)};                          \
-    if (!::sourcemeta::core::comparator(sourcemeta_test_actual,                \
-                                        sourcemeta_test_expected)) {           \
-      ::sourcemeta::core::test_report_failure(                                 \
-          __FILE__, __LINE__,                                                  \
-          ::sourcemeta::core::test_describe_mismatch(                          \
-              #actual " " operation " " #expected, sourcemeta_test_actual,     \
-              sourcemeta_test_expected));                                      \
-    }                                                                          \
-  } while (false)
+  ::sourcemeta::core::test_expect_comparison(                                  \
+      __FILE__, __LINE__, #actual " " operation " " #expected, (actual),       \
+      (expected),                                                              \
+      [](const auto &sourcemeta_test_left,                                     \
+         const auto &sourcemeta_test_right) {                                  \
+        return ::sourcemeta::core::comparator(sourcemeta_test_left,            \
+                                              sourcemeta_test_right);          \
+      })
 
 #define EXPECT_EQ(actual, expected)                                            \
   SOURCEMETA_CORE_TEST_COMPARE(actual, expected, test_compare_equal, "==")

--- a/test/crypto/CMakeLists.txt
+++ b/test/crypto/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME crypto
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME crypto
   SOURCES
     crypto_sha256_test.cc
     crypto_sha384_test.cc

--- a/test/crypto/crypto_base64_test.cc
+++ b/test/crypto/crypto_base64_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -8,177 +8,177 @@
 // RFC 4648 Section 10 test vectors
 // See https://www.rfc-editor.org/rfc/rfc4648#section-10
 
-TEST(Crypto_base64, encode_rfc4648_empty) {
+TEST(encode_rfc4648_empty) {
   EXPECT_EQ(sourcemeta::core::base64_encode(""), "");
 }
 
-TEST(Crypto_base64, encode_rfc4648_f) {
+TEST(encode_rfc4648_f) {
   EXPECT_EQ(sourcemeta::core::base64_encode("f"), "Zg==");
 }
 
-TEST(Crypto_base64, encode_rfc4648_fo) {
+TEST(encode_rfc4648_fo) {
   EXPECT_EQ(sourcemeta::core::base64_encode("fo"), "Zm8=");
 }
 
-TEST(Crypto_base64, encode_rfc4648_foo) {
+TEST(encode_rfc4648_foo) {
   EXPECT_EQ(sourcemeta::core::base64_encode("foo"), "Zm9v");
 }
 
-TEST(Crypto_base64, encode_rfc4648_foob) {
+TEST(encode_rfc4648_foob) {
   EXPECT_EQ(sourcemeta::core::base64_encode("foob"), "Zm9vYg==");
 }
 
-TEST(Crypto_base64, encode_rfc4648_fooba) {
+TEST(encode_rfc4648_fooba) {
   EXPECT_EQ(sourcemeta::core::base64_encode("fooba"), "Zm9vYmE=");
 }
 
-TEST(Crypto_base64, encode_rfc4648_foobar) {
+TEST(encode_rfc4648_foobar) {
   EXPECT_EQ(sourcemeta::core::base64_encode("foobar"), "Zm9vYmFy");
 }
 
-TEST(Crypto_base64, encode_all_high_bytes) {
+TEST(encode_all_high_bytes) {
   EXPECT_EQ(sourcemeta::core::base64_encode("\xFF\xFF\xFF"), "////");
 }
 
-TEST(Crypto_base64, encode_single_high_byte) {
+TEST(encode_single_high_byte) {
   EXPECT_EQ(sourcemeta::core::base64_encode("\xF8"), "+A==");
 }
 
-TEST(Crypto_base64, encode_embedded_nul_byte) {
+TEST(encode_embedded_nul_byte) {
   const std::string input("a\x00"
                           "b",
                           3);
   EXPECT_EQ(sourcemeta::core::base64_encode(input), "YQBi");
 }
 
-TEST(Crypto_base64, encode_stream_overload) {
+TEST(encode_stream_overload) {
   std::ostringstream output;
   sourcemeta::core::base64_encode("foobar", output);
   EXPECT_EQ(output.str(), "Zm9vYmFy");
 }
 
-TEST(Crypto_base64, encode_stream_overload_empty) {
+TEST(encode_stream_overload_empty) {
   std::ostringstream output;
   sourcemeta::core::base64_encode("", output);
   EXPECT_EQ(output.str(), "");
 }
 
-TEST(Crypto_base64, decode_rfc4648_empty) {
+TEST(decode_rfc4648_empty) {
   const auto result{sourcemeta::core::base64_decode("")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(Crypto_base64, decode_rfc4648_f) {
+TEST(decode_rfc4648_f) {
   const auto result{sourcemeta::core::base64_decode("Zg==")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "f");
 }
 
-TEST(Crypto_base64, decode_rfc4648_fo) {
+TEST(decode_rfc4648_fo) {
   const auto result{sourcemeta::core::base64_decode("Zm8=")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "fo");
 }
 
-TEST(Crypto_base64, decode_rfc4648_foo) {
+TEST(decode_rfc4648_foo) {
   const auto result{sourcemeta::core::base64_decode("Zm9v")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo");
 }
 
-TEST(Crypto_base64, decode_rfc4648_foob) {
+TEST(decode_rfc4648_foob) {
   const auto result{sourcemeta::core::base64_decode("Zm9vYg==")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foob");
 }
 
-TEST(Crypto_base64, decode_rfc4648_fooba) {
+TEST(decode_rfc4648_fooba) {
   const auto result{sourcemeta::core::base64_decode("Zm9vYmE=")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "fooba");
 }
 
-TEST(Crypto_base64, decode_rfc4648_foobar) {
+TEST(decode_rfc4648_foobar) {
   const auto result{sourcemeta::core::base64_decode("Zm9vYmFy")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foobar");
 }
 
-TEST(Crypto_base64, decode_all_high_bytes) {
+TEST(decode_all_high_bytes) {
   const auto result{sourcemeta::core::base64_decode("////")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xFF\xFF\xFF");
 }
 
-TEST(Crypto_base64, decode_single_high_byte) {
+TEST(decode_single_high_byte) {
   const auto result{sourcemeta::core::base64_decode("+A==")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xF8");
 }
 
-TEST(Crypto_base64, decode_nul_byte) {
+TEST(decode_nul_byte) {
   const auto result{sourcemeta::core::base64_decode("AA==")};
   EXPECT_TRUE(result.has_value());
   const std::string expected("\x00", 1);
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Crypto_base64, decode_rejects_length_one) {
+TEST(decode_rejects_length_one) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Z").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_missing_padding) {
+TEST(decode_rejects_missing_padding) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zg").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_partial_padding) {
+TEST(decode_rejects_partial_padding) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zm8").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_invalid_character) {
+TEST(decode_rejects_invalid_character) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zm!v").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_interior_space) {
+TEST(decode_rejects_interior_space) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zm 9").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_interior_newline) {
+TEST(decode_rejects_interior_newline) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zm\n9").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_url_safe_minus) {
+TEST(decode_rejects_url_safe_minus) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("-A==").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_url_safe_underscore) {
+TEST(decode_rejects_url_safe_underscore) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("_A==").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_padding_only) {
+TEST(decode_rejects_padding_only) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("====").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_interior_padding) {
+TEST(decode_rejects_interior_padding) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Z=g=").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_triple_padding) {
+TEST(decode_rejects_triple_padding) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Z===").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_padding_across_groups) {
+TEST(decode_rejects_padding_across_groups) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zg==Zg==").has_value());
 }
 
 // RFC 4648 Section 3.5: "Implementations MAY chose to reject the encoding if
 // the pad bits have not been set to zero". We reject so that every value has
 // exactly one accepted encoding
-TEST(Crypto_base64, decode_rejects_nonzero_pad_bits_two_characters) {
+TEST(decode_rejects_nonzero_pad_bits_two_characters) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zh==").has_value());
 }
 
-TEST(Crypto_base64, decode_rejects_nonzero_pad_bits_three_characters) {
+TEST(decode_rejects_nonzero_pad_bits_three_characters) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zm9=").has_value());
 }

--- a/test/crypto/crypto_base64url_test.cc
+++ b/test/crypto/crypto_base64url_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -8,98 +8,98 @@
 // RFC 4648 Section 10 test vectors
 // See https://www.rfc-editor.org/rfc/rfc4648#section-10
 
-TEST(Crypto_base64url, encode_rfc4648_empty) {
+TEST(encode_rfc4648_empty) {
   EXPECT_EQ(sourcemeta::core::base64url_encode(""), "");
 }
 
-TEST(Crypto_base64url, encode_rfc4648_f) {
+TEST(encode_rfc4648_f) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("f"), "Zg");
 }
 
-TEST(Crypto_base64url, encode_rfc4648_fo) {
+TEST(encode_rfc4648_fo) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("fo"), "Zm8");
 }
 
-TEST(Crypto_base64url, encode_rfc4648_foo) {
+TEST(encode_rfc4648_foo) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("foo"), "Zm9v");
 }
 
-TEST(Crypto_base64url, encode_rfc4648_foob) {
+TEST(encode_rfc4648_foob) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("foob"), "Zm9vYg");
 }
 
-TEST(Crypto_base64url, encode_rfc4648_fooba) {
+TEST(encode_rfc4648_fooba) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("fooba"), "Zm9vYmE");
 }
 
-TEST(Crypto_base64url, encode_rfc4648_foobar) {
+TEST(encode_rfc4648_foobar) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("foobar"), "Zm9vYmFy");
 }
 
 // RFC 7515 Appendix C example octets
 // See https://www.rfc-editor.org/rfc/rfc7515#appendix-C
-TEST(Crypto_base64url, encode_rfc7515_appendix_c) {
+TEST(encode_rfc7515_appendix_c) {
   const std::string input("\x03\xEC\xFF\xE0\xC1", 5);
   EXPECT_EQ(sourcemeta::core::base64url_encode(input), "A-z_4ME");
 }
 
-TEST(Crypto_base64url, encode_all_high_bytes) {
+TEST(encode_all_high_bytes) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("\xFF\xFF\xFF"), "____");
 }
 
-TEST(Crypto_base64url, encode_single_high_byte) {
+TEST(encode_single_high_byte) {
   EXPECT_EQ(sourcemeta::core::base64url_encode("\xF8"), "-A");
 }
 
-TEST(Crypto_base64url, encode_stream_overload) {
+TEST(encode_stream_overload) {
   std::ostringstream output;
   sourcemeta::core::base64url_encode("foobar", output);
   EXPECT_EQ(output.str(), "Zm9vYmFy");
 }
 
-TEST(Crypto_base64url, encode_stream_overload_empty) {
+TEST(encode_stream_overload_empty) {
   std::ostringstream output;
   sourcemeta::core::base64url_encode("", output);
   EXPECT_EQ(output.str(), "");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_empty) {
+TEST(decode_rfc4648_empty) {
   const auto result{sourcemeta::core::base64url_decode("")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_f) {
+TEST(decode_rfc4648_f) {
   const auto result{sourcemeta::core::base64url_decode("Zg")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "f");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_fo) {
+TEST(decode_rfc4648_fo) {
   const auto result{sourcemeta::core::base64url_decode("Zm8")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "fo");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_foo) {
+TEST(decode_rfc4648_foo) {
   const auto result{sourcemeta::core::base64url_decode("Zm9v")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_foob) {
+TEST(decode_rfc4648_foob) {
   const auto result{sourcemeta::core::base64url_decode("Zm9vYg")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foob");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_fooba) {
+TEST(decode_rfc4648_fooba) {
   const auto result{sourcemeta::core::base64url_decode("Zm9vYmE")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "fooba");
 }
 
-TEST(Crypto_base64url, decode_rfc4648_foobar) {
+TEST(decode_rfc4648_foobar) {
   const auto result{sourcemeta::core::base64url_decode("Zm9vYmFy")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foobar");
@@ -107,60 +107,60 @@ TEST(Crypto_base64url, decode_rfc4648_foobar) {
 
 // RFC 7515 Appendix C example octets
 // See https://www.rfc-editor.org/rfc/rfc7515#appendix-C
-TEST(Crypto_base64url, decode_rfc7515_appendix_c) {
+TEST(decode_rfc7515_appendix_c) {
   const auto result{sourcemeta::core::base64url_decode("A-z_4ME")};
   EXPECT_TRUE(result.has_value());
   const std::string expected("\x03\xEC\xFF\xE0\xC1", 5);
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Crypto_base64url, decode_all_high_bytes) {
+TEST(decode_all_high_bytes) {
   const auto result{sourcemeta::core::base64url_decode("____")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xFF\xFF\xFF");
 }
 
-TEST(Crypto_base64url, decode_single_high_byte) {
+TEST(decode_single_high_byte) {
   const auto result{sourcemeta::core::base64url_decode("-A")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xF8");
 }
 
-TEST(Crypto_base64url, decode_rejects_length_one) {
+TEST(decode_rejects_length_one) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Z").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_padding) {
+TEST(decode_rejects_padding) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Zg==").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_single_padding_character) {
+TEST(decode_rejects_single_padding_character) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Zm8=").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_plus) {
+TEST(decode_rejects_plus) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("+A").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_slash) {
+TEST(decode_rejects_slash) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("AA//").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_invalid_character) {
+TEST(decode_rejects_invalid_character) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Z!").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_interior_space) {
+TEST(decode_rejects_interior_space) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Zm 9").has_value());
 }
 
 // RFC 4648 Section 3.5: "Implementations MAY chose to reject the encoding if
 // the pad bits have not been set to zero". We reject so that every value has
 // exactly one accepted encoding
-TEST(Crypto_base64url, decode_rejects_nonzero_pad_bits_two_characters) {
+TEST(decode_rejects_nonzero_pad_bits_two_characters) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Zh").has_value());
 }
 
-TEST(Crypto_base64url, decode_rejects_nonzero_pad_bits_three_characters) {
+TEST(decode_rejects_nonzero_pad_bits_three_characters) {
   EXPECT_FALSE(sourcemeta::core::base64url_decode("Zm9").has_value());
 }

--- a/test/crypto/crypto_crc32_test.cc
+++ b/test/crypto/crypto_crc32_test.cc
@@ -1,62 +1,56 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
 #include <cstdint> // std::uint32_t
 #include <string>  // std::string
 
-TEST(Crypto_CRC32, empty_string) {
-  EXPECT_EQ(sourcemeta::core::crc32(""), 0x00000000u);
-}
+TEST(empty_string) { EXPECT_EQ(sourcemeta::core::crc32(""), 0x00000000u); }
 
 // Try $ printf '%s' "a" | gzip -c | tail -c 8 | head -c 4 | xxd
-TEST(Crypto_CRC32, single_byte_a) {
-  EXPECT_EQ(sourcemeta::core::crc32("a"), 0xE8B7BE43u);
-}
+TEST(single_byte_a) { EXPECT_EQ(sourcemeta::core::crc32("a"), 0xE8B7BE43u); }
 
 // Try $ printf '%s' "abc" | gzip -c | tail -c 8 | head -c 4 | xxd
-TEST(Crypto_CRC32, abc_string) {
-  EXPECT_EQ(sourcemeta::core::crc32("abc"), 0x352441C2u);
-}
+TEST(abc_string) { EXPECT_EQ(sourcemeta::core::crc32("abc"), 0x352441C2u); }
 
 // ITU-T V.42 canonical CRC-32 check value
-TEST(Crypto_CRC32, check_string_123456789) {
+TEST(check_string_123456789) {
   EXPECT_EQ(sourcemeta::core::crc32("123456789"), 0xCBF43926u);
 }
 
-TEST(Crypto_CRC32, alphabet_lowercase) {
+TEST(alphabet_lowercase) {
   EXPECT_EQ(sourcemeta::core::crc32("abcdefghijklmnopqrstuvwxyz"), 0x4C2750BDu);
 }
 
-TEST(Crypto_CRC32, quick_brown_fox) {
+TEST(quick_brown_fox) {
   EXPECT_EQ(
       sourcemeta::core::crc32("The quick brown fox jumps over the lazy dog"),
       0x414FA339u);
 }
 
-TEST(Crypto_CRC32, embedded_nuls_and_binary_bytes) {
+TEST(embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   EXPECT_EQ(sourcemeta::core::crc32(input), 0x0854897Fu);
 }
 
-TEST(Crypto_CRC32, all_zero_bytes_eight) {
+TEST(all_zero_bytes_eight) {
   const std::string input(8, '\0');
   EXPECT_EQ(sourcemeta::core::crc32(input), 0x6522DF69u);
 }
 
-TEST(Crypto_CRC32, update_zero_initial_matches_single_shot) {
+TEST(update_zero_initial_matches_single_shot) {
   EXPECT_EQ(sourcemeta::core::crc32_update(0u, "abc"),
             sourcemeta::core::crc32("abc"));
 }
 
-TEST(Crypto_CRC32, update_composes_across_chunks) {
+TEST(update_composes_across_chunks) {
   const auto single{sourcemeta::core::crc32("hello world")};
   auto running{sourcemeta::core::crc32_update(0u, "hello")};
   running = sourcemeta::core::crc32_update(running, " world");
   EXPECT_EQ(running, single);
 }
 
-TEST(Crypto_CRC32, update_composes_across_three_chunks) {
+TEST(update_composes_across_three_chunks) {
   const auto single{sourcemeta::core::crc32("The quick brown fox")};
   auto running{sourcemeta::core::crc32_update(0u, "The ")};
   running = sourcemeta::core::crc32_update(running, "quick ");
@@ -64,11 +58,11 @@ TEST(Crypto_CRC32, update_composes_across_three_chunks) {
   EXPECT_EQ(running, single);
 }
 
-TEST(Crypto_CRC32, update_with_empty_input_returns_previous) {
+TEST(update_with_empty_input_returns_previous) {
   EXPECT_EQ(sourcemeta::core::crc32_update(0xCAFEBABEu, ""), 0xCAFEBABEu);
 }
 
-TEST(Crypto_CRC32, update_byte_by_byte_matches_single_shot) {
+TEST(update_byte_by_byte_matches_single_shot) {
   const std::string input{"hello"};
   const auto single{sourcemeta::core::crc32(input)};
   std::uint32_t running{0u};

--- a/test/crypto/crypto_ecdsa_test.cc
+++ b/test/crypto/crypto_ecdsa_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/text.h>
@@ -59,7 +59,7 @@ auto verify_ecdsa(const sourcemeta::core::EllipticCurve curve,
 }
 } // namespace
 
-TEST(Crypto_ecdsa, verify_p256_sha256_valid_signature) {
+TEST(verify_p256_sha256_valid_signature) {
   EXPECT_TRUE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                            sourcemeta::core::SignatureHashFunction::SHA256,
                            sourcemeta::core::hex_to_bytes(P256_QX).value(),
@@ -68,7 +68,7 @@ TEST(Crypto_ecdsa, verify_p256_sha256_valid_signature) {
                            sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_p384_sha384_valid_signature) {
+TEST(verify_p384_sha384_valid_signature) {
   EXPECT_TRUE(verify_ecdsa(sourcemeta::core::EllipticCurve::P384,
                            sourcemeta::core::SignatureHashFunction::SHA384,
                            sourcemeta::core::hex_to_bytes(P384_QX).value(),
@@ -77,7 +77,7 @@ TEST(Crypto_ecdsa, verify_p384_sha384_valid_signature) {
                            sourcemeta::core::hex_to_bytes(P384_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_p521_sha512_valid_signature) {
+TEST(verify_p521_sha512_valid_signature) {
   EXPECT_TRUE(verify_ecdsa(sourcemeta::core::EllipticCurve::P521,
                            sourcemeta::core::SignatureHashFunction::SHA512,
                            sourcemeta::core::hex_to_bytes(P521_QX).value(),
@@ -86,7 +86,7 @@ TEST(Crypto_ecdsa, verify_p521_sha512_valid_signature) {
                            sourcemeta::core::hex_to_bytes(P521_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_different_message) {
+TEST(verify_rejects_different_message) {
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                             sourcemeta::core::SignatureHashFunction::SHA256,
                             sourcemeta::core::hex_to_bytes(P256_QX).value(),
@@ -95,7 +95,7 @@ TEST(Crypto_ecdsa, verify_rejects_different_message) {
                             sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_tampered_r) {
+TEST(verify_rejects_tampered_r) {
   auto signature{sourcemeta::core::hex_to_bytes(P256_SIG).value()};
   signature[0] = static_cast<char>(signature[0] ^ 0x01);
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
@@ -105,7 +105,7 @@ TEST(Crypto_ecdsa, verify_rejects_tampered_r) {
                             MESSAGE, signature));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_tampered_s) {
+TEST(verify_rejects_tampered_s) {
   auto signature{sourcemeta::core::hex_to_bytes(P256_SIG).value()};
   signature.back() = static_cast<char>(signature.back() ^ 0x01);
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
@@ -115,7 +115,7 @@ TEST(Crypto_ecdsa, verify_rejects_tampered_s) {
                             MESSAGE, signature));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_curve_mismatch) {
+TEST(verify_rejects_curve_mismatch) {
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P384,
                             sourcemeta::core::SignatureHashFunction::SHA256,
                             sourcemeta::core::hex_to_bytes(P256_QX).value(),
@@ -124,7 +124,7 @@ TEST(Crypto_ecdsa, verify_rejects_curve_mismatch) {
                             sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_hash_function_mismatch) {
+TEST(verify_rejects_hash_function_mismatch) {
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                             sourcemeta::core::SignatureHashFunction::SHA384,
                             sourcemeta::core::hex_to_bytes(P256_QX).value(),
@@ -133,7 +133,7 @@ TEST(Crypto_ecdsa, verify_rejects_hash_function_mismatch) {
                             sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_truncated_signature) {
+TEST(verify_rejects_truncated_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(P256_SIG).value()};
   signature.pop_back();
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
@@ -143,7 +143,7 @@ TEST(Crypto_ecdsa, verify_rejects_truncated_signature) {
                             MESSAGE, signature));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_zero_signature) {
+TEST(verify_rejects_zero_signature) {
   const std::string signature(64, '\x00');
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                             sourcemeta::core::SignatureHashFunction::SHA256,
@@ -152,7 +152,7 @@ TEST(Crypto_ecdsa, verify_rejects_zero_signature) {
                             MESSAGE, signature));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_point_not_on_curve) {
+TEST(verify_rejects_point_not_on_curve) {
   auto coordinate_y{sourcemeta::core::hex_to_bytes(P256_QY).value()};
   coordinate_y.back() = static_cast<char>(coordinate_y.back() ^ 0x01);
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
@@ -162,7 +162,7 @@ TEST(Crypto_ecdsa, verify_rejects_point_not_on_curve) {
                             sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_empty_signature) {
+TEST(verify_rejects_empty_signature) {
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                             sourcemeta::core::SignatureHashFunction::SHA256,
                             sourcemeta::core::hex_to_bytes(P256_QX).value(),
@@ -170,7 +170,7 @@ TEST(Crypto_ecdsa, verify_rejects_empty_signature) {
                             MESSAGE, ""));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_empty_coordinate) {
+TEST(verify_rejects_empty_coordinate) {
   EXPECT_FALSE(verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                             sourcemeta::core::SignatureHashFunction::SHA256, "",
                             sourcemeta::core::hex_to_bytes(P256_QY).value(),
@@ -178,7 +178,7 @@ TEST(Crypto_ecdsa, verify_rejects_empty_coordinate) {
                             sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_accepts_leading_zero_padded_coordinates) {
+TEST(verify_accepts_leading_zero_padded_coordinates) {
   EXPECT_TRUE(
       verify_ecdsa(sourcemeta::core::EllipticCurve::P256,
                    sourcemeta::core::SignatureHashFunction::SHA256,
@@ -187,7 +187,7 @@ TEST(Crypto_ecdsa, verify_accepts_leading_zero_padded_coordinates) {
                    MESSAGE, sourcemeta::core::hex_to_bytes(P256_SIG).value()));
 }
 
-TEST(Crypto_ecdsa, verify_rejects_oversized_coordinate) {
+TEST(verify_rejects_oversized_coordinate) {
   const std::string coordinate(40, '\xFF');
   EXPECT_FALSE(
       verify_ecdsa(sourcemeta::core::EllipticCurve::P256,

--- a/test/crypto/crypto_eddsa_test.cc
+++ b/test/crypto/crypto_eddsa_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/text.h>
@@ -54,7 +54,7 @@ auto verify_eddsa(const sourcemeta::core::EdwardsCurve curve,
 }
 } // namespace
 
-TEST(Crypto_eddsa, verify_ed25519_empty_message) {
+TEST(verify_ed25519_empty_message) {
   EXPECT_TRUE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST1_PUBLIC_KEY).value(),
@@ -62,7 +62,7 @@ TEST(Crypto_eddsa, verify_ed25519_empty_message) {
                    sourcemeta::core::hex_to_bytes(TEST1_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed25519_one_byte_message) {
+TEST(verify_ed25519_one_byte_message) {
   EXPECT_TRUE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST2_PUBLIC_KEY).value(),
@@ -70,7 +70,7 @@ TEST(Crypto_eddsa, verify_ed25519_one_byte_message) {
                    sourcemeta::core::hex_to_bytes(TEST2_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed25519_two_byte_message) {
+TEST(verify_ed25519_two_byte_message) {
   EXPECT_TRUE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST3_PUBLIC_KEY).value(),
@@ -78,7 +78,7 @@ TEST(Crypto_eddsa, verify_ed25519_two_byte_message) {
                    sourcemeta::core::hex_to_bytes(TEST3_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed25519_sha512_abc_message) {
+TEST(verify_ed25519_sha512_abc_message) {
   EXPECT_TRUE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST_ABC_PUBLIC_KEY).value(),
@@ -86,7 +86,7 @@ TEST(Crypto_eddsa, verify_ed25519_sha512_abc_message) {
                    sourcemeta::core::hex_to_bytes(TEST_ABC_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_rejects_different_message) {
+TEST(verify_rejects_different_message) {
   EXPECT_FALSE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST3_PUBLIC_KEY).value(),
@@ -94,7 +94,7 @@ TEST(Crypto_eddsa, verify_rejects_different_message) {
                    sourcemeta::core::hex_to_bytes(TEST3_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_rejects_tampered_point) {
+TEST(verify_rejects_tampered_point) {
   auto signature{sourcemeta::core::hex_to_bytes(TEST3_SIGNATURE).value()};
   signature[0] = static_cast<char>(signature[0] ^ 0x01);
   EXPECT_FALSE(verify_eddsa(
@@ -103,7 +103,7 @@ TEST(Crypto_eddsa, verify_rejects_tampered_point) {
       sourcemeta::core::hex_to_bytes(TEST3_MESSAGE).value(), signature));
 }
 
-TEST(Crypto_eddsa, verify_rejects_tampered_scalar) {
+TEST(verify_rejects_tampered_scalar) {
   auto signature{sourcemeta::core::hex_to_bytes(TEST3_SIGNATURE).value()};
   signature.back() = static_cast<char>(signature.back() ^ 0x01);
   EXPECT_FALSE(verify_eddsa(
@@ -112,7 +112,7 @@ TEST(Crypto_eddsa, verify_rejects_tampered_scalar) {
       sourcemeta::core::hex_to_bytes(TEST3_MESSAGE).value(), signature));
 }
 
-TEST(Crypto_eddsa, verify_rejects_wrong_public_key) {
+TEST(verify_rejects_wrong_public_key) {
   EXPECT_FALSE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST2_PUBLIC_KEY).value(),
@@ -120,7 +120,7 @@ TEST(Crypto_eddsa, verify_rejects_wrong_public_key) {
                    sourcemeta::core::hex_to_bytes(TEST3_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_rejects_truncated_signature) {
+TEST(verify_rejects_truncated_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(TEST1_SIGNATURE).value()};
   signature.pop_back();
   EXPECT_FALSE(
@@ -129,14 +129,14 @@ TEST(Crypto_eddsa, verify_rejects_truncated_signature) {
                    TEST1_MESSAGE, signature));
 }
 
-TEST(Crypto_eddsa, verify_rejects_empty_signature) {
+TEST(verify_rejects_empty_signature) {
   EXPECT_FALSE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
                    sourcemeta::core::hex_to_bytes(TEST1_PUBLIC_KEY).value(),
                    TEST1_MESSAGE, ""));
 }
 
-TEST(Crypto_eddsa, verify_rejects_zero_signature) {
+TEST(verify_rejects_zero_signature) {
   const std::string signature(64, '\x00');
   EXPECT_FALSE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519,
@@ -144,7 +144,7 @@ TEST(Crypto_eddsa, verify_rejects_zero_signature) {
                    TEST1_MESSAGE, signature));
 }
 
-TEST(Crypto_eddsa, verify_rejects_scalar_above_order) {
+TEST(verify_rejects_scalar_above_order) {
   // The high half of the signature is the scalar S, which the standard
   // requires to lie below the group order (RFC 8032 Section 5.1.7)
   auto signature{sourcemeta::core::hex_to_bytes(TEST3_SIGNATURE).value()};
@@ -158,7 +158,7 @@ TEST(Crypto_eddsa, verify_rejects_scalar_above_order) {
       sourcemeta::core::hex_to_bytes(TEST3_MESSAGE).value(), signature));
 }
 
-TEST(Crypto_eddsa, verify_rejects_wrong_length_public_key) {
+TEST(verify_rejects_wrong_length_public_key) {
   auto public_key{sourcemeta::core::hex_to_bytes(TEST1_PUBLIC_KEY).value()};
   public_key.pop_back();
   EXPECT_FALSE(verify_eddsa(
@@ -166,7 +166,7 @@ TEST(Crypto_eddsa, verify_rejects_wrong_length_public_key) {
       sourcemeta::core::hex_to_bytes(TEST1_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_rejects_empty_public_key) {
+TEST(verify_rejects_empty_public_key) {
   EXPECT_FALSE(
       verify_eddsa(sourcemeta::core::EdwardsCurve::Ed25519, "", TEST1_MESSAGE,
                    sourcemeta::core::hex_to_bytes(TEST1_SIGNATURE).value()));
@@ -190,7 +190,7 @@ static const std::string ED448_ELEVEN_BYTE_MESSAGE{"0c3e544074ec63b0265e0c"};
 static const std::string ED448_ELEVEN_BYTE_SIGNATURE{"1f0a8888ce25e8d458a21130879b840a9089d999aaba039eaf3e3afa090a09d389dba82c4ff2ae8ac5cdfb7c55e94d5d961a29fe0109941e00b8dbdeea6d3b051068df7254c0cdc129cbe62db2dc957dbb47b51fd3f213fb8698f064774250a5028961c9bf8ffd973fe5d5c206492b140e00"};
 // clang-format on
 
-TEST(Crypto_eddsa, verify_ed448_empty_message) {
+TEST(verify_ed448_empty_message) {
   EXPECT_TRUE(verify_eddsa(
       sourcemeta::core::EdwardsCurve::Ed448,
       sourcemeta::core::hex_to_bytes(ED448_BLANK_PUBLIC_KEY).value(),
@@ -198,7 +198,7 @@ TEST(Crypto_eddsa, verify_ed448_empty_message) {
       sourcemeta::core::hex_to_bytes(ED448_BLANK_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed448_one_byte_message) {
+TEST(verify_ed448_one_byte_message) {
   EXPECT_TRUE(verify_eddsa(
       sourcemeta::core::EdwardsCurve::Ed448,
       sourcemeta::core::hex_to_bytes(ED448_ONE_BYTE_PUBLIC_KEY).value(),
@@ -206,7 +206,7 @@ TEST(Crypto_eddsa, verify_ed448_one_byte_message) {
       sourcemeta::core::hex_to_bytes(ED448_ONE_BYTE_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed448_eleven_byte_message) {
+TEST(verify_ed448_eleven_byte_message) {
   EXPECT_TRUE(verify_eddsa(
       sourcemeta::core::EdwardsCurve::Ed448,
       sourcemeta::core::hex_to_bytes(ED448_ELEVEN_BYTE_PUBLIC_KEY).value(),
@@ -214,7 +214,7 @@ TEST(Crypto_eddsa, verify_ed448_eleven_byte_message) {
       sourcemeta::core::hex_to_bytes(ED448_ELEVEN_BYTE_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed448_rejects_different_message) {
+TEST(verify_ed448_rejects_different_message) {
   EXPECT_FALSE(verify_eddsa(
       sourcemeta::core::EdwardsCurve::Ed448,
       sourcemeta::core::hex_to_bytes(ED448_ELEVEN_BYTE_PUBLIC_KEY).value(),
@@ -222,7 +222,7 @@ TEST(Crypto_eddsa, verify_ed448_rejects_different_message) {
       sourcemeta::core::hex_to_bytes(ED448_ELEVEN_BYTE_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed448_rejects_tampered_scalar) {
+TEST(verify_ed448_rejects_tampered_scalar) {
   auto signature{
       sourcemeta::core::hex_to_bytes(ED448_ONE_BYTE_SIGNATURE).value()};
   signature.back() = static_cast<char>(signature.back() ^ 0x01);
@@ -233,7 +233,7 @@ TEST(Crypto_eddsa, verify_ed448_rejects_tampered_scalar) {
       signature));
 }
 
-TEST(Crypto_eddsa, verify_ed448_rejects_wrong_length_signature) {
+TEST(verify_ed448_rejects_wrong_length_signature) {
   // A 64-byte signature is valid for Ed25519 but not for Ed448
   EXPECT_FALSE(verify_eddsa(
       sourcemeta::core::EdwardsCurve::Ed448,
@@ -242,7 +242,7 @@ TEST(Crypto_eddsa, verify_ed448_rejects_wrong_length_signature) {
       sourcemeta::core::hex_to_bytes(TEST1_SIGNATURE).value()));
 }
 
-TEST(Crypto_eddsa, verify_ed448_rejects_ed25519_inputs) {
+TEST(verify_ed448_rejects_ed25519_inputs) {
   // Ed25519-sized key and signature must not verify under Ed448
   EXPECT_FALSE(verify_eddsa(
       sourcemeta::core::EdwardsCurve::Ed448,

--- a/test/crypto/crypto_fnv128_test.cc
+++ b/test/crypto/crypto_fnv128_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -9,28 +9,28 @@
 
 // The digest of the empty string is the FNV offset basis
 // (draft-eastlake-fnv Section 5)
-TEST(Crypto_FNV128, digest_empty_string) {
+TEST(digest_empty_string) {
   const std::array<std::uint8_t, 16> expected{
       {0x6c, 0x62, 0x27, 0x2e, 0x07, 0xbb, 0x01, 0x42, 0x62, 0xb8, 0x21, 0x75,
        0x62, 0x95, 0xc5, 0x8d}};
   EXPECT_EQ(sourcemeta::core::fnv128_digest(""), expected);
 }
 
-TEST(Crypto_FNV128, digest_a_string) {
+TEST(digest_a_string) {
   const std::array<std::uint8_t, 16> expected{
       {0xd2, 0x28, 0xcb, 0x69, 0x10, 0x1a, 0x8c, 0xaf, 0x78, 0x91, 0x2b, 0x70,
        0x4e, 0x4a, 0x14, 0x1e}};
   EXPECT_EQ(sourcemeta::core::fnv128_digest("a"), expected);
 }
 
-TEST(Crypto_FNV128, digest_foobar_string) {
+TEST(digest_foobar_string) {
   const std::array<std::uint8_t, 16> expected{
       {0x78, 0x96, 0xbf, 0xea, 0x9c, 0x3c, 0x64, 0xbf, 0x6d, 0xc5, 0x83, 0x53,
        0xd2, 0xc2, 0x93, 0xaa}};
   EXPECT_EQ(sourcemeta::core::fnv128_digest("foobar"), expected);
 }
 
-TEST(Crypto_FNV128, digest_embedded_nuls_and_binary_bytes) {
+TEST(digest_embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   const std::array<std::uint8_t, 16> expected{
       {0xa6, 0x8b, 0xb3, 0x93, 0x4b, 0x8b, 0x58, 0x22, 0x83, 0x6d, 0xbc, 0x78,
@@ -38,13 +38,13 @@ TEST(Crypto_FNV128, digest_embedded_nuls_and_binary_bytes) {
   EXPECT_EQ(sourcemeta::core::fnv128_digest(input), expected);
 }
 
-TEST(Crypto_FNV128, empty_string) {
+TEST(empty_string) {
   std::ostringstream result;
   sourcemeta::core::fnv128("", result);
   EXPECT_EQ(result.str(), "6c62272e07bb014262b821756295c58d");
 }
 
-TEST(Crypto_FNV128, a_string) {
+TEST(a_string) {
   std::ostringstream result;
   sourcemeta::core::fnv128("a", result);
   EXPECT_EQ(result.str(), "d228cb69101a8caf78912b704e4a141e");
@@ -52,84 +52,84 @@ TEST(Crypto_FNV128, a_string) {
 
 // FNV-1 hashes that differ only in the last input byte must differ
 // only in the lowest bits, as the final operation is the XOR
-TEST(Crypto_FNV128, b_string) {
+TEST(b_string) {
   std::ostringstream result;
   sourcemeta::core::fnv128("b", result);
   EXPECT_EQ(result.str(), "d228cb69101a8caf78912b704e4a141d");
 }
 
-TEST(Crypto_FNV128, abc_string) {
+TEST(abc_string) {
   std::ostringstream result;
   sourcemeta::core::fnv128("abc", result);
   EXPECT_EQ(result.str(), "a68bb2a4348b5822836dbc78c6aee73b");
 }
 
-TEST(Crypto_FNV128, foobar_string) {
+TEST(foobar_string) {
   std::ostringstream result;
   sourcemeta::core::fnv128("foobar", result);
   EXPECT_EQ(result.str(), "7896bfea9c3c64bf6dc58353d2c293aa");
 }
 
-TEST(Crypto_FNV128, example_string) {
+TEST(example_string) {
   std::ostringstream result;
   sourcemeta::core::fnv128("foo bar", result);
   EXPECT_EQ(result.str(), "b5520317e94ff78c12089824c9add07c");
 }
 
 // Classic test string from the FNV reference implementation
-TEST(Crypto_FNV128, chongo_was_here) {
+TEST(chongo_was_here) {
   std::ostringstream result;
   sourcemeta::core::fnv128("chongo was here!\n", result);
   EXPECT_EQ(result.str(), "40ab469af9cf0fe57236785215beee65");
 }
 
-TEST(Crypto_FNV128, quick_brown_fox) {
+TEST(quick_brown_fox) {
   std::ostringstream result;
   sourcemeta::core::fnv128("The quick brown fox jumps over the lazy dog",
                            result);
   EXPECT_EQ(result.str(), "185adb693e7c97844ecfa9497cb529b6");
 }
 
-TEST(Crypto_FNV128, sixteen_bytes) {
+TEST(sixteen_bytes) {
   std::ostringstream result;
   sourcemeta::core::fnv128("0123456789abcdef", result);
   EXPECT_EQ(result.str(), "fdecd6dfdf1f1b9e66786beed1487911");
 }
 
-TEST(Crypto_FNV128, embedded_nuls_and_binary_bytes) {
+TEST(embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   std::ostringstream result;
   sourcemeta::core::fnv128(input, result);
   EXPECT_EQ(result.str(), "a68bb3934b8b5822836dbc78c7423bae");
 }
 
-TEST(Crypto_FNV128, one_million_a_chars) {
+TEST(one_million_a_chars) {
   const std::string input(1000000, 'a');
   std::ostringstream result;
   sourcemeta::core::fnv128(input, result);
   EXPECT_EQ(result.str(), "bdf8b5a26e7a7e826e6b7b4e16359fcd");
 }
 
-TEST(Crypto_FNV128, to_string_empty) {
+TEST(to_string_empty) {
   EXPECT_EQ(sourcemeta::core::fnv128(""), "6c62272e07bb014262b821756295c58d");
 }
 
-TEST(Crypto_FNV128, to_string_a) {
+TEST(to_string_a) {
   EXPECT_EQ(sourcemeta::core::fnv128("a"), "d228cb69101a8caf78912b704e4a141e");
 }
 
-TEST(Crypto_FNV128, to_string_foobar) {
+TEST(to_string_foobar) {
   EXPECT_EQ(sourcemeta::core::fnv128("foobar"),
             "7896bfea9c3c64bf6dc58353d2c293aa");
 }
 
-TEST(Crypto_FNV128, to_string_quick_brown_fox) {
+TEST(to_string_quick_brown_fox) {
   EXPECT_EQ(
       sourcemeta::core::fnv128("The quick brown fox jumps over the lazy dog"),
       "185adb693e7c97844ecfa9497cb529b6");
 }
 
-TEST(Crypto_FNV128, to_string_one_million_a_chars) {
+TEST(to_string_one_million_a_chars) {
   const std::string input(1000000, 'a');
   EXPECT_EQ(sourcemeta::core::fnv128(input),
             "bdf8b5a26e7a7e826e6b7b4e16359fcd");

--- a/test/crypto/crypto_rsassa_pkcs1_v15_test.cc
+++ b/test/crypto/crypto_rsassa_pkcs1_v15_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/text.h>
@@ -65,7 +65,7 @@ auto verify_pkcs1(const sourcemeta::core::SignatureHashFunction hash,
 }
 } // namespace
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_sha256_valid_signature) {
+TEST(verify_sha256_valid_signature) {
   EXPECT_TRUE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -73,7 +73,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_sha256_valid_signature) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_sha384_valid_signature) {
+TEST(verify_sha384_valid_signature) {
   EXPECT_TRUE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA384,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -81,7 +81,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_sha384_valid_signature) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA384_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_sha512_valid_signature) {
+TEST(verify_sha512_valid_signature) {
   EXPECT_TRUE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA512,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -89,7 +89,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_sha512_valid_signature) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA512_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_exponent_with_leading_zeros) {
+TEST(verify_exponent_with_leading_zeros) {
   EXPECT_TRUE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -97,7 +97,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_exponent_with_leading_zeros) {
       MESSAGE, sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_different_message) {
+TEST(verify_rejects_different_message) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -106,7 +106,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_different_message) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_tampered_signature) {
+TEST(verify_rejects_tampered_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
   signature[0] = static_cast<char>(signature[0] ^ 0x01);
   EXPECT_FALSE(
@@ -116,7 +116,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_tampered_signature) {
                    MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_hash_function_mismatch) {
+TEST(verify_rejects_hash_function_mismatch) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA384,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -124,7 +124,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_hash_function_mismatch) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_truncated_signature) {
+TEST(verify_rejects_truncated_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
   signature.pop_back();
   EXPECT_FALSE(
@@ -134,7 +134,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_truncated_signature) {
                    MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_extended_signature) {
+TEST(verify_rejects_extended_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
   signature.push_back('\x00');
   EXPECT_FALSE(
@@ -144,7 +144,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_extended_signature) {
                    MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_signature_equal_to_modulus) {
+TEST(verify_rejects_signature_equal_to_modulus) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -152,7 +152,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_signature_equal_to_modulus) {
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_wrong_exponent) {
+TEST(verify_rejects_wrong_exponent) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -160,28 +160,28 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_wrong_exponent) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_empty_signature) {
+TEST(verify_rejects_empty_signature) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
       sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(), MESSAGE, ""));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_empty_modulus) {
+TEST(verify_rejects_empty_modulus) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256, "",
       sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(), MESSAGE,
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_empty_exponent) {
+TEST(verify_rejects_empty_exponent) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(), "", MESSAGE,
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_empty_message) {
+TEST(verify_rejects_empty_message) {
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -189,7 +189,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_empty_message) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_modulus_with_leading_zeros) {
+TEST(verify_modulus_with_leading_zeros) {
   EXPECT_TRUE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes("0000" + MODULUS_HEX).value(),
@@ -197,7 +197,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_modulus_with_leading_zeros) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_oversized_modulus) {
+TEST(verify_rejects_oversized_modulus) {
   const std::string modulus(520, '\xFF');
   const std::string signature(520, '\x01');
   EXPECT_FALSE(
@@ -206,7 +206,7 @@ TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_oversized_modulus) {
                    MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pkcs1_v15, verify_rejects_oversized_exponent) {
+TEST(verify_rejects_oversized_exponent) {
   const std::string exponent(520, '\xFF');
   EXPECT_FALSE(verify_pkcs1(
       sourcemeta::core::SignatureHashFunction::SHA256,

--- a/test/crypto/crypto_rsassa_pss_test.cc
+++ b/test/crypto/crypto_rsassa_pss_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/text.h>
@@ -89,7 +89,7 @@ auto verify_pss(const sourcemeta::core::SignatureHashFunction hash,
 }
 } // namespace
 
-TEST(Crypto_rsassa_pss, verify_sha256_valid_signature) {
+TEST(verify_sha256_valid_signature) {
   EXPECT_TRUE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
                  sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -97,7 +97,7 @@ TEST(Crypto_rsassa_pss, verify_sha256_valid_signature) {
                  sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_sha384_valid_signature) {
+TEST(verify_sha384_valid_signature) {
   EXPECT_TRUE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA384,
                  sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -105,7 +105,7 @@ TEST(Crypto_rsassa_pss, verify_sha384_valid_signature) {
                  sourcemeta::core::hex_to_bytes(SIGNATURE_SHA384_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_sha512_valid_signature) {
+TEST(verify_sha512_valid_signature) {
   EXPECT_TRUE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA512,
                  sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -116,7 +116,7 @@ TEST(Crypto_rsassa_pss, verify_sha512_valid_signature) {
 // RFC 7518 Section 3.5: "The size of the salt value is the same size as the
 // hash function output", hence signatures carrying any other salt length
 // must be rejected
-TEST(Crypto_rsassa_pss, verify_rejects_salt_length_other_than_digest) {
+TEST(verify_rejects_salt_length_other_than_digest) {
   EXPECT_FALSE(verify_pss(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -124,7 +124,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_salt_length_other_than_digest) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_SALT_10_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_pkcs1_v15_signature) {
+TEST(verify_rejects_pkcs1_v15_signature) {
   EXPECT_FALSE(verify_pss(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -132,7 +132,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_pkcs1_v15_signature) {
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_PKCS1_V15_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_different_message) {
+TEST(verify_rejects_different_message) {
   EXPECT_FALSE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
                  sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -141,7 +141,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_different_message) {
                  sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_tampered_signature) {
+TEST(verify_rejects_tampered_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
   signature[0] = static_cast<char>(signature[0] ^ 0x01);
   EXPECT_FALSE(verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
@@ -150,7 +150,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_tampered_signature) {
                           MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_hash_function_mismatch) {
+TEST(verify_rejects_hash_function_mismatch) {
   EXPECT_FALSE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA384,
                  sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
@@ -158,7 +158,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_hash_function_mismatch) {
                  sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_truncated_signature) {
+TEST(verify_rejects_truncated_signature) {
   auto signature{sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
   signature.pop_back();
   EXPECT_FALSE(verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
@@ -167,7 +167,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_truncated_signature) {
                           MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_signature_equal_to_modulus) {
+TEST(verify_rejects_signature_equal_to_modulus) {
   EXPECT_FALSE(verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
                           sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
                           sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(),
@@ -175,28 +175,28 @@ TEST(Crypto_rsassa_pss, verify_rejects_signature_equal_to_modulus) {
                           sourcemeta::core::hex_to_bytes(MODULUS_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_empty_signature) {
+TEST(verify_rejects_empty_signature) {
   EXPECT_FALSE(verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
                           sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
                           sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(),
                           MESSAGE, ""));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_empty_modulus) {
+TEST(verify_rejects_empty_modulus) {
   EXPECT_FALSE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA256, "",
                  sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(), MESSAGE,
                  sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_empty_exponent) {
+TEST(verify_rejects_empty_exponent) {
   EXPECT_FALSE(verify_pss(
       sourcemeta::core::SignatureHashFunction::SHA256,
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(), "", MESSAGE,
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_modulus_with_leading_zeros) {
+TEST(verify_modulus_with_leading_zeros) {
   EXPECT_TRUE(
       verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
                  sourcemeta::core::hex_to_bytes("0000" + MODULUS_HEX).value(),
@@ -204,7 +204,7 @@ TEST(Crypto_rsassa_pss, verify_modulus_with_leading_zeros) {
                  sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_oversized_modulus) {
+TEST(verify_rejects_oversized_modulus) {
   const std::string modulus(520, '\xFF');
   const std::string signature(520, '\x01');
   EXPECT_FALSE(verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
@@ -213,7 +213,7 @@ TEST(Crypto_rsassa_pss, verify_rejects_oversized_modulus) {
                           MESSAGE, signature));
 }
 
-TEST(Crypto_rsassa_pss, verify_rejects_oversized_exponent) {
+TEST(verify_rejects_oversized_exponent) {
   const std::string exponent(520, '\xFF');
   EXPECT_FALSE(verify_pss(
       sourcemeta::core::SignatureHashFunction::SHA256,

--- a/test/crypto/crypto_sha1_test.cc
+++ b/test/crypto/crypto_sha1_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -6,7 +6,7 @@
 #include <string>
 
 // Try $ echo -n "" | sha1sum
-TEST(Crypto_SHA1, empty_string) {
+TEST(empty_string) {
   std::ostringstream result;
   sourcemeta::core::sha1("", result);
   EXPECT_EQ(result.str(), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
@@ -14,14 +14,14 @@ TEST(Crypto_SHA1, empty_string) {
 
 // RFC 3174 Section 7.3 TEST1
 // Try $ echo -n "abc" | sha1sum
-TEST(Crypto_SHA1, abc_string) {
+TEST(abc_string) {
   std::ostringstream result;
   sourcemeta::core::sha1("abc", result);
   EXPECT_EQ(result.str(), "a9993e364706816aba3e25717850c26c9cd0d89d");
 }
 
 // RFC 3174 Section 7.3 TEST2
-TEST(Crypto_SHA1, rfc3174_test_2) {
+TEST(rfc3174_test_2) {
   std::ostringstream result;
   sourcemeta::core::sha1(
       "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", result);
@@ -29,7 +29,7 @@ TEST(Crypto_SHA1, rfc3174_test_2) {
 }
 
 // RFC 3174 Section 7.3 TEST4
-TEST(Crypto_SHA1, rfc3174_test_4) {
+TEST(rfc3174_test_4) {
   std::string input;
   for (int repetition = 0; repetition < 10; ++repetition) {
     input += "0123456701234567012345670123456701234567012345670123456701234567";
@@ -41,27 +41,27 @@ TEST(Crypto_SHA1, rfc3174_test_4) {
 }
 
 // Try $ echo -n "foo bar" | sha1sum
-TEST(Crypto_SHA1, example_string) {
+TEST(example_string) {
   std::ostringstream result;
   sourcemeta::core::sha1("foo bar", result);
   EXPECT_EQ(result.str(), "3773dea65156909838fa6c22825cafe090ff8030");
 }
 
 // Try $ echo -n "The quick brown fox jumps over the lazy dog" | sha1sum
-TEST(Crypto_SHA1, quick_brown_fox) {
+TEST(quick_brown_fox) {
   std::ostringstream result;
   sourcemeta::core::sha1("The quick brown fox jumps over the lazy dog", result);
   EXPECT_EQ(result.str(), "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12");
 }
 
-TEST(Crypto_SHA1, one_million_a_chars) {
+TEST(one_million_a_chars) {
   const std::string input(1000000, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "34aa973cd4c4daa4f61eeb2bdbad27316534016f");
 }
 
-TEST(Crypto_SHA1, embedded_nuls_and_binary_bytes) {
+TEST(embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
@@ -69,7 +69,7 @@ TEST(Crypto_SHA1, embedded_nuls_and_binary_bytes) {
 }
 
 // 55 bytes is the largest input that fits in a single padded block
-TEST(Crypto_SHA1, padding_boundary_55_chars) {
+TEST(padding_boundary_55_chars) {
   const std::string input(55, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
@@ -77,76 +77,76 @@ TEST(Crypto_SHA1, padding_boundary_55_chars) {
 }
 
 // 56 bytes forces the length to spill into a second padded block
-TEST(Crypto_SHA1, padding_boundary_56_chars) {
+TEST(padding_boundary_56_chars) {
   const std::string input(56, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "c2db330f6083854c99d4b5bfb6e8f29f201be699");
 }
 
-TEST(Crypto_SHA1, padding_boundary_63_chars) {
+TEST(padding_boundary_63_chars) {
   const std::string input(63, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "03f09f5b158a7a8cdad920bddc29b81c18a551f5");
 }
 
-TEST(Crypto_SHA1, padding_boundary_64_chars) {
+TEST(padding_boundary_64_chars) {
   const std::string input(64, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "0098ba824b5c16427bd7a1122a5a442a25ec644d");
 }
 
-TEST(Crypto_SHA1, padding_boundary_65_chars) {
+TEST(padding_boundary_65_chars) {
   const std::string input(65, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "11655326c708d70319be2610e8a57d9a5b959d3b");
 }
 
-TEST(Crypto_SHA1, padding_boundary_119_chars) {
+TEST(padding_boundary_119_chars) {
   const std::string input(119, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "ee971065aaa017e0632a8ca6c77bb3bf8b1dfc56");
 }
 
-TEST(Crypto_SHA1, padding_boundary_120_chars) {
+TEST(padding_boundary_120_chars) {
   const std::string input(120, 'a');
   std::ostringstream result;
   sourcemeta::core::sha1(input, result);
   EXPECT_EQ(result.str(), "f34c1488385346a55709ba056ddd08280dd4c6d6");
 }
 
-TEST(Crypto_SHA1, to_string_empty) {
+TEST(to_string_empty) {
   EXPECT_EQ(sourcemeta::core::sha1(""),
             "da39a3ee5e6b4b0d3255bfef95601890afd80709");
 }
 
-TEST(Crypto_SHA1, to_string_abc) {
+TEST(to_string_abc) {
   EXPECT_EQ(sourcemeta::core::sha1("abc"),
             "a9993e364706816aba3e25717850c26c9cd0d89d");
 }
 
-TEST(Crypto_SHA1, to_string_example) {
+TEST(to_string_example) {
   EXPECT_EQ(sourcemeta::core::sha1("foo bar"),
             "3773dea65156909838fa6c22825cafe090ff8030");
 }
 
-TEST(Crypto_SHA1, to_string_quick_brown_fox) {
+TEST(to_string_quick_brown_fox) {
   EXPECT_EQ(
       sourcemeta::core::sha1("The quick brown fox jumps over the lazy dog"),
       "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12");
 }
 
-TEST(Crypto_SHA1, to_string_one_million_a_chars) {
+TEST(to_string_one_million_a_chars) {
   const std::string input(1000000, 'a');
   EXPECT_EQ(sourcemeta::core::sha1(input),
             "34aa973cd4c4daa4f61eeb2bdbad27316534016f");
 }
 
-TEST(Crypto_SHA1, to_string_embedded_nuls_and_binary_bytes) {
+TEST(to_string_embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   EXPECT_EQ(sourcemeta::core::sha1(input),
             "0c7a623fd2bbc05b06423be359e4021d36e721ad");

--- a/test/crypto/crypto_sha256_test.cc
+++ b/test/crypto/crypto_sha256_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -8,7 +8,7 @@
 #include <string>
 
 // Try $ echo -n "" | sha256sum
-TEST(Crypto_SHA256, empty_string) {
+TEST(empty_string) {
   std::ostringstream result;
   sourcemeta::core::sha256("", result);
   EXPECT_EQ(result.str(),
@@ -16,7 +16,7 @@ TEST(Crypto_SHA256, empty_string) {
 }
 
 // Try $ echo -n "abc" | sha256sum
-TEST(Crypto_SHA256, abc_string) {
+TEST(abc_string) {
   std::ostringstream result;
   sourcemeta::core::sha256("abc", result);
   EXPECT_EQ(result.str(),
@@ -24,7 +24,7 @@ TEST(Crypto_SHA256, abc_string) {
 }
 
 // Try $ echo -n "foo bar" | sha256sum
-TEST(Crypto_SHA256, example_string) {
+TEST(example_string) {
   std::ostringstream result;
   sourcemeta::core::sha256("foo bar", result);
   EXPECT_EQ(result.str(),
@@ -32,7 +32,7 @@ TEST(Crypto_SHA256, example_string) {
 }
 
 // Try $ echo -n "The quick brown fox jumps over the lazy dog" | sha256sum
-TEST(Crypto_SHA256, quick_brown_fox) {
+TEST(quick_brown_fox) {
   std::ostringstream result;
   sourcemeta::core::sha256("The quick brown fox jumps over the lazy dog",
                            result);
@@ -40,7 +40,7 @@ TEST(Crypto_SHA256, quick_brown_fox) {
             "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
 }
 
-TEST(Crypto_SHA256, one_million_a_chars) {
+TEST(one_million_a_chars) {
   const std::string input(1000000, 'a');
   std::ostringstream result;
   sourcemeta::core::sha256(input, result);
@@ -48,7 +48,7 @@ TEST(Crypto_SHA256, one_million_a_chars) {
             "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
 }
 
-TEST(Crypto_SHA256, embedded_nuls_and_binary_bytes) {
+TEST(embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   std::ostringstream result;
   sourcemeta::core::sha256(input, result);
@@ -56,40 +56,40 @@ TEST(Crypto_SHA256, embedded_nuls_and_binary_bytes) {
             "ae4b3280e56e2faf83f414a6e3dabe9d5fbe18976544c05fed121accb85b53fc");
 }
 
-TEST(Crypto_SHA256, to_string_empty) {
+TEST(to_string_empty) {
   EXPECT_EQ(sourcemeta::core::sha256(""),
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 }
 
-TEST(Crypto_SHA256, to_string_abc) {
+TEST(to_string_abc) {
   EXPECT_EQ(sourcemeta::core::sha256("abc"),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
 }
 
-TEST(Crypto_SHA256, to_string_example) {
+TEST(to_string_example) {
   EXPECT_EQ(sourcemeta::core::sha256("foo bar"),
             "fbc1a9f858ea9e177916964bd88c3d37b91a1e84412765e29950777f265c4b75");
 }
 
-TEST(Crypto_SHA256, to_string_quick_brown_fox) {
+TEST(to_string_quick_brown_fox) {
   EXPECT_EQ(
       sourcemeta::core::sha256("The quick brown fox jumps over the lazy dog"),
       "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
 }
 
-TEST(Crypto_SHA256, to_string_one_million_a_chars) {
+TEST(to_string_one_million_a_chars) {
   const std::string input(1000000, 'a');
   EXPECT_EQ(sourcemeta::core::sha256(input),
             "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
 }
 
-TEST(Crypto_SHA256, to_string_embedded_nuls_and_binary_bytes) {
+TEST(to_string_embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   EXPECT_EQ(sourcemeta::core::sha256(input),
             "ae4b3280e56e2faf83f414a6e3dabe9d5fbe18976544c05fed121accb85b53fc");
 }
 
-TEST(Crypto_SHA256, digest_empty) {
+TEST(digest_empty) {
   const std::array<std::uint8_t, 32> expected{
       {0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4,
        0xc8, 0x99, 0x6f, 0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b,
@@ -97,7 +97,7 @@ TEST(Crypto_SHA256, digest_empty) {
   EXPECT_EQ(sourcemeta::core::sha256_digest(""), expected);
 }
 
-TEST(Crypto_SHA256, digest_abc) {
+TEST(digest_abc) {
   const std::array<std::uint8_t, 32> expected{
       {0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40,
        0xde, 0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17,

--- a/test/crypto/crypto_sha384_test.cc
+++ b/test/crypto/crypto_sha384_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -8,7 +8,7 @@
 #include <string>  // std::string
 
 // Try $ echo -n "" | shasum -a 384
-TEST(Crypto_SHA384, empty_string) {
+TEST(empty_string) {
   std::ostringstream result;
   sourcemeta::core::sha384("", result);
   EXPECT_EQ(result.str(), "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
@@ -16,7 +16,7 @@ TEST(Crypto_SHA384, empty_string) {
 }
 
 // Try $ echo -n "abc" | shasum -a 384
-TEST(Crypto_SHA384, abc_string) {
+TEST(abc_string) {
   std::ostringstream result;
   sourcemeta::core::sha384("abc", result);
   EXPECT_EQ(result.str(), "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
@@ -24,7 +24,7 @@ TEST(Crypto_SHA384, abc_string) {
 }
 
 // Try $ echo -n "foo bar" | shasum -a 384
-TEST(Crypto_SHA384, example_string) {
+TEST(example_string) {
   std::ostringstream result;
   sourcemeta::core::sha384("foo bar", result);
   EXPECT_EQ(result.str(), "6839312f3db343477070d3c0b2becd417b357154d48794d01d"
@@ -32,7 +32,7 @@ TEST(Crypto_SHA384, example_string) {
 }
 
 // Try $ echo -n "The quick brown fox jumps over the lazy dog" | shasum -a 384
-TEST(Crypto_SHA384, quick_brown_fox) {
+TEST(quick_brown_fox) {
   std::ostringstream result;
   sourcemeta::core::sha384("The quick brown fox jumps over the lazy dog",
                            result);
@@ -41,7 +41,7 @@ TEST(Crypto_SHA384, quick_brown_fox) {
 }
 
 // FIPS 180-4 two-block message sample
-TEST(Crypto_SHA384, fips_two_block_message) {
+TEST(fips_two_block_message) {
   std::ostringstream result;
   sourcemeta::core::sha384("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmgh"
                            "ijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnop"
@@ -51,7 +51,7 @@ TEST(Crypto_SHA384, fips_two_block_message) {
                           "a08086e3b0f712fcc7c71a557e2db966c3e9fa91746039");
 }
 
-TEST(Crypto_SHA384, one_million_a_chars) {
+TEST(one_million_a_chars) {
   const std::string input(1000000, 'a');
   std::ostringstream result;
   sourcemeta::core::sha384(input, result);
@@ -59,7 +59,7 @@ TEST(Crypto_SHA384, one_million_a_chars) {
                           "72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985");
 }
 
-TEST(Crypto_SHA384, embedded_nuls_and_binary_bytes) {
+TEST(embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   std::ostringstream result;
   sourcemeta::core::sha384(input, result);
@@ -67,46 +67,46 @@ TEST(Crypto_SHA384, embedded_nuls_and_binary_bytes) {
                           "d76b8fa3cd95ceea29eab6a279f8b08437703ce0b4b91a");
 }
 
-TEST(Crypto_SHA384, to_string_empty) {
+TEST(to_string_empty) {
   EXPECT_EQ(sourcemeta::core::sha384(""),
             "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c"
             "0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b");
 }
 
-TEST(Crypto_SHA384, to_string_abc) {
+TEST(to_string_abc) {
   EXPECT_EQ(sourcemeta::core::sha384("abc"),
             "cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a"
             "8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7");
 }
 
-TEST(Crypto_SHA384, to_string_example) {
+TEST(to_string_example) {
   EXPECT_EQ(sourcemeta::core::sha384("foo bar"),
             "6839312f3db343477070d3c0b2becd417b357154d48794d01d"
             "78cfb4617ed5ab819a77b6832f6542dd18bb738131ef7e");
 }
 
-TEST(Crypto_SHA384, to_string_quick_brown_fox) {
+TEST(to_string_quick_brown_fox) {
   EXPECT_EQ(
       sourcemeta::core::sha384("The quick brown fox jumps over the lazy dog"),
       "ca737f1014a48f4c0b6dd43cb177b0afd9e5169367544c4940"
       "11e3317dbf9a509cb1e5dc1e85a941bbee3d7f2afbc9b1");
 }
 
-TEST(Crypto_SHA384, to_string_one_million_a_chars) {
+TEST(to_string_one_million_a_chars) {
   const std::string input(1000000, 'a');
   EXPECT_EQ(sourcemeta::core::sha384(input),
             "9d0e1809716474cb086e834e310a4a1ced149e9c00f2485279"
             "72cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985");
 }
 
-TEST(Crypto_SHA384, to_string_embedded_nuls_and_binary_bytes) {
+TEST(to_string_embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   EXPECT_EQ(sourcemeta::core::sha384(input),
             "4f895854c1a4fc5aa2e0456eaf8d0ecaa70c196bd901153861"
             "d76b8fa3cd95ceea29eab6a279f8b08437703ce0b4b91a");
 }
 
-TEST(Crypto_SHA384, digest_empty) {
+TEST(digest_empty) {
   const std::array<std::uint8_t, 48> expected{
       {0x38, 0xb0, 0x60, 0xa7, 0x51, 0xac, 0x96, 0x38, 0x4c, 0xd9, 0x32, 0x7e,
        0xb1, 0xb1, 0xe3, 0x6a, 0x21, 0xfd, 0xb7, 0x11, 0x14, 0xbe, 0x07, 0x43,
@@ -115,7 +115,7 @@ TEST(Crypto_SHA384, digest_empty) {
   EXPECT_EQ(sourcemeta::core::sha384_digest(""), expected);
 }
 
-TEST(Crypto_SHA384, digest_abc) {
+TEST(digest_abc) {
   const std::array<std::uint8_t, 48> expected{
       {0xcb, 0x00, 0x75, 0x3f, 0x45, 0xa3, 0x5e, 0x8b, 0xb5, 0xa0, 0x3d, 0x69,
        0x9a, 0xc6, 0x50, 0x07, 0x27, 0x2c, 0x32, 0xab, 0x0e, 0xde, 0xd1, 0x63,

--- a/test/crypto/crypto_sha512_test.cc
+++ b/test/crypto/crypto_sha512_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 
@@ -8,7 +8,7 @@
 #include <string>  // std::string
 
 // Try $ echo -n "" | shasum -a 512
-TEST(Crypto_SHA512, empty_string) {
+TEST(empty_string) {
   std::ostringstream result;
   sourcemeta::core::sha512("", result);
   EXPECT_EQ(result.str(),
@@ -17,7 +17,7 @@ TEST(Crypto_SHA512, empty_string) {
 }
 
 // Try $ echo -n "abc" | shasum -a 512
-TEST(Crypto_SHA512, abc_string) {
+TEST(abc_string) {
   std::ostringstream result;
   sourcemeta::core::sha512("abc", result);
   EXPECT_EQ(result.str(),
@@ -26,7 +26,7 @@ TEST(Crypto_SHA512, abc_string) {
 }
 
 // Try $ echo -n "foo bar" | shasum -a 512
-TEST(Crypto_SHA512, example_string) {
+TEST(example_string) {
   std::ostringstream result;
   sourcemeta::core::sha512("foo bar", result);
   EXPECT_EQ(result.str(),
@@ -35,7 +35,7 @@ TEST(Crypto_SHA512, example_string) {
 }
 
 // Try $ echo -n "The quick brown fox jumps over the lazy dog" | shasum -a 512
-TEST(Crypto_SHA512, quick_brown_fox) {
+TEST(quick_brown_fox) {
   std::ostringstream result;
   sourcemeta::core::sha512("The quick brown fox jumps over the lazy dog",
                            result);
@@ -45,7 +45,7 @@ TEST(Crypto_SHA512, quick_brown_fox) {
 }
 
 // FIPS 180-4 two-block message sample
-TEST(Crypto_SHA512, fips_two_block_message) {
+TEST(fips_two_block_message) {
   std::ostringstream result;
   sourcemeta::core::sha512("abcdefghbcdefghicdefghijdefghijkefghijklfghijklmgh"
                            "ijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnop"
@@ -56,7 +56,7 @@ TEST(Crypto_SHA512, fips_two_block_message) {
             "501d289e4900f7e4331b99dec4b5433ac7d329eeb6dd26545e96e55b874be909");
 }
 
-TEST(Crypto_SHA512, one_million_a_chars) {
+TEST(one_million_a_chars) {
   const std::string input(1000000, 'a');
   std::ostringstream result;
   sourcemeta::core::sha512(input, result);
@@ -65,7 +65,7 @@ TEST(Crypto_SHA512, one_million_a_chars) {
             "de0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b");
 }
 
-TEST(Crypto_SHA512, embedded_nuls_and_binary_bytes) {
+TEST(embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   std::ostringstream result;
   sourcemeta::core::sha512(input, result);
@@ -74,46 +74,46 @@ TEST(Crypto_SHA512, embedded_nuls_and_binary_bytes) {
             "e0f034ea8dc1dacff3361a892d625fbe1b614cda265f87a473c24b0fa1d91dfd");
 }
 
-TEST(Crypto_SHA512, to_string_empty) {
+TEST(to_string_empty) {
   EXPECT_EQ(sourcemeta::core::sha512(""),
             "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce"
             "47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
 }
 
-TEST(Crypto_SHA512, to_string_abc) {
+TEST(to_string_abc) {
   EXPECT_EQ(sourcemeta::core::sha512("abc"),
             "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
             "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f");
 }
 
-TEST(Crypto_SHA512, to_string_example) {
+TEST(to_string_example) {
   EXPECT_EQ(sourcemeta::core::sha512("foo bar"),
             "65019286222ace418f742556366f9b9da5aaf6797527d2f0cba5bfe6b2f8ed24"
             "746542a0f2be1da8d63c2477f688b608eb53628993afa624f378b03f10090ce7");
 }
 
-TEST(Crypto_SHA512, to_string_quick_brown_fox) {
+TEST(to_string_quick_brown_fox) {
   EXPECT_EQ(
       sourcemeta::core::sha512("The quick brown fox jumps over the lazy dog"),
       "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb64"
       "2e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6");
 }
 
-TEST(Crypto_SHA512, to_string_one_million_a_chars) {
+TEST(to_string_one_million_a_chars) {
   const std::string input(1000000, 'a');
   EXPECT_EQ(sourcemeta::core::sha512(input),
             "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973eb"
             "de0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b");
 }
 
-TEST(Crypto_SHA512, to_string_embedded_nuls_and_binary_bytes) {
+TEST(to_string_embedded_nuls_and_binary_bytes) {
   const std::string input("\x00\x01\x02", 3);
   EXPECT_EQ(sourcemeta::core::sha512(input),
             "8081da5f9c1e3d0e1aa16f604d5e5064543cff5d7bace2bb312252461e151b3f"
             "e0f034ea8dc1dacff3361a892d625fbe1b614cda265f87a473c24b0fa1d91dfd");
 }
 
-TEST(Crypto_SHA512, digest_empty) {
+TEST(digest_empty) {
   const std::array<std::uint8_t, 64> expected{
       {0xcf, 0x83, 0xe1, 0x35, 0x7e, 0xef, 0xb8, 0xbd, 0xf1, 0x54, 0x28,
        0x50, 0xd6, 0x6d, 0x80, 0x07, 0xd6, 0x20, 0xe4, 0x05, 0x0b, 0x57,
@@ -124,7 +124,7 @@ TEST(Crypto_SHA512, digest_empty) {
   EXPECT_EQ(sourcemeta::core::sha512_digest(""), expected);
 }
 
-TEST(Crypto_SHA512, digest_abc) {
+TEST(digest_abc) {
   const std::array<std::uint8_t, 64> expected{
       {0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba, 0xcc, 0x41, 0x73,
        0x49, 0xae, 0x20, 0x41, 0x31, 0x12, 0xe6, 0xfa, 0x4e, 0x89, 0xa9,

--- a/test/crypto/crypto_uuid_test.cc
+++ b/test/crypto/crypto_uuid_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/regex.h>
 
-TEST(Crypto_uuid_v4, regex) {
+TEST(regex) {
   const auto uuid{sourcemeta::core::uuidv4()};
   EXPECT_TRUE(sourcemeta::core::matches_if_valid(
       "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
@@ -11,7 +11,7 @@ TEST(Crypto_uuid_v4, regex) {
   EXPECT_TRUE(sourcemeta::core::is_uuid_like(uuid));
 }
 
-TEST(Crypto_uuid_v4, version_and_variant) {
+TEST(version_and_variant) {
   for (auto count = 0; count < 100; ++count) {
     const auto uuid{sourcemeta::core::uuidv4()};
     EXPECT_EQ(uuid[14], '4');
@@ -21,7 +21,7 @@ TEST(Crypto_uuid_v4, version_and_variant) {
   }
 }
 
-TEST(Crypto_uuid_v4, idempotent) {
+TEST(idempotent) {
   const auto uuid_1{sourcemeta::core::uuidv4()};
   const auto uuid_2{sourcemeta::core::uuidv4()};
   const auto uuid_3{sourcemeta::core::uuidv4()};
@@ -33,106 +33,104 @@ TEST(Crypto_uuid_v4, idempotent) {
   EXPECT_TRUE(sourcemeta::core::is_uuid_like(uuid_3));
 }
 
-TEST(Crypto_is_uuid_like, valid_all_upper_case) {
+TEST(valid_all_upper_case) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("2EB8AA08-AA98-11EA-B4AA-73B441D16380"));
 }
 
-TEST(Crypto_is_uuid_like, valid_all_lower_case) {
+TEST(valid_all_lower_case) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, valid_mixed_case) {
+TEST(valid_mixed_case) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("2eb8aa08-AA98-11ea-B4Aa-73B441D16380"));
 }
 
-TEST(Crypto_is_uuid_like, valid_all_zeroes) {
+TEST(valid_all_zeroes) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("00000000-0000-0000-0000-000000000000"));
 }
 
-TEST(Crypto_is_uuid_like, valid_version_4) {
+TEST(valid_version_4) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("98d80576-482e-427f-8434-7f86890ab222"));
 }
 
-TEST(Crypto_is_uuid_like, valid_version_5) {
+TEST(valid_version_5) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("99c17cbb-656f-564a-940f-1a4568f03487"));
 }
 
-TEST(Crypto_is_uuid_like, valid_hypothetical_version_6) {
+TEST(valid_hypothetical_version_6) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("99c17cbb-656f-664a-940f-1a4568f03487"));
 }
 
-TEST(Crypto_is_uuid_like, valid_hypothetical_version_15) {
+TEST(valid_hypothetical_version_15) {
   EXPECT_TRUE(
       sourcemeta::core::is_uuid_like("99c17cbb-656f-f64a-940f-1a4568f03487"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_wrong_length) {
+TEST(invalid_wrong_length) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d1638"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_missing_section) {
+TEST(invalid_missing_section) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-73b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_non_hex_character) {
+TEST(invalid_non_hex_character) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4ga-73b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_no_dashes) {
+TEST(invalid_no_dashes) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08aa9811eab4aa73b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_too_few_dashes) {
+TEST(invalid_too_few_dashes) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08aa98-11ea-b4aa73b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_too_many_dashes) {
+TEST(invalid_too_many_dashes) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8-aa08-aa98-11ea-b4aa73b44-1d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_dashes_in_wrong_spot) {
+TEST(invalid_dashes_in_wrong_spot) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08aa9811eab4aa73b441d16380----"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_shifted_dashes) {
+TEST(invalid_shifted_dashes) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa0-8aa98-11e-ab4aa7-3b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_uuid_like(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_uuid_like("")); }
 
-TEST(Crypto_is_uuid_like, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d16380 "));
 }
 
-TEST(Crypto_is_uuid_like, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like(" 2eb8aa08-aa98-11ea-b4aa-73b441d16380"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_braces) {
+TEST(invalid_braces) {
   EXPECT_FALSE(
       sourcemeta::core::is_uuid_like("{2eb8aa08-aa98-11ea-b4aa-73b441d16380}"));
 }
 
-TEST(Crypto_is_uuid_like, invalid_urn_prefix) {
+TEST(invalid_urn_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_uuid_like(
       "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380"));
 }

--- a/test/css/CMakeLists.txt
+++ b/test/css/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME css
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME css
   SOURCES css2_hex_color_test.cc css2_color_keyword_test.cc
           css2_rgb_function_test.cc css2_color_test.cc)
 

--- a/test/css/css2_color_keyword_test.cc
+++ b/test/css/css2_color_keyword_test.cc
@@ -1,116 +1,114 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/css.h>
 
-TEST(CSS_css2_color_keyword, valid_aqua) {
+TEST(valid_aqua) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("aqua"));
 }
 
-TEST(CSS_css2_color_keyword, valid_black) {
+TEST(valid_black) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("black"));
 }
 
-TEST(CSS_css2_color_keyword, valid_blue) {
+TEST(valid_blue) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("blue"));
 }
 
-TEST(CSS_css2_color_keyword, valid_fuchsia) {
+TEST(valid_fuchsia) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("fuchsia"));
 }
 
-TEST(CSS_css2_color_keyword, valid_gray) {
+TEST(valid_gray) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("gray"));
 }
 
-TEST(CSS_css2_color_keyword, valid_green) {
+TEST(valid_green) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("green"));
 }
 
-TEST(CSS_css2_color_keyword, valid_lime) {
+TEST(valid_lime) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("lime"));
 }
 
-TEST(CSS_css2_color_keyword, valid_maroon) {
+TEST(valid_maroon) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("maroon"));
 }
 
-TEST(CSS_css2_color_keyword, valid_navy) {
+TEST(valid_navy) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("navy"));
 }
 
-TEST(CSS_css2_color_keyword, valid_olive) {
+TEST(valid_olive) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("olive"));
 }
 
-TEST(CSS_css2_color_keyword, valid_orange) {
+TEST(valid_orange) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("orange"));
 }
 
-TEST(CSS_css2_color_keyword, valid_purple) {
+TEST(valid_purple) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("purple"));
 }
 
-TEST(CSS_css2_color_keyword, valid_red) {
-  EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("red"));
-}
+TEST(valid_red) { EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("red")); }
 
-TEST(CSS_css2_color_keyword, valid_silver) {
+TEST(valid_silver) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("silver"));
 }
 
-TEST(CSS_css2_color_keyword, valid_teal) {
+TEST(valid_teal) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("teal"));
 }
 
-TEST(CSS_css2_color_keyword, valid_white) {
+TEST(valid_white) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("white"));
 }
 
-TEST(CSS_css2_color_keyword, valid_yellow) {
+TEST(valid_yellow) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("yellow"));
 }
 
-TEST(CSS_css2_color_keyword, valid_uppercase_red) {
+TEST(valid_uppercase_red) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("RED"));
 }
 
-TEST(CSS_css2_color_keyword, valid_mixed_case_fuchsia) {
+TEST(valid_mixed_case_fuchsia) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("FuChSiA"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_unknown_puce) {
+TEST(invalid_unknown_puce) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword("puce"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_underscore_dash) {
+TEST(invalid_underscore_dash) {
   EXPECT_FALSE(
       sourcemeta::core::is_css2_color_keyword("light_grayish_red-violet"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_empty) {
+TEST(invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword(""));
 }
 
-TEST(CSS_css2_color_keyword, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword(" red"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword("red "));
 }
 
-TEST(CSS_css2_color_keyword, invalid_transparent) {
+TEST(invalid_transparent) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword("transparent"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_system_color) {
+TEST(invalid_system_color) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword("ButtonFace"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_extended_x11) {
+TEST(invalid_extended_x11) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword("papayawhip"));
 }
 
-TEST(CSS_css2_color_keyword, invalid_hex_value) {
+TEST(invalid_hex_value) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color_keyword("#C89"));
 }

--- a/test/css/css2_color_test.cc
+++ b/test/css/css2_color_test.cc
@@ -1,51 +1,47 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/css.h>
 
-TEST(CSS_css2_color, suite_valid_keyword_fuchsia) {
+TEST(suite_valid_keyword_fuchsia) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color("fuchsia"));
 }
 
-TEST(CSS_css2_color, suite_valid_six_digit_hex) {
+TEST(suite_valid_six_digit_hex) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color("#CC8899"));
 }
 
-TEST(CSS_css2_color, suite_valid_three_digit_hex) {
+TEST(suite_valid_three_digit_hex) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color("#C89"));
 }
 
-TEST(CSS_css2_color, suite_invalid_eight_digit_hex) {
+TEST(suite_invalid_eight_digit_hex) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color("#00332520"));
 }
 
-TEST(CSS_css2_color, suite_invalid_unknown_keyword) {
+TEST(suite_invalid_unknown_keyword) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color("puce"));
 }
 
-TEST(CSS_css2_color, suite_invalid_underscore_dash) {
+TEST(suite_invalid_underscore_dash) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color("light_grayish_red-violet"));
 }
 
-TEST(CSS_css2_color, valid_rgb_int) {
+TEST(valid_rgb_int) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color("rgb(255, 0, 0)"));
 }
 
-TEST(CSS_css2_color, valid_rgb_percent) {
+TEST(valid_rgb_percent) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color("rgb(100%, 0%, 0%)"));
 }
 
-TEST(CSS_css2_color, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_css2_color(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_css2_color("")); }
 
-TEST(CSS_css2_color, invalid_random) {
-  EXPECT_FALSE(sourcemeta::core::is_css2_color("hello"));
-}
+TEST(invalid_random) { EXPECT_FALSE(sourcemeta::core::is_css2_color("hello")); }
 
-TEST(CSS_css2_color, invalid_transparent_keyword) {
+TEST(invalid_transparent_keyword) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color("transparent"));
 }
 
-TEST(CSS_css2_color, invalid_rgba_function) {
+TEST(invalid_rgba_function) {
   EXPECT_FALSE(sourcemeta::core::is_css2_color("rgba(0, 0, 0, 1)"));
 }

--- a/test/css/css2_hex_color_test.cc
+++ b/test/css/css2_hex_color_test.cc
@@ -1,79 +1,77 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/css.h>
 
-TEST(CSS_css2_hex_color, valid_six_digit_lower) {
+TEST(valid_six_digit_lower) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#cc8899"));
 }
 
-TEST(CSS_css2_hex_color, valid_six_digit_upper) {
+TEST(valid_six_digit_upper) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#CC8899"));
 }
 
-TEST(CSS_css2_hex_color, valid_six_digit_mixed) {
+TEST(valid_six_digit_mixed) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#Cc88Aa"));
 }
 
-TEST(CSS_css2_hex_color, valid_three_digit) {
+TEST(valid_three_digit) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#C89"));
 }
 
-TEST(CSS_css2_hex_color, valid_three_digit_all_zero) {
+TEST(valid_three_digit_all_zero) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#000"));
 }
 
-TEST(CSS_css2_hex_color, valid_three_digit_all_f) {
+TEST(valid_three_digit_all_f) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#fff"));
 }
 
-TEST(CSS_css2_hex_color, invalid_missing_hash) {
+TEST(invalid_missing_hash) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("cc8899"));
 }
 
-TEST(CSS_css2_hex_color, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_css2_hex_color(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("")); }
 
-TEST(CSS_css2_hex_color, invalid_only_hash) {
+TEST(invalid_only_hash) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#"));
 }
 
-TEST(CSS_css2_hex_color, invalid_two_digits) {
+TEST(invalid_two_digits) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#cc"));
 }
 
-TEST(CSS_css2_hex_color, invalid_four_digits) {
+TEST(invalid_four_digits) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#cc88"));
 }
 
-TEST(CSS_css2_hex_color, invalid_five_digits) {
+TEST(invalid_five_digits) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#cc889"));
 }
 
-TEST(CSS_css2_hex_color, invalid_seven_digits) {
+TEST(invalid_seven_digits) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#cc8899e"));
 }
 
-TEST(CSS_css2_hex_color, invalid_eight_digits) {
+TEST(invalid_eight_digits) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#00332520"));
 }
 
-TEST(CSS_css2_hex_color, invalid_non_hex_letter) {
+TEST(invalid_non_hex_letter) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#zzgggg"));
 }
 
-TEST(CSS_css2_hex_color, invalid_internal_whitespace) {
+TEST(invalid_internal_whitespace) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("# cc8899"));
 }
 
-TEST(CSS_css2_hex_color, invalid_trailing_whitespace) {
+TEST(invalid_trailing_whitespace) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("#cc8899 "));
 }
 
-TEST(CSS_css2_hex_color, invalid_with_named_keyword) {
+TEST(invalid_with_named_keyword) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("red"));
 }
 
-TEST(CSS_css2_hex_color, invalid_with_rgb_function) {
+TEST(invalid_with_rgb_function) {
   EXPECT_FALSE(sourcemeta::core::is_css2_hex_color("rgb(0,0,0)"));
 }

--- a/test/css/css2_rgb_function_test.cc
+++ b/test/css/css2_rgb_function_test.cc
@@ -1,120 +1,120 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/css.h>
 
-TEST(CSS_css2_rgb_function, valid_int_basic) {
+TEST(valid_int_basic) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(255, 0, 128)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_int_no_spaces) {
+TEST(valid_int_no_spaces) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(255,0,128)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_int_internal_whitespace) {
+TEST(valid_int_internal_whitespace) {
   EXPECT_TRUE(
       sourcemeta::core::is_css2_rgb_function("rgb(  255 , 0 ,  128  )"));
 }
 
-TEST(CSS_css2_rgb_function, valid_int_tabs_and_newlines) {
+TEST(valid_int_tabs_and_newlines) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(\t255,\n0,\r128)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_leading_whitespace) {
+TEST(invalid_leading_whitespace) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function(" rgb(0,0,0)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_trailing_whitespace) {
+TEST(invalid_trailing_whitespace) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(0,0,0) "));
 }
 
-TEST(CSS_css2_rgb_function, invalid_whitespace_between_rgb_and_paren) {
+TEST(invalid_whitespace_between_rgb_and_paren) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb (0,0,0)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_percentage_basic) {
+TEST(valid_percentage_basic) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(100%, 0%, 50%)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_percentage_decimal) {
+TEST(valid_percentage_decimal) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(33.3%, 66.6%, 0%)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_percentage_leading_dot) {
+TEST(valid_percentage_leading_dot) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(.5%, .5%, .5%)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_uppercase_function) {
+TEST(valid_uppercase_function) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("RGB(0,0,0)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_mixed_case_function) {
+TEST(valid_mixed_case_function) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("Rgb(0,0,0)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_out_of_range_clamped) {
+TEST(valid_out_of_range_clamped) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(300, -5, 128)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_all_zero) {
+TEST(valid_all_zero) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(0, 0, 0)"));
 }
 
-TEST(CSS_css2_rgb_function, valid_positive_signed_int) {
+TEST(valid_positive_signed_int) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(+10, +20, +30)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_mixed_types) {
+TEST(invalid_mixed_types) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(100%, 0, 50%)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_only_two_values) {
+TEST(invalid_only_two_values) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(0, 0)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_four_values) {
+TEST(invalid_four_values) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(0, 0, 0, 0)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_missing_open_paren) {
+TEST(invalid_missing_open_paren) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb 0, 0, 0)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_missing_close_paren) {
+TEST(invalid_missing_close_paren) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(0, 0, 0"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_unknown_function) {
+TEST(invalid_unknown_function) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("hsl(0, 100%, 50%)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_rgba) {
+TEST(invalid_rgba) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgba(0, 0, 0, 1)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_trailing_garbage) {
+TEST(invalid_trailing_garbage) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(0,0,0)foo"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_int_with_decimal) {
+TEST(invalid_int_with_decimal) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(0.5, 0, 0)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_empty) {
+TEST(invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function(""));
 }
 
-TEST(CSS_css2_rgb_function, invalid_hex_value) {
+TEST(invalid_hex_value) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("#000000"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_keyword) {
+TEST(invalid_keyword) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("red"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_empty_value) {
+TEST(invalid_empty_value) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(, 0, 0)"));
 }
 
-TEST(CSS_css2_rgb_function, invalid_dot_only) {
+TEST(invalid_dot_only) {
   EXPECT_FALSE(sourcemeta::core::is_css2_rgb_function("rgb(., ., .)"));
 }

--- a/test/dns/CMakeLists.txt
+++ b/test/dns/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME dns
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME dns
   SOURCES hostname_test.cc idn_hostname_test.cc)
 
 target_link_libraries(sourcemeta_core_dns_unit

--- a/test/dns/hostname_test.cc
+++ b/test/dns/hostname_test.cc
@@ -1,89 +1,89 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/dns.h>
 
 #include <string>
 
 // RFC 952 §B: <hname> ::= <name>*["."<name>]  (three labels, TS d7+ #7)
-TEST(DNS_hostname, valid_simple_dotted) {
+TEST(valid_simple_dotted) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("www.example.com"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("www.example.com"));
 }
 
 // RFC 952 §B: <hname> allows a single <name> (TS d7+ #8)
-TEST(DNS_hostname, valid_single_label) {
+TEST(valid_single_label) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("hostname"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("hostname"));
 }
 
 // RFC 952 §B: interior digits are let-dig-hyp (TS d7+ #9)
-TEST(DNS_hostname, valid_single_label_with_digits) {
+TEST(valid_single_label_with_digits) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("h0stn4me"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("h0stn4me"));
 }
 
 // RFC 1123 §2.1: first character may be a digit (TS d7+ #10)
-TEST(DNS_hostname, valid_starts_with_digit) {
+TEST(valid_starts_with_digit) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("1host"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("1host"));
 }
 
 // RFC 952 §B: <name> ends with <let-or-digit> (TS d7+ #11)
-TEST(DNS_hostname, valid_ends_with_digit) {
+TEST(valid_ends_with_digit) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("hostnam3"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("hostnam3"));
 }
 
 // RFC 952 §B: interior '-' is let-dig-hyp (TS d7+ #17)
-TEST(DNS_hostname, valid_interior_hyphen) {
+TEST(valid_interior_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("host-name"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("host-name"));
 }
 
 // RFC 952 §B: two minimal single-character labels
-TEST(DNS_hostname, valid_two_labels) {
+TEST(valid_two_labels) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("a.b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a.b"));
 }
 
 // RFC 952 §B: single <let> is a valid <name>
-TEST(DNS_hostname, valid_single_letter) {
+TEST(valid_single_letter) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("a"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a"));
 }
 
 // RFC 1123 §2.1: single digit is a valid label
-TEST(DNS_hostname, valid_single_digit) {
+TEST(valid_single_digit) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("0"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("0"));
 }
 
 // RFC 952 ASSUMPTIONS: no distinction between upper and lower case
-TEST(DNS_hostname, valid_single_uppercase) {
+TEST(valid_single_uppercase) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("A"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("A"));
 }
 
 // RFC 952 ASSUMPTIONS: case-insensitive — mixed case is valid
-TEST(DNS_hostname, valid_mixed_case) {
+TEST(valid_mixed_case) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("HosT.CoM"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("HosT.CoM"));
 }
 
 // RFC 1123 §2.1 MUST: label of exactly 63 chars (TS d4 #17, TS d7+ #23)
-TEST(DNS_hostname, valid_label_exactly_63) {
+TEST(valid_label_exactly_63) {
   EXPECT_TRUE(sourcemeta::core::is_hostname(std::string(63, 'a') + ".com"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(std::string(63, 'a') + ".com"));
 }
 
 // RFC 1123 §2.1 MUST: single label of exactly 63 chars
-TEST(DNS_hostname, valid_single_label_63) {
+TEST(valid_single_label_63) {
   EXPECT_TRUE(sourcemeta::core::is_hostname(std::string(63, 'a')));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(std::string(63, 'a')));
 }
 
 // RFC 1123 §2.1 SHOULD: 253-byte total is under the 255-char cap
-TEST(DNS_hostname, valid_total_253) {
+TEST(valid_total_253) {
   // 63 + '.' + 63 + '.' + 63 + '.' + 61 = 253 bytes
   EXPECT_TRUE(sourcemeta::core::is_hostname(
       std::string(63, 'a') + "." + std::string(63, 'a') + "." +
@@ -95,7 +95,7 @@ TEST(DNS_hostname, valid_total_253) {
 
 // RFC 1123 §2.1: 254-byte hostname is under the 255 cap.
 // RFC 1035 §3.1: IDN strict presentation form caps the total at 253 octets
-TEST(DNS_hostname, total_254) {
+TEST(total_254) {
   // 63 + '.' + 63 + '.' + 63 + '.' + 62 = 254 bytes
   EXPECT_TRUE(sourcemeta::core::is_hostname(
       std::string(63, 'a') + "." + std::string(63, 'a') + "." +
@@ -107,7 +107,7 @@ TEST(DNS_hostname, total_254) {
 
 // RFC 1123 §2.1: exactly at the 255-char SHOULD limit.
 // RFC 1035 §3.1: IDN strict presentation form rejects 255 octets
-TEST(DNS_hostname, total_255) {
+TEST(total_255) {
   // 4 * 63 + 3 dots = 255 bytes
   EXPECT_TRUE(sourcemeta::core::is_hostname(
       std::string(63, 'a') + "." + std::string(63, 'a') + "." +
@@ -118,274 +118,274 @@ TEST(DNS_hostname, total_255) {
 }
 
 // RFC 952 §B: xn-- labels are plain ASCII; grammar accepts (TS d4 #8)
-TEST(DNS_hostname, valid_punycoded_draft4) {
+TEST(valid_punycoded_draft4) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn--4gbwdl.xn--wgbh1c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("xn--4gbwdl.xn--wgbh1c"));
 }
 
 // RFC 5891 §4.2.3.1: case-insensitive xn-- detection treats this as an
 // A-label whose Punycode body fails the IDNA 2008 validation
-TEST(DNS_hostname, xn_positions_34_both_hyphen) {
+TEST(xn_positions_34_both_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("XN--aa---o47jg78q"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("XN--aa---o47jg78q"));
 }
 
 // RFC 5890 §2.3.2.1: a one-character Punycode body that does not decode to a
 // valid U-label cannot be a real A-label
-TEST(DNS_hostname, xn_undecodable_punycode_body) {
+TEST(xn_undecodable_punycode_body) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--X"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--X"));
 }
 
 // RFC 5891 §4.2.3.2: decoded A-label must not start with a Spacing
 // Combining Mark
-TEST(DNS_hostname, xn_leading_spacing_combining_mark) {
+TEST(xn_leading_spacing_combining_mark) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--hello-txk"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--hello-txk"));
 }
 
 // RFC 5891 §4.2.3.2: decoded A-label must not start with a Nonspacing Mark
-TEST(DNS_hostname, xn_leading_nonspacing_mark) {
+TEST(xn_leading_nonspacing_mark) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--hello-zed"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--hello-zed"));
 }
 
 // RFC 5891 §4.2.3.2: decoded A-label must not start with an Enclosing Mark
-TEST(DNS_hostname, xn_leading_enclosing_mark) {
+TEST(xn_leading_enclosing_mark) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--hello-6bf"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--hello-6bf"));
 }
 
 // RFC 5892 §2.6: DISALLOWED code points (e.g. U+302E HANGUL SINGLE DOT
 // TONE MARK) must not appear in the decoded U-label
-TEST(DNS_hostname, xn_disallowed_codepoint_in_first_label) {
+TEST(xn_disallowed_codepoint_in_first_label) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--07jt112bpxg.xn--9t4b11yi5a"));
   EXPECT_FALSE(
       sourcemeta::core::is_idn_hostname("xn--07jt112bpxg.xn--9t4b11yi5a"));
 }
 
 // RFC 5892 §2.6: DISALLOWED right-to-left exception code point
-TEST(DNS_hostname, xn_disallowed_rtl_exception) {
+TEST(xn_disallowed_rtl_exception) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--chb89f"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--chb89f"));
 }
 
 // RFC 5892 §2.6: DISALLOWED combining marks in non-leading position
-TEST(DNS_hostname, xn_disallowed_non_leading_combining_marks) {
+TEST(xn_disallowed_non_leading_combining_marks) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--07jceefgh4c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--07jceefgh4c"));
 }
 
 // RFC 5892 Appendix A.3: MIDDLE DOT must sit between two ASCII "l"
-TEST(DNS_hostname, xn_middle_dot_no_leading_l) {
+TEST(xn_middle_dot_no_leading_l) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--al-0ea"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--al-0ea"));
 }
 
-TEST(DNS_hostname, xn_middle_dot_no_preceding_codepoint) {
+TEST(xn_middle_dot_no_preceding_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--l-fda"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--l-fda"));
 }
 
-TEST(DNS_hostname, xn_middle_dot_no_trailing_l) {
+TEST(xn_middle_dot_no_trailing_l) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--la-0ea"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--la-0ea"));
 }
 
-TEST(DNS_hostname, xn_middle_dot_no_following_codepoint) {
+TEST(xn_middle_dot_no_following_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--l-gda"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--l-gda"));
 }
 
 // RFC 5892 Appendix A.4: Greek KERAIA must be followed by a Greek code point
-TEST(DNS_hostname, xn_keraia_followed_by_non_greek) {
+TEST(xn_keraia_followed_by_non_greek) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--S-jib3p"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--S-jib3p"));
 }
 
-TEST(DNS_hostname, xn_keraia_at_end_of_label) {
+TEST(xn_keraia_at_end_of_label) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--wva3j"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--wva3j"));
 }
 
 // RFC 5892 Appendix A.5: Hebrew GERESH must be preceded by a Hebrew
 // code point
-TEST(DNS_hostname, xn_geresh_preceded_by_latin) {
+TEST(xn_geresh_preceded_by_latin) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--A-2hc5h"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--A-2hc5h"));
 }
 
-TEST(DNS_hostname, xn_geresh_at_start_of_label) {
+TEST(xn_geresh_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--5db1e"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--5db1e"));
 }
 
 // RFC 5892 Appendix A.6: Hebrew GERSHAYIM must be preceded by a Hebrew
 // code point
-TEST(DNS_hostname, xn_gershayim_preceded_by_latin) {
+TEST(xn_gershayim_preceded_by_latin) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--A-2hc8h"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--A-2hc8h"));
 }
 
-TEST(DNS_hostname, xn_gershayim_at_start_of_label) {
+TEST(xn_gershayim_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--5db3e"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--5db3e"));
 }
 
 // RFC 5892 Appendix A.7: KATAKANA MIDDLE DOT requires an adjacent
 // Hiragana, Katakana, or Han code point
-TEST(DNS_hostname, xn_katakana_middle_dot_only_latin_neighbours) {
+TEST(xn_katakana_middle_dot_only_latin_neighbours) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--defabc-k64e"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--defabc-k64e"));
 }
 
-TEST(DNS_hostname, xn_katakana_middle_dot_no_neighbours) {
+TEST(xn_katakana_middle_dot_no_neighbours) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--vek"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--vek"));
 }
 
 // RFC 5892 Appendix A.8: Arabic-Indic digits and Extended Arabic-Indic
 // digits must not coexist in the same label
-TEST(DNS_hostname, xn_mixed_arabic_indic_digit_kinds) {
+TEST(xn_mixed_arabic_indic_digit_kinds) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--ngb6iyr"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--ngb6iyr"));
 }
 
 // RFC 5892 Appendix A.2: ZERO WIDTH JOINER must be preceded by a Virama
-TEST(DNS_hostname, xn_zwj_not_preceded_by_virama) {
+TEST(xn_zwj_not_preceded_by_virama) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--11b2er09f"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--11b2er09f"));
 }
 
-TEST(DNS_hostname, xn_zwj_at_start_of_label) {
+TEST(xn_zwj_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--02b508i"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--02b508i"));
 }
 
 // RFC 952 §B: grammar has no rule against consecutive interior hyphens
-TEST(DNS_hostname, valid_consecutive_interior_hyphens) {
+TEST(valid_consecutive_interior_hyphens) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("a--b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a--b"));
 }
 
 // RFC 1123 §2.1 DISCUSSION: numeric TLD is not forbidden by grammar
-TEST(DNS_hostname, valid_numeric_tld) {
+TEST(valid_numeric_tld) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("example.123"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("example.123"));
 }
 
 // RFC 952 §B: any number of labels separated by dots
-TEST(DNS_hostname, valid_many_labels) {
+TEST(valid_many_labels) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("a.b.c.d.e.f"));
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a.b.c.d.e.f"));
 }
 
 // RFC 952 §B: <hname> requires at least one <name> / label (TS d7+ #12)
-TEST(DNS_hostname, invalid_empty) {
+TEST(invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(""));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(""));
 }
 
 // RFC 952 §B: bare '.' has no <name> before or after (TS d7+ #13)
-TEST(DNS_hostname, invalid_single_dot) {
+TEST(invalid_single_dot) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("."));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("."));
 }
 
 // RFC 952 §B: leading '.' yields an empty label (TS d7+ #14)
-TEST(DNS_hostname, invalid_leading_dot) {
+TEST(invalid_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(".example"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(".example"));
 }
 
 // JSON Schema test suite: trailing dot is invalid from draft 4 onward (TS d7+
 // #15)
-TEST(DNS_hostname, invalid_trailing_dot) {
+TEST(invalid_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("example."));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("example."));
 }
 
 // JSON Schema test suite: trailing dot generalised to single label
-TEST(DNS_hostname, invalid_trailing_dot_single) {
+TEST(invalid_trailing_dot_single) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("host."));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("host."));
 }
 
 // RFC 952 §B: double dot yields an empty label
-TEST(DNS_hostname, invalid_double_dot) {
+TEST(invalid_double_dot) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("example..com"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("example..com"));
 }
 
 // RFC 952 §B: double trailing dot yields empty labels
-TEST(DNS_hostname, invalid_double_trailing_dot) {
+TEST(invalid_double_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.."));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("example.."));
 }
 
 // RFC 1123 §2.1: first char of label must be letter or digit (TS d7+ #18)
-TEST(DNS_hostname, invalid_label_starts_with_hyphen) {
+TEST(invalid_label_starts_with_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("-hostname"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("-hostname"));
 }
 
 // RFC 952 §B + ASSUMPTIONS: last char must not be minus sign (TS d7+ #19)
-TEST(DNS_hostname, invalid_label_ends_with_hyphen) {
+TEST(invalid_label_ends_with_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("hostname-"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("hostname-"));
 }
 
 // RFC 1123 §2.1: first-char rule applies to every label, not just the first
-TEST(DNS_hostname, invalid_middle_label_starts_with_hyphen) {
+TEST(invalid_middle_label_starts_with_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.-b.c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a.-b.c"));
 }
 
 // RFC 952 §B: final-char rule applies to every label, not just the last
-TEST(DNS_hostname, invalid_middle_label_ends_with_hyphen) {
+TEST(invalid_middle_label_ends_with_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.b-.c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a.b-.c"));
 }
 
 // RFC 952 ASSUMPTIONS: underscore is not in the alphabet (TS d4 #14)
-TEST(DNS_hostname, invalid_underscore_start) {
+TEST(invalid_underscore_start) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("_hostname"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("_hostname"));
 }
 
 // RFC 952 ASSUMPTIONS: underscore is not in the alphabet (TS d4 #15)
-TEST(DNS_hostname, invalid_underscore_end) {
+TEST(invalid_underscore_end) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("hostname_"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("hostname_"));
 }
 
 // RFC 952 ASSUMPTIONS: underscore is not in the alphabet (TS d4 #16, d7+ #21)
-TEST(DNS_hostname, invalid_underscore_middle) {
+TEST(invalid_underscore_middle) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("host_name"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("host_name"));
 }
 
 // RFC 952 ASSUMPTIONS: no blank or space characters are permitted
-TEST(DNS_hostname, invalid_space) {
+TEST(invalid_space) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("host name"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("host name"));
 }
 
 // RFC 1123 §2.1 MUST: label exceeds 63-character limit (TS d4 #18, d7+ #24)
-TEST(DNS_hostname, invalid_label_64) {
+TEST(invalid_label_64) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(std::string(64, 'a') + ".com"));
   EXPECT_FALSE(
       sourcemeta::core::is_idn_hostname(std::string(64, 'a') + ".com"));
 }
 
 // RFC 1123 §2.1 MUST: single label of 64 chars exceeds per-label limit
-TEST(DNS_hostname, invalid_single_label_64) {
+TEST(invalid_single_label_64) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(std::string(64, 'a')));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(std::string(64, 'a')));
 }
 
 // RFC 1035 §2.3.4 via RFC 1123 §2.1: total length exceeds 255 (constructed)
-TEST(DNS_hostname, invalid_total_256) {
+TEST(invalid_total_256) {
   // 63 + '.' + 63 + '.' + 63 + '.' + 62 + '.' + 'a' = 256 bytes; all labels
   // ≤ 63
   EXPECT_FALSE(sourcemeta::core::is_hostname(
@@ -398,7 +398,7 @@ TEST(DNS_hostname, invalid_total_256) {
 
 // RFC 1035 §2.3.4 via RFC 1123 §2.1: exact TS d7+ #22 input (259 bytes,
 // mislabelled "256" in the test suite description)
-TEST(DNS_hostname, invalid_ts_256_string) {
+TEST(invalid_ts_256_string) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(
       "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
       "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk."
@@ -415,7 +415,7 @@ TEST(DNS_hostname, invalid_ts_256_string) {
 
 // RFC 952 ASSUMPTIONS: U+FF0E (fullwidth full stop) is not in the ASCII
 // alphabet; UTF-8 bytes 0xEF 0xBC 0x8E (TS d4 #27, d7+ #16)
-TEST(DNS_hostname, invalid_fullwidth_dot) {
+TEST(invalid_fullwidth_dot) {
   // RFC 1123 §2.1: U+FF0E (FULLWIDTH FULL STOP) is not the ASCII label
   // separator. is_idn_hostname accepts it as a normal UTF-8 codepoint within
   // a label per RFC 5890 §2.3.2.3 (best-effort lexical handling); strict
@@ -427,7 +427,7 @@ TEST(DNS_hostname, invalid_fullwidth_dot) {
 }
 
 // RFC 952 ASSUMPTIONS: any byte >= 0x80 is outside the ASCII alphabet
-TEST(DNS_hostname, invalid_high_bit_byte) {
+TEST(invalid_high_bit_byte) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view{"a\x80"
                                                               "b",
                                                               3}));
@@ -437,7 +437,7 @@ TEST(DNS_hostname, invalid_high_bit_byte) {
 }
 
 // RFC 952 ASSUMPTIONS: NUL byte (0x00) is not in the ASCII alphabet
-TEST(DNS_hostname, invalid_nul_byte) {
+TEST(invalid_nul_byte) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view{"a\x00"
                                                               "b",
                                                               3}));
@@ -447,7 +447,7 @@ TEST(DNS_hostname, invalid_nul_byte) {
 }
 
 // RFC 952 ASSUMPTIONS: '@' is not in the alphabet (A-Z 0-9 '-' '.')
-TEST(DNS_hostname, invalid_at_sign) {
+TEST(invalid_at_sign) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("user@host"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("user@host"));
 }

--- a/test/dns/idn_hostname_test.cc
+++ b/test/dns/idn_hostname_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/dns.h>
 
@@ -6,7 +6,7 @@
 
 // example.test rendered in Hangul (RFC 5890 §2.3.2.3)
 // Bytes: 실=EC8BA4 례=EBA180 .=2E 테=ED858C 스=EC8AA4 트=ED8AB8
-TEST(DNS_idn_hostname, valid_hangul_example_test) {
+TEST(valid_hangul_example_test) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xec\x8b\xa4\xeb\xa1\x80"
       ".\xed\x85\x8c\xec\x8a\xa4\xed\x8a\xb8"));
@@ -16,74 +16,74 @@ TEST(DNS_idn_hostname, valid_hangul_example_test) {
 }
 
 // RFC 1123 §2.1: ASCII single label is a subset of the extended grammar
-TEST(DNS_idn_hostname, valid_ascii_single_label) {
+TEST(valid_ascii_single_label) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("hostname"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("hostname"));
 }
 
-TEST(DNS_idn_hostname, valid_ascii_dotted) {
+TEST(valid_ascii_dotted) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("www.example.com"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("www.example.com"));
 }
 
-TEST(DNS_idn_hostname, valid_ascii_with_hyphen) {
+TEST(valid_ascii_with_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("host-name"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("host-name"));
 }
 
-TEST(DNS_idn_hostname, valid_ascii_with_digits) {
+TEST(valid_ascii_with_digits) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("h0stn4me"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("h0stn4me"));
 }
 
-TEST(DNS_idn_hostname, valid_ascii_leading_digit) {
+TEST(valid_ascii_leading_digit) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("1host"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("1host"));
 }
 
-TEST(DNS_idn_hostname, valid_ascii_trailing_digit) {
+TEST(valid_ascii_trailing_digit) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("hostnam3"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("hostnam3"));
 }
 
 // RFC 5890 §2.3.2.1: A-label form xn--... (purely ASCII LDH)
-TEST(DNS_idn_hostname, valid_ascii_a_label_form) {
+TEST(valid_ascii_a_label_form) {
   EXPECT_TRUE(
       sourcemeta::core::is_idn_hostname("xn--ihqwcrb4cv8a8dqg056pqjye"));
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn--ihqwcrb4cv8a8dqg056pqjye"));
 }
 
 // RFC 5890 §2.3.2.3 / RFC 6532 §3.1: U-label (2-byte UTF-8: U+03B1)
-TEST(DNS_idn_hostname, valid_label_two_byte_utf8) {
+TEST(valid_label_two_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xce\xb1"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce\xb1"));
 }
 
 // RFC 5890 §2.3.2.3 / RFC 6532 §3.1: U-label (3-byte UTF-8: U+4E2D 中)
-TEST(DNS_idn_hostname, valid_label_three_byte_utf8) {
+TEST(valid_label_three_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xe4\xb8\xad"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe4\xb8\xad"));
 }
 
 // RFC 5890 §2.3.2.3 / RFC 6532 §3.1: U-label with a 4-byte UTF-8 codepoint
 // (U+20000 CJK UNIFIED IDEOGRAPH-20000, PVALID per RFC 5892)
-TEST(DNS_idn_hostname, valid_label_four_byte_utf8) {
+TEST(valid_label_four_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xf0\xa0\x80\x80"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xf0\xa0\x80\x80"));
 }
 
-TEST(DNS_idn_hostname, valid_mixed_ascii_and_utf8_labels) {
+TEST(valid_mixed_ascii_and_utf8_labels) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("example.\xce\xb1.com"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.\xce\xb1.com"));
 }
 
-TEST(DNS_idn_hostname, valid_utf8_label_with_internal_hyphen) {
+TEST(valid_utf8_label_with_internal_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xce\xb1-\xe4\xb8\xad"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce\xb1-\xe4\xb8\xad"));
 }
 
 // U+03B1, U+4E2D, U+20000 are all PVALID per RFC 5892
-TEST(DNS_idn_hostname, valid_utf8_only_dotted) {
+TEST(valid_utf8_only_dotted) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xce\xb1.\xe4\xb8\xad.\xf0\xa0\x80\x80"));
   EXPECT_FALSE(
@@ -91,7 +91,7 @@ TEST(DNS_idn_hostname, valid_utf8_only_dotted) {
 }
 
 // RFC 1035 §2.3.4: label may be exactly 63 octets
-TEST(DNS_idn_hostname, valid_ascii_label_at_63) {
+TEST(valid_ascii_label_at_63) {
   const std::string label(63, 'a');
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(label));
   EXPECT_TRUE(sourcemeta::core::is_hostname(label));
@@ -100,7 +100,7 @@ TEST(DNS_idn_hostname, valid_ascii_label_at_63) {
 // RFC 5891 §4.2.4: per-label A-label form must be ≤ 63 octets. A U-label of
 // 55 Greek codepoints Punycode-encodes to a 61-character body, giving an
 // A-label of 65 octets even though the codepoint count is well under 63.
-TEST(DNS_idn_hostname, invalid_u_label_a_form_over_63) {
+TEST(invalid_u_label_a_form_over_63) {
   // "παράδειγμα" (10 codepoints) × 5 + "παράδ" (5 codepoints) = 55
   std::string label;
   for (int index = 0; index < 5; ++index) {
@@ -115,7 +115,7 @@ TEST(DNS_idn_hostname, invalid_u_label_a_form_over_63) {
 
 // RFC 5891 §4.2.4: 52 Greek codepoints Punycode-encode to a 57-character
 // body, giving a 61-octet A-label that just fits the per-label cap
-TEST(DNS_idn_hostname, valid_u_label_a_form_at_61) {
+TEST(valid_u_label_a_form_at_61) {
   // "παράδειγμα" × 5 + "πα" = 52 codepoints
   std::string label;
   for (int index = 0; index < 5; ++index) {
@@ -131,7 +131,7 @@ TEST(DNS_idn_hostname, valid_u_label_a_form_at_61) {
 // RFC 1035 §3.1: A-label-form presentation total must be ≤ 253 octets. 32
 // single-α labels have UTF-8 input of only 95 bytes (well below the 255
 // RFC 1123 hostname cap) but the A-label total is 32 × 7 + 31 = 255 octets
-TEST(DNS_idn_hostname, invalid_a_label_total_over_253_short_utf8) {
+TEST(invalid_a_label_total_over_253_short_utf8) {
   std::string hostname{"\xce\xb1"};
   for (int index = 0; index < 31; ++index) {
     hostname.append(".\xce\xb1");
@@ -142,7 +142,7 @@ TEST(DNS_idn_hostname, invalid_a_label_total_over_253_short_utf8) {
 }
 
 // 31 single-α labels: A-label total = 31 × 7 + 30 = 247 ≤ 253
-TEST(DNS_idn_hostname, valid_a_label_total_at_247_short_utf8) {
+TEST(valid_a_label_total_at_247_short_utf8) {
   std::string hostname{"\xce\xb1"};
   for (int index = 0; index < 30; ++index) {
     hostname.append(".\xce\xb1");
@@ -154,7 +154,7 @@ TEST(DNS_idn_hostname, valid_a_label_total_at_247_short_utf8) {
 
 // RFC 1035 §3.1: presentation form may be exactly 253 octets for IDN.
 // RFC 1123 §2.1 is more permissive and accepts up to 255 characters
-TEST(DNS_idn_hostname, total_length_boundary_253_vs_255) {
+TEST(total_length_boundary_253_vs_255) {
   // 4 × 63 + 3 dots = 255 (RFC 1123) but not RFC 1035 presentation
   std::string at_255;
   for (int index = 0; index < 3; ++index) {
@@ -178,66 +178,66 @@ TEST(DNS_idn_hostname, total_length_boundary_253_vs_255) {
   EXPECT_TRUE(sourcemeta::core::is_hostname(at_253));
 }
 
-TEST(DNS_idn_hostname, invalid_empty) {
+TEST(invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(""));
   EXPECT_FALSE(sourcemeta::core::is_hostname(""));
 }
 
 // RFC 1123 §2.1: a label may not begin with a hyphen
-TEST(DNS_idn_hostname, invalid_leading_hyphen) {
+TEST(invalid_leading_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("-hello"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("-hello"));
 }
 
 // RFC 952 §B: a label may not end with a hyphen
-TEST(DNS_idn_hostname, invalid_trailing_hyphen) {
+TEST(invalid_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("hello-"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("hello-"));
 }
 
-TEST(DNS_idn_hostname, invalid_leading_and_trailing_hyphen) {
+TEST(invalid_leading_and_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("-hello-"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("-hello-"));
 }
 
-TEST(DNS_idn_hostname, invalid_utf8_label_trailing_hyphen) {
+TEST(invalid_utf8_label_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xce\xb1-"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce\xb1-"));
 }
 
-TEST(DNS_idn_hostname, invalid_leading_dot) {
+TEST(invalid_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(".example"));
   EXPECT_FALSE(sourcemeta::core::is_hostname(".example"));
 }
 
-TEST(DNS_idn_hostname, invalid_trailing_dot) {
+TEST(invalid_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("example."));
   EXPECT_FALSE(sourcemeta::core::is_hostname("example."));
 }
 
-TEST(DNS_idn_hostname, invalid_consecutive_dots) {
+TEST(invalid_consecutive_dots) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a..b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a..b"));
 }
 
 // Space and "$" are neither ASCII LDH nor UTF-8 lead bytes
-TEST(DNS_idn_hostname, invalid_dollar_amount_with_arrows) {
+TEST(invalid_dollar_amount_with_arrows) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("-> $1.00 <--"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("-> $1.00 <--"));
 }
 
-TEST(DNS_idn_hostname, invalid_internal_space) {
+TEST(invalid_internal_space) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a b"));
 }
 
-TEST(DNS_idn_hostname, invalid_underscore) {
+TEST(invalid_underscore) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a_b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a_b"));
 }
 
 // RFC 1035 §2.3.4: 64-octet label exceeds the per-label cap
-TEST(DNS_idn_hostname, invalid_ascii_label_at_64) {
+TEST(invalid_ascii_label_at_64) {
   const std::string label(64, 'a');
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(label));
   EXPECT_FALSE(sourcemeta::core::is_hostname(label));
@@ -245,7 +245,7 @@ TEST(DNS_idn_hostname, invalid_ascii_label_at_64) {
 
 // RFC 5321 §4.5.3.1.2: 256-octet total exceeds the cap. Construction avoids
 // trailing-dot and per-label confounds (see idn_email_test.cc rationale)
-TEST(DNS_idn_hostname, invalid_total_at_256) {
+TEST(invalid_total_at_256) {
   std::string hostname;
   for (int index = 0; index < 4; ++index) {
     hostname.append(51, 'a');
@@ -259,60 +259,60 @@ TEST(DNS_idn_hostname, invalid_total_at_256) {
 }
 
 // RFC 6532 §3.1: lone continuation byte (0xBF) cannot start a UTF-8 sequence
-TEST(DNS_idn_hostname, invalid_lone_continuation_byte) {
+TEST(invalid_lone_continuation_byte) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xbf"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xbf"));
 }
 
 // RFC 6532 §3.1: 2-byte starter without a continuation byte
-TEST(DNS_idn_hostname, invalid_truncated_two_byte) {
+TEST(invalid_truncated_two_byte) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xce"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce"));
 }
 
 // RFC 6532 §3.1: %xE0 %x80-9F is an overlong 3-byte encoding
-TEST(DNS_idn_hostname, invalid_overlong_three_byte) {
+TEST(invalid_overlong_three_byte) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xe0\x80\xa0"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe0\x80\xa0"));
 }
 
 // RFC 6532 §3.1: U+D800 surrogate codepoint is forbidden
-TEST(DNS_idn_hostname, invalid_surrogate_codepoint) {
+TEST(invalid_surrogate_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xed\xa0\x80"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xed\xa0\x80"));
 }
 
 // RFC 6532 §3.1: codepoints above U+10FFFF are forbidden
-TEST(DNS_idn_hostname, invalid_above_max_codepoint) {
+TEST(invalid_above_max_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xf4\x90\x80\x80"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xf4\x90\x80\x80"));
 }
 
 // RFC 6532 §3.1: 4-byte starter with truncated continuation
-TEST(DNS_idn_hostname, invalid_truncated_four_byte) {
+TEST(invalid_truncated_four_byte) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xf0\x9f\x98"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xf0\x9f\x98"));
 }
 
 // RFC 6532 §3.1: %xC0 is a forbidden lead byte (overlong U+0000)
-TEST(DNS_idn_hostname, invalid_overlong_c0) {
+TEST(invalid_overlong_c0) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xc0\x80"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xc0\x80"));
 }
 
 // RFC 6532 §3.1: %xF5 is not a valid lead byte
-TEST(DNS_idn_hostname, invalid_lead_f5) {
+TEST(invalid_lead_f5) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xf5\x80\x80\x80"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xf5\x80\x80\x80"));
 }
 
-TEST(DNS_idn_hostname, invalid_invalid_utf8_in_middle_label) {
+TEST(invalid_invalid_utf8_in_middle_label) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a.\xc0\x80.b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.\xc0\x80.b"));
 }
 
 // RFC 5890 §2.3.2.3: 실례.테스트 ("example.test" in Hangul)
-TEST(DNS_idn_hostname, valid_hangul_example_test_full) {
+TEST(valid_hangul_example_test_full) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xec\x8b\xa4\xeb\xa1\x80.\xed\x85\x8c\xec\x8a\xa4\xed\x8a\xb8"));
   EXPECT_FALSE(sourcemeta::core::is_hostname(
@@ -321,7 +321,7 @@ TEST(DNS_idn_hostname, valid_hangul_example_test_full) {
 
 // RFC 5891 §4.2.3.2: first character must not be a combining mark.
 // U+302E (HANGUL SINGLE DOT TONE MARK) is a Spacing Combining Mark
-TEST(DNS_idn_hostname, invalid_first_char_combining_mark_u302e) {
+TEST(invalid_first_char_combining_mark_u302e) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\xe3\x80\xae\xec\x8b\xa4\xeb\xa1\x80.\xed\x85\x8c\xec\x8a\xa4\xed\x8a"
       "\xb8"));
@@ -331,7 +331,7 @@ TEST(DNS_idn_hostname, invalid_first_char_combining_mark_u302e) {
 }
 
 // RFC 5892 Table A: U+302E is DISALLOWED, so it cannot appear anywhere
-TEST(DNS_idn_hostname, invalid_disallowed_u302e_middle) {
+TEST(invalid_disallowed_u302e_middle) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\xec\x8b\xa4\xe3\x80\xae\xeb\xa1\x80.\xed\x85\x8c\xec\x8a\xa4\xed\x8a"
       "\xb8"));
@@ -341,32 +341,32 @@ TEST(DNS_idn_hostname, invalid_disallowed_u302e_middle) {
 }
 
 // RFC 5891 §4.2.3.2: first character is a Nonspacing Mark (U+0300)
-TEST(DNS_idn_hostname, invalid_first_char_nonspacing_mark) {
+TEST(invalid_first_char_nonspacing_mark) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xcc\x80hello"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xcc\x80hello"));
 }
 
 // RFC 5891 §4.2.3.2: first character is a Spacing Combining Mark (U+0903)
-TEST(DNS_idn_hostname, invalid_first_char_spacing_combining_mark) {
+TEST(invalid_first_char_spacing_combining_mark) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xe0\xa4\x83hello"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe0\xa4\x83hello"));
 }
 
 // RFC 5891 §4.2.3.2: first character is an Enclosing Mark (U+0488)
-TEST(DNS_idn_hostname, invalid_first_char_enclosing_mark) {
+TEST(invalid_first_char_enclosing_mark) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xd2\x88hello"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd2\x88hello"));
 }
 
 // RFC 3492 §6.2: 'xn--X' has no Punycode body that decodes meaningfully,
 // and RFC 5890 §2.3.2.1 routes the ACE prefix through A-label validation
-TEST(DNS_idn_hostname, invalid_punycode_xn_dash_dash_X) {
+TEST(invalid_punycode_xn_dash_dash_X) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("xn--X"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--X"));
 }
 
 // RFC 5892 §2.6: PVALID exceptions ßς་〇 (LTR)
-TEST(DNS_idn_hostname, valid_pvalid_exceptions_ltr) {
+TEST(valid_pvalid_exceptions_ltr) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xc3\x9f\xcf\x82\xe0\xbc\x8b\xe3\x80\x87"));
   EXPECT_FALSE(sourcemeta::core::is_hostname(
@@ -374,19 +374,19 @@ TEST(DNS_idn_hostname, valid_pvalid_exceptions_ltr) {
 }
 
 // RFC 5892 §2.6: PVALID exceptions ۽۾ (RTL, Arabic signs)
-TEST(DNS_idn_hostname, valid_pvalid_exceptions_rtl) {
+TEST(valid_pvalid_exceptions_rtl) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xdb\xbd\xdb\xbe"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xdb\xbd\xdb\xbe"));
 }
 
 // RFC 5892 §2.6: ـ (U+0640 TATWEEL) and ߺ (U+07FA) are DISALLOWED
-TEST(DNS_idn_hostname, invalid_disallowed_exceptions_rtl) {
+TEST(invalid_disallowed_exceptions_rtl) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xd9\x80\xdf\xba"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd9\x80\xdf\xba"));
 }
 
 // RFC 5892 §2.6: 〱〲〳〴〵〮〯〻 are all DISALLOWED
-TEST(DNS_idn_hostname, invalid_disallowed_exceptions_ltr) {
+TEST(invalid_disallowed_exceptions_ltr) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\xe3\x80\xb1\xe3\x80\xb2\xe3\x80\xb3\xe3\x80\xb4\xe3\x80\xb5\xe3\x80"
       "\xae\xe3\x80\xaf\xe3\x80\xbb"));
@@ -396,93 +396,93 @@ TEST(DNS_idn_hostname, invalid_disallowed_exceptions_ltr) {
 }
 
 // RFC 5892 Appendix A.3: MIDDLE DOT requires surrounding 'l' codepoints
-TEST(DNS_idn_hostname, valid_middle_dot_between_l) {
+TEST(valid_middle_dot_between_l) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("l\xc2\xb7l"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("l\xc2\xb7l"));
 }
 
-TEST(DNS_idn_hostname, invalid_middle_dot_no_preceding_l) {
+TEST(invalid_middle_dot_no_preceding_l) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a\xc2\xb7l"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xc2\xb7l"));
 }
 
-TEST(DNS_idn_hostname, invalid_middle_dot_no_following_l) {
+TEST(invalid_middle_dot_no_following_l) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("l\xc2\xb7"
                                                  "a"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("l\xc2\xb7"
                                              "a"));
 }
 
-TEST(DNS_idn_hostname, invalid_middle_dot_leading) {
+TEST(invalid_middle_dot_leading) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xc2\xb7l"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xc2\xb7l"));
 }
 
-TEST(DNS_idn_hostname, invalid_middle_dot_trailing) {
+TEST(invalid_middle_dot_trailing) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("l\xc2\xb7"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("l\xc2\xb7"));
 }
 
 // RFC 5892 Appendix A.4: Greek KERAIA must be followed by a Greek codepoint
-TEST(DNS_idn_hostname, valid_keraia_followed_by_greek) {
+TEST(valid_keraia_followed_by_greek) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xce\xb1\xcd\xb5\xce\xb2"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce\xb1\xcd\xb5\xce\xb2"));
 }
 
-TEST(DNS_idn_hostname, invalid_keraia_followed_by_latin) {
+TEST(invalid_keraia_followed_by_latin) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xce\xb1\xcd\xb5S"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce\xb1\xcd\xb5S"));
 }
 
-TEST(DNS_idn_hostname, invalid_keraia_trailing) {
+TEST(invalid_keraia_trailing) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xce\xb1\xcd\xb5"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xce\xb1\xcd\xb5"));
 }
 
 // RFC 5892 Appendix A.5: Hebrew GERESH must be preceded by a Hebrew codepoint
-TEST(DNS_idn_hostname, valid_geresh_preceded_by_hebrew) {
+TEST(valid_geresh_preceded_by_hebrew) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xd7\x90\xd7\xb3\xd7\x91"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd7\x90\xd7\xb3\xd7\x91"));
 }
 
-TEST(DNS_idn_hostname, invalid_geresh_preceded_by_latin) {
+TEST(invalid_geresh_preceded_by_latin) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("A\xd7\xb3\xd7\x91"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("A\xd7\xb3\xd7\x91"));
 }
 
-TEST(DNS_idn_hostname, invalid_geresh_leading) {
+TEST(invalid_geresh_leading) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xd7\xb3\xd7\x91"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd7\xb3\xd7\x91"));
 }
 
 // RFC 5892 Appendix A.6: Hebrew GERSHAYIM must be preceded by Hebrew
-TEST(DNS_idn_hostname, valid_gershayim_preceded_by_hebrew) {
+TEST(valid_gershayim_preceded_by_hebrew) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xd7\x90\xd7\xb4\xd7\x91"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd7\x90\xd7\xb4\xd7\x91"));
 }
 
-TEST(DNS_idn_hostname, invalid_gershayim_preceded_by_latin) {
+TEST(invalid_gershayim_preceded_by_latin) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("A\xd7\xb4\xd7\x91"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("A\xd7\xb4\xd7\x91"));
 }
 
 // RFC 5892 Appendix A.7: KATAKANA MIDDLE DOT requires Hiragana/Katakana/Han
-TEST(DNS_idn_hostname, valid_katakana_middle_dot_with_hiragana) {
+TEST(valid_katakana_middle_dot_with_hiragana) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xe3\x83\xbb\xe3\x81\x81"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe3\x83\xbb\xe3\x81\x81"));
 }
 
-TEST(DNS_idn_hostname, valid_katakana_middle_dot_with_katakana) {
+TEST(valid_katakana_middle_dot_with_katakana) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xe3\x83\xbb\xe3\x82\xa1"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe3\x83\xbb\xe3\x82\xa1"));
 }
 
-TEST(DNS_idn_hostname, valid_katakana_middle_dot_with_han) {
+TEST(valid_katakana_middle_dot_with_han) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xe3\x83\xbb\xe4\xb8\x88"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe3\x83\xbb\xe4\xb8\x88"));
 }
 
-TEST(DNS_idn_hostname, invalid_katakana_middle_dot_without_japanese) {
+TEST(invalid_katakana_middle_dot_without_japanese) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("def\xe3\x83\xbb"
                                                  "abc"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("def\xe3\x83\xbb"
@@ -491,25 +491,25 @@ TEST(DNS_idn_hostname, invalid_katakana_middle_dot_without_japanese) {
 
 // RFC 5892 Appendix A.8/A.9: Arabic-Indic and Extended Arabic-Indic digits
 // must not mix within a label
-TEST(DNS_idn_hostname, valid_arabic_indic_digits_only) {
+TEST(valid_arabic_indic_digits_only) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xd8\xa8\xd9\xa0\xd8\xa8"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd8\xa8\xd9\xa0\xd8\xa8"));
 }
 
-TEST(DNS_idn_hostname, invalid_mixed_arabic_indic_digits) {
+TEST(invalid_mixed_arabic_indic_digits) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xd8\xa8\xd9\xa0\xdb\xb0"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xd8\xa8\xd9\xa0\xdb\xb0"));
 }
 
 // RFC 5892 Appendix A.2: ZERO WIDTH JOINER must be preceded by Virama
-TEST(DNS_idn_hostname, valid_zwj_after_virama) {
+TEST(valid_zwj_after_virama) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xe0\xa4\x95\xe0\xa5\x8d\xe2\x80\x8d\xe0\xa4\xb7"));
   EXPECT_FALSE(sourcemeta::core::is_hostname(
       "\xe0\xa4\x95\xe0\xa5\x8d\xe2\x80\x8d\xe0\xa4\xb7"));
 }
 
-TEST(DNS_idn_hostname, invalid_zwj_not_after_virama) {
+TEST(invalid_zwj_not_after_virama) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\xe0\xa4\x95\xe2\x80\x8d\xe0\xa4\xb7"));
   EXPECT_FALSE(
@@ -518,14 +518,14 @@ TEST(DNS_idn_hostname, invalid_zwj_not_after_virama) {
 
 // RFC 5892 Appendix A.1: ZERO WIDTH NON-JOINER requires Virama or proper
 // joining-context match
-TEST(DNS_idn_hostname, valid_zwnj_after_virama) {
+TEST(valid_zwnj_after_virama) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xe0\xa4\x95\xe0\xa5\x8d\xe2\x80\x8c\xe0\xa4\xb7"));
   EXPECT_FALSE(sourcemeta::core::is_hostname(
       "\xe0\xa4\x95\xe0\xa5\x8d\xe2\x80\x8c\xe0\xa4\xb7"));
 }
 
-TEST(DNS_idn_hostname, valid_zwnj_between_arabic_joiners) {
+TEST(valid_zwnj_between_arabic_joiners) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname(
       "\xd8\xa8\xd9\x8a\xe2\x80\x8c\xd8\xa8\xd9\x8a"));
   EXPECT_FALSE(sourcemeta::core::is_hostname(
@@ -533,40 +533,40 @@ TEST(DNS_idn_hostname, valid_zwnj_between_arabic_joiners) {
 }
 
 // UTS #46 §3.1: alternative label separators are recognised
-TEST(DNS_idn_hostname, valid_ideographic_full_stop_separator) {
+TEST(valid_ideographic_full_stop_separator) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a\xe3\x80\x82"
                                                 "b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xe3\x80\x82"
                                              "b"));
 }
 
-TEST(DNS_idn_hostname, valid_fullwidth_full_stop_separator) {
+TEST(valid_fullwidth_full_stop_separator) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a\xef\xbc\x8e"
                                                 "b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xef\xbc\x8e"
                                              "b"));
 }
 
-TEST(DNS_idn_hostname, valid_halfwidth_ideographic_full_stop_separator) {
+TEST(valid_halfwidth_ideographic_full_stop_separator) {
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("a\xef\xbd\xa1"
                                                 "b"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xef\xbd\xa1"
                                              "b"));
 }
 
-TEST(DNS_idn_hostname, invalid_leading_ideographic_full_stop) {
+TEST(invalid_leading_ideographic_full_stop) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xe3\x80\x82"
                                                  "example"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe3\x80\x82"
                                              "example"));
 }
 
-TEST(DNS_idn_hostname, invalid_trailing_ideographic_full_stop) {
+TEST(invalid_trailing_ideographic_full_stop) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("example\xe3\x80\x82"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("example\xe3\x80\x82"));
 }
 
-TEST(DNS_idn_hostname, invalid_single_ideographic_full_stop) {
+TEST(invalid_single_ideographic_full_stop) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\xe3\x80\x82"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xe3\x80\x82"));
 }
@@ -574,13 +574,13 @@ TEST(DNS_idn_hostname, invalid_single_ideographic_full_stop) {
 // RFC 5891 §4.1.2.A: a U-label must be in Unicode Normalisation Form C.
 // Decomposed `a` + combining grave (both PVALID) is rejected; the
 // precomposed `\u00E0` form is accepted
-TEST(DNS_idn_hostname, decomposed_label_rejected_not_nfc) {
+TEST(decomposed_label_rejected_not_nfc) {
   // UTF-8 of "a\u0300": "a" then \xCC\x80
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a\xcc\x80"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xcc\x80"));
 }
 
-TEST(DNS_idn_hostname, precomposed_label_accepted) {
+TEST(precomposed_label_accepted) {
   // UTF-8 of U+00E0: 0xC3 0xA0
   EXPECT_TRUE(sourcemeta::core::is_idn_hostname("\xc3\xa0"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("\xc3\xa0"));
@@ -588,7 +588,7 @@ TEST(DNS_idn_hostname, precomposed_label_accepted) {
 
 // Out-of-order combining marks fail the NFC check inside the label
 // validator, so the whole hostname is rejected
-TEST(DNS_idn_hostname, label_with_out_of_order_combining_marks_rejected) {
+TEST(label_with_out_of_order_combining_marks_rejected) {
   // a + U+0301 + U+0316: "a" 0xCC 0x81 0xCC 0x96
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("a\xcc\x81\xcc\x96"));
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xcc\x81\xcc\x96"));
@@ -596,57 +596,57 @@ TEST(DNS_idn_hostname, label_with_out_of_order_combining_marks_rejected) {
 
 // RFC 5893 sec 2: a digit-first label is invalid in a Bidi domain name
 // (whole-name rule)
-TEST(DNS_idn_hostname, invalid_bidi_digit_first_in_bidi_domain) {
+TEST(invalid_bidi_digit_first_in_bidi_domain) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x30\x61\x2e\xd7\x90"));
 }
 
 // RFC 5893 sec 2 cond 1: label must start with L, R or AL
-TEST(DNS_idn_hostname, invalid_bidi_single_label_digit_then_rtl) {
+TEST(invalid_bidi_single_label_digit_then_rtl) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x30\xd8\xa7"));
 }
 
 // RFC 5893 sec 2 cond 5: an LTR label may not contain an RTL letter
-TEST(DNS_idn_hostname, invalid_bidi_ltr_label_with_rtl_letter) {
+TEST(invalid_bidi_ltr_label_with_rtl_letter) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x61\xd7\x90"));
 }
 
 // RFC 5890 sec 2.3.2.1 + 5892 sec 2.6: decodes to U+00A1 (DISALLOWED)
-TEST(DNS_idn_hostname, invalid_a_label_decodes_to_disallowed) {
+TEST(invalid_a_label_decodes_to_disallowed) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x78\x6e\x2d\x2d\x37\x61"));
 }
 
 // RFC 5890 sec 2.3.2.1: A-label decodes to the all-ASCII label example
-TEST(DNS_idn_hostname, invalid_a_label_decodes_to_ascii_only) {
+TEST(invalid_a_label_decodes_to_ascii_only) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\x78\x6e\x2d\x2d\x65\x78\x61\x6d\x70\x6c\x65\x2d"));
 }
 
 // RFC 5890 sec 2.3.2.1 + 5893: decodes to a-grave + Hebrew aleph
-TEST(DNS_idn_hostname, invalid_a_label_decodes_to_bidi_violation) {
+TEST(invalid_a_label_decodes_to_bidi_violation) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\x78\x6e\x2d\x2d\x30\x63\x61\x32\x34\x77"));
 }
 
 // RFC 5891 sec 5.4: non-canonical Punycode; canonical form is xn--9uc
-TEST(DNS_idn_hostname, invalid_noncanonical_punycode) {
+TEST(invalid_noncanonical_punycode) {
   EXPECT_FALSE(
       sourcemeta::core::is_idn_hostname("\x78\x6e\x2d\x2d\x2d\x39\x75\x63"));
 }
 
 // RFC 5892 sec 2.6: fullwidth digits U+FF11..U+FF13 are DISALLOWED
-TEST(DNS_idn_hostname, invalid_fullwidth_digits) {
+TEST(invalid_fullwidth_digits) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\xef\xbc\x91\xef\xbc\x92\xef\xbc\x93"));
 }
 
 // RFC 5892 sec 2.6: U+200B (ZERO WIDTH SPACE) is DISALLOWED
-TEST(DNS_idn_hostname, invalid_zero_width_space) {
+TEST(invalid_zero_width_space) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("\x61\xe2\x80\x8b\x62"));
 }
 
 // RFC 5892 appendix A.1 (errata 3312): the ZWNJ rule must hold at every
 // occurrence
-TEST(DNS_idn_hostname, invalid_zwnj_failing_at_one_occurrence) {
+TEST(invalid_zwnj_failing_at_one_occurrence) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname(
       "\xe0\xa4\x95\xe0\xa5\x8d\xe2\x80\x8c\xe0\xa4\xb7\x78\xe2\x80\x8c\x79"));
 }

--- a/test/email/CMakeLists.txt
+++ b/test/email/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME email
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME email
   SOURCES email_test.cc idn_email_test.cc)
 
 target_link_libraries(sourcemeta_core_email_unit

--- a/test/email/email_test.cc
+++ b/test/email/email_test.cc
@@ -1,396 +1,396 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/email.h>
 
 #include <string>
 
 // RFC 5321 §4.1.2: minimal Dot-string Atom + minimal Domain sub-domain
-TEST(Email, valid_dot_string_single_letter) {
+TEST(valid_dot_string_single_letter) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
 }
 
 // RFC 5321 §4.1.2: atext includes DIGIT
-TEST(Email, valid_dot_string_single_digit) {
+TEST(valid_dot_string_single_digit) {
   EXPECT_TRUE(sourcemeta::core::is_email("1@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("1@b"));
 }
 
 // RFC 5321 §4.1.2: Atom = 1*atext
-TEST(Email, valid_dot_string_multi_letter_atom) {
+TEST(valid_dot_string_multi_letter_atom) {
   EXPECT_TRUE(sourcemeta::core::is_email("abc@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("abc@b"));
 }
 
 // RFC 5321 §4.1.2: atext mixes ALPHA and DIGIT
-TEST(Email, valid_dot_string_alpha_digit_mix) {
+TEST(valid_dot_string_alpha_digit_mix) {
   EXPECT_TRUE(sourcemeta::core::is_email("a1b2@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a1b2@b"));
 }
 
 // RFC 5321 §4.1.2: Dot-string = Atom *("." Atom) with two atoms
-TEST(Email, valid_dot_string_two_atoms) {
+TEST(valid_dot_string_two_atoms) {
   EXPECT_TRUE(sourcemeta::core::is_email("a.b@c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a.b@c"));
 }
 
 // RFC 5321 §4.1.2: Dot-string with many atoms
-TEST(Email, valid_dot_string_many_atoms) {
+TEST(valid_dot_string_many_atoms) {
   EXPECT_TRUE(sourcemeta::core::is_email("a.b.c.d.e@f"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a.b.c.d.e@f"));
 }
 
 // RFC 5321 §4.1.2: ALPHA covers A-Z
-TEST(Email, valid_dot_string_uppercase_atom) {
+TEST(valid_dot_string_uppercase_atom) {
   EXPECT_TRUE(sourcemeta::core::is_email("ABC@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("ABC@b"));
 }
 
 // RFC 5321 §4.1.2: ALPHA covers both cases in one atom
-TEST(Email, valid_dot_string_mixed_case_atom) {
+TEST(valid_dot_string_mixed_case_atom) {
   EXPECT_TRUE(sourcemeta::core::is_email("aBc@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("aBc@b"));
 }
 
 // RFC 5321 §4.1.2: "!" is atext
-TEST(Email, valid_atext_bang) {
+TEST(valid_atext_bang) {
   EXPECT_TRUE(sourcemeta::core::is_email("!@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("!@b"));
 }
 
 // RFC 5321 §4.1.2: "#" is atext
-TEST(Email, valid_atext_hash) {
+TEST(valid_atext_hash) {
   EXPECT_TRUE(sourcemeta::core::is_email("#@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("#@b"));
 }
 
 // RFC 5321 §4.1.2: "$" is atext
-TEST(Email, valid_atext_dollar) {
+TEST(valid_atext_dollar) {
   EXPECT_TRUE(sourcemeta::core::is_email("$@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("$@b"));
 }
 
 // RFC 5321 §4.1.2: "%" is atext
-TEST(Email, valid_atext_percent) {
+TEST(valid_atext_percent) {
   EXPECT_TRUE(sourcemeta::core::is_email("%@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("%@b"));
 }
 
 // RFC 5321 §4.1.2: "&" is atext
-TEST(Email, valid_atext_ampersand) {
+TEST(valid_atext_ampersand) {
   EXPECT_TRUE(sourcemeta::core::is_email("&@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("&@b"));
 }
 
 // RFC 5321 §4.1.2: "'" is atext
-TEST(Email, valid_atext_apostrophe) {
+TEST(valid_atext_apostrophe) {
   EXPECT_TRUE(sourcemeta::core::is_email("'@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("'@b"));
 }
 
 // RFC 5321 §4.1.2: "*" is atext
-TEST(Email, valid_atext_asterisk) {
+TEST(valid_atext_asterisk) {
   EXPECT_TRUE(sourcemeta::core::is_email("*@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("*@b"));
 }
 
 // RFC 5321 §4.1.2: "+" is atext
-TEST(Email, valid_atext_plus) {
+TEST(valid_atext_plus) {
   EXPECT_TRUE(sourcemeta::core::is_email("+@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("+@b"));
 }
 
 // RFC 5321 §4.1.2: "-" is atext
-TEST(Email, valid_atext_hyphen) {
+TEST(valid_atext_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_email("-@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("-@b"));
 }
 
 // RFC 5321 §4.1.2: "/" is atext
-TEST(Email, valid_atext_slash) {
+TEST(valid_atext_slash) {
   EXPECT_TRUE(sourcemeta::core::is_email("/@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("/@b"));
 }
 
 // RFC 5321 §4.1.2: "=" is atext
-TEST(Email, valid_atext_equals) {
+TEST(valid_atext_equals) {
   EXPECT_TRUE(sourcemeta::core::is_email("=@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("=@b"));
 }
 
 // RFC 5321 §4.1.2: "?" is atext
-TEST(Email, valid_atext_question) {
+TEST(valid_atext_question) {
   EXPECT_TRUE(sourcemeta::core::is_email("?@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("?@b"));
 }
 
 // RFC 5321 §4.1.2: "^" is atext
-TEST(Email, valid_atext_caret) {
+TEST(valid_atext_caret) {
   EXPECT_TRUE(sourcemeta::core::is_email("^@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("^@b"));
 }
 
 // RFC 5321 §4.1.2: "_" is atext
-TEST(Email, valid_atext_underscore) {
+TEST(valid_atext_underscore) {
   EXPECT_TRUE(sourcemeta::core::is_email("_@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("_@b"));
 }
 
 // RFC 5321 §4.1.2: "`" is atext
-TEST(Email, valid_atext_backtick) {
+TEST(valid_atext_backtick) {
   EXPECT_TRUE(sourcemeta::core::is_email("`@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("`@b"));
 }
 
 // RFC 5321 §4.1.2: "{" is atext
-TEST(Email, valid_atext_lbrace) {
+TEST(valid_atext_lbrace) {
   EXPECT_TRUE(sourcemeta::core::is_email("{@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("{@b"));
 }
 
 // RFC 5321 §4.1.2: "|" is atext
-TEST(Email, valid_atext_pipe) {
+TEST(valid_atext_pipe) {
   EXPECT_TRUE(sourcemeta::core::is_email("|@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("|@b"));
 }
 
 // RFC 5321 §4.1.2: "}" is atext
-TEST(Email, valid_atext_rbrace) {
+TEST(valid_atext_rbrace) {
   EXPECT_TRUE(sourcemeta::core::is_email("}@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("}@b"));
 }
 
 // RFC 5321 §4.1.2: "~" is atext
-TEST(Email, valid_atext_tilde) {
+TEST(valid_atext_tilde) {
   EXPECT_TRUE(sourcemeta::core::is_email("~@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("~@b"));
 }
 
 // RFC 5321 §4.1.2: a single Atom may include every atext special at once
-TEST(Email, valid_dot_string_all_specials_one_atom) {
+TEST(valid_dot_string_all_specials_one_atom) {
   EXPECT_TRUE(sourcemeta::core::is_email("!#$%&'*+-/=?^_`{|}~@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("!#$%&'*+-/=?^_`{|}~@b"));
 }
 
 // RFC 5321 §4.5.3.1.1: Local-part octet limit is 64
-TEST(Email, valid_local_part_length_64) {
+TEST(valid_local_part_length_64) {
   EXPECT_TRUE(sourcemeta::core::is_email(std::string(64, 'a') + "@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email(std::string(64, 'a') + "@b"));
 }
 
 // RFC 5321 §4.1.2: Atom = 1*atext, single byte is the minimum
-TEST(Email, valid_local_part_length_1) {
+TEST(valid_local_part_length_1) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
 }
 
 // RFC 5321 §4.1.2: Mailbox requires both a Local-part and a Domain
-TEST(Email, invalid_no_at_sign) {
+TEST(invalid_no_at_sign) {
   EXPECT_FALSE(sourcemeta::core::is_email("plain"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("plain"));
 }
 
 // RFC 5321 §4.1.2: Local-part = Dot-string / Quoted-string, both non-empty
-TEST(Email, invalid_only_at_sign) {
+TEST(invalid_only_at_sign) {
   EXPECT_FALSE(sourcemeta::core::is_email("@"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("@"));
 }
 
 // RFC 5321 §4.1.2: Atom = 1*atext, empty Local-part is invalid
-TEST(Email, invalid_empty_local) {
+TEST(invalid_empty_local) {
   EXPECT_FALSE(sourcemeta::core::is_email("@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("@b"));
 }
 
 // RFC 5321 §4.1.2: Domain = sub-domain *("." sub-domain), empty is invalid
-TEST(Email, invalid_empty_domain) {
+TEST(invalid_empty_domain) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@"));
 }
 
 // RFC 5321 §4.1.2: only one "@" allowed outside a Quoted-string
-TEST(Email, invalid_two_at_signs_unquoted) {
+TEST(invalid_two_at_signs_unquoted) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b@c"));
 }
 
 // RFC 5321 §4.1.2: three unquoted "@" signs
-TEST(Email, invalid_three_at_signs_unquoted) {
+TEST(invalid_three_at_signs_unquoted) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b@c@d"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b@c@d"));
 }
 
 // RFC 5321 §4.1.2: Dot-string requires a leading Atom
-TEST(Email, invalid_local_leading_dot) {
+TEST(invalid_local_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email(".a@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(".a@b"));
 }
 
 // RFC 5321 §4.1.2: Dot-string requires a trailing Atom
-TEST(Email, invalid_local_trailing_dot) {
+TEST(invalid_local_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a.@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a.@b"));
 }
 
 // RFC 5321 §4.1.2: Atom = 1*atext, double dot yields an empty Atom
-TEST(Email, invalid_local_double_dot) {
+TEST(invalid_local_double_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a..b@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a..b@c"));
 }
 
 // RFC 5321 §4.1.2: lone "." has no atext on either side
-TEST(Email, invalid_local_only_dot) {
+TEST(invalid_local_only_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email(".@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(".@b"));
 }
 
 // RFC 5321 §4.1.2: ".." has no atext between the dots
-TEST(Email, invalid_local_only_dots) {
+TEST(invalid_local_only_dots) {
   EXPECT_FALSE(sourcemeta::core::is_email("..@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("..@b"));
 }
 
 // RFC 5321 §4.5.3.1.1: Local-part may not exceed 64 octets
-TEST(Email, invalid_local_part_length_65) {
+TEST(invalid_local_part_length_65) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string(65, 'a') + "@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(std::string(65, 'a') + "@b"));
 }
 
 // RFC 5321 §4.1.2: "(" is not in atext
-TEST(Email, invalid_atext_lparen) {
+TEST(invalid_atext_lparen) {
   EXPECT_FALSE(sourcemeta::core::is_email("(@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("(@b"));
 }
 
 // RFC 5321 §4.1.2: ")" is not in atext
-TEST(Email, invalid_atext_rparen) {
+TEST(invalid_atext_rparen) {
   EXPECT_FALSE(sourcemeta::core::is_email(")@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(")@b"));
 }
 
 // RFC 5321 §4.1.2: "," is not in atext
-TEST(Email, invalid_atext_comma) {
+TEST(invalid_atext_comma) {
   EXPECT_FALSE(sourcemeta::core::is_email(",@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(",@b"));
 }
 
 // RFC 5321 §4.1.2: ":" is not in atext
-TEST(Email, invalid_atext_colon) {
+TEST(invalid_atext_colon) {
   EXPECT_FALSE(sourcemeta::core::is_email(":@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(":@b"));
 }
 
 // RFC 5321 §4.1.2: ";" is not in atext
-TEST(Email, invalid_atext_semicolon) {
+TEST(invalid_atext_semicolon) {
   EXPECT_FALSE(sourcemeta::core::is_email(";@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(";@b"));
 }
 
 // RFC 5321 §4.1.2: "<" is not in atext
-TEST(Email, invalid_atext_lt) {
+TEST(invalid_atext_lt) {
   EXPECT_FALSE(sourcemeta::core::is_email("<@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("<@b"));
 }
 
 // RFC 5321 §4.1.2: ">" is not in atext
-TEST(Email, invalid_atext_gt) {
+TEST(invalid_atext_gt) {
   EXPECT_FALSE(sourcemeta::core::is_email(">@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(">@b"));
 }
 
 // RFC 5321 §4.1.2: "[" is not in atext
-TEST(Email, invalid_atext_lbracket) {
+TEST(invalid_atext_lbracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("[@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("[@b"));
 }
 
 // RFC 5321 §4.1.2: "\" is not in atext (only valid inside quoted-pair)
-TEST(Email, invalid_atext_backslash) {
+TEST(invalid_atext_backslash) {
   EXPECT_FALSE(sourcemeta::core::is_email("\\@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\\@b"));
 }
 
 // RFC 5321 §4.1.2: "]" is not in atext
-TEST(Email, invalid_atext_rbracket) {
+TEST(invalid_atext_rbracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("]@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("]@b"));
 }
 
 // RFC 5321 §4.1.2: SP is not in atext
-TEST(Email, invalid_atext_space_unquoted) {
+TEST(invalid_atext_space_unquoted) {
   EXPECT_FALSE(sourcemeta::core::is_email(" @b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(" @b"));
 }
 
 // RFC 5321 §4.1.2: atext is ASCII; bytes >= 0x80 are excluded
-TEST(Email, invalid_local_high_bit_byte) {
+TEST(invalid_local_high_bit_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("a\x80@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a\x80@b"));
 }
 
 // RFC 5321 §4.1.2: NUL is not in atext
-TEST(Email, invalid_local_nul_byte) {
+TEST(invalid_local_nul_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string_view{"a\x00@b", 4}));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(std::string_view{"a\x00@b", 4}));
 }
 
 // RFC 5321 §4.1.2: control characters are not in atext
-TEST(Email, invalid_local_control_byte) {
+TEST(invalid_local_control_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("a\x01@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a\x01@b"));
 }
 
 // RFC 5321 §4.1.2: DEL is not in atext
-TEST(Email, invalid_local_del_byte) {
+TEST(invalid_local_del_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("a\x7f@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a\x7f@b"));
 }
 
 // RFC 5321 §4.1.2 Domain: sub-domain *("." sub-domain) with one label
-TEST(Email, valid_domain_single_label) {
+TEST(valid_domain_single_label) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
 }
 
 // RFC 5321 §4.1.2 Domain: two labels separated by "."
-TEST(Email, valid_domain_two_labels) {
+TEST(valid_domain_two_labels) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b.c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b.c"));
 }
 
 // RFC 5321 §4.1.2 Domain: many labels
-TEST(Email, valid_domain_three_labels) {
+TEST(valid_domain_three_labels) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b.c.d"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b.c.d"));
 }
 
 // RFC 5321 §4.1.2 Domain: sub-domain = Let-dig [Ldh-str], digit is Let-dig
-TEST(Email, valid_domain_label_starts_with_digit) {
+TEST(valid_domain_label_starts_with_digit) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@1b.c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@1b.c"));
 }
 
 // RFC 5321 §4.1.2 Domain: grammar allows numeric-only labels
-TEST(Email, valid_domain_numeric_tld) {
+TEST(valid_domain_numeric_tld) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@example.123"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@example.123"));
 }
 
 // RFC 5321 §4.1.2 Domain: case is preserved but accepted
-TEST(Email, valid_domain_uppercase) {
+TEST(valid_domain_uppercase) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@EXAMPLE.COM"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@EXAMPLE.COM"));
 }
 
 // RFC 1035 §2.3.4 via §4.1.2 Domain: 63-byte label is the cap
-TEST(Email, valid_domain_label_63) {
+TEST(valid_domain_label_63) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@" + std::string(63, 'b')));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@" + std::string(63, 'b')));
 }
 
 // RFC 5321 §4.5.3.1.2 Domain: 255-byte domain is the RFC 1123 cap.
 // RFC 1035 §3.1: IDN strict presentation form caps the domain at 253 octets
-TEST(Email, domain_total_255) {
+TEST(domain_total_255) {
   EXPECT_TRUE(sourcemeta::core::is_email(
       "a@" + std::string(63, 'b') + "." + std::string(63, 'c') + "." +
       std::string(63, 'd') + "." + std::string(63, 'e')));
@@ -400,50 +400,50 @@ TEST(Email, domain_total_255) {
 }
 
 // RFC 5321 §4.1.2 Domain: Ldh-str excludes "_"
-TEST(Email, invalid_domain_underscore) {
+TEST(invalid_domain_underscore) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@host_name"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@host_name"));
 }
 
 // RFC 5321 §4.1.2 Domain: sub-domain must start with Let-dig
-TEST(Email, invalid_domain_leading_hyphen) {
+TEST(invalid_domain_leading_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@-host"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@-host"));
 }
 
 // RFC 5321 §4.1.2 Domain: Ldh-str must end with Let-dig
-TEST(Email, invalid_domain_trailing_hyphen) {
+TEST(invalid_domain_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@host-"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@host-"));
 }
 
 // RFC 5321 §4.1.2 Domain: no trailing "."
-TEST(Email, invalid_domain_trailing_dot) {
+TEST(invalid_domain_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@host."));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@host."));
 }
 
 // RFC 5321 §4.1.2 Domain: "." between labels requires a sub-domain on each side
-TEST(Email, invalid_domain_double_dot) {
+TEST(invalid_domain_double_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@x..y"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@x..y"));
 }
 
 // RFC 5321 §4.1.2 Domain: no leading "."
-TEST(Email, invalid_domain_leading_dot) {
+TEST(invalid_domain_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@.host"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@.host"));
 }
 
 // RFC 1035 §2.3.4 via §4.1.2 Domain: 64-byte label exceeds cap
-TEST(Email, invalid_domain_label_64) {
+TEST(invalid_domain_label_64) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@" + std::string(64, 'b')));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@" + std::string(64, 'b')));
 }
 
 // RFC 5321 §4.5.3.1.2 Domain: 256-byte domain exceeds cap (63 + "." + 63 +
 // "." + 63 + "." + 62 + "." + "f" = 256 bytes)
-TEST(Email, invalid_domain_total_256) {
+TEST(invalid_domain_total_256) {
   EXPECT_FALSE(sourcemeta::core::is_email(
       "a@" + std::string(63, 'b') + "." + std::string(63, 'c') + "." +
       std::string(63, 'd') + "." + std::string(62, 'e') + ".f"));
@@ -453,236 +453,236 @@ TEST(Email, invalid_domain_total_256) {
 }
 
 // RFC 5321 §4.1.2 Domain: ASCII only, bytes >= 0x80 excluded
-TEST(Email, invalid_domain_high_bit_byte) {
+TEST(invalid_domain_high_bit_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@hos\x80t"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@hos\x80t"));
 }
 
 // RFC 5321 §4.1.2 Domain: SP is not in Ldh-str
-TEST(Email, invalid_domain_space) {
+TEST(invalid_domain_space) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@host name"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@host name"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string = DQUOTE *QcontentSMTP DQUOTE permits zero
 // content bytes
-TEST(Email, valid_quoted_empty) {
+TEST(valid_quoted_empty) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP includes %d32 SP
-TEST(Email, valid_quoted_single_space) {
+TEST(valid_quoted_single_space) {
   EXPECT_TRUE(sourcemeta::core::is_email("\" \"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\" \"@b"));
 }
 
 // RFC 5321 §4.1.2: any atext byte is also in qtextSMTP
-TEST(Email, valid_quoted_single_atext) {
+TEST(valid_quoted_single_atext) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP %d35-91 includes "@"
-TEST(Email, valid_quoted_at_inside) {
+TEST(valid_quoted_at_inside) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a@b\"@c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a@b\"@c"));
 }
 
 // RFC 5321 §4.1.2: Dot-string rules do not apply inside Quoted-string
-TEST(Email, valid_quoted_dot_inside) {
+TEST(valid_quoted_dot_inside) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a.b\"@c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a.b\"@c"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string permits a leading "." inside
-TEST(Email, valid_quoted_dot_at_start) {
+TEST(valid_quoted_dot_at_start) {
   EXPECT_TRUE(sourcemeta::core::is_email("\".a\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\".a\"@b"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string permits a trailing "." inside
-TEST(Email, valid_quoted_dot_at_end) {
+TEST(valid_quoted_dot_at_end) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a.\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a.\"@b"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string permits consecutive "." inside
-TEST(Email, valid_quoted_double_dot_inside) {
+TEST(valid_quoted_double_dot_inside) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a..b\"@c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a..b\"@c"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP starts at %d32 (SP)
-TEST(Email, valid_quoted_qtext_d32_space) {
+TEST(valid_quoted_qtext_d32_space) {
   EXPECT_TRUE(sourcemeta::core::is_email("\" \"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\" \"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP includes %d33 "!"
-TEST(Email, valid_quoted_qtext_d33_bang) {
+TEST(valid_quoted_qtext_d33_bang) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"!\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"!\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP resumes at %d35 "#" after skipping DQUOTE
-TEST(Email, valid_quoted_qtext_d35_hash) {
+TEST(valid_quoted_qtext_d35_hash) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"#\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"#\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP %d35-91 ends at "[" (%d91)
-TEST(Email, valid_quoted_qtext_d91_lbracket) {
+TEST(valid_quoted_qtext_d91_lbracket) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"[\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"[\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP resumes at "]" (%d93) after skipping "\\"
-TEST(Email, valid_quoted_qtext_d93_rbracket) {
+TEST(valid_quoted_qtext_d93_rbracket) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"]\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"]\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP ends at "~" (%d126)
-TEST(Email, valid_quoted_qtext_d126_tilde) {
+TEST(valid_quoted_qtext_d126_tilde) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"~\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"~\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP escapes DQUOTE
-TEST(Email, valid_quoted_pair_dquote) {
+TEST(valid_quoted_pair_dquote) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\\"\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\\"\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP escapes backslash itself
-TEST(Email, valid_quoted_pair_backslash) {
+TEST(valid_quoted_pair_backslash) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\\\\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\\\\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body %d32 is SP
-TEST(Email, valid_quoted_pair_space) {
+TEST(valid_quoted_pair_space) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\ \"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\ \"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body covers any ASCII graphic
-TEST(Email, valid_quoted_pair_letter) {
+TEST(valid_quoted_pair_letter) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\a\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\a\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body %d126 is "~"
-TEST(Email, valid_quoted_pair_tilde) {
+TEST(valid_quoted_pair_tilde) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\~\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\~\"@b"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string accepts qtextSMTP and quoted-pairSMTP mixed
-TEST(Email, valid_quoted_mixed_qtext_and_pair) {
+TEST(valid_quoted_mixed_qtext_and_pair) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a\\\"b\\\\c\"@d"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a\\\"b\\\\c\"@d"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP includes ',' and ';' (both in %d35-91)
-TEST(Email, valid_quoted_with_comma_semicolon) {
+TEST(valid_quoted_with_comma_semicolon) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a,b;c\"@d"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a,b;c\"@d"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP includes '(' and ')' (both in %d35-91)
-TEST(Email, valid_quoted_with_parens) {
+TEST(valid_quoted_with_parens) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"(comment)\"@d"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"(comment)\"@d"));
 }
 
 // RFC 5321 §4.5.3.1.1: 62 qtext bytes plus two DQUOTEs equals 64 octets
-TEST(Email, valid_quoted_local_length_64) {
+TEST(valid_quoted_local_length_64) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"" + std::string(62, 'a') + "\"@b"));
   EXPECT_TRUE(
       sourcemeta::core::is_idn_email("\"" + std::string(62, 'a') + "\"@b"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string must terminate with DQUOTE
-TEST(Email, invalid_quoted_unterminated) {
+TEST(invalid_quoted_unterminated) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"foo@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"foo@b"));
 }
 
 // RFC 5321 §4.1.2: extra content after closing DQUOTE is not Mailbox grammar
-TEST(Email, invalid_quoted_followed_by_atext) {
+TEST(invalid_quoted_followed_by_atext) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"a\"b@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"a\"b@c"));
 }
 
 // RFC 5321 §4.1.2: Mailbox grammar does not permit mixing Quoted-string and
 // Dot-string in a Local-part
-TEST(Email, invalid_quoted_followed_by_dot_atext) {
+TEST(invalid_quoted_followed_by_dot_atext) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"a\".b@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"a\".b@c"));
 }
 
 // RFC 5321 §4.1.2: a Quoted-string cannot be preceded by atext
-TEST(Email, invalid_quoted_preceded_by_atext) {
+TEST(invalid_quoted_preceded_by_atext) {
   EXPECT_FALSE(sourcemeta::core::is_email("a\"b\"@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a\"b\"@c"));
 }
 
 // RFC 5321 §4.1.2: bare DQUOTE inside a Quoted-string closes it; the trailing
 // bytes break the Mailbox grammar
-TEST(Email, invalid_quoted_bare_dquote_inside) {
+TEST(invalid_quoted_bare_dquote_inside) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"a\"b\"@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"a\"b\"@c"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP consumes the byte after "\\"; if that byte
 // is DQUOTE the Quoted-string is left unterminated
-TEST(Email, invalid_quoted_dangling_backslash) {
+TEST(invalid_quoted_dangling_backslash) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"a\\\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"a\\\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP excludes controls (%d0-31)
-TEST(Email, invalid_quoted_qtext_control_byte) {
+TEST(invalid_quoted_qtext_control_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"\x01\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\x01\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP excludes NUL
-TEST(Email, invalid_quoted_qtext_nul) {
+TEST(invalid_quoted_qtext_nul) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string_view{"\"\x00\"@b", 5}));
   EXPECT_FALSE(
       sourcemeta::core::is_idn_email(std::string_view{"\"\x00\"@b", 5}));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP is ASCII, bytes >= 0x80 are excluded
-TEST(Email, invalid_quoted_qtext_high_bit) {
+TEST(invalid_quoted_qtext_high_bit) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"\x80\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\x80\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body is %d32-126, controls are excluded
-TEST(Email, invalid_quoted_pair_control_byte) {
+TEST(invalid_quoted_pair_control_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"\\\x01\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\\\x01\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body ends at %d126, DEL is excluded
-TEST(Email, invalid_quoted_pair_del_byte) {
+TEST(invalid_quoted_pair_del_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"\\\x7f\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\\\x7f\"@b"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body is ASCII, bytes >= 0x80 are excluded
-TEST(Email, invalid_quoted_pair_high_bit_byte) {
+TEST(invalid_quoted_pair_high_bit_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"\\\x80\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\\\x80\"@b"));
 }
 
 // RFC 5321 §4.5.3.1.1: 63 qtext bytes plus two DQUOTEs equals 65 octets, one
 // past the cap
-TEST(Email, invalid_quoted_local_length_65) {
+TEST(invalid_quoted_local_length_65) {
   EXPECT_FALSE(
       sourcemeta::core::is_email("\"" + std::string(63, 'a') + "\"@b"));
   EXPECT_FALSE(
@@ -691,177 +691,177 @@ TEST(Email, invalid_quoted_local_length_65) {
 
 // RFC 5321 §4.1.2: a Quoted-string may contain an unquoted "@" but the outer
 // boundary "@" is still required after the closing DQUOTE
-TEST(Email, valid_two_at_signs_one_quoted) {
+TEST(valid_two_at_signs_one_quoted) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"a@b\"@c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a@b\"@c"));
 }
 
 // RFC 5321 §4.1.2: two embedded "@" inside a Quoted-string are still qtextSMTP
-TEST(Email, valid_two_at_signs_quoted_with_atext) {
+TEST(valid_two_at_signs_quoted_with_atext) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"x@y@z\"@d"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"x@y@z\"@d"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal Snum 3("." Snum) covers 0.0.0.0
-TEST(Email, valid_ipv4_literal_zeros) {
+TEST(valid_ipv4_literal_zeros) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[0.0.0.0]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[0.0.0.0]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal Snum max is 255
-TEST(Email, valid_ipv4_literal_max) {
+TEST(valid_ipv4_literal_max) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[255.255.255.255]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[255.255.255.255]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal typical RFC 1918 address
-TEST(Email, valid_ipv4_literal_typical) {
+TEST(valid_ipv4_literal_typical) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[192.168.1.1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[192.168.1.1]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal loopback
-TEST(Email, valid_ipv4_literal_loopback) {
+TEST(valid_ipv4_literal_loopback) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[127.0.0.1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[127.0.0.1]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal one-digit Snum
-TEST(Email, valid_ipv4_literal_single_digit) {
+TEST(valid_ipv4_literal_single_digit) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[1.2.3.4]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[1.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal two-digit Snum
-TEST(Email, valid_ipv4_literal_two_digit) {
+TEST(valid_ipv4_literal_two_digit) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[10.20.30.40]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[10.20.30.40]"));
 }
 
 // RFC 5321 §4.1.2: Domain accepts numeric-only labels without brackets
-TEST(Email, valid_domain_dotted_numeric) {
+TEST(valid_domain_dotted_numeric) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@1.2.3.4"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@1.2.3.4"));
 }
 
 // RFC 5321 §4.1.3: Snum value range 0-255, 256 is out of range
-TEST(Email, invalid_ipv4_octet_256) {
+TEST(invalid_ipv4_octet_256) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[256.0.0.0]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[256.0.0.0]"));
 }
 
 // RFC 5321 §4.1.3: Snum value range 0-255, 999 is out of range
-TEST(Email, invalid_ipv4_octet_999) {
+TEST(invalid_ipv4_octet_999) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[999.0.0.1]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[999.0.0.1]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal requires exactly four Snum octets
-TEST(Email, invalid_ipv4_three_octets) {
+TEST(invalid_ipv4_three_octets) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[1.2.3]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[1.2.3]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal rejects five Snum octets
-TEST(Email, invalid_ipv4_five_octets) {
+TEST(invalid_ipv4_five_octets) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[1.2.3.4.5]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[1.2.3.4.5]"));
 }
 
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT, leading zeros are permitted
-TEST(Email, valid_ipv4_leading_zero) {
+TEST(valid_ipv4_leading_zero) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[01.2.3.4]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[01.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT, a fully zero-padded octet is permitted
-TEST(Email, valid_ipv4_padded_octets) {
+TEST(valid_ipv4_padded_octets) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[001.002.003.004]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[001.002.003.004]"));
 }
 
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT, an octet wider than three digits is
 // rejected
-TEST(Email, invalid_ipv4_four_digit_octet) {
+TEST(invalid_ipv4_four_digit_octet) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[0001.2.3.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[0001.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal cannot end with a "."
-TEST(Email, invalid_ipv4_trailing_dot) {
+TEST(invalid_ipv4_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[1.2.3.4.]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[1.2.3.4.]"));
 }
 
 // RFC 5321 §4.1.3: IPv4-address-literal cannot begin with a "."
-TEST(Email, invalid_ipv4_leading_dot) {
+TEST(invalid_ipv4_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[.1.2.3.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[.1.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT, "-" is not a digit
-TEST(Email, invalid_ipv4_negative_octet) {
+TEST(invalid_ipv4_negative_octet) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[-1.2.3.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[-1.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: Snum = 1*3DIGIT, alphabetic bytes are not digits
-TEST(Email, invalid_ipv4_alpha_octet) {
+TEST(invalid_ipv4_alpha_octet) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[1.2.a.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[1.2.a.4]"));
 }
 
 // RFC 5321 §4.1.3: address-literal requires a closing "]"
-TEST(Email, invalid_ipv4_missing_close_bracket) {
+TEST(invalid_ipv4_missing_close_bracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[1.2.3.4"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[1.2.3.4"));
 }
 
 // RFC 5321 §4.1.2 Domain: "]" is not in Ldh-str, so unbracketed forms fail
-TEST(Email, invalid_ipv4_missing_open_bracket) {
+TEST(invalid_ipv4_missing_open_bracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@1.2.3.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@1.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: no content is permitted after the closing "]"
-TEST(Email, invalid_ipv4_trailing_garbage) {
+TEST(invalid_ipv4_trailing_garbage) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[1.2.3.4]x"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[1.2.3.4]x"));
 }
 
 // RFC 5321 §4.1.2 Domain: "[" is not in Ldh-str, so embedded brackets fail
-TEST(Email, invalid_ipv4_leading_garbage) {
+TEST(invalid_ipv4_leading_garbage) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@x[1.2.3.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@x[1.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3: address-literal requires at least one of IPv4, IPv6, or
 // General-address-literal between the brackets
-TEST(Email, invalid_ipv4_empty_brackets) {
+TEST(invalid_ipv4_empty_brackets) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[]"));
 }
 
 // RFC 5321 §4.1.3: IPv6-address-literal = "IPv6:" IPv6-addr, loopback form
-TEST(Email, valid_ipv6_literal_loopback) {
+TEST(valid_ipv6_literal_loopback) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:::1]"));
 }
 
 // RFC 4291 §2.2: "::" compresses an all-zeros address
-TEST(Email, valid_ipv6_literal_all_zeros) {
+TEST(valid_ipv6_literal_all_zeros) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:::]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:::]"));
 }
 
 // RFC 5321 §4.1.3: IPv6-address-literal with one compressed group
-TEST(Email, valid_ipv6_literal_typical) {
+TEST(valid_ipv6_literal_typical) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:2001:db8::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:2001:db8::1]"));
 }
 
 // RFC 4291 §2.2: IPv6-full form with eight 1-4 hex groups
-TEST(Email, valid_ipv6_literal_full_form) {
+TEST(valid_ipv6_literal_full_form) {
   EXPECT_TRUE(sourcemeta::core::is_email(
       "a@[IPv6:2001:0db8:0000:0000:0000:0000:0000:0001]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email(
@@ -869,19 +869,19 @@ TEST(Email, valid_ipv6_literal_full_form) {
 }
 
 // RFC 4291 §2.5.6: link-local prefix fe80::/10
-TEST(Email, valid_ipv6_literal_link_local) {
+TEST(valid_ipv6_literal_link_local) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:fe80::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:fe80::1]"));
 }
 
 // RFC 4291 §2.2: IPv4-mapped IPv6 address form
-TEST(Email, valid_ipv6_literal_v4_mapped) {
+TEST(valid_ipv6_literal_v4_mapped) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:::ffff:192.168.1.1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:::ffff:192.168.1.1]"));
 }
 
 // RFC 4291 §2.5.5: IPv4-compatible IPv6 address form
-TEST(Email, valid_ipv6_literal_v4_compat) {
+TEST(valid_ipv6_literal_v4_compat) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:::192.168.1.1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:::192.168.1.1]"));
 }
@@ -889,26 +889,26 @@ TEST(Email, valid_ipv6_literal_v4_compat) {
 // RFC 5321 §4.1.3: without the "IPv6:" tag the literal is parsed as
 // General-address-literal (tag "2001", content "db8::1"), which is valid
 // because ":" is in dcontent (%d58 is within %d33-90)
-TEST(Email, valid_no_ipv6_prefix_as_general) {
+TEST(valid_no_ipv6_prefix_as_general) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[2001:db8::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[2001:db8::1]"));
 }
 
 // RFC 5234 §2.3: ABNF literal strings are case-insensitive by default, so the
 // "IPv6:" prefix matches "ipv6:"
-TEST(Email, valid_lowercase_ipv6_literal) {
+TEST(valid_lowercase_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[ipv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[ipv6:::1]"));
 }
 
 // RFC 5234 §2.3: case-insensitive literal also matches "IPV6:"
-TEST(Email, valid_uppercase_ipv6_literal) {
+TEST(valid_uppercase_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPV6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPV6:::1]"));
 }
 
 // RFC 5234 §2.3: mixed-case prefix also matches the IPv6 tag
-TEST(Email, valid_mixed_case_ipv6_literal) {
+TEST(valid_mixed_case_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[iPv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[iPv6:::1]"));
 }
@@ -916,106 +916,106 @@ TEST(Email, valid_mixed_case_ipv6_literal) {
 // RFC 5234 §3.2: ABNF alternatives are unordered. The literal five-byte
 // prefix "IPv6:" is stripped, ":1" fails IPv6-addr, and the input falls
 // through to General-address-literal with tag "IPv6" and content ":1"
-TEST(Email, valid_ipv6_prefix_no_colon_as_general) {
+TEST(valid_ipv6_prefix_no_colon_as_general) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6::1]"));
 }
 
 // RFC 5234 §3.2: a failed IPv6-addr match falls through to General-address-
 // literal with tag "IPv6" and content "not-an-address" (all dcontent)
-TEST(Email, valid_ipv6_body_garbage_as_general) {
+TEST(valid_ipv6_body_garbage_as_general) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:not-an-address]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:not-an-address]"));
 }
 
 // RFC 5321 §4.1.3: IPv6-addr requires at least one group
-TEST(Email, invalid_ipv6_body_empty) {
+TEST(invalid_ipv6_body_empty) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6:]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:]"));
 }
 
 // RFC 5234 §3.2: nine groups fail IPv6-addr but the input still matches
 // General-address-literal with tag "IPv6" and content "1:2:3:4:5:6:7:8:9"
-TEST(Email, valid_ipv6_too_many_groups_as_general) {
+TEST(valid_ipv6_too_many_groups_as_general) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv6:1:2:3:4:5:6:7:8:9]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv6:1:2:3:4:5:6:7:8:9]"));
 }
 
 // RFC 5321 §4.1.3: address-literal needs a closing "]"
-TEST(Email, invalid_ipv6_missing_close_bracket) {
+TEST(invalid_ipv6_missing_close_bracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6:::1"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:::1"));
 }
 
 // RFC 5321 §4.1.3: no content is permitted after the closing "]"
-TEST(Email, invalid_ipv6_trailing_garbage) {
+TEST(invalid_ipv6_trailing_garbage) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[IPv6:::1]x"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[IPv6:::1]x"));
 }
 
 // RFC 5321 §4.1.3: General-address-literal = Standardized-tag ":" 1*dcontent
-TEST(Email, valid_general_literal_minimal) {
+TEST(valid_general_literal_minimal) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[X:y]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[X:y]"));
 }
 
 // RFC 5321 §4.1.3: typical X400 tag from the IANA Standardized-tag registry
-TEST(Email, valid_general_literal_x400) {
+TEST(valid_general_literal_x400) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[X400:foo]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[X400:foo]"));
 }
 
 // RFC 5321 §4.1.2: Ldh-str body permits DIGIT before the terminal Let-dig
-TEST(Email, valid_general_literal_tag_with_digits) {
+TEST(valid_general_literal_tag_with_digits) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[tag1:foo]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[tag1:foo]"));
 }
 
 // RFC 5321 §4.1.2: Ldh-str body permits interior "-"
-TEST(Email, valid_general_literal_tag_with_interior_hyphen) {
+TEST(valid_general_literal_tag_with_interior_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[tag-name:foo]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[tag-name:foo]"));
 }
 
 // RFC 5321 §4.1.2: Ldh-str = *( ALPHA / DIGIT / "-" ) Let-dig permits a
 // leading "-" because Standardized-tag is Ldh-str, not Let-dig [Ldh-str]
-TEST(Email, valid_general_literal_tag_leading_hyphen) {
+TEST(valid_general_literal_tag_leading_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[-tag:foo]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[-tag:foo]"));
 }
 
 // RFC 5321 §4.1.3: dcontent starts at %d33 "!"
-TEST(Email, valid_general_literal_dcontent_lower_bound) {
+TEST(valid_general_literal_dcontent_lower_bound) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:!]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:!]"));
 }
 
 // RFC 5321 §4.1.3: dcontent %d33-90 ends at "Z"
-TEST(Email, valid_general_literal_dcontent_upper_first_range) {
+TEST(valid_general_literal_dcontent_upper_first_range) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:Z]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:Z]"));
 }
 
 // RFC 5321 §4.1.3: dcontent %d94-126 starts at "^"
-TEST(Email, valid_general_literal_dcontent_lower_second_range) {
+TEST(valid_general_literal_dcontent_lower_second_range) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:^]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:^]"));
 }
 
 // RFC 5321 §4.1.3: dcontent ends at "~" (%d126)
-TEST(Email, valid_general_literal_dcontent_upper_bound) {
+TEST(valid_general_literal_dcontent_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:~]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:~]"));
 }
 
 // RFC 5321 §4.1.3: dcontent %d33-90 includes ":" (%d58)
-TEST(Email, valid_general_literal_dcontent_with_colon) {
+TEST(valid_general_literal_dcontent_with_colon) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[Tag:foo:bar]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[Tag:foo:bar]"));
 }
 
 // RFC 5321 §4.1.3: 1*dcontent permits long content
-TEST(Email, valid_general_literal_dcontent_long) {
+TEST(valid_general_literal_dcontent_long) {
   EXPECT_TRUE(
       sourcemeta::core::is_email("a@[Tag:" + std::string(200, 'a') + "]"));
   EXPECT_TRUE(
@@ -1023,82 +1023,82 @@ TEST(Email, valid_general_literal_dcontent_long) {
 }
 
 // RFC 5321 §4.1.2: Ldh-str must end with Let-dig, trailing "-" is invalid
-TEST(Email, invalid_general_tag_trailing_hyphen) {
+TEST(invalid_general_tag_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[tag-:x]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[tag-:x]"));
 }
 
 // RFC 5321 §4.1.2: Ldh-str requires a terminal Let-dig, lone "-" is invalid
-TEST(Email, invalid_general_tag_single_hyphen) {
+TEST(invalid_general_tag_single_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[-:x]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[-:x]"));
 }
 
 // RFC 5321 §4.1.2: Ldh-str alphabet excludes "_"
-TEST(Email, invalid_general_tag_with_underscore) {
+TEST(invalid_general_tag_with_underscore) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[tag_name:x]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[tag_name:x]"));
 }
 
 // RFC 5321 §4.1.2: Standardized-tag = Ldh-str, minimum length is one byte
-TEST(Email, invalid_general_tag_empty) {
+TEST(invalid_general_tag_empty) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[:x]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[:x]"));
 }
 
 // RFC 5321 §4.1.3: General-address-literal = tag ":" 1*dcontent, empty content
 // is invalid
-TEST(Email, invalid_general_empty_dcontent) {
+TEST(invalid_general_empty_dcontent) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:]"));
 }
 
 // RFC 5321 §4.1.3: General-address-literal requires ":" between tag and
 // content
-TEST(Email, invalid_general_no_colon) {
+TEST(invalid_general_no_colon) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400foo]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400foo]"));
 }
 
 // RFC 5321 §4.1.3: dcontent excludes "[" (%d91)
-TEST(Email, invalid_general_dcontent_lbracket) {
+TEST(invalid_general_dcontent_lbracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:[]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:[]"));
 }
 
 // RFC 5321 §4.1.3: dcontent excludes "\\" (%d92)
-TEST(Email, invalid_general_dcontent_backslash) {
+TEST(invalid_general_dcontent_backslash) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:\\]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:\\]"));
 }
 
 // RFC 5321 §4.1.3: dcontent excludes "]" (%d93)
-TEST(Email, invalid_general_dcontent_rbracket) {
+TEST(invalid_general_dcontent_rbracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:a]b]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:a]b]"));
 }
 
 // RFC 5321 §4.1.3: dcontent excludes SP (%d32)
-TEST(Email, invalid_general_dcontent_space) {
+TEST(invalid_general_dcontent_space) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:a b]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:a b]"));
 }
 
 // RFC 5321 §4.1.3: dcontent excludes controls (%d0-31)
-TEST(Email, invalid_general_dcontent_control) {
+TEST(invalid_general_dcontent_control) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:\x01]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:\x01]"));
 }
 
 // RFC 5321 §4.1.3: dcontent is ASCII, bytes >= 0x80 are excluded
-TEST(Email, invalid_general_dcontent_high_bit) {
+TEST(invalid_general_dcontent_high_bit) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[X400:\x80]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:\x80]"));
 }
 
 // RFC 5321 §4.5.3.1: 64-byte Local-part plus "@" plus a 254-byte Domain fits
 // the RFC 1123 cap. RFC 1035 §3.1 caps the IDN domain at 253 octets
-TEST(Email, max_length_email) {
+TEST(max_length_email) {
   EXPECT_TRUE(sourcemeta::core::is_email(
       std::string(64, 'a') + "@" + std::string(63, 'b') + "." +
       std::string(63, 'c') + "." + std::string(63, 'd') + "." +
@@ -1111,14 +1111,14 @@ TEST(Email, max_length_email) {
 
 // RFC 5321 §4.5.3.1.1: 65-byte Local-part exceeds the cap even with a valid
 // Domain
-TEST(Email, invalid_local_65_with_valid_domain) {
+TEST(invalid_local_65_with_valid_domain) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string(65, 'a') + "@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(std::string(65, 'a') + "@b"));
 }
 
 // RFC 5321 §4.5.3.1.2: a Domain exceeding the cap is rejected even with a
 // valid Local-part
-TEST(Email, invalid_local_64_with_domain_over_cap) {
+TEST(invalid_local_64_with_domain_over_cap) {
   EXPECT_FALSE(sourcemeta::core::is_email(
       std::string(64, 'a') + "@" + std::string(63, 'b') + "." +
       std::string(63, 'c') + "." + std::string(63, 'd') + "." +
@@ -1130,45 +1130,45 @@ TEST(Email, invalid_local_64_with_domain_over_cap) {
 }
 
 // RFC 5321 §4.1.2 + §4.1.3: Quoted-string Local-part with IPv4 address-literal
-TEST(Email, valid_quoted_local_with_ipv4_literal) {
+TEST(valid_quoted_local_with_ipv4_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"foo\"@[192.168.1.1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"foo\"@[192.168.1.1]"));
 }
 
 // RFC 5321 §4.1.2 + §4.1.3: Quoted-string Local-part with IPv6 address-literal
-TEST(Email, valid_quoted_local_with_ipv6_literal) {
+TEST(valid_quoted_local_with_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"foo\"@[IPv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"foo\"@[IPv6:::1]"));
 }
 
 // RFC 5321 §4.1.2 + §4.1.3: Quoted-string Local-part with General-address-
 // literal
-TEST(Email, valid_quoted_local_with_general_literal) {
+TEST(valid_quoted_local_with_general_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"foo\"@[X400:bar]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"foo\"@[X400:bar]"));
 }
 
 // RFC 5321 §4.1.2 + §4.1.3: Dot-string Local-part with IPv4 address-literal
-TEST(Email, valid_dot_string_with_ipv4_literal) {
+TEST(valid_dot_string_with_ipv4_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("foo@[192.168.1.1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("foo@[192.168.1.1]"));
 }
 
 // RFC 5321 §4.1.2 + §4.1.3: Dot-string Local-part with IPv6 address-literal
-TEST(Email, valid_dot_string_with_ipv6_literal) {
+TEST(valid_dot_string_with_ipv6_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("foo@[IPv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("foo@[IPv6:::1]"));
 }
 
 // RFC 5321 §4.1.2 + §4.1.3: Dot-string Local-part with General-address-literal
-TEST(Email, valid_dot_string_with_general_literal) {
+TEST(valid_dot_string_with_general_literal) {
   EXPECT_TRUE(sourcemeta::core::is_email("foo@[X400:bar]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("foo@[X400:bar]"));
 }
 
 // RFC 5321 §4.5.3.1.2: an address-literal whose total length equals the
 // 255-octet domain cap (including the surrounding "[" and "]") is accepted
-TEST(Email, valid_address_literal_length_255) {
+TEST(valid_address_literal_length_255) {
   EXPECT_TRUE(
       sourcemeta::core::is_email("a@[X:" + std::string(251, 'a') + "]"));
   EXPECT_TRUE(
@@ -1177,7 +1177,7 @@ TEST(Email, valid_address_literal_length_255) {
 
 // RFC 5321 §4.5.3.1.2: an address-literal one octet past the 255-octet cap is
 // rejected
-TEST(Email, invalid_address_literal_length_256) {
+TEST(invalid_address_literal_length_256) {
   EXPECT_FALSE(
       sourcemeta::core::is_email("a@[X:" + std::string(252, 'a') + "]"));
   EXPECT_FALSE(
@@ -1185,195 +1185,195 @@ TEST(Email, invalid_address_literal_length_256) {
 }
 
 // RFC 5321 §4.1.2: Mailbox cannot be empty
-TEST(Email, invalid_empty_input) {
+TEST(invalid_empty_input) {
   EXPECT_FALSE(sourcemeta::core::is_email(""));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(""));
 }
 
 // RFC 5321 §4.1.2: SP is not in atext, qtextSMTP, or Ldh-str outside a
 // Quoted-string
-TEST(Email, invalid_whitespace_only) {
+TEST(invalid_whitespace_only) {
   EXPECT_FALSE(sourcemeta::core::is_email("   "));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("   "));
 }
 
 // RFC 5321 §4.1.2: leading SP is not part of Dot-string or Quoted-string
-TEST(Email, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_email(" a@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(" a@b"));
 }
 
 // RFC 5321 §4.1.2 Domain: trailing SP is not in Ldh-str
-TEST(Email, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b "));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b "));
 }
 
 // RFC 5321 §4.1.2 Domain: NUL is not in Ldh-str
-TEST(Email, invalid_nul_in_domain) {
+TEST(invalid_nul_in_domain) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string_view{"a@b\x00c", 5}));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(std::string_view{"a@b\x00c", 5}));
 }
 
 // RFC 5321 §4.1.2: CRLF bytes are not in the Mailbox alphabet
-TEST(Email, invalid_crlf) {
+TEST(invalid_crlf) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b\r\n"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b\r\n"));
 }
 
 // RFC 5321 §4.1.2: LF is not in the Mailbox alphabet
-TEST(Email, invalid_lf) {
+TEST(invalid_lf) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b\n"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b\n"));
 }
 
 // RFC 5321 §4.1.2: TAB is not in atext or Ldh-str
-TEST(Email, invalid_tab_in_local) {
+TEST(invalid_tab_in_local) {
   EXPECT_FALSE(sourcemeta::core::is_email("a\tb@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a\tb@c"));
 }
 
 // RFC 5321 §4.1.2 Domain: TAB is not in Ldh-str
-TEST(Email, invalid_tab_in_domain) {
+TEST(invalid_tab_in_domain) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b\tc"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b\tc"));
 }
 
 // RFC 5321 §4.1.2: two consecutive "@" produce an empty Local-part on the
 // left and a Dot-string Atom on the right that contains "@"
-TEST(Email, invalid_consecutive_at_signs) {
+TEST(invalid_consecutive_at_signs) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@@b"));
 }
 
 // RFC 5321 §4.1.2: a single Quoted-string byte must still be followed by the
 // "@" boundary and a Domain
-TEST(Email, invalid_quoted_only) {
+TEST(invalid_quoted_only) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"a\""));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"a\""));
 }
 
 // RFC 5321 §4.1.2: a lone DQUOTE is an unterminated Quoted-string
-TEST(Email, invalid_lone_dquote) {
+TEST(invalid_lone_dquote) {
   EXPECT_FALSE(sourcemeta::core::is_email("\""));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\""));
 }
 
 // RFC 5321 §4.1.2: a lone "@" has neither Local-part nor Domain
-TEST(Email, invalid_lone_at) {
+TEST(invalid_lone_at) {
   EXPECT_FALSE(sourcemeta::core::is_email("@"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("@"));
 }
 
 // RFC 5321 §4.1.2: minimum-length Mailbox is a single atext byte plus "@"
 // plus a single Let-dig byte
-TEST(Email, valid_minimum_length_mailbox) {
+TEST(valid_minimum_length_mailbox) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
 }
 
 // RFC 5321 §4.1.3: a single dcontent byte is the minimum 1*dcontent
-TEST(Email, valid_general_literal_minimum_dcontent) {
+TEST(valid_general_literal_minimum_dcontent) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[A:B]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[A:B]"));
 }
 
 // RFC 5321 §4.1.2 ALPHA upper bound: "Z" (%d90) is in atext
-TEST(Email, valid_atext_alpha_upper_Z) {
+TEST(valid_atext_alpha_upper_Z) {
   EXPECT_TRUE(sourcemeta::core::is_email("Z@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("Z@b"));
 }
 
 // RFC 5321 §4.1.2 ALPHA upper bound: "z" (%d122) is in atext
-TEST(Email, valid_atext_alpha_lower_z) {
+TEST(valid_atext_alpha_lower_z) {
   EXPECT_TRUE(sourcemeta::core::is_email("z@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("z@b"));
 }
 
 // RFC 5321 §4.1.2 DIGIT upper bound: "9" (%d57) is in atext
-TEST(Email, valid_atext_digit_nine) {
+TEST(valid_atext_digit_nine) {
   EXPECT_TRUE(sourcemeta::core::is_email("9@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("9@b"));
 }
 
 // RFC 5321 §4.1.2: Atom = 1*atext, an all-digit atom is permitted
-TEST(Email, valid_dot_string_numeric_atom) {
+TEST(valid_dot_string_numeric_atom) {
   EXPECT_TRUE(sourcemeta::core::is_email("123@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("123@b"));
 }
 
 // RFC 5321 §4.1.2: atext mixes letters, digits, and specials in one atom
-TEST(Email, valid_dot_string_alpha_digit_special_mix) {
+TEST(valid_dot_string_alpha_digit_special_mix) {
   EXPECT_TRUE(sourcemeta::core::is_email("aB1!c2#@d"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("aB1!c2#@d"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP %d93-126 excludes %d127 (DEL)
-TEST(Email, invalid_quoted_qtext_del_byte) {
+TEST(invalid_quoted_qtext_del_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"\x7f\"@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\x7f\"@b"));
 }
 
 // RFC 5321 §4.1.2: qtextSMTP excludes %d9 (TAB)
-TEST(Email, invalid_quoted_qtext_tab) {
+TEST(invalid_quoted_qtext_tab) {
   EXPECT_FALSE(sourcemeta::core::is_email("\"a\tb\"@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"a\tb\"@c"));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body excludes NUL (%d0)
-TEST(Email, invalid_quoted_pair_nul_byte) {
+TEST(invalid_quoted_pair_nul_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string_view{"\"\\\x00\"@b", 6}));
   EXPECT_FALSE(
       sourcemeta::core::is_idn_email(std::string_view{"\"\\\x00\"@b", 6}));
 }
 
 // RFC 5321 §4.1.2: quoted-pairSMTP body permits "@" (%d64)
-TEST(Email, valid_quoted_pair_at_sign) {
+TEST(valid_quoted_pair_at_sign) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\@\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\@\"@b"));
 }
 
 // RFC 5321 §4.1.2: two consecutive quoted-pairs back-to-back inside a
 // Quoted-string
-TEST(Email, valid_quoted_two_consecutive_pairs) {
+TEST(valid_quoted_two_consecutive_pairs) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"\\\\\\\"\"@b"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\\\\\\\"\"@b"));
 }
 
 // RFC 5321 §4.1.2 Domain: a single Let-dig digit is a valid sub-domain
-TEST(Email, valid_domain_single_digit) {
+TEST(valid_domain_single_digit) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@1"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@1"));
 }
 
 // RFC 5321 §4.1.2: a single atext byte is not a valid Mailbox without "@"
-TEST(Email, invalid_single_atext_no_at) {
+TEST(invalid_single_atext_no_at) {
   EXPECT_FALSE(sourcemeta::core::is_email("a"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a"));
 }
 
 // RFC 5321 §4.1.2 Domain: a stray "]" with no opening "[" cannot match
 // address-literal and "]" is not in Ldh-str
-TEST(Email, invalid_unbalanced_closing_bracket) {
+TEST(invalid_unbalanced_closing_bracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b]"));
 }
 
 // RFC 5321 §4.1.2 Domain: "[" embedded in a Domain is not in Ldh-str
-TEST(Email, invalid_bracket_in_middle_of_domain) {
+TEST(invalid_bracket_in_middle_of_domain) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b[c]d"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b[c]d"));
 }
 
 // RFC 5321 §4.1.3: a domain consisting of just "[" never closes the
 // address-literal
-TEST(Email, invalid_domain_just_open_bracket) {
+TEST(invalid_domain_just_open_bracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@["));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@["));
 }
 
 // RFC 5321 §4.1.2 Domain: a domain consisting of just "]" is not Ldh-str
-TEST(Email, invalid_domain_just_close_bracket) {
+TEST(invalid_domain_just_close_bracket) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@]"));
 }
@@ -1381,95 +1381,95 @@ TEST(Email, invalid_domain_just_close_bracket) {
 // RFC 5321 §4.1.3: "::1" between brackets has no "IPv6:" prefix and an empty
 // Standardized-tag for General-address-literal, so all three alternatives
 // reject it
-TEST(Email, invalid_bracket_just_ipv6_addr_no_prefix) {
+TEST(invalid_bracket_just_ipv6_addr_no_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[::1]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[::1]"));
 }
 
 // RFC 5321 §4.1.3: a bracketed word without ":" cannot match General, and
 // without digits cannot match IPv4
-TEST(Email, invalid_bracket_with_plain_word) {
+TEST(invalid_bracket_with_plain_word) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[hello]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[hello]"));
 }
 
 // RFC 5321 §4.1.3: leading SP inside the brackets fails IPv4 (non-digit) and
 // fails General (Standardized-tag has no SP)
-TEST(Email, invalid_bracket_with_leading_space) {
+TEST(invalid_bracket_with_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[ 1.2.3.4]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[ 1.2.3.4]"));
 }
 
 // RFC 5321 §4.1.3 + RFC 5234 §3.2: a case-insensitive "IPv6:" match that
 // fails IPv6-addr still falls through to General-address-literal
-TEST(Email, valid_lowercase_ipv6_fallthrough_to_general) {
+TEST(valid_lowercase_ipv6_fallthrough_to_general) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[ipv6:not-an-address]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[ipv6:not-an-address]"));
 }
 
 // RFC 5321 §4.1.2 Ldh-str: leading "-" before another "-" before Let-dig is
 // still a valid Ldh-str
-TEST(Email, valid_general_literal_multiple_leading_hyphens) {
+TEST(valid_general_literal_multiple_leading_hyphens) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[--a:b]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[--a:b]"));
 }
 
 // RFC 5321 §4.1.3: any Ldh-str is a valid Standardized-tag per the grammar,
 // including ones not registered with IANA such as "IPv7"
-TEST(Email, valid_general_literal_ipv7_like_tag) {
+TEST(valid_general_literal_ipv7_like_tag) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[IPv7:foo]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[IPv7:foo]"));
 }
 
 // RFC 5321 §4.1.2 Ldh-str alphabet excludes ".", so a tag with "." cannot
 // match Standardized-tag
-TEST(Email, invalid_general_tag_with_dot) {
+TEST(invalid_general_tag_with_dot) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[a.b:c]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[a.b:c]"));
 }
 
 // RFC 5321 §4.1.3: General-address-literal content of just ":" is a single
 // dcontent byte (%d58 is in %d33-90)
-TEST(Email, valid_general_literal_content_just_colon) {
+TEST(valid_general_literal_content_just_colon) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@[a::]"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@[a::]"));
 }
 
 // RFC 5321 §4.1.3 + RFC 5234 §3.2: bracketed input where the first colon
 // produces an empty tag fails the Standardized-tag rule
-TEST(Email, invalid_bracket_empty_tag) {
+TEST(invalid_bracket_empty_tag) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[:foo]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[:foo]"));
 }
 
 // RFC 5321 §4.1.2 Domain: an address-literal whose Domain branch tries
 // is_hostname must reject a stray "[" inside what would otherwise be Ldh-str
-TEST(Email, invalid_domain_open_bracket_inside) {
+TEST(invalid_domain_open_bracket_inside) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@b[c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b[c"));
 }
 
 // RFC 5321 §4.1.2 Dot-string: a Quoted-string opener "\"" inside an
 // otherwise Dot-string Local-part is not in atext
-TEST(Email, invalid_dquote_inside_dot_string) {
+TEST(invalid_dquote_inside_dot_string) {
   EXPECT_FALSE(sourcemeta::core::is_email("a\"b@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a\"b@c"));
 }
 
 // RFC 5321 §4.1.2 Mailbox: a Mailbox cannot start with the boundary "@"
-TEST(Email, invalid_starts_with_at) {
+TEST(invalid_starts_with_at) {
   EXPECT_FALSE(sourcemeta::core::is_email("@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("@example.com"));
 }
 
 // RFC 5321 §4.1.2 Mailbox: a Mailbox cannot end with the boundary "@"
-TEST(Email, invalid_ends_with_at) {
+TEST(invalid_ends_with_at) {
   EXPECT_FALSE(sourcemeta::core::is_email("user@"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user@"));
 }
 
 // RFC 5321 §4.1.2: Local-part = 64 octets via Dot-string that includes "."
-TEST(Email, valid_local_part_length_64_with_dots) {
+TEST(valid_local_part_length_64_with_dots) {
   EXPECT_TRUE(sourcemeta::core::is_email(std::string(31, 'a') + "." +
                                          std::string(32, 'b') + "@c"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email(std::string(31, 'a') + "." +
@@ -1477,7 +1477,7 @@ TEST(Email, valid_local_part_length_64_with_dots) {
 }
 
 // RFC 5321 §4.5.3.1.1: 65-octet Dot-string Local-part that contains "."
-TEST(Email, invalid_local_part_length_65_with_dots) {
+TEST(invalid_local_part_length_65_with_dots) {
   EXPECT_FALSE(sourcemeta::core::is_email(std::string(32, 'a') + "." +
                                           std::string(32, 'b') + "@c"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(std::string(32, 'a') + "." +
@@ -1485,13 +1485,13 @@ TEST(Email, invalid_local_part_length_65_with_dots) {
 }
 
 // RFC 5321 §4.1.2: a Domain consisting of many short labels still parses
-TEST(Email, valid_domain_many_short_labels) {
+TEST(valid_domain_many_short_labels) {
   EXPECT_TRUE(sourcemeta::core::is_email("a@a.b.c.d.e.f.g.h.i.j.k"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@a.b.c.d.e.f.g.h.i.j.k"));
 }
 
 // RFC 5321 §4.1.3: dcontent excludes DEL (%d127)
-TEST(Email, invalid_general_dcontent_del_byte) {
+TEST(invalid_general_dcontent_del_byte) {
   EXPECT_FALSE(sourcemeta::core::is_email("a@[Tag:\x7f]"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[Tag:\x7f]"));
 }
@@ -1499,7 +1499,7 @@ TEST(Email, invalid_general_dcontent_del_byte) {
 // RFC 5321 §4.1.3 + §4.5.3.1.2: a General-address-literal whose Domain total
 // length equals the 255-octet cap ("[" + "Tag" + ":" + 249 dcontent + "]") is
 // accepted
-TEST(Email, valid_general_literal_inner_at_cap) {
+TEST(valid_general_literal_inner_at_cap) {
   EXPECT_TRUE(
       sourcemeta::core::is_email("a@[Tag:" + std::string(249, 'x') + "]"));
   EXPECT_TRUE(
@@ -1508,7 +1508,7 @@ TEST(Email, valid_general_literal_inner_at_cap) {
 
 // RFC 5321 §4.5.3.1.2: General-address-literal one octet past the 255-octet
 // Domain cap is rejected
-TEST(Email, invalid_general_literal_inner_over_cap) {
+TEST(invalid_general_literal_inner_over_cap) {
   EXPECT_FALSE(
       sourcemeta::core::is_email("a@[Tag:" + std::string(250, 'x') + "]"));
   EXPECT_FALSE(
@@ -1516,14 +1516,14 @@ TEST(Email, invalid_general_literal_inner_over_cap) {
 }
 
 // RFC 5321 §4.1.2: a single quoted byte plus minimal Domain
-TEST(Email, valid_quoted_single_letter_then_minimal_domain) {
+TEST(valid_quoted_single_letter_then_minimal_domain) {
   EXPECT_TRUE(sourcemeta::core::is_email("\"x\"@y"));
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"x\"@y"));
 }
 
 // RFC 5321 §4.1.2: Dot-string ending with the boundary "@" right after the
 // dot has no terminating Atom
-TEST(Email, invalid_dot_then_at) {
+TEST(invalid_dot_then_at) {
   EXPECT_FALSE(sourcemeta::core::is_email("a.@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a.@b"));
 }

--- a/test/email/idn_email_test.cc
+++ b/test/email/idn_email_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/email.h>
 
@@ -7,7 +7,7 @@
 // example@example.test rendered in Hangul (RFC 6531 §3.3)
 // Bytes: 실=EC8BA4 례=EBA180 @=40 실=EC8BA4 례=EBA180 .=2E 테=ED858C 스=EC8AA4
 // 트=ED8AB8
-TEST(IdnEmail, valid_hangul_example_at_example_test) {
+TEST(valid_hangul_example_at_example_test) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email(
       "\xec\x8b\xa4\xeb\xa1\x80"
       "@"
@@ -18,176 +18,176 @@ TEST(IdnEmail, valid_hangul_example_at_example_test) {
       "\xec\x8b\xa4\xeb\xa1\x80.\xed\x85\x8c\xec\x8a\xa4\xed\x8a\xb8"));
 }
 
-TEST(IdnEmail, invalid_bare_number) {
+TEST(invalid_bare_number) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("2962"));
   EXPECT_FALSE(sourcemeta::core::is_email("2962"));
 }
 
-TEST(IdnEmail, valid_typical_ascii_address) {
+TEST(valid_typical_ascii_address) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("joe.bloggs@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("joe.bloggs@example.com"));
 }
 
 // RFC 5321 §4.1.2: ASCII Dot-string is a subset of the extended grammar
-TEST(IdnEmail, valid_ascii_single_atom) {
+TEST(valid_ascii_single_atom) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
   EXPECT_TRUE(sourcemeta::core::is_email("a@b"));
 }
 
-TEST(IdnEmail, valid_ascii_two_atoms) {
+TEST(valid_ascii_two_atoms) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a.b@c"));
   EXPECT_TRUE(sourcemeta::core::is_email("a.b@c"));
 }
 
-TEST(IdnEmail, valid_ascii_many_atoms) {
+TEST(valid_ascii_many_atoms) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a.b.c.d@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("a.b.c.d@example.com"));
 }
 
-TEST(IdnEmail, valid_ascii_atext_symbols) {
+TEST(valid_ascii_atext_symbols) {
   EXPECT_TRUE(
       sourcemeta::core::is_idn_email("a!#$%&'*+-/=?^_`{|}~@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("a!#$%&'*+-/=?^_`{|}~@example.com"));
 }
 
-TEST(IdnEmail, valid_ascii_uppercase_local) {
+TEST(valid_ascii_uppercase_local) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("ABC@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("ABC@example.com"));
 }
 
-TEST(IdnEmail, valid_ascii_digit_local) {
+TEST(valid_ascii_digit_local) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("123@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("123@example.com"));
 }
 
 // RFC 6531 §3.3: atext =/ UTF8-non-ascii (2-byte: U+03B1 GREEK SMALL ALPHA)
-TEST(IdnEmail, valid_local_two_byte_utf8) {
+TEST(valid_local_two_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xce\xb1@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xce\xb1@b"));
 }
 
 // RFC 6531 §3.3: atext =/ UTF8-non-ascii (3-byte: U+4E2D CJK 中)
-TEST(IdnEmail, valid_local_three_byte_utf8) {
+TEST(valid_local_three_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xe4\xb8\xad@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xe4\xb8\xad@b"));
 }
 
 // RFC 6531 §3.3: atext =/ UTF8-non-ascii (4-byte: U+1F600 GRINNING FACE)
-TEST(IdnEmail, valid_local_four_byte_utf8) {
+TEST(valid_local_four_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xf0\x9f\x98\x80@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xf0\x9f\x98\x80@b"));
 }
 
-TEST(IdnEmail, valid_local_mixed_ascii_and_utf8) {
+TEST(valid_local_mixed_ascii_and_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("user.\xce\xb1@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("user.\xce\xb1@example.com"));
 }
 
-TEST(IdnEmail, valid_local_multi_atom_with_utf8) {
+TEST(valid_local_multi_atom_with_utf8) {
   EXPECT_TRUE(
       sourcemeta::core::is_idn_email("\xe4\xb8\xad.\xce\xb1.user@example.com"));
   EXPECT_FALSE(
       sourcemeta::core::is_email("\xe4\xb8\xad.\xce\xb1.user@example.com"));
 }
 
-TEST(IdnEmail, valid_local_utf8_only_two_atoms) {
+TEST(valid_local_utf8_only_two_atoms) {
   EXPECT_TRUE(
       sourcemeta::core::is_idn_email("\xce\xb1.\xe4\xb8\xad@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xce\xb1.\xe4\xb8\xad@example.com"));
 }
 
 // RFC 6531 §3.3: sub-domain =/ U-label (2-byte U-label only)
-TEST(IdnEmail, valid_domain_two_byte_utf8) {
+TEST(valid_domain_two_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@\xce\xb1"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xce\xb1"));
 }
 
 // RFC 6531 §3.3: sub-domain =/ U-label (3-byte U-label only)
-TEST(IdnEmail, valid_domain_three_byte_utf8) {
+TEST(valid_domain_three_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@\xe4\xb8\xad"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xe4\xb8\xad"));
 }
 
-TEST(IdnEmail, valid_domain_mixed_labels) {
+TEST(valid_domain_mixed_labels) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@example.\xce\xb1.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@example.\xce\xb1.com"));
 }
 
-TEST(IdnEmail, valid_domain_utf8_with_hyphen) {
+TEST(valid_domain_utf8_with_hyphen) {
   // U-labels may contain hyphens; just not at the start/end of a label
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@\xce\xb1-\xe4\xb8\xad"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xce\xb1-\xe4\xb8\xad"));
 }
 
-TEST(IdnEmail, valid_domain_many_labels) {
+TEST(valid_domain_many_labels) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@a.b.c.\xce\xb1.d.e"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@a.b.c.\xce\xb1.d.e"));
 }
 
 // RFC 5321 §4.1.2: Quoted-string with ASCII-only content
-TEST(IdnEmail, valid_quoted_ascii) {
+TEST(valid_quoted_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a b\"@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("\"a b\"@example.com"));
 }
 
 // RFC 6531 §3.3: qtextSMTP =/ UTF8-non-ascii
-TEST(IdnEmail, valid_quoted_with_two_byte_utf8) {
+TEST(valid_quoted_with_two_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\xce\xb1\"@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\xce\xb1\"@example.com"));
 }
 
-TEST(IdnEmail, valid_quoted_with_three_byte_utf8) {
+TEST(valid_quoted_with_three_byte_utf8) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\xe4\xb8\xad\"@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\xe4\xb8\xad\"@example.com"));
 }
 
-TEST(IdnEmail, valid_quoted_with_four_byte_utf8) {
+TEST(valid_quoted_with_four_byte_utf8) {
   EXPECT_TRUE(
       sourcemeta::core::is_idn_email("\"\xf0\x9f\x98\x80\"@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\xf0\x9f\x98\x80\"@example.com"));
 }
 
-TEST(IdnEmail, valid_quoted_mixed_ascii_and_utf8) {
+TEST(valid_quoted_mixed_ascii_and_utf8) {
   EXPECT_TRUE(
       sourcemeta::core::is_idn_email("\"\xce\xb1 \xe4\xb8\xad\"@example.com"));
   EXPECT_FALSE(
       sourcemeta::core::is_email("\"\xce\xb1 \xe4\xb8\xad\"@example.com"));
 }
 
-TEST(IdnEmail, valid_quoted_with_quoted_pair) {
+TEST(valid_quoted_with_quoted_pair) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a\\\"b\"@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("\"a\\\"b\"@example.com"));
 }
 
 // RFC 5321 §4.1.3: address-literal IPv4 stays ASCII (no IDNA applies)
-TEST(IdnEmail, valid_address_literal_ipv4) {
+TEST(valid_address_literal_ipv4) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[192.168.1.1]"));
   EXPECT_TRUE(sourcemeta::core::is_email("user@[192.168.1.1]"));
 }
 
-TEST(IdnEmail, valid_address_literal_ipv6) {
+TEST(valid_address_literal_ipv6) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[IPv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_email("user@[IPv6:::1]"));
 }
 
-TEST(IdnEmail, valid_address_literal_ipv6_lowercase_tag) {
+TEST(valid_address_literal_ipv6_lowercase_tag) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[ipv6:::1]"));
   EXPECT_TRUE(sourcemeta::core::is_email("user@[ipv6:::1]"));
 }
 
-TEST(IdnEmail, valid_address_literal_with_utf8_local) {
+TEST(valid_address_literal_with_utf8_local) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xce\xb1@[192.168.1.1]"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xce\xb1@[192.168.1.1]"));
 }
 
 // RFC 5321 §4.5.3.1.1: Local-part is allowed up to 64 octets
-TEST(IdnEmail, valid_local_at_octet_limit) {
+TEST(valid_local_at_octet_limit) {
   const std::string local(64, 'a');
   EXPECT_TRUE(sourcemeta::core::is_idn_email(local + "@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email(local + "@example.com"));
 }
 
-TEST(IdnEmail, valid_local_at_octet_limit_with_utf8) {
+TEST(valid_local_at_octet_limit_with_utf8) {
   // 21 Greek alpha (CE B1 = 2 bytes each) = 42 bytes, plus 22 ASCII 'a' = 64
   std::string local;
   for (int index = 0; index < 21; ++index) {
@@ -199,164 +199,164 @@ TEST(IdnEmail, valid_local_at_octet_limit_with_utf8) {
   EXPECT_FALSE(sourcemeta::core::is_email(local + "@example.com"));
 }
 
-TEST(IdnEmail, invalid_missing_at) {
+TEST(invalid_missing_at) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("plain"));
   EXPECT_FALSE(sourcemeta::core::is_email("plain"));
 }
 
-TEST(IdnEmail, invalid_empty_local) {
+TEST(invalid_empty_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("@example.com"));
 }
 
-TEST(IdnEmail, invalid_empty_domain) {
+TEST(invalid_empty_domain) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user@"));
   EXPECT_FALSE(sourcemeta::core::is_email("user@"));
 }
 
-TEST(IdnEmail, invalid_empty) {
+TEST(invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email(""));
   EXPECT_FALSE(sourcemeta::core::is_email(""));
 }
 
-TEST(IdnEmail, invalid_two_at_signs) {
+TEST(invalid_two_at_signs) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@b@c"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@b@c"));
 }
 
-TEST(IdnEmail, invalid_local_leading_dot) {
+TEST(invalid_local_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email(".user@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email(".user@example.com"));
 }
 
-TEST(IdnEmail, invalid_local_trailing_dot) {
+TEST(invalid_local_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user.@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("user.@example.com"));
 }
 
-TEST(IdnEmail, invalid_local_consecutive_dots) {
+TEST(invalid_local_consecutive_dots) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a..b@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a..b@example.com"));
 }
 
-TEST(IdnEmail, invalid_local_just_dot) {
+TEST(invalid_local_just_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email(".@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email(".@example.com"));
 }
 
 // RFC 6532 §3.1: lone continuation byte 0xBF is not the start of UTF-8
-TEST(IdnEmail, invalid_lone_continuation_byte) {
+TEST(invalid_lone_continuation_byte) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xbf@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xbf@b"));
 }
 
 // RFC 6532 §3.1: 2-byte starter with no continuation byte
-TEST(IdnEmail, invalid_truncated_two_byte_at_end_of_local) {
+TEST(invalid_truncated_two_byte_at_end_of_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xce@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xce@b"));
 }
 
 // RFC 6532 §3.1: %xE0 %x80-9F is overlong (codepoints < U+0800)
-TEST(IdnEmail, invalid_overlong_three_byte) {
+TEST(invalid_overlong_three_byte) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xe0\x80\xa0@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xe0\x80\xa0@b"));
 }
 
 // RFC 6532 §3.1: U+D800 surrogate is forbidden
-TEST(IdnEmail, invalid_surrogate_codepoint_in_local) {
+TEST(invalid_surrogate_codepoint_in_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xed\xa0\x80@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xed\xa0\x80@b"));
 }
 
 // RFC 6532 §3.1: codepoints above U+10FFFF are forbidden
-TEST(IdnEmail, invalid_above_max_codepoint_in_local) {
+TEST(invalid_above_max_codepoint_in_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xf4\x90\x80\x80@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xf4\x90\x80\x80@b"));
 }
 
 // RFC 6532 §3.1: 4-byte starter with truncated continuation
-TEST(IdnEmail, invalid_truncated_four_byte_in_local) {
+TEST(invalid_truncated_four_byte_in_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xf0\x9f\x98@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xf0\x9f\x98@b"));
 }
 
 // RFC 6532 §3.1: %xC0 is a forbidden lead byte (overlong U+0000)
-TEST(IdnEmail, invalid_overlong_c0_in_local) {
+TEST(invalid_overlong_c0_in_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xc0\x80@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xc0\x80@b"));
 }
 
 // RFC 6532 §3.1: %xF5 is not a valid lead byte
-TEST(IdnEmail, invalid_lead_f5_in_local) {
+TEST(invalid_lead_f5_in_local) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\xf5\x80\x80\x80@b"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xf5\x80\x80\x80@b"));
 }
 
-TEST(IdnEmail, invalid_invalid_utf8_in_domain) {
+TEST(invalid_invalid_utf8_in_domain) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@\xc0\x80"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xc0\x80"));
 }
 
-TEST(IdnEmail, invalid_surrogate_in_domain) {
+TEST(invalid_surrogate_in_domain) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@\xed\xa0\x80"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xed\xa0\x80"));
 }
 
-TEST(IdnEmail, invalid_lone_continuation_in_domain) {
+TEST(invalid_lone_continuation_in_domain) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@\xbf"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xbf"));
 }
 
-TEST(IdnEmail, invalid_invalid_utf8_in_quoted) {
+TEST(invalid_invalid_utf8_in_quoted) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\xc0\x80\"@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\xc0\x80\"@example.com"));
 }
 
-TEST(IdnEmail, invalid_truncated_utf8_in_quoted) {
+TEST(invalid_truncated_utf8_in_quoted) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\xce\"@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\xce\"@example.com"));
 }
 
 // RFC 6531 §3.3: domain label cannot start with a hyphen
-TEST(IdnEmail, invalid_domain_leading_hyphen) {
+TEST(invalid_domain_leading_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@-example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@-example.com"));
 }
 
 // RFC 6531 §3.3: domain label cannot end with a hyphen
-TEST(IdnEmail, invalid_domain_trailing_hyphen) {
+TEST(invalid_domain_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@example-.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@example-.com"));
 }
 
-TEST(IdnEmail, invalid_domain_label_trailing_hyphen_with_utf8) {
+TEST(invalid_domain_label_trailing_hyphen_with_utf8) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@\xce\xb1-"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@\xce\xb1-"));
 }
 
-TEST(IdnEmail, invalid_domain_trailing_dot) {
+TEST(invalid_domain_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@example.com."));
   EXPECT_FALSE(sourcemeta::core::is_email("a@example.com."));
 }
 
-TEST(IdnEmail, invalid_domain_empty_label_in_middle) {
+TEST(invalid_domain_empty_label_in_middle) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@example..com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@example..com"));
 }
 
-TEST(IdnEmail, invalid_domain_leading_dot) {
+TEST(invalid_domain_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@.example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a@.example.com"));
 }
 
 // RFC 5321 §4.5.3.1.1: Local-part > 64 octets is invalid
-TEST(IdnEmail, invalid_local_one_over_octet_limit) {
+TEST(invalid_local_one_over_octet_limit) {
   const std::string local(65, 'a');
   EXPECT_FALSE(sourcemeta::core::is_idn_email(local + "@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email(local + "@example.com"));
 }
 
-TEST(IdnEmail, invalid_local_one_over_octet_limit_with_utf8) {
+TEST(invalid_local_one_over_octet_limit_with_utf8) {
   // 21 alpha (42 bytes) + 23 'a' = 65 bytes
   std::string local;
   for (int index = 0; index < 21; ++index) {
@@ -369,13 +369,13 @@ TEST(IdnEmail, invalid_local_one_over_octet_limit_with_utf8) {
 }
 
 // RFC 1035 §2.3.4: single label > 63 octets is invalid
-TEST(IdnEmail, invalid_domain_label_too_long) {
+TEST(invalid_domain_label_too_long) {
   const std::string label(64, 'a');
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@" + label));
   EXPECT_FALSE(sourcemeta::core::is_email("a@" + label));
 }
 
-TEST(IdnEmail, valid_domain_label_at_max_length) {
+TEST(valid_domain_label_at_max_length) {
   const std::string label(63, 'a');
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@" + label));
   EXPECT_TRUE(sourcemeta::core::is_email("a@" + label));
@@ -385,7 +385,7 @@ TEST(IdnEmail, valid_domain_label_at_max_length) {
 // Construction must avoid trailing-dot and per-label (>63) confounds: 5
 // labels of 51/51/51/51/48 'a' chars separated by 4 dots = 256 octets, no
 // trailing dot, every label within the 63-octet RFC 1035 cap
-TEST(IdnEmail, invalid_domain_total_too_long) {
+TEST(invalid_domain_total_too_long) {
   std::string domain;
   for (int index = 0; index < 4; ++index) {
     domain.append(51, 'a');
@@ -402,7 +402,7 @@ TEST(IdnEmail, invalid_domain_total_too_long) {
 // domain U-label (RFC 5890 §2.3.2.1), imposes no NFC requirement on it. So
 // "cafe" + U+0301 COMBINING ACUTE (NFD, bytes 63 61 66 65 CC 81) is a valid
 // local-part even though it is not in NFC.
-TEST(IdnEmail, valid_local_non_nfc) {
+TEST(valid_local_non_nfc) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("cafe\xcc\x81@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("cafe\xcc\x81@example.com"));
 }
@@ -410,14 +410,14 @@ TEST(IdnEmail, valid_local_non_nfc) {
 // RFC 5890 §2.3.2.1: a domain U-label MUST be in NFC. The same "cafe" +
 // U+0301 (NFD) sequence that is valid in the local-part is invalid as a
 // domain label.
-TEST(IdnEmail, invalid_domain_non_nfc) {
+TEST(invalid_domain_non_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user@cafe\xcc\x81.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("user@cafe\xcc\x81.com"));
 }
 
 // RFC 5321 §4.1.2: SP is not atext and is only allowed inside a quoted
 // string, so an unquoted space in the local-part is invalid.
-TEST(IdnEmail, invalid_local_unquoted_space) {
+TEST(invalid_local_unquoted_space) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a b@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("a b@example.com"));
 }
@@ -425,7 +425,7 @@ TEST(IdnEmail, invalid_local_unquoted_space) {
 // RFC 5321 §4.1.2: quoted-pairSMTP = %d92 %d32-126, so the octet after a
 // backslash must be ASCII. A backslash followed by UTF8-non-ascii (U+03B1,
 // bytes CE B1) is invalid even under RFC 6531.
-TEST(IdnEmail, invalid_quoted_pair_non_ascii) {
+TEST(invalid_quoted_pair_non_ascii) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("\"\\\xce\xb1\"@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\\\xce\xb1\"@example.com"));
 }
@@ -434,7 +434,7 @@ TEST(IdnEmail, invalid_quoted_pair_non_ascii) {
 // digits U+FF11 U+FF12 U+FF13 (bytes EF BC 91 EF BC 92 EF BC 93) are
 // DISALLOWED by RFC 5892 §2.6, so the domain - and the whole address - is
 // invalid.
-TEST(IdnEmail, invalid_domain_idna_disallowed_codepoint) {
+TEST(invalid_domain_idna_disallowed_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email(
       "user@\xef\xbc\x91\xef\xbc\x92\xef\xbc\x93.com"));
   EXPECT_FALSE(sourcemeta::core::is_email(
@@ -443,7 +443,7 @@ TEST(IdnEmail, invalid_domain_idna_disallowed_codepoint) {
 
 // RFC 5321 §4.1.2: Quoted-string = DQUOTE *QcontentSMTP DQUOTE, so zero quoted
 // content is permitted - an empty quoted string is a valid local-part.
-TEST(IdnEmail, valid_quoted_empty) {
+TEST(valid_quoted_empty) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\"@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("\"\"@example.com"));
 }
@@ -451,14 +451,14 @@ TEST(IdnEmail, valid_quoted_empty) {
 // RFC 5321 §4.1.2: "@" (%d64) is qtextSMTP, so it is ordinary content inside a
 // quoted string and does not start the domain - the address has one @
 // separator.
-TEST(IdnEmail, valid_quoted_local_with_at) {
+TEST(valid_quoted_local_with_at) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a@b\"@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("\"a@b\"@example.com"));
 }
 
 // RFC 5321 §4.1.2: "." (%d46) is qtextSMTP, so the Dot-string rules (no
 // leading, trailing, or consecutive dots) do not apply inside a quoted string.
-TEST(IdnEmail, valid_quoted_local_consecutive_dots) {
+TEST(valid_quoted_local_consecutive_dots) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"a..b\"@example.com"));
   EXPECT_TRUE(sourcemeta::core::is_email("\"a..b\"@example.com"));
 }
@@ -466,7 +466,7 @@ TEST(IdnEmail, valid_quoted_local_consecutive_dots) {
 // RFC 6531 §3.3: atext =/ UTF8-non-ascii puts no IDNA codepoint restriction on
 // the local-part, so U+2665 BLACK HEART (bytes E2 99 A5) is a valid local atom
 // even though it is DISALLOWED (RFC 5892 §2.6) in a domain U-label.
-TEST(IdnEmail, valid_local_symbol_codepoint) {
+TEST(valid_local_symbol_codepoint) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xe2\x99\xa5@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xe2\x99\xa5@example.com"));
 }
@@ -474,7 +474,7 @@ TEST(IdnEmail, valid_local_symbol_codepoint) {
 // RFC 6531 §3.3: the local-part has no Bidi constraint (unlike a domain
 // U-label, RFC 5893), so a right-to-left character U+05D0 HEBREW ALEF (bytes D7
 // 90) is a valid local atom.
-TEST(IdnEmail, valid_local_rtl_codepoint) {
+TEST(valid_local_rtl_codepoint) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xd7\x90@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xd7\x90@example.com"));
 }
@@ -482,7 +482,7 @@ TEST(IdnEmail, valid_local_rtl_codepoint) {
 // RFC 6531 §3.3: the local-part has no leading-combining-mark rule (unlike a
 // domain U-label, RFC 5891 §4.2.3.2), so a lone U+0301 COMBINING ACUTE (bytes
 // CC 81) is a valid local atom.
-TEST(IdnEmail, valid_local_combining_mark) {
+TEST(valid_local_combining_mark) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xcc\x81@example.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xcc\x81@example.com"));
 }
@@ -490,14 +490,14 @@ TEST(IdnEmail, valid_local_combining_mark) {
 // RFC 5893 §2: in a domain that has a right-to-left label, every label must
 // satisfy the Bidi rule. The LTR label "0a" (starts with EN digit U+0030) in a
 // name that also has the RTL label U+05D0 (bytes D7 90) violates it.
-TEST(IdnEmail, invalid_domain_bidi_rule) {
+TEST(invalid_domain_bidi_rule) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user@0a.\xd7\x90"));
   EXPECT_FALSE(sourcemeta::core::is_email("user@0a.\xd7\x90"));
 }
 
 // RFC 5892 §2.6: U+200B ZERO WIDTH SPACE (bytes E2 80 8B) is DISALLOWED, so a
 // domain label containing it is invalid (lenient processors silently strip it).
-TEST(IdnEmail, invalid_domain_zero_width) {
+TEST(invalid_domain_zero_width) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user@a\xe2\x80\x8b"
                                               "b.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("user@a\xe2\x80\x8b"
@@ -508,7 +508,7 @@ TEST(IdnEmail, invalid_domain_zero_width) {
 // leading U+0301 COMBINING ACUTE (bytes CC 81) is invalid in the domain - the
 // mirror of valid_local_combining_mark, where the same mark is fine in the
 // local.
-TEST(IdnEmail, invalid_domain_leading_combining_mark) {
+TEST(invalid_domain_leading_combining_mark) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("user@\xcc\x81"
                                               "a.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("user@\xcc\x81"
@@ -518,14 +518,14 @@ TEST(IdnEmail, invalid_domain_leading_combining_mark) {
 // RFC 6531 §3.3: a quoted non-ASCII local-part with a U-label domain. Local
 // U+03B1 GREEK ALPHA (CE B1) inside quotes; domain "m" + U+00FC (C3 BC) +
 // "nchen.de".
-TEST(IdnEmail, valid_quoted_local_and_ulabel_domain) {
+TEST(valid_quoted_local_and_ulabel_domain) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\"\xce\xb1\"@m\xc3\xbcnchen.de"));
   EXPECT_FALSE(sourcemeta::core::is_email("\"\xce\xb1\"@m\xc3\xbcnchen.de"));
 }
 
 // RFC 6531 §3.3 + RFC 5890 §2.3.2.1: a U-label local-part (U+03B1 GREEK ALPHA,
 // CE B1) combined with a valid A-label domain (xn--nxasmq6b).
-TEST(IdnEmail, valid_ulabel_local_and_alabel_domain) {
+TEST(valid_ulabel_local_and_alabel_domain) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("\xce\xb1@xn--nxasmq6b.com"));
   EXPECT_FALSE(sourcemeta::core::is_email("\xce\xb1@xn--nxasmq6b.com"));
 }

--- a/test/error/CMakeLists.txt
+++ b/test/error/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME error
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME error
   SOURCES error_file_test.cc)
 
 target_link_libraries(sourcemeta_core_error_unit

--- a/test/error/error_file_test.cc
+++ b/test/error/error_file_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/error.h>
 
@@ -6,7 +6,7 @@
 #include <stdexcept>
 #include <string>
 
-TEST(Error_file_error, stores_path) {
+TEST(stores_path) {
   const std::filesystem::path path{std::filesystem::temp_directory_path()};
   try {
     throw sourcemeta::core::FileError<std::runtime_error>(path, "test message");
@@ -15,7 +15,7 @@ TEST(Error_file_error, stores_path) {
   }
 }
 
-TEST(Error_file_error, inherits_what) {
+TEST(inherits_what) {
   const std::filesystem::path path{std::filesystem::temp_directory_path()};
   try {
     throw sourcemeta::core::FileError<std::runtime_error>(path, "test message");
@@ -24,7 +24,7 @@ TEST(Error_file_error, inherits_what) {
   }
 }
 
-TEST(Error_file_error, catchable_as_base) {
+TEST(catchable_as_base) {
   const std::filesystem::path path{std::filesystem::temp_directory_path()};
   try {
     throw sourcemeta::core::FileError<std::runtime_error>(path, "test message");
@@ -33,7 +33,7 @@ TEST(Error_file_error, catchable_as_base) {
   }
 }
 
-TEST(Error_file_error, catchable_as_exception) {
+TEST(catchable_as_exception) {
   const std::filesystem::path path{std::filesystem::temp_directory_path()};
   try {
     throw sourcemeta::core::FileError<std::runtime_error>(path, "test message");
@@ -42,7 +42,7 @@ TEST(Error_file_error, catchable_as_exception) {
   }
 }
 
-TEST(Error_file_error, works_with_logic_error) {
+TEST(works_with_logic_error) {
   const std::filesystem::path path{std::filesystem::temp_directory_path()};
   try {
     throw sourcemeta::core::FileError<std::logic_error>(path, "logic failure");

--- a/test/gzip/CMakeLists.txt
+++ b/test/gzip/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME gzip
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME gzip
   SOURCES
     gzip_test.cc
     gzip_streambuf_test.cc)

--- a/test/gzip/gzip_streambuf_test.cc
+++ b/test/gzip/gzip_streambuf_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/gzip.h>
 #include <sourcemeta/core/io.h>
@@ -31,7 +31,7 @@ auto decompress_via_stream(const std::string &compressed) -> std::string {
 
 } // namespace
 
-TEST(GZIP_stream_buffer, empty) {
+TEST(empty) {
   const std::string input;
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -39,7 +39,7 @@ TEST(GZIP_stream_buffer, empty) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(GZIP_stream_buffer, hello_world) {
+TEST(hello_world) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -47,7 +47,7 @@ TEST(GZIP_stream_buffer, hello_world) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, large_input) {
+TEST(large_input) {
   const std::string pattern{"The quick brown fox jumps over the lazy dog. "};
   std::string input;
   for (int index = 0; index < 1000; ++index) {
@@ -60,7 +60,7 @@ TEST(GZIP_stream_buffer, large_input) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, binary_data) {
+TEST(binary_data) {
   std::string input;
   input.resize(256);
   for (unsigned int index = 0; index < 256; ++index) {
@@ -74,7 +74,7 @@ TEST(GZIP_stream_buffer, binary_data) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, read_char_by_char) {
+TEST(read_char_by_char) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -91,7 +91,7 @@ TEST(GZIP_stream_buffer, read_char_by_char) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, multiple_small_reads) {
+TEST(multiple_small_reads) {
   const std::string pattern{"abcdefghij"};
   std::string input;
   for (int index = 0; index < 500; ++index) {
@@ -116,7 +116,7 @@ TEST(GZIP_stream_buffer, multiple_small_reads) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, invalid_input_throws) {
+TEST(invalid_input_throws) {
   const std::string garbage{"this is not gzip data"};
   try {
     decompress_via_stream(garbage);
@@ -126,7 +126,7 @@ TEST(GZIP_stream_buffer, invalid_input_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, truncated_input_throws) {
+TEST(truncated_input_throws) {
   const std::string input{"hello world, this needs to be long enough"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -139,7 +139,7 @@ TEST(GZIP_stream_buffer, truncated_input_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, output_size_one_byte) {
+TEST(output_size_one_byte) {
   const std::string input{"X"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -147,7 +147,7 @@ TEST(GZIP_stream_buffer, output_size_one_byte) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, output_size_two_bytes) {
+TEST(output_size_two_bytes) {
   const std::string input{"AB"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -155,7 +155,7 @@ TEST(GZIP_stream_buffer, output_size_two_bytes) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, output_size_16383) {
+TEST(output_size_16383) {
   std::string input;
   input.resize(16383);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -168,7 +168,7 @@ TEST(GZIP_stream_buffer, output_size_16383) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, output_size_16384) {
+TEST(output_size_16384) {
   std::string input;
   input.resize(16384);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -181,7 +181,7 @@ TEST(GZIP_stream_buffer, output_size_16384) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, output_size_16385) {
+TEST(output_size_16385) {
   std::string input;
   input.resize(16385);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -194,7 +194,7 @@ TEST(GZIP_stream_buffer, output_size_16385) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, output_size_32768) {
+TEST(output_size_32768) {
   std::string input;
   input.resize(32768);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -207,7 +207,7 @@ TEST(GZIP_stream_buffer, output_size_32768) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, output_size_one_megabyte) {
+TEST(output_size_one_megabyte) {
   std::string input;
   input.resize(1024 * 1024);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -220,7 +220,7 @@ TEST(GZIP_stream_buffer, output_size_one_megabyte) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, highly_compressible_zeros) {
+TEST(highly_compressible_zeros) {
   const std::string input(65536, '\0');
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -230,7 +230,7 @@ TEST(GZIP_stream_buffer, highly_compressible_zeros) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, highly_compressible_repeated_byte) {
+TEST(highly_compressible_repeated_byte) {
   const std::string input(65536, static_cast<char>(0xff));
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -240,7 +240,7 @@ TEST(GZIP_stream_buffer, highly_compressible_repeated_byte) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, incompressible_random_bytes) {
+TEST(incompressible_random_bytes) {
   std::mt19937 generator{42};
   std::uniform_int_distribution<int> distribution{0, 255};
   std::string input;
@@ -255,7 +255,7 @@ TEST(GZIP_stream_buffer, incompressible_random_bytes) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, read_after_end_returns_eof) {
+TEST(read_after_end_returns_eof) {
   const std::string input{"hello"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -271,7 +271,7 @@ TEST(GZIP_stream_buffer, read_after_end_returns_eof) {
   EXPECT_EQ(decompressed.get(), std::char_traits<char>::eof());
 }
 
-TEST(GZIP_stream_buffer, peek_returns_first_byte) {
+TEST(peek_returns_first_byte) {
   const std::string input{"hello"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -285,7 +285,7 @@ TEST(GZIP_stream_buffer, peek_returns_first_byte) {
   EXPECT_EQ(decompressed.peek(), 'e');
 }
 
-TEST(GZIP_stream_buffer, mixed_peek_and_get) {
+TEST(mixed_peek_and_get) {
   const std::string input{"abcdef"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -305,7 +305,7 @@ TEST(GZIP_stream_buffer, mixed_peek_and_get) {
   EXPECT_EQ(decompressed.peek(), std::char_traits<char>::eof());
 }
 
-TEST(GZIP_stream_buffer, read_chunk_equal_to_internal_buffer) {
+TEST(read_chunk_equal_to_internal_buffer) {
   std::string input;
   input.resize(50000);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -329,7 +329,7 @@ TEST(GZIP_stream_buffer, read_chunk_equal_to_internal_buffer) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, read_chunk_larger_than_internal_buffer) {
+TEST(read_chunk_larger_than_internal_buffer) {
   std::string input;
   input.resize(50000);
   for (std::size_t index = 0; index < input.size(); ++index) {
@@ -353,7 +353,7 @@ TEST(GZIP_stream_buffer, read_chunk_larger_than_internal_buffer) {
   EXPECT_EQ(std::memcmp(result.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP_stream_buffer, header_with_ftext_flag) {
+TEST(header_with_ftext_flag) {
   // RFC 1952 section 2.3 gzip stream with FLG.FTEXT (0x01) set.
   // FTEXT is informational, so the streambuf must accept and ignore it.
   sourcemeta::core::InputByteStream stream{
@@ -374,7 +374,7 @@ TEST(GZIP_stream_buffer, header_with_ftext_flag) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_fname) {
+TEST(header_with_fname) {
   // FLG.FNAME (0x08) introduces a null-terminated filename after the fixed
   // 10-byte header
   sourcemeta::core::InputByteStream stream{
@@ -392,7 +392,7 @@ TEST(GZIP_stream_buffer, header_with_fname) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_fcomment) {
+TEST(header_with_fcomment) {
   // FLG.FCOMMENT (0x10) introduces a null-terminated comment after the fixed
   // 10-byte header
   sourcemeta::core::InputByteStream stream{
@@ -411,7 +411,7 @@ TEST(GZIP_stream_buffer, header_with_fcomment) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_fextra) {
+TEST(header_with_fextra) {
   // FLG.FEXTRA (0x04) introduces a length-prefixed extra field after the
   // fixed 10-byte header. XLEN is a little-endian 16-bit count of the
   // following bytes
@@ -431,7 +431,7 @@ TEST(GZIP_stream_buffer, header_with_fextra) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_fhcrc) {
+TEST(header_with_fhcrc) {
   // FLG.FHCRC (0x02) appends a 16-bit CRC of the preceding header bytes.
   // The 16-bit CRC is the low 16 bits of the CRC-32 of the 10 header bytes
   sourcemeta::core::InputByteStream stream{
@@ -449,7 +449,7 @@ TEST(GZIP_stream_buffer, header_with_fhcrc) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_all_optional_flags) {
+TEST(header_with_all_optional_flags) {
   // Every optional FLG bit set at once. RFC 1952 fixes the order of optional
   // fields: FEXTRA, FNAME, FCOMMENT, FHCRC
   sourcemeta::core::InputByteStream stream{
@@ -471,7 +471,7 @@ TEST(GZIP_stream_buffer, header_with_all_optional_flags) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, wrong_first_magic_byte_throws) {
+TEST(wrong_first_magic_byte_throws) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -484,7 +484,7 @@ TEST(GZIP_stream_buffer, wrong_first_magic_byte_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, wrong_second_magic_byte_throws) {
+TEST(wrong_second_magic_byte_throws) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -497,7 +497,7 @@ TEST(GZIP_stream_buffer, wrong_second_magic_byte_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, unsupported_compression_method_throws) {
+TEST(unsupported_compression_method_throws) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -510,7 +510,7 @@ TEST(GZIP_stream_buffer, unsupported_compression_method_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, reserved_flag_bit_5_set_throws) {
+TEST(reserved_flag_bit_5_set_throws) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -523,7 +523,7 @@ TEST(GZIP_stream_buffer, reserved_flag_bit_5_set_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, reserved_flag_bit_6_set_throws) {
+TEST(reserved_flag_bit_6_set_throws) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -536,7 +536,7 @@ TEST(GZIP_stream_buffer, reserved_flag_bit_6_set_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, reserved_flag_bit_7_set_throws) {
+TEST(reserved_flag_bit_7_set_throws) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -549,7 +549,7 @@ TEST(GZIP_stream_buffer, reserved_flag_bit_7_set_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, corrupted_trailing_crc32_throws) {
+TEST(corrupted_trailing_crc32_throws) {
   const std::string input{
       "hello world, this is long enough to produce a real deflate body"};
   auto compressed{sourcemeta::core::gzip(
@@ -564,7 +564,7 @@ TEST(GZIP_stream_buffer, corrupted_trailing_crc32_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, corrupted_trailing_isize_throws) {
+TEST(corrupted_trailing_isize_throws) {
   const std::string input{
       "hello world, this is long enough to produce a real deflate body"};
   auto compressed{sourcemeta::core::gzip(
@@ -579,7 +579,7 @@ TEST(GZIP_stream_buffer, corrupted_trailing_isize_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, empty_source_stream_throws) {
+TEST(empty_source_stream_throws) {
   try {
     decompress_via_stream("");
     FAIL();
@@ -588,7 +588,7 @@ TEST(GZIP_stream_buffer, empty_source_stream_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, trailing_data_after_member_is_ignored) {
+TEST(trailing_data_after_member_is_ignored) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -597,7 +597,7 @@ TEST(GZIP_stream_buffer, trailing_data_after_member_is_ignored) {
   EXPECT_EQ(result, input);
 }
 
-TEST(GZIP_stream_buffer, fhcrc_mismatch_throws) {
+TEST(fhcrc_mismatch_throws) {
   // RFC 1952 section 2.3.1.2: a compliant decoder must reject an FHCRC
   // mismatch. The correct CRC16 over the preceding 10 header bytes is
   // 0x90 0xc9, so flipping a bit must cause a hard failure
@@ -619,7 +619,7 @@ TEST(GZIP_stream_buffer, fhcrc_mismatch_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, multiple_deflate_blocks) {
+TEST(multiple_deflate_blocks) {
   // RFC 1951 allows a deflate stream to contain multiple blocks. Only the
   // last block has BFINAL set. This fixture splits "hello world" into two
   // stored blocks
@@ -640,7 +640,7 @@ TEST(GZIP_stream_buffer, multiple_deflate_blocks) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, fextra_with_zero_xlen) {
+TEST(fextra_with_zero_xlen) {
   // RFC 1952: XLEN=0 is a valid FEXTRA encoding (no extra-field bytes)
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00, 0x00, 0x00,
@@ -651,7 +651,7 @@ TEST(GZIP_stream_buffer, fextra_with_zero_xlen) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, mtime_nonzero_is_accepted) {
+TEST(mtime_nonzero_is_accepted) {
   // RFC 1952 section 2.3.1.2: MTIME is informational and any value, including
   // non-zero, must be accepted
   sourcemeta::core::InputByteStream stream{
@@ -662,7 +662,7 @@ TEST(GZIP_stream_buffer, mtime_nonzero_is_accepted) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, xfl_max_compression_is_accepted) {
+TEST(xfl_max_compression_is_accepted) {
   // RFC 1952 section 2.3.1.2: XFL=2 indicates maximum compression
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -673,7 +673,7 @@ TEST(GZIP_stream_buffer, xfl_max_compression_is_accepted) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, xfl_fastest_compression_is_accepted) {
+TEST(xfl_fastest_compression_is_accepted) {
   // RFC 1952 section 2.3.1.2: XFL=4 indicates fastest compression
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -684,7 +684,7 @@ TEST(GZIP_stream_buffer, xfl_fastest_compression_is_accepted) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, os_field_unix_is_accepted) {
+TEST(os_field_unix_is_accepted) {
   // RFC 1952 section 2.3.1.2: OS=3 indicates Unix; decoders must accept any
   // value
   sourcemeta::core::InputByteStream stream{
@@ -695,7 +695,7 @@ TEST(GZIP_stream_buffer, os_field_unix_is_accepted) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, fname_with_latin1_high_bytes) {
+TEST(fname_with_latin1_high_bytes) {
   // RFC 1952 section 2.3.1.2: FNAME is ISO 8859-1 (Latin-1), so bytes in the
   // 0x80 to 0xff range must be accepted
   sourcemeta::core::InputByteStream stream{
@@ -706,7 +706,7 @@ TEST(GZIP_stream_buffer, fname_with_latin1_high_bytes) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, fcomment_with_latin1_high_bytes) {
+TEST(fcomment_with_latin1_high_bytes) {
   // RFC 1952 section 2.3.1.2: FCOMMENT is ISO 8859-1
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xc0, 0xc1,
@@ -716,7 +716,7 @@ TEST(GZIP_stream_buffer, fcomment_with_latin1_high_bytes) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, read_via_getline) {
+TEST(read_via_getline) {
   const std::string input{"line one\nline two\nline three"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -735,7 +735,7 @@ TEST(GZIP_stream_buffer, read_via_getline) {
   EXPECT_EQ(third_line, "line three");
 }
 
-TEST(GZIP_stream_buffer, ignore_skips_bytes) {
+TEST(ignore_skips_bytes) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -750,7 +750,7 @@ TEST(GZIP_stream_buffer, ignore_skips_bytes) {
   EXPECT_EQ(remaining, "world");
 }
 
-TEST(GZIP_stream_buffer, operator_in_extracts_tokens) {
+TEST(operator_in_extracts_tokens) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -765,7 +765,7 @@ TEST(GZIP_stream_buffer, operator_in_extracts_tokens) {
   EXPECT_EQ(second, "world");
 }
 
-TEST(GZIP_stream_buffer, stored_block_with_empty_non_final_then_data) {
+TEST(stored_block_with_empty_non_final_then_data) {
   // RFC 1951 section 3.2.4: a stored block with LEN=0 is well-formed
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
@@ -779,7 +779,7 @@ TEST(GZIP_stream_buffer, stored_block_with_empty_non_final_then_data) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, empty_payload_via_empty_final_stored_block) {
+TEST(empty_payload_via_empty_final_stored_block) {
   // Hand-crafted minimum valid gzip member encoding an empty payload
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
@@ -791,7 +791,7 @@ TEST(GZIP_stream_buffer, empty_payload_via_empty_final_stored_block) {
   EXPECT_TRUE(decompress_via_stream(stream).empty());
 }
 
-TEST(GZIP_stream_buffer, header_with_fextra_and_fname) {
+TEST(header_with_fextra_and_fname) {
   // RFC 1952 fixes the order: FEXTRA precedes FNAME
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x0c, 0x00, 0x00, 0x00, 0x00,
@@ -804,7 +804,7 @@ TEST(GZIP_stream_buffer, header_with_fextra_and_fname) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_fextra_and_fcomment) {
+TEST(header_with_fextra_and_fcomment) {
   // RFC 1952 fixes the order: FEXTRA precedes FCOMMENT
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x14, 0x00, 0x00, 0x00, 0x00,
@@ -817,7 +817,7 @@ TEST(GZIP_stream_buffer, header_with_fextra_and_fcomment) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, header_with_fname_and_fcomment) {
+TEST(header_with_fname_and_fcomment) {
   // RFC 1952 fixes the order: FNAME precedes FCOMMENT
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 'a',  '.',
@@ -828,7 +828,7 @@ TEST(GZIP_stream_buffer, header_with_fname_and_fcomment) {
   EXPECT_EQ(decompress_via_stream(stream), "hello world");
 }
 
-TEST(GZIP_stream_buffer, reserved_deflate_block_type_throws) {
+TEST(reserved_deflate_block_type_throws) {
   // RFC 1951 section 3.2.3: BTYPE=11 is reserved and a compliant decoder
   // must reject it. Deflate packs bits LSB-first, so BFINAL=1 + BTYPE=11
   // is the byte 0b00000111 = 0x07
@@ -845,7 +845,7 @@ TEST(GZIP_stream_buffer, reserved_deflate_block_type_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, stored_block_with_mismatched_nlen_throws) {
+TEST(stored_block_with_mismatched_nlen_throws) {
   // RFC 1951 section 3.2.4: NLEN must be the one's complement of LEN
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
@@ -862,7 +862,7 @@ TEST(GZIP_stream_buffer, stored_block_with_mismatched_nlen_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, two_concatenated_members) {
+TEST(two_concatenated_members) {
   const std::string first{"hello"};
   const std::string second{" world"};
   const auto first_gzip{sourcemeta::core::gzip(
@@ -874,7 +874,7 @@ TEST(GZIP_stream_buffer, two_concatenated_members) {
   EXPECT_EQ(result, first + second);
 }
 
-TEST(GZIP_stream_buffer, three_concatenated_members_with_empty) {
+TEST(three_concatenated_members_with_empty) {
   const std::string first{"foo"};
   const std::string second;
   const std::string third{"baz"};
@@ -889,7 +889,7 @@ TEST(GZIP_stream_buffer, three_concatenated_members_with_empty) {
   EXPECT_EQ(result, first + second + third);
 }
 
-TEST(GZIP_stream_buffer, header_only_source_throws) {
+TEST(header_only_source_throws) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -902,7 +902,7 @@ TEST(GZIP_stream_buffer, header_only_source_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, truncated_mid_fname_throws) {
+TEST(truncated_mid_fname_throws) {
   // FLG.FNAME set but the source stream ends before the null terminator
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x08, 0x00, 0x00, 0x00,
@@ -915,7 +915,7 @@ TEST(GZIP_stream_buffer, truncated_mid_fname_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, truncated_mid_fcomment_throws) {
+TEST(truncated_mid_fcomment_throws) {
   // FLG.FCOMMENT set but the source stream ends before the null terminator
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x10, 0x00, 0x00, 0x00,
@@ -928,7 +928,7 @@ TEST(GZIP_stream_buffer, truncated_mid_fcomment_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, truncated_mid_fextra_throws) {
+TEST(truncated_mid_fextra_throws) {
   // FLG.FEXTRA with XLEN=10 but only 3 bytes of extra-field data present
   sourcemeta::core::InputByteStream stream{
       0x1f, 0x8b, 0x08, 0x04, 0x00, 0x00,
@@ -942,7 +942,7 @@ TEST(GZIP_stream_buffer, truncated_mid_fextra_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, fextra_spans_internal_buffer) {
+TEST(fextra_spans_internal_buffer) {
   std::string compressed;
   compressed.append("\x1f\x8b\x08\x04\x00\x00\x00\x00\x00\xff", 10);
   const std::size_t extra_size{20000};
@@ -955,7 +955,7 @@ TEST(GZIP_stream_buffer, fextra_spans_internal_buffer) {
   EXPECT_EQ(decompress_via_stream(compressed), "hello world");
 }
 
-TEST(GZIP_stream_buffer, dynamic_block_hlit_above_286_throws) {
+TEST(dynamic_block_hlit_above_286_throws) {
   // RFC 1951 section 3.2.7 caps the literal/length alphabet at 286 symbols.
   // The deflate payload starts a dynamic block with HLIT encoding 288 codes
   // (BFINAL=1, BTYPE=10, HLIT field = 31 so 31 + 257 = 288)
@@ -970,7 +970,7 @@ TEST(GZIP_stream_buffer, dynamic_block_hlit_above_286_throws) {
   }
 }
 
-TEST(GZIP_stream_buffer, dynamic_block_incomplete_code_throws) {
+TEST(dynamic_block_incomplete_code_throws) {
   // RFC 1951 forbids incomplete Huffman codes outside the single-code case.
   // The deflate payload starts a dynamic block whose code-length code tree
   // assigns length two to two symbols, leaving the alphabet incomplete

--- a/test/gzip/gzip_test.cc
+++ b/test/gzip/gzip_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/gzip.h>
 
@@ -6,7 +6,7 @@
 #include <cstring> // std::memcmp
 #include <string>  // std::string
 
-TEST(GZIP, compress_empty_input) {
+TEST(compress_empty_input) {
   const std::string input;
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -18,7 +18,7 @@ TEST(GZIP, compress_empty_input) {
   EXPECT_EQ(decompressed, input);
 }
 
-TEST(GZIP, compress_hello_world) {
+TEST(compress_hello_world) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -31,7 +31,7 @@ TEST(GZIP, compress_hello_world) {
   EXPECT_EQ(decompressed, input);
 }
 
-TEST(GZIP, compress_round_trip_binary_data) {
+TEST(compress_round_trip_binary_data) {
   std::string input;
   input.resize(256);
   for (unsigned int index = 0; index < 256; ++index) {
@@ -49,7 +49,7 @@ TEST(GZIP, compress_round_trip_binary_data) {
   EXPECT_EQ(std::memcmp(decompressed.data(), input.data(), input.size()), 0);
 }
 
-TEST(GZIP, compress_round_trip_large_input) {
+TEST(compress_round_trip_large_input) {
   const std::string pattern{"The quick brown fox jumps over the lazy dog. "};
   std::string input;
   for (int index = 0; index < 1000; ++index) {
@@ -67,7 +67,7 @@ TEST(GZIP, compress_round_trip_large_input) {
   EXPECT_EQ(decompressed, input);
 }
 
-TEST(GZIP, decompress_with_output_hint) {
+TEST(decompress_with_output_hint) {
   const std::string input{"hello world"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -78,7 +78,7 @@ TEST(GZIP, decompress_with_output_hint) {
   EXPECT_EQ(decompressed, input);
 }
 
-TEST(GZIP, compress_with_explicit_level_round_trips) {
+TEST(compress_with_explicit_level_round_trips) {
   const std::string pattern{"The quick brown fox jumps over the lazy dog. "};
   std::string input;
   for (int index = 0; index < 1000; ++index) {
@@ -95,7 +95,7 @@ TEST(GZIP, compress_with_explicit_level_round_trips) {
   EXPECT_EQ(decompressed, input);
 }
 
-TEST(GZIP, compress_higher_level_is_not_larger) {
+TEST(compress_higher_level_is_not_larger) {
   const std::string pattern{"The quick brown fox jumps over the lazy dog. "};
   std::string input;
   for (int index = 0; index < 1000; ++index) {
@@ -109,7 +109,7 @@ TEST(GZIP, compress_higher_level_is_not_larger) {
   EXPECT_LE(smallest.size(), fastest.size());
 }
 
-TEST(GZIP, decompress_invalid_input_throws) {
+TEST(decompress_invalid_input_throws) {
   const std::string garbage{"this is not gzip data"};
   try {
     sourcemeta::core::gunzip(

--- a/test/html/CMakeLists.txt
+++ b/test/html/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME html
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME html
   SOURCES html_encoder_test.cc html_escape_test.cc)
 
 target_link_libraries(sourcemeta_core_html_unit

--- a/test/html/html_encoder_test.cc
+++ b/test/html/html_encoder_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/html.h>
 
-TEST(HTML_writer, example_1) {
+TEST(example_1) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.h1("Title");
@@ -19,7 +19,7 @@ TEST(HTML_writer, example_1) {
                             "<li>baz</li></ul><p>Footer</p></div>");
 }
 
-TEST(HTML_writer, escaped_text_content) {
+TEST(escaped_text_content) {
   sourcemeta::core::HTMLWriter document;
   document.p(
       "This contains <dangerous> & \"potentially\" 'harmful' characters");
@@ -29,7 +29,7 @@ TEST(HTML_writer, escaped_text_content) {
             "&#39;harmful&#39; characters</p>");
 }
 
-TEST(HTML_writer, raw_html_basic) {
+TEST(raw_html_basic) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.raw("<strong>Bold text</strong>");
@@ -38,7 +38,7 @@ TEST(HTML_writer, raw_html_basic) {
   EXPECT_EQ(document.str(), "<div><strong>Bold text</strong></div>");
 }
 
-TEST(HTML_writer, raw_html_with_dangerous_content) {
+TEST(raw_html_with_dangerous_content) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.raw("<script>alert('xss')</script>");
@@ -47,7 +47,7 @@ TEST(HTML_writer, raw_html_with_dangerous_content) {
   EXPECT_EQ(document.str(), "<div><script>alert('xss')</script></div>");
 }
 
-TEST(HTML_writer, raw_html_mixed_with_escaped) {
+TEST(raw_html_mixed_with_escaped) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.text("Safe text: <script>");
@@ -59,7 +59,7 @@ TEST(HTML_writer, raw_html_mixed_with_escaped) {
                             "&amp; more safe text</div>");
 }
 
-TEST(HTML_writer, raw_html_in_list) {
+TEST(raw_html_in_list) {
   sourcemeta::core::HTMLWriter document;
   document.ul();
   document.li("Regular item");
@@ -74,7 +74,7 @@ TEST(HTML_writer, raw_html_in_list) {
             "item</li><li>Another &amp; escaped item</li></ul>");
 }
 
-TEST(HTML_writer, raw_html_empty_content) {
+TEST(raw_html_empty_content) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.raw("");
@@ -83,7 +83,7 @@ TEST(HTML_writer, raw_html_empty_content) {
   EXPECT_EQ(document.str(), "<div></div>");
 }
 
-TEST(HTML_writer, raw_html_with_entities) {
+TEST(raw_html_with_entities) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.raw("&lt;already&gt; &amp; &quot;escaped&quot;");
@@ -93,7 +93,7 @@ TEST(HTML_writer, raw_html_with_entities) {
             "<div>&lt;already&gt; &amp; &quot;escaped&quot;</div>");
 }
 
-TEST(HTML_writer, empty_elements) {
+TEST(empty_elements) {
   {
     sourcemeta::core::HTMLWriter document;
     document.div();
@@ -114,7 +114,7 @@ TEST(HTML_writer, empty_elements) {
   }
 }
 
-TEST(HTML_writer, void_elements_self_closing) {
+TEST(void_elements_self_closing) {
   {
     sourcemeta::core::HTMLWriter document;
     document.br();
@@ -142,7 +142,7 @@ TEST(HTML_writer, void_elements_self_closing) {
   }
 }
 
-TEST(HTML_writer, single_text_node_inline_rendering) {
+TEST(single_text_node_inline_rendering) {
   {
     sourcemeta::core::HTMLWriter document;
     document.p("Hello");
@@ -160,7 +160,7 @@ TEST(HTML_writer, single_text_node_inline_rendering) {
   }
 }
 
-TEST(HTML_writer, multiple_children_block_rendering) {
+TEST(multiple_children_block_rendering) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.text("Text 1");
@@ -170,7 +170,7 @@ TEST(HTML_writer, multiple_children_block_rendering) {
   EXPECT_EQ(document.str(), "<div>Text 1<span>Text 2</span></div>");
 }
 
-TEST(HTML_writer, attribute_value_escaping) {
+TEST(attribute_value_escaping) {
   sourcemeta::core::HTMLWriter document;
   document.div()
       .attribute("title", "Alert: \"Click here\" & 'submit'")
@@ -185,7 +185,7 @@ TEST(HTML_writer, attribute_value_escaping) {
       "Content</div>");
 }
 
-TEST(HTML_writer, empty_attribute_values) {
+TEST(empty_attribute_values) {
   sourcemeta::core::HTMLWriter document;
   document.input()
       .attribute("type", "text")
@@ -196,7 +196,7 @@ TEST(HTML_writer, empty_attribute_values) {
             "<input type=\"text\" value=\"\" placeholder=\"Enter text\" />");
 }
 
-TEST(HTML_writer, nested_html_elements) {
+TEST(nested_html_elements) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.p("First paragraph");
@@ -213,7 +213,7 @@ TEST(HTML_writer, nested_html_elements) {
             "<p>Last paragraph</p></div>");
 }
 
-TEST(HTML_writer, complex_table_structure) {
+TEST(complex_table_structure) {
   sourcemeta::core::HTMLWriter document;
   document.table();
   document.thead();
@@ -254,7 +254,7 @@ TEST(HTML_writer, complex_table_structure) {
   EXPECT_EQ(document.str(), expected);
 }
 
-TEST(HTML_writer, form_elements_combination) {
+TEST(form_elements_combination) {
   sourcemeta::core::HTMLWriter document;
   document.form().attribute("action", "/submit").attribute("method", "post");
   document.fieldset();
@@ -301,14 +301,14 @@ TEST(HTML_writer, form_elements_combination) {
   EXPECT_EQ(document.str(), expected);
 }
 
-TEST(HTML_writer, unicode_and_special_characters) {
+TEST(unicode_and_special_characters) {
   sourcemeta::core::HTMLWriter document;
   document.p("Unicode: 你好世界 🌍 ñáéíóú");
 
   EXPECT_EQ(document.str(), "<p>Unicode: 你好世界 🌍 ñáéíóú</p>");
 }
 
-TEST(HTML_writer, whitespace_handling) {
+TEST(whitespace_handling) {
   sourcemeta::core::HTMLWriter document;
   document.pre("  Whitespace\n  should be\n    preserved  ");
 
@@ -316,7 +316,7 @@ TEST(HTML_writer, whitespace_handling) {
             "<pre>  Whitespace\n  should be\n    preserved  </pre>");
 }
 
-TEST(HTML_writer, mixed_raw_and_escaped_complex) {
+TEST(mixed_raw_and_escaped_complex) {
   sourcemeta::core::HTMLWriter document;
   document.article();
   document.h2("Article Title & <subtitle>");
@@ -342,7 +342,7 @@ TEST(HTML_writer, mixed_raw_and_escaped_complex) {
   EXPECT_EQ(document.str(), expected);
 }
 
-TEST(HTML_writer, semantic_html5_elements) {
+TEST(semantic_html5_elements) {
   sourcemeta::core::HTMLWriter document;
   document.main().attribute("role", "main");
   document.header();
@@ -387,7 +387,7 @@ TEST(HTML_writer, semantic_html5_elements) {
   EXPECT_EQ(document.str(), expected);
 }
 
-TEST(HTML_writer, attribute_order_consistency) {
+TEST(attribute_order_consistency) {
   sourcemeta::core::HTMLWriter document;
   document.div()
       .attribute("z-index", "1")
@@ -400,7 +400,7 @@ TEST(HTML_writer, attribute_order_consistency) {
             "<div z-index=\"1\" class=\"test\" id=\"main\">Content</div>");
 }
 
-TEST(HTML_writer, zero_length_strings) {
+TEST(zero_length_strings) {
   {
     sourcemeta::core::HTMLWriter document;
     document.p("");
@@ -415,7 +415,7 @@ TEST(HTML_writer, zero_length_strings) {
   }
 }
 
-TEST(HTML_writer, escaped_text_in_container) {
+TEST(escaped_text_in_container) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.text("Safe: <script>alert('xss')</script>");
@@ -425,7 +425,7 @@ TEST(HTML_writer, escaped_text_in_container) {
                             "&lt;/script&gt;</div>");
 }
 
-TEST(HTML_writer, template_element_tag_name) {
+TEST(template_element_tag_name) {
   {
     sourcemeta::core::HTMLWriter document;
     document.template_("Content");
@@ -441,7 +441,7 @@ TEST(HTML_writer, template_element_tag_name) {
   }
 }
 
-TEST(HTML_writer, chaining) {
+TEST(chaining) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.span().text("hello").close();
@@ -450,7 +450,7 @@ TEST(HTML_writer, chaining) {
   EXPECT_EQ(document.str(), "<div><span>hello</span></div>");
 }
 
-TEST(HTML_writer, write_to_stream) {
+TEST(write_to_stream) {
   sourcemeta::core::HTMLWriter document;
   document.p("Hello");
 
@@ -460,7 +460,7 @@ TEST(HTML_writer, write_to_stream) {
   EXPECT_EQ(output.str(), "<p>Hello</p>");
 }
 
-TEST(HTML_writer, reserve_does_not_change_output) {
+TEST(reserve_does_not_change_output) {
   sourcemeta::core::HTMLWriter document;
   document.reserve(1024);
   document.div("Content");
@@ -468,7 +468,7 @@ TEST(HTML_writer, reserve_does_not_change_output) {
   EXPECT_EQ(document.str(), "<div>Content</div>");
 }
 
-TEST(HTML_writer, void_element_with_attributes) {
+TEST(void_element_with_attributes) {
   sourcemeta::core::HTMLWriter document;
   document.div();
   document.img().attribute("src", "photo.png").attribute("alt", "A photo");
@@ -478,7 +478,7 @@ TEST(HTML_writer, void_element_with_attributes) {
             "<div><img src=\"photo.png\" alt=\"A photo\" /></div>");
 }
 
-TEST(HTML_writer, attribute_chaining) {
+TEST(attribute_chaining) {
   sourcemeta::core::HTMLWriter document;
   document.a().attribute("href", "/test").attribute("class", "link");
   document.text("Click");

--- a/test/html/html_escape_test.cc
+++ b/test/html/html_escape_test.cc
@@ -1,158 +1,158 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/html.h>
 
-TEST(HTML_escape, empty_string) {
+TEST(empty_string) {
   std::string text = "";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "");
 }
 
-TEST(HTML_escape, no_escape_needed_letters) {
+TEST(no_escape_needed_letters) {
   std::string text = "hello";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "hello");
 }
 
-TEST(HTML_escape, no_escape_needed_alphanumeric) {
+TEST(no_escape_needed_alphanumeric) {
   std::string text = "test123";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "test123");
 }
 
-TEST(HTML_escape, no_escape_needed_spaces_only) {
+TEST(no_escape_needed_spaces_only) {
   std::string text = "   ";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "   ");
 }
 
-TEST(HTML_escape, ampersand_single) {
+TEST(ampersand_single) {
   std::string text = "&";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;");
 }
 
-TEST(HTML_escape, ampersand_in_text) {
+TEST(ampersand_in_text) {
   std::string text = "Tom & Jerry";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "Tom &amp; Jerry");
 }
 
-TEST(HTML_escape, ampersand_multiple) {
+TEST(ampersand_multiple) {
   std::string text = "A&B&C";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "A&amp;B&amp;C");
 }
 
-TEST(HTML_escape, ampersand_already_escaped) {
+TEST(ampersand_already_escaped) {
   std::string text = "&amp;";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;amp;");
 }
 
-TEST(HTML_escape, ampersand_business_context) {
+TEST(ampersand_business_context) {
   std::string text = "R&D";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "R&amp;D");
 }
 
-TEST(HTML_escape, less_than_single) {
+TEST(less_than_single) {
   std::string text = "<";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;");
 }
 
-TEST(HTML_escape, less_than_in_comparison) {
+TEST(less_than_in_comparison) {
   std::string text = "x < y";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "x &lt; y");
 }
 
-TEST(HTML_escape, less_than_tag_like) {
+TEST(less_than_tag_like) {
   std::string text = "<script>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;script&gt;");
 }
 
-TEST(HTML_escape, less_than_multiple) {
+TEST(less_than_multiple) {
   std::string text = "a<b<c";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "a&lt;b&lt;c");
 }
 
-TEST(HTML_escape, greater_than_single) {
+TEST(greater_than_single) {
   std::string text = ">";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&gt;");
 }
 
-TEST(HTML_escape, greater_than_in_comparison) {
+TEST(greater_than_in_comparison) {
   std::string text = "x > y";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "x &gt; y");
 }
 
-TEST(HTML_escape, greater_than_multiple) {
+TEST(greater_than_multiple) {
   std::string text = "a>b>c";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "a&gt;b&gt;c");
 }
 
-TEST(HTML_escape, double_quote_single) {
+TEST(double_quote_single) {
   std::string text = "\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&quot;");
 }
 
-TEST(HTML_escape, double_quote_in_sentence) {
+TEST(double_quote_in_sentence) {
   std::string text = "She said \"Hello\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "She said &quot;Hello&quot;");
 }
 
-TEST(HTML_escape, double_quote_consecutive) {
+TEST(double_quote_consecutive) {
   std::string text = "\"\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&quot;&quot;");
 }
 
-TEST(HTML_escape, double_quote_attribute_like) {
+TEST(double_quote_attribute_like) {
   std::string text = "value=\"test\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "value=&quot;test&quot;");
 }
 
-TEST(HTML_escape, single_quote_single) {
+TEST(single_quote_single) {
   std::string text = "'";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&#39;");
 }
 
-TEST(HTML_escape, single_quote_contraction) {
+TEST(single_quote_contraction) {
   std::string text = "It's";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "It&#39;s");
 }
 
-TEST(HTML_escape, single_quote_cant) {
+TEST(single_quote_cant) {
   std::string text = "can't";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "can&#39;t");
 }
 
-TEST(HTML_escape, single_quote_consecutive) {
+TEST(single_quote_consecutive) {
   std::string text = "''";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&#39;&#39;");
 }
 
-TEST(HTML_escape, all_five_entities) {
+TEST(all_five_entities) {
   std::string text = "&<>'\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;&lt;&gt;&#39;&quot;");
 }
 
-TEST(HTML_escape, html_tag_with_attributes) {
+TEST(html_tag_with_attributes) {
   std::string text =
       "<tag attr=\"value\" data-test='other'>content & more</tag>";
   sourcemeta::core::html_escape(text);
@@ -161,207 +161,207 @@ TEST(HTML_escape, html_tag_with_attributes) {
             "data-test=&#39;other&#39;&gt;content &amp; more&lt;/tag&gt;");
 }
 
-TEST(HTML_escape, mixed_quotes_and_ampersand) {
+TEST(mixed_quotes_and_ampersand) {
   std::string text = "Hello & \"World\" <test>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "Hello &amp; &quot;World&quot; &lt;test&gt;");
 }
 
-TEST(HTML_escape, script_tag_xss) {
+TEST(script_tag_xss) {
   std::string text = "<script>alert('xss')</script>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
 }
 
-TEST(HTML_escape, img_onerror_xss) {
+TEST(img_onerror_xss) {
   std::string text = "<img src='x' onerror='alert(1)'>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;img src=&#39;x&#39; onerror=&#39;alert(1)&#39;&gt;");
 }
 
-TEST(HTML_escape, svg_onload_xss) {
+TEST(svg_onload_xss) {
   std::string text = "<svg onload=alert(1)>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;svg onload=alert(1)&gt;");
 }
 
-TEST(HTML_escape, javascript_url) {
+TEST(javascript_url) {
   std::string text = "javascript:alert('test')";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "javascript:alert(&#39;test&#39;)");
 }
 
-TEST(HTML_escape, mxss_img_in_attribute) {
+TEST(mxss_img_in_attribute) {
   std::string text = "attr='<img src=x onerror=alert(1)>'";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "attr=&#39;&lt;img src=x onerror=alert(1)&gt;&#39;");
 }
 
-TEST(HTML_escape, mxss_svg_in_attribute) {
+TEST(mxss_svg_in_attribute) {
   std::string text = "data=\"<svg onload=alert('xss')>\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "data=&quot;&lt;svg onload=alert(&#39;xss&#39;)&gt;&quot;");
 }
 
-TEST(HTML_escape, mxss_iframe_javascript) {
+TEST(mxss_iframe_javascript) {
   std::string text = "<iframe src=\"javascript:alert('xss')\">";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text,
             "&lt;iframe src=&quot;javascript:alert(&#39;xss&#39;)&quot;&gt;");
 }
 
-TEST(HTML_escape, unicode_cafe) {
+TEST(unicode_cafe) {
   std::string text = "café";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "café");
 }
 
-TEST(HTML_escape, unicode_naive) {
+TEST(unicode_naive) {
   std::string text = "naïve";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "naïve");
 }
 
-TEST(HTML_escape, unicode_japanese) {
+TEST(unicode_japanese) {
   std::string text = "東京";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "東京");
 }
 
-TEST(HTML_escape, unicode_emoji) {
+TEST(unicode_emoji) {
   std::string text = "🚀";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "🚀");
 }
 
-TEST(HTML_escape, unicode_with_html_entities) {
+TEST(unicode_with_html_entities) {
   std::string text = "café & 東京 < 🚀";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "café &amp; 東京 &lt; 🚀");
 }
 
-TEST(HTML_escape, newline_only) {
+TEST(newline_only) {
   std::string text = "\n";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "\n");
 }
 
-TEST(HTML_escape, tab_only) {
+TEST(tab_only) {
   std::string text = "\t";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "\t");
 }
 
-TEST(HTML_escape, carriage_return_only) {
+TEST(carriage_return_only) {
   std::string text = "\r";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "\r");
 }
 
-TEST(HTML_escape, multiline_text) {
+TEST(multiline_text) {
   std::string text = "line1\nline2";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "line1\nline2");
 }
 
-TEST(HTML_escape, whitespace_with_entities) {
+TEST(whitespace_with_entities) {
   std::string text = "line1\n<tag> & test";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "line1\n&lt;tag&gt; &amp; test");
 }
 
-TEST(HTML_escape, numeric_entity_39) {
+TEST(numeric_entity_39) {
   std::string text = "&#39;";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;#39;");
 }
 
-TEST(HTML_escape, numeric_entity_34) {
+TEST(numeric_entity_34) {
   std::string text = "&#34;";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;#34;");
 }
 
-TEST(HTML_escape, hex_entity) {
+TEST(hex_entity) {
   std::string text = "&#x27;";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;#x27;");
 }
 
-TEST(HTML_escape, numeric_entity_60) {
+TEST(numeric_entity_60) {
   std::string text = "&#60;";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;#60;");
 }
 
-TEST(HTML_escape, div_with_class) {
+TEST(div_with_class) {
   std::string text = "<div class=\"container\">";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;div class=&quot;container&quot;&gt;");
 }
 
-TEST(HTML_escape, input_with_mixed_quotes) {
+TEST(input_with_mixed_quotes) {
   std::string text = "<input type='text' value=\"test\">";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;input type=&#39;text&#39; value=&quot;test&quot;&gt;");
 }
 
-TEST(HTML_escape, html_document_end) {
+TEST(html_document_end) {
   std::string text = "</body></html>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;/body&gt;&lt;/html&gt;");
 }
 
-TEST(HTML_escape, meta_charset) {
+TEST(meta_charset) {
   std::string text = "<meta charset=\"utf-8\">";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;meta charset=&quot;utf-8&quot;&gt;");
 }
 
-TEST(HTML_escape, basic_html_comment) {
+TEST(basic_html_comment) {
   std::string text = "<!-- comment -->";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;!-- comment --&gt;");
 }
 
-TEST(HTML_escape, comment_with_entities) {
+TEST(comment_with_entities) {
   std::string text = "<!-- <script> & 'test' -->";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;!-- &lt;script&gt; &amp; &#39;test&#39; --&gt;");
 }
 
-TEST(HTML_escape, css_with_quotes) {
+TEST(css_with_quotes) {
   std::string text = "body { color: 'red'; }";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "body { color: &#39;red&#39;; }");
 }
 
-TEST(HTML_escape, css_selector) {
+TEST(css_selector) {
   std::string text = "div > p";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "div &gt; p");
 }
 
-TEST(HTML_escape, javascript_condition) {
+TEST(javascript_condition) {
   std::string text = "if (x < y && z > 'test') { alert(\"hello\"); }";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "if (x &lt; y &amp;&amp; z &gt; &#39;test&#39;) { "
                   "alert(&quot;hello&quot;); }");
 }
 
-TEST(HTML_escape, cdata_basic) {
+TEST(cdata_basic) {
   std::string text = "<![CDATA[content]]>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;![CDATA[content]]&gt;");
 }
 
-TEST(HTML_escape, cdata_with_entities) {
+TEST(cdata_with_entities) {
   std::string text = "<![CDATA[<tag> & 'test']]>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;![CDATA[&lt;tag&gt; &amp; &#39;test&#39;]]&gt;");
 }
 
-TEST(HTML_escape, url_with_query_params) {
+TEST(url_with_query_params) {
   std::string text = "http://example.com?param='value'&other=\"test\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(
@@ -369,50 +369,50 @@ TEST(HTML_escape, url_with_query_params) {
       "http://example.com?param=&#39;value&#39;&amp;other=&quot;test&quot;");
 }
 
-TEST(HTML_escape, search_url_with_script) {
+TEST(search_url_with_script) {
   std::string text = "search?q=<script>&format='json'";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "search?q=&lt;script&gt;&amp;format=&#39;json&#39;");
 }
 
-TEST(HTML_escape, long_string_no_escaping) {
+TEST(long_string_no_escaping) {
   std::string text = "abcdefghijklmnopqrstuvwxyz0123456789";
   std::string expected = text;
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, expected);
 }
 
-TEST(HTML_escape, consecutive_ampersands) {
+TEST(consecutive_ampersands) {
   std::string text = "&&&";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&amp;&amp;&amp;");
 }
 
-TEST(HTML_escape, consecutive_less_than) {
+TEST(consecutive_less_than) {
   std::string text = "<<<";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&lt;&lt;&lt;");
 }
 
-TEST(HTML_escape, consecutive_greater_than) {
+TEST(consecutive_greater_than) {
   std::string text = ">>>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&gt;&gt;&gt;");
 }
 
-TEST(HTML_escape, consecutive_double_quotes) {
+TEST(consecutive_double_quotes) {
   std::string text = "\"\"\"";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&quot;&quot;&quot;");
 }
 
-TEST(HTML_escape, consecutive_single_quotes) {
+TEST(consecutive_single_quotes) {
   std::string text = "'''";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text, "&#39;&#39;&#39;");
 }
 
-TEST(HTML_escape, complex_mixed_content) {
+TEST(complex_mixed_content) {
   std::string text = "This is a test & it contains < and > symbols, "
                      "\"quotes\", 'apostrophes', and <tags>";
   sourcemeta::core::html_escape(text);
@@ -421,116 +421,116 @@ TEST(HTML_escape, complex_mixed_content) {
             "&quot;quotes&quot;, &#39;apostrophes&#39;, and &lt;tags&gt;");
 }
 
-TEST(HTML_escape, possessive_with_quotes_and_entities) {
+TEST(possessive_with_quotes_and_entities) {
   std::string text = "Tom's \"Café\" & Jerry's <adventures>";
   sourcemeta::core::html_escape(text);
   EXPECT_EQ(text,
             "Tom&#39;s &quot;Café&quot; &amp; Jerry&#39;s &lt;adventures&gt;");
 }
 
-TEST(HTML_escape_append_string, empty) {
+TEST(empty) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "");
   EXPECT_EQ(output, "");
 }
 
-TEST(HTML_escape_append_string, no_escaping_needed) {
+TEST(no_escaping_needed) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "hello world");
   EXPECT_EQ(output, "hello world");
 }
 
-TEST(HTML_escape_append_string, ampersand) {
+TEST(ampersand) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "a & b");
   EXPECT_EQ(output, "a &amp; b");
 }
 
-TEST(HTML_escape_append_string, less_than) {
+TEST(less_than) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "a < b");
   EXPECT_EQ(output, "a &lt; b");
 }
 
-TEST(HTML_escape_append_string, greater_than) {
+TEST(greater_than) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "a > b");
   EXPECT_EQ(output, "a &gt; b");
 }
 
-TEST(HTML_escape_append_string, double_quote) {
+TEST(double_quote) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "say \"hello\"");
   EXPECT_EQ(output, "say &quot;hello&quot;");
 }
 
-TEST(HTML_escape_append_string, single_quote) {
+TEST(single_quote) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "it's");
   EXPECT_EQ(output, "it&#39;s");
 }
 
-TEST(HTML_escape_append_string, all_special_characters) {
+TEST(all_special_characters) {
   std::string output;
   sourcemeta::core::html_escape_append(output, "&<>\"'");
   EXPECT_EQ(output, "&amp;&lt;&gt;&quot;&#39;");
 }
 
-TEST(HTML_escape_append_string, appends_to_existing) {
+TEST(appends_to_existing) {
   std::string output = "prefix:";
   sourcemeta::core::html_escape_append(output, "<tag>");
   EXPECT_EQ(output, "prefix:&lt;tag&gt;");
 }
 
-TEST(HTML_escape_append_buffer, empty) {
+TEST(buffer_empty) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "");
   EXPECT_EQ(buffer.str(), "");
 }
 
-TEST(HTML_escape_append_buffer, no_escaping_needed) {
+TEST(buffer_no_escaping_needed) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "hello world");
   EXPECT_EQ(buffer.str(), "hello world");
 }
 
-TEST(HTML_escape_append_buffer, ampersand) {
+TEST(buffer_ampersand) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "a & b");
   EXPECT_EQ(buffer.str(), "a &amp; b");
 }
 
-TEST(HTML_escape_append_buffer, less_than) {
+TEST(buffer_less_than) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "a < b");
   EXPECT_EQ(buffer.str(), "a &lt; b");
 }
 
-TEST(HTML_escape_append_buffer, greater_than) {
+TEST(buffer_greater_than) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "a > b");
   EXPECT_EQ(buffer.str(), "a &gt; b");
 }
 
-TEST(HTML_escape_append_buffer, double_quote) {
+TEST(buffer_double_quote) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "say \"hello\"");
   EXPECT_EQ(buffer.str(), "say &quot;hello&quot;");
 }
 
-TEST(HTML_escape_append_buffer, single_quote) {
+TEST(buffer_single_quote) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "it's");
   EXPECT_EQ(buffer.str(), "it&#39;s");
 }
 
-TEST(HTML_escape_append_buffer, all_special_characters) {
+TEST(buffer_all_special_characters) {
   sourcemeta::core::HTMLBuffer buffer;
   sourcemeta::core::html_escape_append(buffer, "&<>\"'");
   EXPECT_EQ(buffer.str(), "&amp;&lt;&gt;&quot;&#39;");
 }
 
-TEST(HTML_escape_append_buffer, with_reserve) {
+TEST(with_reserve) {
   sourcemeta::core::HTMLBuffer buffer;
   buffer.reserve(1024);
   sourcemeta::core::html_escape_append(buffer, "<script>alert('xss')</script>");

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME http
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
   SOURCES http_status_test.cc http_make_problem_details_test.cc
           http_match_accept_test.cc http_match_accept_language_test.cc
           http_negotiate_encoding_test.cc http_from_date_test.cc

--- a/test/http/ci/CMakeLists.txt
+++ b/test/http/ci/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME http_ci
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http_ci
   SOURCES http_system_request_test.cc)
 
 target_link_libraries(sourcemeta_core_http_ci_unit

--- a/test/http/ci/http_system_request_test.cc
+++ b/test/http/ci/http_system_request_test.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/json.h>
 
 #include <chrono> // std::chrono::milliseconds
 
-TEST(HTTP_SystemRequest, get_health_ok) {
+TEST(get_health_ok) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/health"};
   const auto response{request.send()};
@@ -16,7 +16,7 @@ TEST(HTTP_SystemRequest, get_health_ok) {
       "https://schemas.sourcemeta.com/self/v1/health"));
 }
 
-TEST(HTTP_SystemRequest, head_health_ok) {
+TEST(head_health_ok) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/health",
       sourcemeta::core::HTTPMethod::HEAD};
@@ -25,14 +25,14 @@ TEST(HTTP_SystemRequest, head_health_ok) {
   EXPECT_TRUE(response.body.empty());
 }
 
-TEST(HTTP_SystemRequest, get_list_json_body) {
+TEST(get_list_json_body) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/api/list"};
   const auto response{request.send()};
   EXPECT_EQ(response.status, sourcemeta::core::HTTP_STATUS_OK);
   const auto content_type{
       sourcemeta::core::http_header_find(response.headers, "content-type")};
-  ASSERT_TRUE(content_type.has_value());
+  EXPECT_TRUE(content_type.has_value());
   EXPECT_NE(content_type.value().find("application/json"),
             std::string_view::npos);
   const auto body{sourcemeta::core::parse_json(response.body)};
@@ -40,7 +40,7 @@ TEST(HTTP_SystemRequest, get_list_json_body) {
   EXPECT_TRUE(body.defines("entries"));
 }
 
-TEST(HTTP_SystemRequest, get_missing_path_not_found) {
+TEST(get_missing_path_not_found) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/api/list/"
       "this-directory-does-not-exist-xyz"};
@@ -48,12 +48,12 @@ TEST(HTTP_SystemRequest, get_missing_path_not_found) {
   EXPECT_EQ(response.status, sourcemeta::core::HTTP_STATUS_NOT_FOUND);
   const auto content_type{
       sourcemeta::core::http_header_find(response.headers, "content-type")};
-  ASSERT_TRUE(content_type.has_value());
+  EXPECT_TRUE(content_type.has_value());
   EXPECT_NE(content_type.value().find("application/problem+json"),
             std::string_view::npos);
 }
 
-TEST(HTTP_SystemRequest, post_health_method_not_allowed) {
+TEST(post_health_method_not_allowed) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/health",
       sourcemeta::core::HTTPMethod::POST};
@@ -61,7 +61,7 @@ TEST(HTTP_SystemRequest, post_health_method_not_allowed) {
   EXPECT_EQ(response.status, sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED);
 }
 
-TEST(HTTP_SystemRequest, post_evaluate_with_body) {
+TEST(post_evaluate_with_body) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/api/schemas/evaluate/"
       "cloudevents/v1.0.2/cloudevents",
@@ -71,12 +71,12 @@ TEST(HTTP_SystemRequest, post_evaluate_with_body) {
   EXPECT_EQ(response.status, sourcemeta::core::HTTP_STATUS_OK);
   const auto body{sourcemeta::core::parse_json(response.body)};
   EXPECT_TRUE(body.is_object());
-  ASSERT_TRUE(body.defines("valid"));
+  EXPECT_TRUE(body.defines("valid"));
   EXPECT_TRUE(body.at("valid").is_boolean());
   EXPECT_FALSE(body.at("valid").to_boolean());
 }
 
-TEST(HTTP_SystemRequest, post_evaluate_missing_instance_bad_request) {
+TEST(post_evaluate_missing_instance_bad_request) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/api/schemas/evaluate/"
       "cloudevents/v1.0.2/cloudevents",
@@ -85,7 +85,7 @@ TEST(HTTP_SystemRequest, post_evaluate_missing_instance_bad_request) {
   EXPECT_EQ(response.status, sourcemeta::core::HTTP_STATUS_BAD_REQUEST);
 }
 
-TEST(HTTP_SystemRequest, follow_redirect_to_https) {
+TEST(follow_redirect_to_https) {
   sourcemeta::core::HTTPSystemRequest request{
       "http://schemas.sourcemeta.com/self/v1/health"};
   request.follow_redirects(true);
@@ -97,7 +97,7 @@ TEST(HTTP_SystemRequest, follow_redirect_to_https) {
       "https://schemas.sourcemeta.com/self/v1/health"));
 }
 
-TEST(HTTP_SystemRequest, no_follow_redirect_returns_redirect) {
+TEST(no_follow_redirect_returns_redirect) {
   sourcemeta::core::HTTPSystemRequest request{
       "http://schemas.sourcemeta.com/self/v1/health"};
   request.follow_redirects(false);
@@ -106,7 +106,7 @@ TEST(HTTP_SystemRequest, no_follow_redirect_returns_redirect) {
   EXPECT_LT(response.status.code, 400);
 }
 
-TEST(HTTP_SystemRequest, timeout_against_unreachable_host_throws) {
+TEST(timeout_against_unreachable_host_throws) {
   // A non-routable RFC 5737 TEST-NET-1 address never completes the request,
   // so a bounded timeout reliably surfaces an error rather than racing the
   // sub-millisecond timer granularity of some backends
@@ -121,7 +121,7 @@ TEST(HTTP_SystemRequest, timeout_against_unreachable_host_throws) {
   }
 }
 
-TEST(HTTP_SystemRequest, unresolvable_host_throws) {
+TEST(unresolvable_host_throws) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://this-host-does-not-exist.sourcemeta.invalid/"};
   try {
@@ -134,7 +134,7 @@ TEST(HTTP_SystemRequest, unresolvable_host_throws) {
   }
 }
 
-TEST(HTTP_SystemRequest, maximum_response_size_exceeded_throws) {
+TEST(maximum_response_size_exceeded_throws) {
   sourcemeta::core::HTTPSystemRequest request{
       "https://schemas.sourcemeta.com/self/v1/api/list"};
   request.maximum_response_size(1);

--- a/test/http/http_accept_includes_all_test.cc
+++ b/test/http/http_accept_includes_all_test.cc
@@ -1,93 +1,92 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_accept_includes_all, empty_header_returns_true) {
+TEST(empty_header_returns_true) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "", {"text/html", "application/json"}));
 }
 
-TEST(HTTP_accept_includes_all, whitespace_only_header_returns_true) {
+TEST(whitespace_only_header_returns_true) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all("   ", {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all, empty_media_types_returns_true) {
+TEST(empty_media_types_returns_true) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all("text/html", {}));
 }
 
-TEST(HTTP_accept_includes_all, single_exact_match) {
+TEST(single_exact_match) {
   EXPECT_TRUE(
       sourcemeta::core::http_accept_includes_all("text/html", {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all, single_no_match) {
+TEST(single_no_match) {
   EXPECT_FALSE(
       sourcemeta::core::http_accept_includes_all("text/html", {"image/png"}));
 }
 
-TEST(HTTP_accept_includes_all, two_media_types_both_present) {
+TEST(two_media_types_both_present) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "text/html, application/json", {"text/html", "application/json"}));
 }
 
-TEST(HTTP_accept_includes_all, two_media_types_only_first_present) {
+TEST(two_media_types_only_first_present) {
   EXPECT_FALSE(sourcemeta::core::http_accept_includes_all(
       "text/html", {"text/html", "application/json"}));
 }
 
-TEST(HTTP_accept_includes_all, two_media_types_only_second_present) {
+TEST(two_media_types_only_second_present) {
   EXPECT_FALSE(sourcemeta::core::http_accept_includes_all(
       "application/json", {"text/html", "application/json"}));
 }
 
-TEST(HTTP_accept_includes_all, full_wildcard_covers_every_type) {
+TEST(full_wildcard_covers_every_type) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "*/*", {"text/html", "application/json", "image/png"}));
 }
 
-TEST(HTTP_accept_includes_all, type_wildcard_covers_matching_subtypes) {
+TEST(type_wildcard_covers_matching_subtypes) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "text/*", {"text/html", "text/plain"}));
 }
 
-TEST(HTTP_accept_includes_all, type_wildcard_does_not_cover_other_type) {
+TEST(type_wildcard_does_not_cover_other_type) {
   EXPECT_FALSE(sourcemeta::core::http_accept_includes_all(
       "text/*", {"text/html", "application/json"}));
 }
 
-TEST(HTTP_accept_includes_all, q_zero_excludes_type) {
+TEST(q_zero_excludes_type) {
   EXPECT_FALSE(sourcemeta::core::http_accept_includes_all(
       "text/html;q=0, application/json", {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all,
-     q_zero_on_specific_excludes_even_when_wildcard_present) {
+TEST(q_zero_on_specific_excludes_even_when_wildcard_present) {
   EXPECT_FALSE(sourcemeta::core::http_accept_includes_all("text/html;q=0, */*",
                                                           {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all, q_zero_on_wildcard_does_not_exclude_specific) {
+TEST(q_zero_on_wildcard_does_not_exclude_specific) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all("text/html, */*;q=0",
                                                          {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all, case_insensitive_match) {
+TEST(case_insensitive_match) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "TEXT/HTML, Application/JSON", {"text/html", "application/json"}));
 }
 
-TEST(HTTP_accept_includes_all, parameters_on_entry_ignored) {
+TEST(parameters_on_entry_ignored) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "text/html;charset=UTF-8", {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all, browser_accept_covers_text_html) {
+TEST(browser_accept_covers_text_html) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(
       "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       {"text/html"}));
 }
 
-TEST(HTTP_accept_includes_all, three_types_one_missing) {
+TEST(three_types_one_missing) {
   EXPECT_FALSE(sourcemeta::core::http_accept_includes_all(
       "text/html, application/json",
       {"text/html", "application/json", "image/png"}));

--- a/test/http/http_accumulate_header_line_test.cc
+++ b/test/http/http_accumulate_header_line_test.cc
@@ -1,16 +1,16 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_message.h>
 
 #include <string> // std::string
 
-TEST(HTTP_accumulate_header_line, status_line_into_empty_buffer) {
+TEST(status_line_into_empty_buffer) {
   std::string buffer;
   sourcemeta::core::http_accumulate_header_line(buffer, "HTTP/1.1 200 OK\r\n");
   EXPECT_EQ(buffer, "HTTP/1.1 200 OK\r\n");
 }
 
-TEST(HTTP_accumulate_header_line, field_lines_after_status_line) {
+TEST(field_lines_after_status_line) {
   std::string buffer;
   sourcemeta::core::http_accumulate_header_line(buffer, "HTTP/1.1 200 OK\r\n");
   sourcemeta::core::http_accumulate_header_line(buffer,
@@ -21,7 +21,7 @@ TEST(HTTP_accumulate_header_line, field_lines_after_status_line) {
             "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nServer: test\r\n\r\n");
 }
 
-TEST(HTTP_accumulate_header_line, redirect_block_replaces_previous_block) {
+TEST(redirect_block_replaces_previous_block) {
   std::string buffer;
   sourcemeta::core::http_accumulate_header_line(
       buffer, "HTTP/1.1 301 Moved Permanently\r\n");
@@ -33,7 +33,7 @@ TEST(HTTP_accumulate_header_line, redirect_block_replaces_previous_block) {
   EXPECT_EQ(buffer, "HTTP/1.1 200 OK\r\nServer: test\r\n\r\n");
 }
 
-TEST(HTTP_accumulate_header_line, interim_response_block_replaced) {
+TEST(interim_response_block_replaced) {
   std::string buffer;
   sourcemeta::core::http_accumulate_header_line(buffer,
                                                 "HTTP/1.1 100 Continue\r\n");
@@ -43,7 +43,7 @@ TEST(HTTP_accumulate_header_line, interim_response_block_replaced) {
   EXPECT_EQ(buffer, "HTTP/1.1 200 OK\r\n\r\n");
 }
 
-TEST(HTTP_accumulate_header_line, field_line_without_status_line) {
+TEST(field_line_without_status_line) {
   std::string buffer;
   sourcemeta::core::http_accumulate_header_line(buffer, "Server: test\r\n");
   EXPECT_EQ(buffer, "Server: test\r\n");

--- a/test/http/http_cache_control_max_age_test.cc
+++ b/test/http/http_cache_control_max_age_test.cc
@@ -1,158 +1,158 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
 #include <chrono> // std::chrono::seconds
 
-TEST(HTTP_cache_control_max_age, single_directive) {
+TEST(single_directive) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("max-age=600")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{600});
 }
 
-TEST(HTTP_cache_control_max_age, zero) {
+TEST(zero) {
   const auto result{sourcemeta::core::http_cache_control_max_age("max-age=0")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{0});
 }
 
-TEST(HTTP_cache_control_max_age, among_other_directives) {
+TEST(among_other_directives) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "public, max-age=3600, must-revalidate")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{3600});
 }
 
-TEST(HTTP_cache_control_max_age, leading_other_directive) {
+TEST(leading_other_directive) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("no-cache, max-age=120")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{120});
 }
 
-TEST(HTTP_cache_control_max_age, case_insensitive_directive_name) {
+TEST(case_insensitive_directive_name) {
   const auto result{sourcemeta::core::http_cache_control_max_age("Max-Age=42")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{42});
 }
 
-TEST(HTTP_cache_control_max_age, surrounding_whitespace_trimmed) {
+TEST(surrounding_whitespace_trimmed) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "  public ,  max-age=90  , no-store ")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{90});
 }
 
-TEST(HTTP_cache_control_max_age, absent) {
+TEST(absent) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("public, no-store")
                    .has_value());
 }
 
-TEST(HTTP_cache_control_max_age, empty_header) {
+TEST(empty_header) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("").has_value());
 }
 
-TEST(HTTP_cache_control_max_age, no_value) {
+TEST(no_value) {
   EXPECT_FALSE(
       sourcemeta::core::http_cache_control_max_age("max-age").has_value());
 }
 
-TEST(HTTP_cache_control_max_age, empty_value) {
+TEST(empty_value) {
   EXPECT_FALSE(
       sourcemeta::core::http_cache_control_max_age("max-age=").has_value());
 }
 
-TEST(HTTP_cache_control_max_age, non_numeric_value) {
+TEST(non_numeric_value) {
   EXPECT_FALSE(
       sourcemeta::core::http_cache_control_max_age("max-age=abc").has_value());
 }
 
-TEST(HTTP_cache_control_max_age, partly_numeric_value) {
+TEST(partly_numeric_value) {
   EXPECT_FALSE(
       sourcemeta::core::http_cache_control_max_age("max-age=12x").has_value());
 }
 
-TEST(HTTP_cache_control_max_age, prefix_only_directive_ignored) {
+TEST(prefix_only_directive_ignored) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "max-age-extension=5, max-age=7")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{7});
 }
 
-TEST(HTTP_cache_control_max_age, quoted_string_value) {
+TEST(quoted_string_value) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("max-age=\"600\"")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{600});
 }
 
-TEST(HTTP_cache_control_max_age, quoted_string_value_among_directives) {
+TEST(quoted_string_value_among_directives) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "public, max-age=\"42\", must-revalidate")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{42});
 }
 
-TEST(HTTP_cache_control_max_age, empty_quoted_string_value) {
+TEST(empty_quoted_string_value) {
   EXPECT_FALSE(
       sourcemeta::core::http_cache_control_max_age("max-age=\"\"").has_value());
 }
 
-TEST(HTTP_cache_control_max_age, unterminated_quote_rejected) {
+TEST(unterminated_quote_rejected) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"600")
                    .has_value());
 }
 
-TEST(HTTP_cache_control_max_age, non_numeric_quoted_value_rejected) {
+TEST(non_numeric_quoted_value_rejected) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"abc\"")
                    .has_value());
 }
 
-TEST(HTTP_cache_control_max_age, quoted_pair_escaped_digits) {
+TEST(quoted_pair_escaped_digits) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("max-age=\"6\\0\\0\"")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{600});
 }
 
-TEST(HTTP_cache_control_max_age, quoted_pair_escaped_non_digit_rejected) {
+TEST(quoted_pair_escaped_non_digit_rejected) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"6\\a0\"")
                    .has_value());
 }
 
-TEST(HTTP_cache_control_max_age, dangling_escape_rejected) {
+TEST(dangling_escape_rejected) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=\"60\\\"")
                    .has_value());
 }
 
-TEST(HTTP_cache_control_max_age, backslash_in_token_form_rejected) {
+TEST(backslash_in_token_form_rejected) {
   EXPECT_FALSE(sourcemeta::core::http_cache_control_max_age("max-age=6\\00")
                    .has_value());
 }
 
-TEST(HTTP_cache_control_max_age, far_above_overflow_boundary) {
+TEST(far_above_overflow_boundary) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("max-age=4294967296")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{2147483648});
 }
 
-TEST(HTTP_cache_control_max_age, overflow_saturates) {
+TEST(overflow_saturates) {
   const auto result{sourcemeta::core::http_cache_control_max_age(
       "max-age=999999999999999999999999")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{2147483648});
 }
 
-TEST(HTTP_cache_control_max_age, at_overflow_boundary) {
+TEST(at_overflow_boundary) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("max-age=2147483648")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), std::chrono::seconds{2147483648});
 }
 
-TEST(HTTP_cache_control_max_age, just_below_overflow_boundary) {
+TEST(just_below_overflow_boundary) {
   const auto result{
       sourcemeta::core::http_cache_control_max_age("max-age=2147483647")};
   EXPECT_TRUE(result.has_value());

--- a/test/http/http_content_type_matches_test.cc
+++ b/test/http/http_content_type_matches_test.cc
@@ -1,93 +1,93 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_content_type_matches, exact_match) {
+TEST(exact_match) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("application/json",
                                                           "application/json"));
 }
 
-TEST(HTTP_content_type_matches, exact_no_match) {
+TEST(exact_no_match) {
   EXPECT_FALSE(sourcemeta::core::http_content_type_matches("application/xml",
                                                            "application/json"));
 }
 
-TEST(HTTP_content_type_matches, charset_parameter_stripped) {
+TEST(charset_parameter_stripped) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "application/json; charset=UTF-8", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, charset_parameter_no_space_after_semicolon) {
+TEST(charset_parameter_no_space_after_semicolon) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "application/json;charset=UTF-8", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, multiple_parameters_stripped) {
+TEST(multiple_parameters_stripped) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "application/json; charset=UTF-8; boundary=foo", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, leading_whitespace_trimmed) {
+TEST(leading_whitespace_trimmed) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("   application/json",
                                                           "application/json"));
 }
 
-TEST(HTTP_content_type_matches, trailing_whitespace_trimmed) {
+TEST(trailing_whitespace_trimmed) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("application/json   ",
                                                           "application/json"));
 }
 
-TEST(HTTP_content_type_matches, whitespace_before_semicolon_trimmed) {
+TEST(whitespace_before_semicolon_trimmed) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "application/json ; charset=UTF-8", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, tab_whitespace_trimmed) {
+TEST(tab_whitespace_trimmed) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "\tapplication/json\t", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, case_insensitive_uppercase_header) {
+TEST(case_insensitive_uppercase_header) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("APPLICATION/JSON",
                                                           "application/json"));
 }
 
-TEST(HTTP_content_type_matches, case_insensitive_mixed_case_header) {
+TEST(case_insensitive_mixed_case_header) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("Application/Json",
                                                           "application/json"));
 }
 
-TEST(HTTP_content_type_matches, case_insensitive_uppercase_media_type) {
+TEST(case_insensitive_uppercase_media_type) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("application/json",
                                                           "APPLICATION/JSON"));
 }
 
-TEST(HTTP_content_type_matches, empty_header_does_not_match) {
+TEST(empty_header_does_not_match) {
   EXPECT_FALSE(
       sourcemeta::core::http_content_type_matches("", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, header_with_only_parameters_does_not_match) {
+TEST(header_with_only_parameters_does_not_match) {
   EXPECT_FALSE(sourcemeta::core::http_content_type_matches("; charset=UTF-8",
                                                            "application/json"));
 }
 
-TEST(HTTP_content_type_matches, problem_json_does_not_match_json) {
+TEST(problem_json_does_not_match_json) {
   EXPECT_FALSE(sourcemeta::core::http_content_type_matches(
       "application/problem+json", "application/json"));
 }
 
-TEST(HTTP_content_type_matches, text_html_matches) {
+TEST(text_html_matches) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "text/html; charset=UTF-8", "text/html"));
 }
 
-TEST(HTTP_content_type_matches, problem_json_exact_match) {
+TEST(problem_json_exact_match) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches(
       "application/problem+json", "application/problem+json"));
 }
 
-TEST(HTTP_content_type_matches, different_length_no_match) {
+TEST(different_length_no_match) {
   EXPECT_FALSE(sourcemeta::core::http_content_type_matches("application/jsons",
                                                            "application/json"));
 }

--- a/test/http/http_error_test.cc
+++ b/test/http/http_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_error.h>
 #include <sourcemeta/core/http_method.h>
@@ -7,49 +7,49 @@
 #include <optional> // std::optional
 #include <string>   // std::string
 
-TEST(HTTP_error, message) {
+TEST(message) {
   const sourcemeta::core::HTTPError error{sourcemeta::core::HTTPMethod::GET,
                                           "https://example.com",
                                           "Connection refused"};
   EXPECT_STREQ(error.what(), "Connection refused");
 }
 
-TEST(HTTP_error, method) {
+TEST(method) {
   const sourcemeta::core::HTTPError error{sourcemeta::core::HTTPMethod::POST,
                                           "https://example.com",
                                           "Connection refused"};
   EXPECT_EQ(error.method(), sourcemeta::core::HTTPMethod::POST);
 }
 
-TEST(HTTP_error, url) {
+TEST(url) {
   const sourcemeta::core::HTTPError error{sourcemeta::core::HTTPMethod::GET,
                                           "https://example.com/schema.json",
                                           "Connection refused"};
   EXPECT_EQ(error.url(), "https://example.com/schema.json");
 }
 
-TEST(HTTP_error, status_error_message) {
+TEST(status_error_message) {
   const sourcemeta::core::HTTPStatusError error{
       sourcemeta::core::HTTPMethod::GET, "https://example.com",
       sourcemeta::core::HTTP_STATUS_NOT_FOUND};
   EXPECT_STREQ(error.what(), "Unsuccessful HTTP response");
 }
 
-TEST(HTTP_error, status_error_method) {
+TEST(status_error_method) {
   const sourcemeta::core::HTTPStatusError error{
       sourcemeta::core::HTTPMethod::POST, "https://example.com",
       sourcemeta::core::HTTP_STATUS_NOT_FOUND};
   EXPECT_EQ(error.method(), sourcemeta::core::HTTPMethod::POST);
 }
 
-TEST(HTTP_error, status_error_url) {
+TEST(status_error_url) {
   const sourcemeta::core::HTTPStatusError error{
       sourcemeta::core::HTTPMethod::GET, "https://example.com/schema.json",
       sourcemeta::core::HTTP_STATUS_NOT_FOUND};
   EXPECT_EQ(error.url(), "https://example.com/schema.json");
 }
 
-TEST(HTTP_error, status_error_status) {
+TEST(status_error_status) {
   const sourcemeta::core::HTTPStatusError error{
       sourcemeta::core::HTTPMethod::GET, "https://example.com",
       sourcemeta::core::HTTP_STATUS_SERVICE_UNAVAILABLE};
@@ -57,7 +57,7 @@ TEST(HTTP_error, status_error_status) {
   EXPECT_EQ(error.status().code, 503);
 }
 
-TEST(HTTP_error, status_error_owns_status_data) {
+TEST(status_error_owns_status_data) {
   std::optional<sourcemeta::core::HTTPStatusError> error;
   {
     const std::string phrase{"Custom Experimental Phrase"};

--- a/test/http/http_field_list_contains_any_test.cc
+++ b/test/http/http_field_list_contains_any_test.cc
@@ -1,99 +1,99 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_field_list_contains_any, single_match) {
+TEST(single_match) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any("a", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, single_no_match) {
+TEST(single_no_match) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("a", {"b"}));
 }
 
-TEST(HTTP_field_list_contains_any, empty_header_returns_false) {
+TEST(empty_header_returns_false) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, whitespace_only_header_returns_false) {
+TEST(whitespace_only_header_returns_false) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("   ", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, empty_token_list_returns_false) {
+TEST(empty_token_list_returns_false) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("a", {}));
 }
 
-TEST(HTTP_field_list_contains_any, comma_separated_match_first) {
+TEST(comma_separated_match_first) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any("a, b, c", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, comma_separated_match_middle) {
+TEST(comma_separated_match_middle) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any("a, b, c", {"b"}));
 }
 
-TEST(HTTP_field_list_contains_any, comma_separated_match_last) {
+TEST(comma_separated_match_last) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any("a, b, c", {"c"}));
 }
 
-TEST(HTTP_field_list_contains_any, comma_separated_no_match) {
+TEST(comma_separated_no_match) {
   EXPECT_FALSE(
       sourcemeta::core::http_field_list_contains_any("a, b, c", {"d"}));
 }
 
-TEST(HTTP_field_list_contains_any, multiple_tokens_any_match) {
+TEST(multiple_tokens_any_match) {
   EXPECT_TRUE(
       sourcemeta::core::http_field_list_contains_any("c", {"a", "b", "c"}));
 }
 
-TEST(HTTP_field_list_contains_any, multiple_tokens_none_match) {
+TEST(multiple_tokens_none_match) {
   EXPECT_FALSE(
       sourcemeta::core::http_field_list_contains_any("z", {"a", "b", "c"}));
 }
 
-TEST(HTTP_field_list_contains_any, strips_parameters_before_comparison) {
+TEST(strips_parameters_before_comparison) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any("a;p=1", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, whitespace_around_entries_tolerated) {
+TEST(whitespace_around_entries_tolerated) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "  a  ,  b  ,  c  ", {"b"}));
 }
 
-TEST(HTTP_field_list_contains_any, exact_match_required_not_substring) {
+TEST(exact_match_required_not_substring) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("abcd", {"abc"}));
 }
 
-TEST(HTTP_field_list_contains_any, case_sensitive_comparison) {
+TEST(case_sensitive_comparison) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("A", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, if_none_match_wildcard) {
+TEST(if_none_match_wildcard) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "*", {"*", "\"abc\"", "W/\"abc\""}));
 }
 
-TEST(HTTP_field_list_contains_any, if_none_match_strong_etag) {
+TEST(if_none_match_strong_etag) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "\"abc\"", {"*", "\"abc\"", "W/\"abc\""}));
 }
 
-TEST(HTTP_field_list_contains_any, if_none_match_weak_etag) {
+TEST(if_none_match_weak_etag) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "W/\"abc\"", {"*", "\"abc\"", "W/\"abc\""}));
 }
 
-TEST(HTTP_field_list_contains_any, if_none_match_etag_list_with_match) {
+TEST(if_none_match_etag_list_with_match) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "\"xyz\", \"abc\", \"def\"", {"*", "\"abc\"", "W/\"abc\""}));
 }
 
-TEST(HTTP_field_list_contains_any, if_none_match_etag_list_without_match) {
+TEST(if_none_match_etag_list_without_match) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any(
       "\"xyz\", \"def\", \"ghi\"", {"*", "\"abc\"", "W/\"abc\""}));
 }
 
-TEST(HTTP_field_list_contains_any, runtime_constructed_strings_safe) {
+TEST(runtime_constructed_strings_safe) {
   const std::string checksum{"abc123"};
   const std::string strong_etag{std::string{"\""} + checksum + "\""};
   const std::string weak_etag{std::string{"W/\""} + checksum + "\""};
@@ -101,52 +101,50 @@ TEST(HTTP_field_list_contains_any, runtime_constructed_strings_safe) {
       "\"abc123\"", {"*", strong_etag, weak_etag}));
 }
 
-TEST(HTTP_field_list_contains_any, stops_at_first_match_no_false_positive) {
+TEST(stops_at_first_match_no_false_positive) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any("x, y, z",
                                                               {"a", "b", "c"}));
 }
 
-TEST(HTTP_field_list_contains_any, single_comma_only_header) {
+TEST(single_comma_only_header) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any(",", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, leading_comma_with_value) {
+TEST(leading_comma_with_value) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(", a", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, trailing_comma_with_value) {
+TEST(trailing_comma_with_value) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any("a,", {"a"}));
 }
 
-TEST(HTTP_field_list_contains_any, vary_style_header) {
+TEST(vary_style_header) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "Accept-Encoding, User-Agent", {"Accept-Encoding"}));
 }
 
-TEST(HTTP_field_list_contains_any, cache_control_no_cache_predicate) {
+TEST(cache_control_no_cache_predicate) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       "no-cache, no-store, max-age=0", {"no-cache"}));
 }
 
-TEST(HTTP_field_list_contains_any, etag_with_comma_inside_quotes_kept_whole) {
+TEST(etag_with_comma_inside_quotes_kept_whole) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       R"("abc,def", "ghi")", {R"("abc,def")"}));
 }
 
-TEST(HTTP_field_list_contains_any,
-     etag_with_comma_inside_quotes_not_split_into_pieces) {
+TEST(etag_with_comma_inside_quotes_not_split_into_pieces) {
   EXPECT_FALSE(sourcemeta::core::http_field_list_contains_any(R"("abc,def")",
                                                               {R"("abc)"}));
 }
 
-TEST(HTTP_field_list_contains_any, escaped_quote_in_quoted_string_handled) {
+TEST(escaped_quote_in_quoted_string_handled) {
   const std::string_view header{"\"a\\\"b,c\", \"xyz\""};
   const std::string_view token{"\"a\\\"b,c\""};
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(header, {token}));
 }
 
-TEST(HTTP_field_list_contains_any,
-     weak_etag_with_comma_in_opaque_tag_kept_whole) {
+TEST(weak_etag_with_comma_in_opaque_tag_kept_whole) {
   EXPECT_TRUE(sourcemeta::core::http_field_list_contains_any(
       R"(W/"abc,def", "ghi")", {R"(W/"abc,def")"}));
 }

--- a/test/http/http_format_link_test.cc
+++ b/test/http/http_format_link_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>
 #include <string>
@@ -6,19 +6,19 @@
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_format_link, single_rel_describedby) {
+TEST(single_rel_describedby) {
   const auto value{sourcemeta::core::http_format_link(
       {.target = "https://example.com/schema.json", .rel = "describedby"})};
   EXPECT_EQ(value, "<https://example.com/schema.json>; rel=\"describedby\"");
 }
 
-TEST(HTTP_format_link, alternative_rel) {
+TEST(alternative_rel) {
   const auto value{sourcemeta::core::http_format_link(
       {.target = "/style.css", .rel = "stylesheet"})};
   EXPECT_EQ(value, "</style.css>; rel=\"stylesheet\"");
 }
 
-TEST(HTTP_format_link, single_parameter) {
+TEST(single_parameter) {
   const std::array<std::pair<std::string_view, std::string_view>, 1> parameters{
       {{"title", "Example Title"}}};
   const auto value{sourcemeta::core::http_format_link(
@@ -26,7 +26,7 @@ TEST(HTTP_format_link, single_parameter) {
   EXPECT_EQ(value, "</page>; rel=\"next\"; title=\"Example Title\"");
 }
 
-TEST(HTTP_format_link, multiple_parameters) {
+TEST(multiple_parameters) {
   const std::array<std::pair<std::string_view, std::string_view>, 2> parameters{
       {{"title", "Doc"}, {"hreflang", "en"}}};
   const auto value{sourcemeta::core::http_format_link(
@@ -34,39 +34,39 @@ TEST(HTTP_format_link, multiple_parameters) {
   EXPECT_EQ(value, "</x>; rel=\"alternate\"; title=\"Doc\"; hreflang=\"en\"");
 }
 
-TEST(HTTP_format_link, sink_overload_appends) {
+TEST(sink_overload_appends) {
   std::string buffer{"prefix:"};
   sourcemeta::core::http_format_link({.target = "/a", .rel = "self"}, buffer);
   EXPECT_EQ(buffer, "prefix:</a>; rel=\"self\"");
 }
 
-TEST(HTTP_format_link, sink_overload_starts_empty) {
+TEST(sink_overload_starts_empty) {
   std::string buffer;
   sourcemeta::core::http_format_link({.target = "/a", .rel = "self"}, buffer);
   EXPECT_EQ(buffer, "</a>; rel=\"self\"");
 }
 
-TEST(HTTP_format_link, empty_target_is_taken_verbatim) {
+TEST(empty_target_is_taken_verbatim) {
   const auto value{
       sourcemeta::core::http_format_link({.target = "", .rel = "self"})};
   EXPECT_EQ(value, "<>; rel=\"self\"");
 }
 
-TEST(HTTP_format_links, single_entry) {
+TEST(single_entry) {
   const std::array<sourcemeta::core::HTTPLink, 1> links{
       {{.target = "/a", .rel = "self"}}};
   const auto value{sourcemeta::core::http_format_links(links)};
   EXPECT_EQ(value, "</a>; rel=\"self\"");
 }
 
-TEST(HTTP_format_links, two_entries) {
+TEST(two_entries) {
   const std::array<sourcemeta::core::HTTPLink, 2> links{
       {{.target = "/a", .rel = "self"}, {.target = "/b", .rel = "next"}}};
   const auto value{sourcemeta::core::http_format_links(links)};
   EXPECT_EQ(value, "</a>; rel=\"self\", </b>; rel=\"next\"");
 }
 
-TEST(HTTP_format_links, three_entries) {
+TEST(three_entries) {
   const std::array<sourcemeta::core::HTTPLink, 3> links{
       {{.target = "/a", .rel = "self"},
        {.target = "/b", .rel = "next"},
@@ -76,7 +76,7 @@ TEST(HTTP_format_links, three_entries) {
             "</a>; rel=\"self\", </b>; rel=\"next\", </c>; rel=\"prev\"");
 }
 
-TEST(HTTP_format_links, sink_overload_appends) {
+TEST(links_sink_overload_appends) {
   std::string buffer{"X-"};
   const std::array<sourcemeta::core::HTTPLink, 1> links{
       {{.target = "/a", .rel = "self"}}};
@@ -84,13 +84,13 @@ TEST(HTTP_format_links, sink_overload_appends) {
   EXPECT_EQ(buffer, "X-</a>; rel=\"self\"");
 }
 
-TEST(HTTP_format_links, empty_span_produces_empty_output) {
+TEST(empty_span_produces_empty_output) {
   const std::array<sourcemeta::core::HTTPLink, 0> links{};
   const auto value{sourcemeta::core::http_format_links(links)};
   EXPECT_EQ(value, "");
 }
 
-TEST(HTTP_format_links, mixed_with_parameters) {
+TEST(mixed_with_parameters) {
   const std::array<std::pair<std::string_view, std::string_view>, 1>
       first_parameters{{{"title", "Schema"}}};
   const std::array<sourcemeta::core::HTTPLink, 2> links{
@@ -103,7 +103,7 @@ TEST(HTTP_format_links, mixed_with_parameters) {
                    "</profile>; rel=\"profile\"");
 }
 
-TEST(HTTP_format_link, sink_can_be_reused_across_calls) {
+TEST(sink_can_be_reused_across_calls) {
   std::string buffer;
   sourcemeta::core::http_format_link({.target = "/a", .rel = "self"}, buffer);
   buffer.append("|");

--- a/test/http/http_from_date_test.cc
+++ b/test/http/http_from_date_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>
 #include <ctime>
@@ -25,72 +25,72 @@ auto make_nov_6_1994_08_49_37() -> std::chrono::system_clock::time_point {
 
 } // namespace
 
-TEST(HTTP_from_date, accepts_imf_fixdate) {
+TEST(accepts_imf_fixdate) {
   const auto result{
       sourcemeta::core::http_from_date("Sun, 06 Nov 1994 08:49:37 GMT")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), make_nov_6_1994_08_49_37());
 }
 
-TEST(HTTP_from_date, accepts_rfc850_date) {
+TEST(accepts_rfc850_date) {
   const auto result{
       sourcemeta::core::http_from_date("Sunday, 06-Nov-94 08:49:37 GMT")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), make_nov_6_1994_08_49_37());
 }
 
-TEST(HTTP_from_date, accepts_asctime) {
+TEST(accepts_asctime) {
   const auto result{
       sourcemeta::core::http_from_date("Sun Nov  6 08:49:37 1994")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), make_nov_6_1994_08_49_37());
 }
 
-TEST(HTTP_from_date, rejects_empty) {
+TEST(rejects_empty) {
   EXPECT_FALSE(sourcemeta::core::http_from_date("").has_value());
 }
 
-TEST(HTTP_from_date, rejects_garbage) {
+TEST(rejects_garbage) {
   EXPECT_FALSE(sourcemeta::core::http_from_date("FOO").has_value());
 }
 
-TEST(HTTP_from_date, rejects_iso8601) {
+TEST(rejects_iso8601) {
   EXPECT_FALSE(
       sourcemeta::core::http_from_date("1994-11-06T08:49:37Z").has_value());
 }
 
-TEST(HTTP_from_date, rejects_lowercase_imf_fixdate_gmt) {
+TEST(rejects_lowercase_imf_fixdate_gmt) {
   EXPECT_FALSE(sourcemeta::core::http_from_date("Sun, 06 Nov 1994 08:49:37 gmt")
                    .has_value());
 }
 
-TEST(HTTP_from_date, accepts_imf_fixdate_epoch) {
+TEST(accepts_imf_fixdate_epoch) {
   EXPECT_TRUE(sourcemeta::core::http_from_date("Thu, 01 Jan 1970 00:00:00 GMT")
                   .has_value());
 }
 
-TEST(HTTP_from_date, accepts_rfc850_recent) {
+TEST(accepts_rfc850_recent) {
   EXPECT_TRUE(
       sourcemeta::core::http_from_date("Wednesday, 21-Oct-15 11:28:00 GMT")
           .has_value());
 }
 
-TEST(HTTP_from_date, accepts_asctime_two_digit_day) {
+TEST(accepts_asctime_two_digit_day) {
   EXPECT_TRUE(
       sourcemeta::core::http_from_date("Wed Oct 21 11:28:00 2015").has_value());
 }
 
-TEST(HTTP_from_date, rejects_imf_fixdate_missing_day_of_week) {
+TEST(rejects_imf_fixdate_missing_day_of_week) {
   EXPECT_FALSE(
       sourcemeta::core::http_from_date("06 Nov 1994 08:49:37 GMT").has_value());
 }
 
-TEST(HTTP_from_date, rejects_truncated_input) {
+TEST(rejects_truncated_input) {
   EXPECT_FALSE(
       sourcemeta::core::http_from_date("Sun, 06 Nov 1994").has_value());
 }
 
-TEST(HTTP_from_date, rejects_garbage_with_correct_length_imf) {
+TEST(rejects_garbage_with_correct_length_imf) {
   EXPECT_FALSE(sourcemeta::core::http_from_date("xxx, 06 Nov 1994 08:49:37 GMT")
                    .has_value());
 }

--- a/test/http/http_header_find_test.cc
+++ b/test/http/http_header_find_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_message.h>
 
@@ -8,7 +8,7 @@
 #include <utility>    // std::pair
 #include <vector>     // std::vector
 
-TEST(HTTP_header_find, present) {
+TEST(present) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"content-type", "text/html"}, {"server", "test"}};
   const auto result{
@@ -17,7 +17,7 @@ TEST(HTTP_header_find, present) {
   EXPECT_EQ(result.value(), "text/html");
 }
 
-TEST(HTTP_header_find, repeated_returns_first) {
+TEST(repeated_returns_first) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"set-cookie", "a=1"}, {"set-cookie", "b=2"}};
   const auto result{sourcemeta::core::http_header_find(headers, "set-cookie")};
@@ -25,27 +25,27 @@ TEST(HTTP_header_find, repeated_returns_first) {
   EXPECT_EQ(result.value(), "a=1");
 }
 
-TEST(HTTP_header_find, missing) {
+TEST(missing) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"server", "test"}};
   EXPECT_FALSE(
       sourcemeta::core::http_header_find(headers, "content-type").has_value());
 }
 
-TEST(HTTP_header_find, empty_headers) {
+TEST(empty_headers) {
   const std::vector<std::pair<std::string, std::string>> headers;
   EXPECT_FALSE(
       sourcemeta::core::http_header_find(headers, "server").has_value());
 }
 
-TEST(HTTP_header_find, lookup_is_exact_match) {
+TEST(lookup_is_exact_match) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"server", "test"}};
   EXPECT_FALSE(
       sourcemeta::core::http_header_find(headers, "Server").has_value());
 }
 
-TEST(HTTP_header_find, empty_value_is_a_match) {
+TEST(empty_value_is_a_match) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"x-empty", ""}};
   const auto result{sourcemeta::core::http_header_find(headers, "x-empty")};
@@ -53,7 +53,7 @@ TEST(HTTP_header_find, empty_value_is_a_match) {
   EXPECT_TRUE(result.value().empty());
 }
 
-TEST(HTTP_header_find, associative_container_present) {
+TEST(associative_container_present) {
   const std::map<std::string, std::string, std::less<>> headers{
       {"content-type", "text/html"}, {"server", "test"}};
   const auto result{sourcemeta::core::http_header_find(headers, "server")};
@@ -61,14 +61,14 @@ TEST(HTTP_header_find, associative_container_present) {
   EXPECT_EQ(result.value(), "test");
 }
 
-TEST(HTTP_header_find, associative_container_missing) {
+TEST(associative_container_missing) {
   const std::map<std::string, std::string, std::less<>> headers{
       {"server", "test"}};
   EXPECT_FALSE(
       sourcemeta::core::http_header_find(headers, "content-type").has_value());
 }
 
-TEST(HTTP_header_find, associative_container_without_transparent_lookup) {
+TEST(associative_container_without_transparent_lookup) {
   const std::map<std::string, std::string> headers{{"server", "test"}};
   const auto result{sourcemeta::core::http_header_find(headers, "server")};
   EXPECT_TRUE(result.has_value());

--- a/test/http/http_is_status_line_test.cc
+++ b/test/http/http_is_status_line_test.cc
@@ -1,41 +1,39 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_message.h>
 
-TEST(HTTP_is_status_line, http_1_1) {
+TEST(http_1_1) {
   EXPECT_TRUE(sourcemeta::core::http_is_status_line("HTTP/1.1 200 OK"));
 }
 
-TEST(HTTP_is_status_line, http_1_0) {
+TEST(http_1_0) {
   EXPECT_TRUE(
       sourcemeta::core::http_is_status_line("HTTP/1.0 301 Moved Permanently"));
 }
 
-TEST(HTTP_is_status_line, http_2) {
+TEST(http_2) {
   EXPECT_TRUE(sourcemeta::core::http_is_status_line("HTTP/2 200"));
 }
 
-TEST(HTTP_is_status_line, status_line_without_reason_phrase) {
+TEST(status_line_without_reason_phrase) {
   EXPECT_TRUE(sourcemeta::core::http_is_status_line("HTTP/1.1 204 "));
 }
 
-TEST(HTTP_is_status_line, prefix_only) {
+TEST(prefix_only) {
   EXPECT_TRUE(sourcemeta::core::http_is_status_line("HTTP/"));
 }
 
-TEST(HTTP_is_status_line, field_line) {
+TEST(field_line) {
   EXPECT_FALSE(
       sourcemeta::core::http_is_status_line("Content-Type: text/html"));
 }
 
-TEST(HTTP_is_status_line, empty) {
-  EXPECT_FALSE(sourcemeta::core::http_is_status_line(""));
-}
+TEST(empty) { EXPECT_FALSE(sourcemeta::core::http_is_status_line("")); }
 
-TEST(HTTP_is_status_line, lowercase_protocol_name) {
+TEST(lowercase_protocol_name) {
   EXPECT_FALSE(sourcemeta::core::http_is_status_line("http/1.1 200 OK"));
 }
 
-TEST(HTTP_is_status_line, truncated_protocol_name) {
+TEST(truncated_protocol_name) {
   EXPECT_FALSE(sourcemeta::core::http_is_status_line("HTTP"));
 }

--- a/test/http/http_make_problem_details_test.cc
+++ b/test/http/http_make_problem_details_test.cc
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_problem.h>
 #include <sourcemeta/core/http_status.h>
 #include <sourcemeta/core/json.h>
 
-TEST(HTTP_make_problem_details, defaults_only_with_not_found_status) {
+TEST(defaults_only_with_not_found_status) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_NOT_FOUND})};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -15,7 +15,7 @@ TEST(HTTP_make_problem_details, defaults_only_with_not_found_status) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, defaults_only_with_internal_server_error) {
+TEST(defaults_only_with_internal_server_error) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR})};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -26,7 +26,7 @@ TEST(HTTP_make_problem_details, defaults_only_with_internal_server_error) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, type_override_replaces_about_blank) {
+TEST(type_override_replaces_about_blank) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
        .type = "https://example.com/probs/invalid-uri"})};
@@ -38,7 +38,7 @@ TEST(HTTP_make_problem_details, type_override_replaces_about_blank) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, title_override_replaces_status_phrase) {
+TEST(title_override_replaces_status_phrase) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_NOT_FOUND,
        .title = "Schema unavailable"})};
@@ -50,7 +50,7 @@ TEST(HTTP_make_problem_details, title_override_replaces_status_phrase) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, detail_added_when_non_empty) {
+TEST(detail_added_when_non_empty) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_NOT_FOUND,
        .detail = "There is nothing at this URL"})};
@@ -63,7 +63,7 @@ TEST(HTTP_make_problem_details, detail_added_when_non_empty) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, instance_added_when_non_empty) {
+TEST(instance_added_when_non_empty) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_NOT_FOUND,
        .instance = "/requests/abc-123"})};
@@ -76,7 +76,7 @@ TEST(HTTP_make_problem_details, instance_added_when_non_empty) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, every_field_set) {
+TEST(every_field_set) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_BAD_REQUEST,
        .type = "https://example.com/probs/invalid-uri",
@@ -93,7 +93,7 @@ TEST(HTTP_make_problem_details, every_field_set) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, sourcemeta_urn_type) {
+TEST(sourcemeta_urn_type) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_NOT_FOUND,
        .type = "sourcemeta:one/not-found",
@@ -107,7 +107,7 @@ TEST(HTTP_make_problem_details, sourcemeta_urn_type) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, ok_status_200) {
+TEST(ok_status_200) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_OK})};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -118,7 +118,7 @@ TEST(HTTP_make_problem_details, ok_status_200) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, method_not_allowed_with_detail) {
+TEST(method_not_allowed_with_detail) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED,
        .detail = "This HTTP method is invalid for this URL"})};
@@ -131,7 +131,7 @@ TEST(HTTP_make_problem_details, method_not_allowed_with_detail) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, content_too_large_with_full_fields) {
+TEST(content_too_large_with_full_fields) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE,
        .type = "sourcemeta:one/content-too-large",
@@ -147,13 +147,13 @@ TEST(HTTP_make_problem_details, content_too_large_with_full_fields) {
   EXPECT_EQ(body, expected);
 }
 
-TEST(HTTP_make_problem_details, output_is_object) {
+TEST(output_is_object) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_OK})};
   EXPECT_TRUE(body.is_object());
 }
 
-TEST(HTTP_make_problem_details, key_order_is_canonical) {
+TEST(key_order_is_canonical) {
   const auto body{sourcemeta::core::http_make_problem_details(
       {.status = sourcemeta::core::HTTP_STATUS_NOT_FOUND,
        .type = "t",

--- a/test/http/http_match_accept_language_test.cc
+++ b/test/http/http_match_accept_language_test.cc
@@ -1,155 +1,153 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_match_accept_language, exact_match) {
+TEST(exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en", {"en", "fr"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, prefix_match_at_subtag_boundary) {
+TEST(prefix_match_at_subtag_boundary) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en-US", {"en", "fr"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, longer_prefix_match) {
+TEST(longer_prefix_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en-US-x-foo", {"en"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, candidate_more_specific_than_range_no_match) {
+TEST(candidate_more_specific_than_range_no_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en", {"en-US"}), "");
 }
 
-TEST(HTTP_match_accept_language, wildcard_returns_first_candidate) {
+TEST(wildcard_returns_first_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("*", {"en", "fr"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, empty_header_returns_first_candidate) {
+TEST(empty_header_returns_first_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("", {"en", "fr"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, q_value_prefers_higher) {
+TEST(q_value_prefers_higher) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en;q=0.5, fr;q=0.9",
                                                          {"en", "fr"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language, q_value_zero_excludes_entry) {
+TEST(q_value_zero_excludes_entry) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept_language("en;q=0, fr", {"en", "fr"}),
       "fr");
 }
 
-TEST(HTTP_match_accept_language, q_value_default_is_one) {
+TEST(q_value_default_is_one) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("fr-CA;q=0.9, en",
                                                          {"en", "fr"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, prefix_match_with_q_value) {
+TEST(prefix_match_with_q_value) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept_language("fr-CA;q=0.9", {"en", "fr"}),
       "fr");
 }
 
-TEST(HTTP_match_accept_language, no_match_returns_empty) {
+TEST(no_match_returns_empty) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("de", {"en", "fr"}),
             "");
 }
 
-TEST(HTTP_match_accept_language, empty_candidate_list_returns_empty) {
+TEST(empty_candidate_list_returns_empty) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en", {}), "");
 }
 
-TEST(HTTP_match_accept_language, candidate_order_breaks_q_tie) {
+TEST(candidate_order_breaks_q_tie) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en;q=0.5, fr;q=0.5",
                                                          {"fr", "en"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language, exact_match_outranks_prefix_at_same_q) {
+TEST(exact_match_outranks_prefix_at_same_q) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en-US, fr",
                                                          {"en-US", "fr"}),
             "en-US");
 }
 
-TEST(HTTP_match_accept_language, wildcard_loses_to_exact_match) {
+TEST(wildcard_loses_to_exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("*, fr", {"en", "fr"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language, hyphen_not_at_boundary_does_not_match) {
+TEST(hyphen_not_at_boundary_does_not_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("enx-US", {"en"}), "");
 }
 
-TEST(HTTP_match_accept_language, multi_token_range_truncates_correctly) {
+TEST(multi_token_range_truncates_correctly) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("zh-Hant-TW", {"zh"}),
             "zh");
 }
 
-TEST(HTTP_match_accept_language, three_candidates_picks_best) {
+TEST(three_candidates_picks_best) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language(
                 "en;q=0.3, de;q=0.7, fr;q=0.9", {"en", "de", "fr"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language,
-     whitespace_only_header_returns_first_candidate) {
+TEST(whitespace_only_header_returns_first_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("   ", {"en"}), "en");
 }
 
-TEST(HTTP_match_accept_language, case_insensitive_exact_match) {
+TEST(case_insensitive_exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("EN", {"en"}), "en");
 }
 
-TEST(HTTP_match_accept_language, case_insensitive_prefix_match) {
+TEST(case_insensitive_prefix_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("EN-US", {"en", "fr"}),
             "en");
 }
 
-TEST(HTTP_match_accept_language, case_insensitive_mixed_case_with_q_value) {
+TEST(case_insensitive_mixed_case_with_q_value) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language(
                 "Fr-CA;q=0.9, En;q=0.5", {"en", "fr"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language, case_insensitive_subtag_boundary) {
+TEST(case_insensitive_subtag_boundary) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("ZH-Hant-TW", {"zh"}),
             "zh");
 }
 
-TEST(HTTP_match_accept_language, case_insensitive_candidate_uppercase) {
+TEST(case_insensitive_candidate_uppercase) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept_language("fr-CA;q=0.9", {"EN", "FR"}),
       "FR");
 }
 
-TEST(HTTP_match_accept_language,
-     hyphen_followed_by_matching_chars_not_a_full_match) {
+TEST(hyphen_followed_by_matching_chars_not_a_full_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("english", {"en"}),
             "");
 }
 
-TEST(HTTP_match_accept_language, mixed_q_with_wildcard) {
+TEST(mixed_q_with_wildcard) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("fr;q=0.5, *;q=0.1",
                                                          {"en", "fr"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language, q_one_no_decimal_for_priority) {
+TEST(q_one_no_decimal_for_priority) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("fr;q=1, en;q=0",
                                                          {"en", "fr"}),
             "fr");
 }
 
-TEST(HTTP_match_accept_language, leading_and_trailing_comma_tolerated) {
+TEST(leading_and_trailing_comma_tolerated) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language(",fr,", {"fr"}), "fr");
 }
 
-TEST(HTTP_match_accept_language, three_subtag_match) {
+TEST(three_subtag_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en-GB-x-private",
                                                          {"en-GB", "en"}),
             "en-GB");

--- a/test/http/http_match_accept_test.cc
+++ b/test/http/http_match_accept_test.cc
@@ -1,142 +1,141 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_match_accept, exact_match) {
+TEST(exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, exact_match_second_candidate) {
+TEST(exact_match_second_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "application/json", {"text/html", "application/json"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, no_match_returns_empty) {
+TEST(no_match_returns_empty) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "image/png", {"text/html", "application/json"}),
             "");
 }
 
-TEST(HTTP_match_accept, empty_header_returns_first_candidate) {
+TEST(empty_header_returns_first_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, type_wildcard_matches_subtype) {
+TEST(type_wildcard_matches_subtype) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/*", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, type_wildcard_does_not_match_other_type) {
+TEST(type_wildcard_does_not_match_other_type) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("image/*", {"text/html"}), "");
 }
 
-TEST(HTTP_match_accept, full_wildcard_matches_first_candidate) {
+TEST(full_wildcard_matches_first_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "*/*", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, q_value_orders_candidates) {
+TEST(q_value_orders_candidates) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("application/json, text/html;q=0.5",
                                           {"text/html", "application/json"}),
       "application/json");
 }
 
-TEST(HTTP_match_accept, q_value_zero_excludes_entry) {
+TEST(q_value_zero_excludes_entry) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0, application/json;q=0.5",
                 {"text/html", "application/json"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, q_value_zero_on_all_returns_empty) {
+TEST(q_value_zero_on_all_returns_empty) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("text/html;q=0, application/json;q=0",
                                           {"text/html", "application/json"}),
       "");
 }
 
-TEST(HTTP_match_accept, specificity_prefers_exact_over_wildcard) {
+TEST(specificity_prefers_exact_over_wildcard) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("text/*;q=0.5, application/json",
                                           {"text/html", "application/json"}),
       "application/json");
 }
 
-TEST(HTTP_match_accept, candidate_specificity_breaks_q_tie_between_candidates) {
+TEST(candidate_specificity_breaks_q_tie_between_candidates) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("*/*;q=0.5, application/json;q=0.5",
                                           {"text/html", "application/json"}),
       "application/json");
 }
 
-TEST(HTTP_match_accept,
-     candidate_specificity_breaks_q_tie_even_when_candidate_order_reversed) {
+TEST(candidate_specificity_breaks_q_tie_even_when_candidate_order_reversed) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("*/*;q=0.5, application/json;q=0.5",
                                           {"application/json", "text/html"}),
       "application/json");
 }
 
-TEST(HTTP_match_accept, specificity_prefers_type_wildcard_over_full_wildcard) {
+TEST(specificity_prefers_type_wildcard_over_full_wildcard) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/*;q=0.5, */*;q=0.5", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, q_value_tie_broken_by_candidate_order) {
+TEST(q_value_tie_broken_by_candidate_order) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.5, application/json;q=0.5",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, q_value_tie_broken_by_candidate_order_reversed) {
+TEST(q_value_tie_broken_by_candidate_order_reversed) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.5, application/json;q=0.5",
                 {"application/json", "text/html"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, ignores_non_q_parameters) {
+TEST(ignores_non_q_parameters) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;level=2;q=0.4, application/json;q=0.3",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, q_value_default_is_one) {
+TEST(q_value_default_is_one) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("text/html, application/json;q=0.9",
                                           {"application/json", "text/html"}),
       "text/html");
 }
 
-TEST(HTTP_match_accept, empty_candidate_list_returns_empty) {
+TEST(empty_candidate_list_returns_empty) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("text/html", {}), "");
 }
 
-TEST(HTTP_match_accept, whitespace_around_entries_tolerated) {
+TEST(whitespace_around_entries_tolerated) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("text/html , application/json",
                                                 {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, whitespace_around_q_parameter_tolerated) {
+TEST(whitespace_around_q_parameter_tolerated) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html; q=0.5, application/json; q=0.9",
                 {"text/html", "application/json"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, three_candidates_picks_best_q) {
+TEST(three_candidates_picks_best_q) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.3, application/json;q=0.9, text/plain;q=0.5",
                 {"text/html", "application/json", "text/plain"}),
@@ -144,7 +143,7 @@ TEST(HTTP_match_accept, three_candidates_picks_best_q) {
 }
 
 // RFC 9110 §12.4.2: a malformed weight is a fail-safe refusal, treated as 0
-TEST(HTTP_match_accept, malformed_q_treated_as_zero) {
+TEST(malformed_q_treated_as_zero) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("text/html;q=abc", {"text/html"}),
       "");
@@ -152,20 +151,20 @@ TEST(HTTP_match_accept, malformed_q_treated_as_zero) {
 
 // RFC 9110 §5.6.6: a semicolon inside a quoted string does not separate
 // parameters, so the quoted content does not synthesise a phantom q parameter
-TEST(HTTP_match_accept, quoted_parameter_semicolon_not_split) {
+TEST(quoted_parameter_semicolon_not_split) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;foo=\"a;q=0.1\", application/json;q=0.5",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, html_or_json_returns_html_for_html_accept) {
+TEST(html_or_json_returns_html_for_html_accept) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, html_or_json_returns_html_for_browser_accept) {
+TEST(html_or_json_returns_html_for_browser_accept) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept(
           "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -173,119 +172,117 @@ TEST(HTTP_match_accept, html_or_json_returns_html_for_browser_accept) {
       "text/html");
 }
 
-TEST(HTTP_match_accept, html_or_json_returns_json_for_json_accept) {
+TEST(html_or_json_returns_json_for_json_accept) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "application/json", {"text/html", "application/json"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, whitespace_only_header_returns_first_candidate) {
+TEST(whitespace_only_header_returns_first_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("   ", {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, case_insensitive_exact_match) {
+TEST(case_insensitive_exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("Text/HTML", {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, case_insensitive_uppercase_request) {
+TEST(case_insensitive_uppercase_request) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "TEXT/HTML", {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, case_insensitive_type_wildcard) {
+TEST(case_insensitive_type_wildcard) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("TEXT/*", {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, case_insensitive_mixed_case_subtype) {
+TEST(case_insensitive_mixed_case_subtype) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("application/JSON, text/html;q=0.5",
                                           {"text/html", "application/json"}),
       "application/json");
 }
 
-TEST(HTTP_match_accept, q_value_boundary_at_zero_point_one) {
+TEST(q_value_boundary_at_zero_point_one) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.1, application/json;q=0.2",
                 {"text/html", "application/json"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, q_value_three_decimal_digits) {
+TEST(q_value_three_decimal_digits) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.999, application/json;q=0.998",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, q_value_one_no_decimal) {
+TEST(q_value_one_no_decimal) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=1, application/json;q=0.999",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, leading_and_trailing_comma_tolerated) {
+TEST(leading_and_trailing_comma_tolerated) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(",text/html,", {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, many_empty_entries_tolerated) {
+TEST(many_empty_entries_tolerated) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept(", , text/html , ,", {"text/html"}),
       "text/html");
 }
 
-TEST(HTTP_match_accept, charset_parameter_does_not_change_match) {
+TEST(charset_parameter_does_not_change_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("text/html;charset=UTF-8",
                                                 {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, type_wildcard_specificity_beats_full_wildcard) {
+TEST(type_wildcard_specificity_beats_full_wildcard) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("text/*, */*", {"text/html"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, candidate_with_charset_in_name_treated_verbatim) {
+TEST(candidate_with_charset_in_name_treated_verbatim) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("image/png",
                                                 {"image/png", "image/jpeg"}),
             "image/png");
 }
 
-TEST(HTTP_match_accept, parameter_after_q_is_ignored) {
+TEST(parameter_after_q_is_ignored) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.5;extra=foo, application/json;q=0.4",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept,
-     more_specific_match_overrides_higher_q_wildcard_for_same_candidate) {
+TEST(more_specific_match_overrides_higher_q_wildcard_for_same_candidate) {
   EXPECT_EQ(sourcemeta::core::http_match_accept("text/html;q=0.5, text/*;q=1.0",
                                                 {"text/html", "text/plain"}),
             "text/plain");
 }
 
-TEST(HTTP_match_accept,
-     specific_low_q_wins_over_wildcard_high_q_within_candidate) {
+TEST(specific_low_q_wins_over_wildcard_high_q_within_candidate) {
   EXPECT_EQ(
       sourcemeta::core::http_match_accept("text/html;q=0.5, */*;q=1.0",
                                           {"text/html", "application/json"}),
       "application/json");
 }
 
-TEST(HTTP_match_accept, quoted_string_with_comma_does_not_split_entry) {
+TEST(quoted_string_with_comma_does_not_split_entry) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 R"(text/html;profile="urn:a,b", application/json;q=0.5)",
                 {"text/html", "application/json"}),
             "text/html");
 }
 
-TEST(HTTP_match_accept, escaped_quote_inside_quoted_string_handled) {
+TEST(escaped_quote_inside_quoted_string_handled) {
   const std::string_view header{
       "text/html;profile=\"a\\\"b,c\", application/json;q=0.5"};
   EXPECT_EQ(sourcemeta::core::http_match_accept(
@@ -293,14 +290,14 @@ TEST(HTTP_match_accept, escaped_quote_inside_quoted_string_handled) {
             "text/html");
 }
 
-TEST(HTTP_match_accept, q_value_zero_dot_no_digits_is_zero) {
+TEST(q_value_zero_dot_no_digits_is_zero) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0., application/json;q=0.5",
                 {"text/html", "application/json"}),
             "application/json");
 }
 
-TEST(HTTP_match_accept, q_value_one_dot_no_digits_is_one) {
+TEST(q_value_one_dot_no_digits_is_one) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=1., application/json;q=0.5",
                 {"text/html", "application/json"}),
@@ -309,7 +306,7 @@ TEST(HTTP_match_accept, q_value_one_dot_no_digits_is_one) {
 
 // RFC 9110 §12.4.2: qvalue allows at most three fractional digits, so a
 // four-digit fraction is malformed and is a fail-safe refusal treated as 0
-TEST(HTTP_match_accept, q_value_four_decimal_digits_treated_as_zero) {
+TEST(q_value_four_decimal_digits_treated_as_zero) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(
                 "text/html;q=0.1234, application/json;q=0.5",
                 {"text/html", "application/json"}),

--- a/test/http/http_method_test.cc
+++ b/test/http/http_method_test.cc
@@ -1,56 +1,56 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_method.h>
 
-TEST(HTTP_method, get_token) {
+TEST(get_token) {
   EXPECT_EQ(
       sourcemeta::core::http_method_string(sourcemeta::core::HTTPMethod::GET),
       "GET");
 }
 
-TEST(HTTP_method, head_token) {
+TEST(head_token) {
   EXPECT_EQ(
       sourcemeta::core::http_method_string(sourcemeta::core::HTTPMethod::HEAD),
       "HEAD");
 }
 
-TEST(HTTP_method, post_token) {
+TEST(post_token) {
   EXPECT_EQ(
       sourcemeta::core::http_method_string(sourcemeta::core::HTTPMethod::POST),
       "POST");
 }
 
-TEST(HTTP_method, put_token) {
+TEST(put_token) {
   EXPECT_EQ(
       sourcemeta::core::http_method_string(sourcemeta::core::HTTPMethod::PUT),
       "PUT");
 }
 
-TEST(HTTP_method, delete_token) {
+TEST(delete_token) {
   EXPECT_EQ(sourcemeta::core::http_method_string(
                 sourcemeta::core::HTTPMethod::DELETE),
             "DELETE");
 }
 
-TEST(HTTP_method, connect_token) {
+TEST(connect_token) {
   EXPECT_EQ(sourcemeta::core::http_method_string(
                 sourcemeta::core::HTTPMethod::CONNECT),
             "CONNECT");
 }
 
-TEST(HTTP_method, options_token) {
+TEST(options_token) {
   EXPECT_EQ(sourcemeta::core::http_method_string(
                 sourcemeta::core::HTTPMethod::OPTIONS),
             "OPTIONS");
 }
 
-TEST(HTTP_method, trace_token) {
+TEST(trace_token) {
   EXPECT_EQ(
       sourcemeta::core::http_method_string(sourcemeta::core::HTTPMethod::TRACE),
       "TRACE");
 }
 
-TEST(HTTP_method, patch_token) {
+TEST(patch_token) {
   EXPECT_EQ(
       sourcemeta::core::http_method_string(sourcemeta::core::HTTPMethod::PATCH),
       "PATCH");

--- a/test/http/http_negotiate_encoding_test.cc
+++ b/test/http/http_negotiate_encoding_test.cc
@@ -1,108 +1,106 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_negotiate_encoding, empty_header_returns_identity) {
+TEST(empty_header_returns_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, gzip_only_returns_gzip) {
+TEST(gzip_only_returns_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, identity_only_returns_identity) {
+TEST(identity_only_returns_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "identity", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding,
-     gzip_and_identity_tiebreak_to_server_preference_gzip) {
+TEST(gzip_and_identity_tiebreak_to_server_preference_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip, identity", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding,
-     gzip_and_identity_tiebreak_to_server_preference_identity) {
+TEST(gzip_and_identity_tiebreak_to_server_preference_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip, identity", sourcemeta::core::HTTPContentEncoding::Identity)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, identity_q_zero_then_gzip) {
+TEST(identity_q_zero_then_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "identity;q=0, gzip", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, gzip_higher_q_wins) {
+TEST(gzip_higher_q_wins) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "identity;q=0.3, gzip;q=0.9",
       sourcemeta::core::HTTPContentEncoding::Identity)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, identity_higher_q_wins) {
+TEST(identity_higher_q_wins) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0.3, identity;q=0.9",
       sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, identity_excluded_no_gzip_returns_nullopt) {
+TEST(identity_excluded_no_gzip_returns_nullopt) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "identity;q=0", sourcemeta::core::HTTPContentEncoding::GZIP)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(HTTP_negotiate_encoding, wildcard_excludes_all_returns_nullopt) {
+TEST(wildcard_excludes_all_returns_nullopt) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "*;q=0", sourcemeta::core::HTTPContentEncoding::GZIP)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(HTTP_negotiate_encoding, wildcard_fills_in_for_unlisted_codings) {
+TEST(wildcard_fills_in_for_unlisted_codings) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "*", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, x_gzip_alias) {
+TEST(x_gzip_alias) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "x-gzip", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, unknown_coding_alone_returns_identity_default) {
+TEST(unknown_coding_alone_returns_identity_default) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "br", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, identity_excluded_via_wildcard_no_gzip) {
+TEST(identity_excluded_via_wildcard_no_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "*;q=0, gzip", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, identity_excluded_via_wildcard_no_explicit_gzip) {
+TEST(identity_excluded_via_wildcard_no_explicit_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "*;q=0", sourcemeta::core::HTTPContentEncoding::GZIP)};
   EXPECT_FALSE(result.has_value());
@@ -110,117 +108,117 @@ TEST(HTTP_negotiate_encoding, identity_excluded_via_wildcard_no_explicit_gzip) {
 
 // RFC 9110 §12.4.2: a malformed weight is a fail-safe refusal, treated as 0,
 // so gzip is refused and the implicit identity encoding is selected
-TEST(HTTP_negotiate_encoding, garbage_q_treated_as_zero) {
+TEST(garbage_q_treated_as_zero) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=abc", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, multiple_gzip_entries_take_max_q) {
+TEST(multiple_gzip_entries_take_max_q) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0.1, gzip;q=0.9, identity;q=0.5",
       sourcemeta::core::HTTPContentEncoding::Identity)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, gzip_with_identity_q_zero_via_wildcard) {
+TEST(gzip_with_identity_q_zero_via_wildcard) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0.5, *;q=0", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, only_whitespace_returns_identity) {
+TEST(only_whitespace_returns_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "   ", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, gzip_explicit_zero_with_identity) {
+TEST(gzip_explicit_zero_with_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0, identity", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, case_insensitive_uppercase_gzip) {
+TEST(case_insensitive_uppercase_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "GZIP", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, case_insensitive_mixed_case_gzip) {
+TEST(case_insensitive_mixed_case_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "GzIp", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, case_insensitive_uppercase_identity) {
+TEST(case_insensitive_uppercase_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "IDENTITY", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, case_insensitive_uppercase_x_gzip) {
+TEST(case_insensitive_uppercase_x_gzip) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "X-GZIP", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, wildcard_zero_then_wildcard_one_takes_higher_q) {
+TEST(wildcard_zero_then_wildcard_one_takes_higher_q) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "*;q=0, *;q=1", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, identity_zero_then_identity_one_takes_higher_q) {
+TEST(identity_zero_then_identity_one_takes_higher_q) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "identity;q=0, identity;q=1",
       sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, gzip_zero_with_wildcard_one_uses_wildcard) {
+TEST(gzip_zero_with_wildcard_one_uses_wildcard) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0, *;q=1", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, q_value_one_no_decimal) {
+TEST(q_value_one_no_decimal) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=1", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, q_value_zero_no_decimal_excludes) {
+TEST(q_value_zero_no_decimal_excludes) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::Identity);
 }
 
-TEST(HTTP_negotiate_encoding, q_value_three_decimal_digits) {
+TEST(q_value_three_decimal_digits) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       "gzip;q=0.999, identity;q=0.998",
       sourcemeta::core::HTTPContentEncoding::Identity)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }
 
-TEST(HTTP_negotiate_encoding, leading_and_trailing_comma_tolerated) {
+TEST(leading_and_trailing_comma_tolerated) {
   const auto result{sourcemeta::core::http_negotiate_encoding(
       ",gzip,", sourcemeta::core::HTTPContentEncoding::GZIP)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::HTTPContentEncoding::GZIP);
 }

--- a/test/http/http_parse_bearer_test.cc
+++ b/test/http/http_parse_bearer_test.cc
@@ -1,101 +1,101 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http.h>
 
-TEST(HTTP_parse_bearer, plain_token) {
+TEST(plain_token) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer abc123"), "abc123");
 }
 
-TEST(HTTP_parse_bearer, scheme_lowercase) {
+TEST(scheme_lowercase) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("bearer abc123"), "abc123");
 }
 
-TEST(HTTP_parse_bearer, scheme_uppercase) {
+TEST(scheme_uppercase) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("BEARER abc123"), "abc123");
 }
 
-TEST(HTTP_parse_bearer, scheme_mixed_case) {
+TEST(scheme_mixed_case) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("BeArEr abc123"), "abc123");
 }
 
-TEST(HTTP_parse_bearer, trailing_whitespace_trimmed) {
+TEST(trailing_whitespace_trimmed) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer abc123   "), "abc123");
 }
 
-TEST(HTTP_parse_bearer, leading_whitespace_trimmed) {
+TEST(leading_whitespace_trimmed) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer    abc123"), "abc123");
 }
 
-TEST(HTTP_parse_bearer, surrounding_whitespace_trimmed) {
+TEST(surrounding_whitespace_trimmed) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer   abc123   "),
             "abc123");
 }
 
-TEST(HTTP_parse_bearer, tab_whitespace_trimmed) {
+TEST(tab_whitespace_trimmed) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer \tabc123\t"), "abc123");
 }
 
-TEST(HTTP_parse_bearer, empty_header) {
+TEST(empty_header) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("").empty());
 }
 
-TEST(HTTP_parse_bearer, other_scheme) {
+TEST(other_scheme) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Basic abc123").empty());
 }
 
-TEST(HTTP_parse_bearer, scheme_only) {
+TEST(scheme_only) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer").empty());
 }
 
-TEST(HTTP_parse_bearer, scheme_with_space_but_no_token) {
+TEST(scheme_with_space_but_no_token) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer ").empty());
 }
 
-TEST(HTTP_parse_bearer, scheme_with_only_whitespace) {
+TEST(scheme_with_only_whitespace) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer   ").empty());
 }
 
-TEST(HTTP_parse_bearer, scheme_without_separating_space) {
+TEST(scheme_without_separating_space) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearerabc123").empty());
 }
 
-TEST(HTTP_parse_bearer, internal_space_rejected) {
+TEST(internal_space_rejected) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer abc def").empty());
 }
 
-TEST(HTTP_parse_bearer, internal_tab_rejected) {
+TEST(internal_tab_rejected) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer abc\tdef").empty());
 }
 
-TEST(HTTP_parse_bearer, invalid_character_rejected) {
+TEST(invalid_character_rejected) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer abc@def").empty());
 }
 
-TEST(HTTP_parse_bearer, control_character_rejected) {
+TEST(control_character_rejected) {
   EXPECT_TRUE(
       sourcemeta::core::http_parse_bearer("Bearer abc\x01zdef").empty());
 }
 
-TEST(HTTP_parse_bearer, b64token_alphabet_accepted) {
+TEST(b64token_alphabet_accepted) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer aZ09-._~+/"),
             "aZ09-._~+/");
 }
 
-TEST(HTTP_parse_bearer, base64_padding_accepted) {
+TEST(base64_padding_accepted) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer YWJjMTIz=="),
             "YWJjMTIz==");
 }
 
-TEST(HTTP_parse_bearer, jwt_like_accepted) {
+TEST(jwt_like_accepted) {
   EXPECT_EQ(
       sourcemeta::core::http_parse_bearer("Bearer eyJhbGc.eyJzdWIi.SflKxwRJ"),
       "eyJhbGc.eyJzdWIi.SflKxwRJ");
 }
 
-TEST(HTTP_parse_bearer, only_padding_rejected) {
+TEST(only_padding_rejected) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer ===").empty());
 }
 
-TEST(HTTP_parse_bearer, padding_before_alphabet_rejected) {
+TEST(padding_before_alphabet_rejected) {
   EXPECT_TRUE(sourcemeta::core::http_parse_bearer("Bearer ab=cd").empty());
 }

--- a/test/http/http_parse_headers_test.cc
+++ b/test/http/http_parse_headers_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_message.h>
 
@@ -22,19 +22,17 @@ auto collect(const std::string_view input)
 
 } // namespace
 
-TEST(HTTP_parse_headers, callback_empty_input) {
-  EXPECT_TRUE(collect("").empty());
-}
+TEST(callback_empty_input) { EXPECT_TRUE(collect("").empty()); }
 
-TEST(HTTP_parse_headers, callback_status_line_only) {
+TEST(callback_status_line_only) {
   EXPECT_TRUE(collect("HTTP/1.1 200 OK\r\n\r\n").empty());
 }
 
-TEST(HTTP_parse_headers, callback_status_line_without_terminator) {
+TEST(callback_status_line_without_terminator) {
   EXPECT_TRUE(collect("HTTP/1.1 200 OK").empty());
 }
 
-TEST(HTTP_parse_headers, callback_single_field_line) {
+TEST(callback_single_field_line) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
@@ -42,7 +40,7 @@ TEST(HTTP_parse_headers, callback_single_field_line) {
   EXPECT_EQ(headers.at(0).second, "text/html");
 }
 
-TEST(HTTP_parse_headers, callback_multiple_field_lines) {
+TEST(callback_multiple_field_lines) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\nServer: test\r\nContent-Length: 12\r\n\r\n")};
   EXPECT_EQ(headers.size(), 2);
@@ -52,60 +50,60 @@ TEST(HTTP_parse_headers, callback_multiple_field_lines) {
   EXPECT_EQ(headers.at(1).second, "12");
 }
 
-TEST(HTTP_parse_headers, callback_preserves_name_case) {
+TEST(callback_preserves_name_case) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nX-FOO-Bar: baz\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "X-FOO-Bar");
   EXPECT_EQ(headers.at(0).second, "baz");
 }
 
-TEST(HTTP_parse_headers, callback_no_space_after_colon) {
+TEST(callback_no_space_after_colon) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nServer:test\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "Server");
   EXPECT_EQ(headers.at(0).second, "test");
 }
 
-TEST(HTTP_parse_headers, callback_trims_multiple_leading_spaces) {
+TEST(callback_trims_multiple_leading_spaces) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nServer:   test\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).second, "test");
 }
 
-TEST(HTTP_parse_headers, callback_trims_leading_horizontal_tab) {
+TEST(callback_trims_leading_horizontal_tab) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nServer:\ttest\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).second, "test");
 }
 
-TEST(HTTP_parse_headers, callback_trims_trailing_whitespace) {
+TEST(callback_trims_trailing_whitespace) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nServer: test \t\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).second, "test");
 }
 
-TEST(HTTP_parse_headers, callback_preserves_internal_whitespace) {
+TEST(callback_preserves_internal_whitespace) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\nUser-Agent: foo bar\tbaz\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).second, "foo bar\tbaz");
 }
 
-TEST(HTTP_parse_headers, callback_empty_value_without_space) {
+TEST(callback_empty_value_without_space) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nX-Empty:\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "X-Empty");
   EXPECT_TRUE(headers.at(0).second.empty());
 }
 
-TEST(HTTP_parse_headers, callback_empty_value_with_space) {
+TEST(callback_empty_value_with_space) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nX-Empty: \r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "X-Empty");
   EXPECT_TRUE(headers.at(0).second.empty());
 }
 
-TEST(HTTP_parse_headers, callback_value_with_colons) {
+TEST(callback_value_with_colons) {
   const auto headers{collect(
       "HTTP/1.1 200 OK\r\nLocation: https://example.com:8080/x\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
@@ -113,7 +111,7 @@ TEST(HTTP_parse_headers, callback_value_with_colons) {
   EXPECT_EQ(headers.at(0).second, "https://example.com:8080/x");
 }
 
-TEST(HTTP_parse_headers, callback_repeated_field_names_in_order) {
+TEST(callback_repeated_field_names_in_order) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nSet-Cookie: a=1\r\n"
                              "Set-Cookie: b=2\r\n\r\n")};
   EXPECT_EQ(headers.size(), 2);
@@ -123,21 +121,21 @@ TEST(HTTP_parse_headers, callback_repeated_field_names_in_order) {
   EXPECT_EQ(headers.at(1).second, "b=2");
 }
 
-TEST(HTTP_parse_headers, callback_skips_line_without_colon) {
+TEST(callback_skips_line_without_colon) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\ngarbage\r\nServer: test\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "Server");
 }
 
-TEST(HTTP_parse_headers, callback_skips_empty_field_name) {
+TEST(callback_skips_empty_field_name) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\n: anonymous\r\nServer: test\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "Server");
 }
 
-TEST(HTTP_parse_headers, callback_skips_whitespace_before_colon) {
+TEST(callback_skips_whitespace_before_colon) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\nServer : nginx\r\nDate: now\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
@@ -145,7 +143,7 @@ TEST(HTTP_parse_headers, callback_skips_whitespace_before_colon) {
   EXPECT_EQ(headers.at(0).second, "now");
 }
 
-TEST(HTTP_parse_headers, callback_obs_fold_reported_with_empty_name) {
+TEST(callback_obs_fold_reported_with_empty_name) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\nX-Long: first\r\n second part\r\n\r\n")};
   EXPECT_EQ(headers.size(), 2);
@@ -155,7 +153,7 @@ TEST(HTTP_parse_headers, callback_obs_fold_reported_with_empty_name) {
   EXPECT_EQ(headers.at(1).second, "second part");
 }
 
-TEST(HTTP_parse_headers, callback_obs_fold_with_embedded_colon) {
+TEST(callback_obs_fold_with_embedded_colon) {
   const auto headers{
       collect("HTTP/1.1 200 OK\r\nX-Long: first\r\n\tnote: detail\r\n\r\n")};
   EXPECT_EQ(headers.size(), 2);
@@ -165,34 +163,34 @@ TEST(HTTP_parse_headers, callback_obs_fold_with_embedded_colon) {
   EXPECT_EQ(headers.at(1).second, "note: detail");
 }
 
-TEST(HTTP_parse_headers, callback_first_line_always_skipped) {
+TEST(callback_first_line_always_skipped) {
   const auto headers{collect("Fake: line\r\nReal: value\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "Real");
   EXPECT_EQ(headers.at(0).second, "value");
 }
 
-TEST(HTTP_parse_headers, callback_ignores_field_line_without_terminator) {
+TEST(callback_ignores_field_line_without_terminator) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nA: b\r\nB: c")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "A");
   EXPECT_EQ(headers.at(0).second, "b");
 }
 
-TEST(HTTP_parse_headers, callback_stops_at_blank_line) {
+TEST(callback_stops_at_blank_line) {
   const auto headers{collect("HTTP/1.1 200 OK\r\nA: b\r\n\r\nB: c\r\n\r\n")};
   EXPECT_EQ(headers.size(), 1);
   EXPECT_EQ(headers.at(0).first, "A");
   EXPECT_EQ(headers.at(0).second, "b");
 }
 
-TEST(HTTP_parse_headers, container_empty_input) {
+TEST(container_empty_input) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers("", headers);
   EXPECT_TRUE(headers.empty());
 }
 
-TEST(HTTP_parse_headers, container_lowercases_names) {
+TEST(container_lowercases_names) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers(
       "HTTP/1.1 200 OK\r\nContent-TYPE: text/html\r\nX-Foo-9: bar\r\n\r\n",
@@ -204,7 +202,7 @@ TEST(HTTP_parse_headers, container_lowercases_names) {
   EXPECT_EQ(headers.at(1).second, "bar");
 }
 
-TEST(HTTP_parse_headers, container_preserves_repeated_fields_in_order) {
+TEST(container_preserves_repeated_fields_in_order) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers(
       "HTTP/1.1 200 OK\r\nSet-Cookie: a=1\r\nSet-Cookie: b=2\r\n\r\n", headers);
@@ -215,7 +213,7 @@ TEST(HTTP_parse_headers, container_preserves_repeated_fields_in_order) {
   EXPECT_EQ(headers.at(1).second, "b=2");
 }
 
-TEST(HTTP_parse_headers, container_joins_obs_fold_with_space) {
+TEST(container_joins_obs_fold_with_space) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers(
       "HTTP/1.1 200 OK\r\nX-Long: first\r\n second part\r\n\r\n", headers);
@@ -224,7 +222,7 @@ TEST(HTTP_parse_headers, container_joins_obs_fold_with_space) {
   EXPECT_EQ(headers.at(0).second, "first second part");
 }
 
-TEST(HTTP_parse_headers, container_joins_obs_fold_with_horizontal_tab) {
+TEST(container_joins_obs_fold_with_horizontal_tab) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers(
       "HTTP/1.1 200 OK\r\nX-Long: first\r\n\tsecond\r\n\r\n", headers);
@@ -233,7 +231,7 @@ TEST(HTTP_parse_headers, container_joins_obs_fold_with_horizontal_tab) {
   EXPECT_EQ(headers.at(0).second, "first second");
 }
 
-TEST(HTTP_parse_headers, container_ignores_orphan_obs_fold) {
+TEST(container_ignores_orphan_obs_fold) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers(
       "HTTP/1.1 200 OK\r\n orphan\r\nServer: test\r\n\r\n", headers);
@@ -242,7 +240,7 @@ TEST(HTTP_parse_headers, container_ignores_orphan_obs_fold) {
   EXPECT_EQ(headers.at(0).second, "test");
 }
 
-TEST(HTTP_parse_headers, container_empty_value) {
+TEST(container_empty_value) {
   std::vector<std::pair<std::string, std::string>> headers;
   sourcemeta::core::http_parse_headers("HTTP/1.1 200 OK\r\nX-Empty:\r\n\r\n",
                                        headers);

--- a/test/http/http_serialize_headers_test.cc
+++ b/test/http/http_serialize_headers_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_message.h>
 
@@ -7,46 +7,46 @@
 #include <utility>     // std::pair
 #include <vector>      // std::vector
 
-TEST(HTTP_serialize_headers, empty) {
+TEST(empty) {
   const std::vector<std::pair<std::string, std::string>> headers;
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers), "");
 }
 
-TEST(HTTP_serialize_headers, single_header) {
+TEST(single_header) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"Accept", "application/json"}};
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers),
             "Accept: application/json\r\n");
 }
 
-TEST(HTTP_serialize_headers, multiple_headers_in_order) {
+TEST(multiple_headers_in_order) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"Accept", "application/json"}, {"User-Agent", "test/1.0"}};
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers),
             "Accept: application/json\r\nUser-Agent: test/1.0\r\n");
 }
 
-TEST(HTTP_serialize_headers, repeated_field_names) {
+TEST(repeated_field_names) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"Set-Cookie", "a=1"}, {"Set-Cookie", "b=2"}};
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers),
             "Set-Cookie: a=1\r\nSet-Cookie: b=2\r\n");
 }
 
-TEST(HTTP_serialize_headers, empty_value) {
+TEST(empty_value) {
   const std::vector<std::pair<std::string, std::string>> headers{
       {"X-Empty", ""}};
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers), "X-Empty: \r\n");
 }
 
-TEST(HTTP_serialize_headers, view_pairs) {
+TEST(view_pairs) {
   const std::vector<std::pair<std::string_view, std::string_view>> headers{
       {"Accept", "application/json"}};
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers),
             "Accept: application/json\r\n");
 }
 
-TEST(HTTP_serialize_headers, round_trip_through_parse) {
+TEST(round_trip_through_parse) {
   std::vector<std::pair<std::string, std::string>> parsed;
   sourcemeta::core::http_parse_headers(
       "HTTP/1.1 200 OK\r\nserver: test\r\ndate: now\r\n\r\n", parsed);

--- a/test/http/http_status_from_code_test.cc
+++ b/test/http/http_status_from_code_test.cc
@@ -1,388 +1,388 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_status.h>
 
-TEST(HTTP_status_from_code, continue_100) {
+TEST(continue_100) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(100),
             sourcemeta::core::HTTP_STATUS_CONTINUE);
 }
 
-TEST(HTTP_status_from_code, switching_protocols_101) {
+TEST(switching_protocols_101) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(101),
             sourcemeta::core::HTTP_STATUS_SWITCHING_PROTOCOLS);
 }
 
-TEST(HTTP_status_from_code, processing_102) {
+TEST(processing_102) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(102),
             sourcemeta::core::HTTP_STATUS_PROCESSING);
 }
 
-TEST(HTTP_status_from_code, early_hints_103) {
+TEST(early_hints_103) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(103),
             sourcemeta::core::HTTP_STATUS_EARLY_HINTS);
 }
 
-TEST(HTTP_status_from_code, ok_200) {
+TEST(ok_200) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(200),
             sourcemeta::core::HTTP_STATUS_OK);
 }
 
-TEST(HTTP_status_from_code, created_201) {
+TEST(created_201) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(201),
             sourcemeta::core::HTTP_STATUS_CREATED);
 }
 
-TEST(HTTP_status_from_code, accepted_202) {
+TEST(accepted_202) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(202),
             sourcemeta::core::HTTP_STATUS_ACCEPTED);
 }
 
-TEST(HTTP_status_from_code, non_authoritative_information_203) {
+TEST(non_authoritative_information_203) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(203),
             sourcemeta::core::HTTP_STATUS_NON_AUTHORITATIVE_INFORMATION);
 }
 
-TEST(HTTP_status_from_code, no_content_204) {
+TEST(no_content_204) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(204),
             sourcemeta::core::HTTP_STATUS_NO_CONTENT);
 }
 
-TEST(HTTP_status_from_code, reset_content_205) {
+TEST(reset_content_205) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(205),
             sourcemeta::core::HTTP_STATUS_RESET_CONTENT);
 }
 
-TEST(HTTP_status_from_code, partial_content_206) {
+TEST(partial_content_206) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(206),
             sourcemeta::core::HTTP_STATUS_PARTIAL_CONTENT);
 }
 
-TEST(HTTP_status_from_code, multi_status_207) {
+TEST(multi_status_207) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(207),
             sourcemeta::core::HTTP_STATUS_MULTI_STATUS);
 }
 
-TEST(HTTP_status_from_code, already_reported_208) {
+TEST(already_reported_208) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(208),
             sourcemeta::core::HTTP_STATUS_ALREADY_REPORTED);
 }
 
-TEST(HTTP_status_from_code, im_used_226) {
+TEST(im_used_226) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(226),
             sourcemeta::core::HTTP_STATUS_IM_USED);
 }
 
-TEST(HTTP_status_from_code, multiple_choices_300) {
+TEST(multiple_choices_300) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(300),
             sourcemeta::core::HTTP_STATUS_MULTIPLE_CHOICES);
 }
 
-TEST(HTTP_status_from_code, moved_permanently_301) {
+TEST(moved_permanently_301) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(301),
             sourcemeta::core::HTTP_STATUS_MOVED_PERMANENTLY);
 }
 
-TEST(HTTP_status_from_code, found_302) {
+TEST(found_302) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(302),
             sourcemeta::core::HTTP_STATUS_FOUND);
 }
 
-TEST(HTTP_status_from_code, see_other_303) {
+TEST(see_other_303) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(303),
             sourcemeta::core::HTTP_STATUS_SEE_OTHER);
 }
 
-TEST(HTTP_status_from_code, not_modified_304) {
+TEST(not_modified_304) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(304),
             sourcemeta::core::HTTP_STATUS_NOT_MODIFIED);
 }
 
-TEST(HTTP_status_from_code, use_proxy_305) {
+TEST(use_proxy_305) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(305),
             sourcemeta::core::HTTP_STATUS_USE_PROXY);
 }
 
-TEST(HTTP_status_from_code, temporary_redirect_307) {
+TEST(temporary_redirect_307) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(307),
             sourcemeta::core::HTTP_STATUS_TEMPORARY_REDIRECT);
 }
 
-TEST(HTTP_status_from_code, permanent_redirect_308) {
+TEST(permanent_redirect_308) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(308),
             sourcemeta::core::HTTP_STATUS_PERMANENT_REDIRECT);
 }
 
-TEST(HTTP_status_from_code, bad_request_400) {
+TEST(bad_request_400) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(400),
             sourcemeta::core::HTTP_STATUS_BAD_REQUEST);
 }
 
-TEST(HTTP_status_from_code, unauthorized_401) {
+TEST(unauthorized_401) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(401),
             sourcemeta::core::HTTP_STATUS_UNAUTHORIZED);
 }
 
-TEST(HTTP_status_from_code, payment_required_402) {
+TEST(payment_required_402) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(402),
             sourcemeta::core::HTTP_STATUS_PAYMENT_REQUIRED);
 }
 
-TEST(HTTP_status_from_code, forbidden_403) {
+TEST(forbidden_403) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(403),
             sourcemeta::core::HTTP_STATUS_FORBIDDEN);
 }
 
-TEST(HTTP_status_from_code, not_found_404) {
+TEST(not_found_404) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(404),
             sourcemeta::core::HTTP_STATUS_NOT_FOUND);
 }
 
-TEST(HTTP_status_from_code, method_not_allowed_405) {
+TEST(method_not_allowed_405) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(405),
             sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED);
 }
 
-TEST(HTTP_status_from_code, not_acceptable_406) {
+TEST(not_acceptable_406) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(406),
             sourcemeta::core::HTTP_STATUS_NOT_ACCEPTABLE);
 }
 
-TEST(HTTP_status_from_code, proxy_authentication_required_407) {
+TEST(proxy_authentication_required_407) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(407),
             sourcemeta::core::HTTP_STATUS_PROXY_AUTHENTICATION_REQUIRED);
 }
 
-TEST(HTTP_status_from_code, request_timeout_408) {
+TEST(request_timeout_408) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(408),
             sourcemeta::core::HTTP_STATUS_REQUEST_TIMEOUT);
 }
 
-TEST(HTTP_status_from_code, conflict_409) {
+TEST(conflict_409) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(409),
             sourcemeta::core::HTTP_STATUS_CONFLICT);
 }
 
-TEST(HTTP_status_from_code, gone_410) {
+TEST(gone_410) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(410),
             sourcemeta::core::HTTP_STATUS_GONE);
 }
 
-TEST(HTTP_status_from_code, length_required_411) {
+TEST(length_required_411) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(411),
             sourcemeta::core::HTTP_STATUS_LENGTH_REQUIRED);
 }
 
-TEST(HTTP_status_from_code, precondition_failed_412) {
+TEST(precondition_failed_412) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(412),
             sourcemeta::core::HTTP_STATUS_PRECONDITION_FAILED);
 }
 
-TEST(HTTP_status_from_code, content_too_large_413) {
+TEST(content_too_large_413) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(413),
             sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE);
 }
 
-TEST(HTTP_status_from_code, uri_too_long_414) {
+TEST(uri_too_long_414) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(414),
             sourcemeta::core::HTTP_STATUS_URI_TOO_LONG);
 }
 
-TEST(HTTP_status_from_code, unsupported_media_type_415) {
+TEST(unsupported_media_type_415) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(415),
             sourcemeta::core::HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE);
 }
 
-TEST(HTTP_status_from_code, range_not_satisfiable_416) {
+TEST(range_not_satisfiable_416) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(416),
             sourcemeta::core::HTTP_STATUS_RANGE_NOT_SATISFIABLE);
 }
 
-TEST(HTTP_status_from_code, expectation_failed_417) {
+TEST(expectation_failed_417) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(417),
             sourcemeta::core::HTTP_STATUS_EXPECTATION_FAILED);
 }
 
-TEST(HTTP_status_from_code, im_a_teapot_418) {
+TEST(im_a_teapot_418) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(418),
             sourcemeta::core::HTTP_STATUS_IM_A_TEAPOT);
 }
 
-TEST(HTTP_status_from_code, misdirected_request_421) {
+TEST(misdirected_request_421) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(421),
             sourcemeta::core::HTTP_STATUS_MISDIRECTED_REQUEST);
 }
 
-TEST(HTTP_status_from_code, unprocessable_content_422) {
+TEST(unprocessable_content_422) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(422),
             sourcemeta::core::HTTP_STATUS_UNPROCESSABLE_CONTENT);
 }
 
-TEST(HTTP_status_from_code, locked_423) {
+TEST(locked_423) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(423),
             sourcemeta::core::HTTP_STATUS_LOCKED);
 }
 
-TEST(HTTP_status_from_code, failed_dependency_424) {
+TEST(failed_dependency_424) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(424),
             sourcemeta::core::HTTP_STATUS_FAILED_DEPENDENCY);
 }
 
-TEST(HTTP_status_from_code, too_early_425) {
+TEST(too_early_425) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(425),
             sourcemeta::core::HTTP_STATUS_TOO_EARLY);
 }
 
-TEST(HTTP_status_from_code, upgrade_required_426) {
+TEST(upgrade_required_426) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(426),
             sourcemeta::core::HTTP_STATUS_UPGRADE_REQUIRED);
 }
 
-TEST(HTTP_status_from_code, precondition_required_428) {
+TEST(precondition_required_428) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(428),
             sourcemeta::core::HTTP_STATUS_PRECONDITION_REQUIRED);
 }
 
-TEST(HTTP_status_from_code, too_many_requests_429) {
+TEST(too_many_requests_429) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(429),
             sourcemeta::core::HTTP_STATUS_TOO_MANY_REQUESTS);
 }
 
-TEST(HTTP_status_from_code, request_header_fields_too_large_431) {
+TEST(request_header_fields_too_large_431) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(431),
             sourcemeta::core::HTTP_STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE);
 }
 
-TEST(HTTP_status_from_code, unavailable_for_legal_reasons_451) {
+TEST(unavailable_for_legal_reasons_451) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(451),
             sourcemeta::core::HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS);
 }
 
-TEST(HTTP_status_from_code, internal_server_error_500) {
+TEST(internal_server_error_500) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(500),
             sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR);
 }
 
-TEST(HTTP_status_from_code, not_implemented_501) {
+TEST(not_implemented_501) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(501),
             sourcemeta::core::HTTP_STATUS_NOT_IMPLEMENTED);
 }
 
-TEST(HTTP_status_from_code, bad_gateway_502) {
+TEST(bad_gateway_502) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(502),
             sourcemeta::core::HTTP_STATUS_BAD_GATEWAY);
 }
 
-TEST(HTTP_status_from_code, service_unavailable_503) {
+TEST(service_unavailable_503) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(503),
             sourcemeta::core::HTTP_STATUS_SERVICE_UNAVAILABLE);
 }
 
-TEST(HTTP_status_from_code, gateway_timeout_504) {
+TEST(gateway_timeout_504) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(504),
             sourcemeta::core::HTTP_STATUS_GATEWAY_TIMEOUT);
 }
 
-TEST(HTTP_status_from_code, http_version_not_supported_505) {
+TEST(http_version_not_supported_505) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(505),
             sourcemeta::core::HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED);
 }
 
-TEST(HTTP_status_from_code, variant_also_negotiates_506) {
+TEST(variant_also_negotiates_506) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(506),
             sourcemeta::core::HTTP_STATUS_VARIANT_ALSO_NEGOTIATES);
 }
 
-TEST(HTTP_status_from_code, insufficient_storage_507) {
+TEST(insufficient_storage_507) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(507),
             sourcemeta::core::HTTP_STATUS_INSUFFICIENT_STORAGE);
 }
 
-TEST(HTTP_status_from_code, loop_detected_508) {
+TEST(loop_detected_508) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(508),
             sourcemeta::core::HTTP_STATUS_LOOP_DETECTED);
 }
 
-TEST(HTTP_status_from_code, not_extended_510) {
+TEST(not_extended_510) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(510),
             sourcemeta::core::HTTP_STATUS_NOT_EXTENDED);
 }
 
-TEST(HTTP_status_from_code, network_authentication_required_511) {
+TEST(network_authentication_required_511) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(511),
             sourcemeta::core::HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED);
 }
 
-TEST(HTTP_status_from_code, unknown_0) {
+TEST(unknown_0) {
   const auto status{sourcemeta::core::http_status_from_code(0)};
   EXPECT_EQ(status.code, 0);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_99) {
+TEST(unknown_99) {
   const auto status{sourcemeta::core::http_status_from_code(99)};
   EXPECT_EQ(status.code, 99);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_199) {
+TEST(unknown_199) {
   const auto status{sourcemeta::core::http_status_from_code(199)};
   EXPECT_EQ(status.code, 199);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_299) {
+TEST(unknown_299) {
   const auto status{sourcemeta::core::http_status_from_code(299)};
   EXPECT_EQ(status.code, 299);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_306) {
+TEST(unknown_306) {
   const auto status{sourcemeta::core::http_status_from_code(306)};
   EXPECT_EQ(status.code, 306);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_399) {
+TEST(unknown_399) {
   const auto status{sourcemeta::core::http_status_from_code(399)};
   EXPECT_EQ(status.code, 399);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_420) {
+TEST(unknown_420) {
   const auto status{sourcemeta::core::http_status_from_code(420)};
   EXPECT_EQ(status.code, 420);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_499) {
+TEST(unknown_499) {
   const auto status{sourcemeta::core::http_status_from_code(499)};
   EXPECT_EQ(status.code, 499);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_509) {
+TEST(unknown_509) {
   const auto status{sourcemeta::core::http_status_from_code(509)};
   EXPECT_EQ(status.code, 509);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_599) {
+TEST(unknown_599) {
   const auto status{sourcemeta::core::http_status_from_code(599)};
   EXPECT_EQ(status.code, 599);
   EXPECT_TRUE(status.phrase.empty());
   EXPECT_TRUE(status.wire.empty());
 }
 
-TEST(HTTP_status_from_code, unknown_999) {
+TEST(unknown_999) {
   const auto status{sourcemeta::core::http_status_from_code(999)};
   EXPECT_EQ(status.code, 999);
   EXPECT_TRUE(status.phrase.empty());

--- a/test/http/http_status_test.cc
+++ b/test/http/http_status_test.cc
@@ -1,51 +1,51 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/http_status.h>
 
-TEST(HTTP_status, ok_fields) {
+TEST(ok_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_OK.code, 200);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_OK.phrase, "OK");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_OK.wire, "200 OK");
 }
 
-TEST(HTTP_status, created_fields) {
+TEST(created_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_CREATED.code, 201);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_CREATED.phrase, "Created");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_CREATED.wire, "201 Created");
 }
 
-TEST(HTTP_status, no_content_fields) {
+TEST(no_content_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NO_CONTENT.code, 204);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NO_CONTENT.phrase, "No Content");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NO_CONTENT.wire, "204 No Content");
 }
 
-TEST(HTTP_status, not_modified_fields) {
+TEST(not_modified_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_MODIFIED.code, 304);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_MODIFIED.phrase, "Not Modified");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_MODIFIED.wire,
             "304 Not Modified");
 }
 
-TEST(HTTP_status, bad_request_fields) {
+TEST(bad_request_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_BAD_REQUEST.code, 400);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_BAD_REQUEST.phrase, "Bad Request");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_BAD_REQUEST.wire, "400 Bad Request");
 }
 
-TEST(HTTP_status, forbidden_fields) {
+TEST(forbidden_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_FORBIDDEN.code, 403);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_FORBIDDEN.phrase, "Forbidden");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_FORBIDDEN.wire, "403 Forbidden");
 }
 
-TEST(HTTP_status, not_found_fields) {
+TEST(not_found_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_FOUND.code, 404);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_FOUND.phrase, "Not Found");
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_FOUND.wire, "404 Not Found");
 }
 
-TEST(HTTP_status, method_not_allowed_fields) {
+TEST(method_not_allowed_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED.code, 405);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_METHOD_NOT_ALLOWED.phrase,
             "Method Not Allowed");
@@ -53,7 +53,7 @@ TEST(HTTP_status, method_not_allowed_fields) {
             "405 Method Not Allowed");
 }
 
-TEST(HTTP_status, not_acceptable_fields) {
+TEST(not_acceptable_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_ACCEPTABLE.code, 406);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NOT_ACCEPTABLE.phrase,
             "Not Acceptable");
@@ -61,7 +61,7 @@ TEST(HTTP_status, not_acceptable_fields) {
             "406 Not Acceptable");
 }
 
-TEST(HTTP_status, content_too_large_fields) {
+TEST(content_too_large_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE.code, 413);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_CONTENT_TOO_LARGE.phrase,
             "Content Too Large");
@@ -69,7 +69,7 @@ TEST(HTTP_status, content_too_large_fields) {
             "413 Content Too Large");
 }
 
-TEST(HTTP_status, unsupported_media_type_fields) {
+TEST(unsupported_media_type_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE.code, 415);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_UNSUPPORTED_MEDIA_TYPE.phrase,
             "Unsupported Media Type");
@@ -77,7 +77,7 @@ TEST(HTTP_status, unsupported_media_type_fields) {
             "415 Unsupported Media Type");
 }
 
-TEST(HTTP_status, internal_server_error_fields) {
+TEST(internal_server_error_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR.code, 500);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_INTERNAL_SERVER_ERROR.phrase,
             "Internal Server Error");
@@ -85,7 +85,7 @@ TEST(HTTP_status, internal_server_error_fields) {
             "500 Internal Server Error");
 }
 
-TEST(HTTP_status, service_unavailable_fields) {
+TEST(service_unavailable_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_SERVICE_UNAVAILABLE.code, 503);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_SERVICE_UNAVAILABLE.phrase,
             "Service Unavailable");
@@ -93,48 +93,48 @@ TEST(HTTP_status, service_unavailable_fields) {
             "503 Service Unavailable");
 }
 
-TEST(HTTP_status, equality_reflexive) {
+TEST(equality_reflexive) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_OK, sourcemeta::core::HTTP_STATUS_OK);
 }
 
-TEST(HTTP_status, inequality_different_codes) {
+TEST(inequality_different_codes) {
   EXPECT_NE(sourcemeta::core::HTTP_STATUS_OK,
             sourcemeta::core::HTTP_STATUS_NOT_FOUND);
 }
 
-TEST(HTTP_status, equality_copy) {
+TEST(equality_copy) {
   constexpr auto copy{sourcemeta::core::HTTP_STATUS_OK};
   EXPECT_EQ(copy, sourcemeta::core::HTTP_STATUS_OK);
 }
 
-TEST(HTTP_status, webdav_multi_status) {
+TEST(webdav_multi_status) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_MULTI_STATUS.code, 207);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_MULTI_STATUS.wire,
             "207 Multi-Status");
 }
 
-TEST(HTTP_status, im_a_teapot) {
+TEST(im_a_teapot) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_IM_A_TEAPOT.code, 418);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_IM_A_TEAPOT.wire, "418 I'm a Teapot");
 }
 
-TEST(HTTP_status, unavailable_for_legal_reasons) {
+TEST(unavailable_for_legal_reasons) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_UNAVAILABLE_FOR_LEGAL_REASONS.code,
             451);
 }
 
-TEST(HTTP_status, switching_protocols) {
+TEST(switching_protocols) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_SWITCHING_PROTOCOLS.code, 101);
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_SWITCHING_PROTOCOLS.wire,
             "101 Switching Protocols");
 }
 
-TEST(HTTP_status, network_authentication_required) {
+TEST(network_authentication_required) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_NETWORK_AUTHENTICATION_REQUIRED.code,
             511);
 }
 
-TEST(HTTP_status, wire_starts_with_code_string) {
+TEST(wire_starts_with_code_string) {
   EXPECT_TRUE(sourcemeta::core::HTTP_STATUS_OK.wire.starts_with("200"));
   EXPECT_TRUE(sourcemeta::core::HTTP_STATUS_NOT_FOUND.wire.starts_with("404"));
   EXPECT_TRUE(

--- a/test/idna/CMakeLists.txt
+++ b/test/idna/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME idna
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME idna
   SOURCES
     idna_property_test.cc
     idna_passes_contexto_test.cc

--- a/test/idna/idna_classify_label_test.cc
+++ b/test/idna/idna_classify_label_test.cc
@@ -1,72 +1,72 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
 #include <optional>
 #include <string>
 
-TEST(IDNA_classify_label, empty_label_returns_nullopt) {
+TEST(empty_label_returns_nullopt) {
   std::u32string decoded;
   EXPECT_EQ(sourcemeta::core::idna_classify_label(U"", decoded), std::nullopt);
 }
 
-TEST(IDNA_classify_label, pure_ascii_letters_classify_as_ascii) {
+TEST(pure_ascii_letters_classify_as_ascii) {
   std::u32string decoded;
   const auto kind{sourcemeta::core::idna_classify_label(U"example", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::Ascii);
   EXPECT_EQ(decoded, U"example");
 }
 
-TEST(IDNA_classify_label, ascii_with_hyphen_classify_as_ascii) {
+TEST(ascii_with_hyphen_classify_as_ascii) {
   std::u32string decoded;
   const auto kind{sourcemeta::core::idna_classify_label(U"host-name", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::Ascii);
   EXPECT_EQ(decoded, U"host-name");
 }
 
 // RFC 5891 §4.2.3.1: Ascii classification does not enforce the U-label
 // "no consecutive hyphens at positions 3,4" rule. That is the caller's job.
-TEST(IDNA_classify_label, ascii_with_consecutive_hyphens_classify_as_ascii) {
+TEST(ascii_with_consecutive_hyphens_classify_as_ascii) {
   std::u32string decoded;
   const auto kind{sourcemeta::core::idna_classify_label(U"a--b", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::Ascii);
   EXPECT_EQ(decoded, U"a--b");
 }
 
 // RFC 5890 §2.3.2.1: ACE prefix "xn--" detection is case-insensitive
-TEST(IDNA_classify_label, valid_a_label_lowercase_prefix) {
+TEST(valid_a_label_lowercase_prefix) {
   std::u32string decoded;
   const auto kind{
       sourcemeta::core::idna_classify_label(U"xn--mnchen-3ya", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::ALabel);
   // U+00FC LATIN SMALL LETTER U WITH DIAERESIS
   EXPECT_EQ(decoded, U"m\u00FCnchen");
 }
 
-TEST(IDNA_classify_label, valid_a_label_uppercase_prefix) {
+TEST(valid_a_label_uppercase_prefix) {
   std::u32string decoded;
   const auto kind{
       sourcemeta::core::idna_classify_label(U"XN--mnchen-3ya", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::ALabel);
   EXPECT_EQ(decoded, U"m\u00FCnchen");
 }
 
-TEST(IDNA_classify_label, valid_a_label_mixed_case_prefix) {
+TEST(valid_a_label_mixed_case_prefix) {
   std::u32string decoded;
   const auto kind{
       sourcemeta::core::idna_classify_label(U"Xn--mnchen-3ya", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::ALabel);
   EXPECT_EQ(decoded, U"m\u00FCnchen");
 }
 
 // RFC 5891 §4.2: A-label Punycode body must round-trip
-TEST(IDNA_classify_label, invalid_a_label_decoded_violates_u_label_rules) {
+TEST(invalid_a_label_decoded_violates_u_label_rules) {
   std::u32string decoded;
   // Body decodes to "aa--點看" which has "--" at positions 3 and 4
   EXPECT_EQ(
@@ -74,45 +74,45 @@ TEST(IDNA_classify_label, invalid_a_label_decoded_violates_u_label_rules) {
       std::nullopt);
 }
 
-TEST(IDNA_classify_label, invalid_a_label_empty_body) {
+TEST(invalid_a_label_empty_body) {
   std::u32string decoded;
   EXPECT_EQ(sourcemeta::core::idna_classify_label(U"xn--", decoded),
             std::nullopt);
 }
 
-TEST(IDNA_classify_label, invalid_a_label_garbage_body) {
+TEST(invalid_a_label_garbage_body) {
   std::u32string decoded;
   EXPECT_EQ(sourcemeta::core::idna_classify_label(U"xn--X", decoded),
             std::nullopt);
 }
 
 // RFC 5890 §2.3.2.2: U-label has at least one non-ASCII codepoint
-TEST(IDNA_classify_label, valid_u_label_two_byte) {
+TEST(valid_u_label_two_byte) {
   std::u32string decoded;
   const auto kind{sourcemeta::core::idna_classify_label(U"\u03B1", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::ULabel);
   EXPECT_EQ(decoded, U"\u03B1");
 }
 
-TEST(IDNA_classify_label, valid_u_label_mixed_pvalid_codepoints) {
+TEST(valid_u_label_mixed_pvalid_codepoints) {
   std::u32string decoded;
   const auto kind{
       sourcemeta::core::idna_classify_label(U"m\u00FCnchen", decoded)};
-  ASSERT_TRUE(kind.has_value());
+  EXPECT_TRUE(kind.has_value());
   EXPECT_EQ(*kind, sourcemeta::core::IDNALabelKind::ULabel);
   EXPECT_EQ(decoded, U"m\u00FCnchen");
 }
 
 // RFC 5891 §4.2.3.1: U-label must not start with a hyphen
-TEST(IDNA_classify_label, invalid_u_label_leading_hyphen) {
+TEST(invalid_u_label_leading_hyphen) {
   std::u32string decoded;
   EXPECT_EQ(sourcemeta::core::idna_classify_label(U"-\u03B1", decoded),
             std::nullopt);
 }
 
 // RFC 5891 §4.2.3.2: U-label first codepoint must not be a combining mark
-TEST(IDNA_classify_label, invalid_u_label_leading_combining_mark) {
+TEST(invalid_u_label_leading_combining_mark) {
   std::u32string decoded;
   // U+0300 COMBINING GRAVE ACCENT
   EXPECT_EQ(sourcemeta::core::idna_classify_label(U"\u0300hello", decoded),
@@ -120,7 +120,7 @@ TEST(IDNA_classify_label, invalid_u_label_leading_combining_mark) {
 }
 
 // RFC 5892: DISALLOWED codepoint rejects
-TEST(IDNA_classify_label, invalid_u_label_disallowed_codepoint) {
+TEST(invalid_u_label_disallowed_codepoint) {
   std::u32string decoded;
   // U+302E HANGUL SINGLE DOT TONE MARK is DISALLOWED
   EXPECT_EQ(sourcemeta::core::idna_classify_label(U"a\u302Eb", decoded),

--- a/test/idna/idna_is_valid_a_label_test.cc
+++ b/test/idna/idna_is_valid_a_label_test.cc
@@ -1,56 +1,54 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
 #include <string> // std::string
 
-TEST(IDNA_is_valid_a_label, munich_german) {
+TEST(munich_german) {
   // xn--mnchen-3ya decodes to "M\u00FCnchen"
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_a_label("xn--mnchen-3ya"));
 }
 
-TEST(IDNA_is_valid_a_label, volos_greek) {
+TEST(volos_greek) {
   // xn--nxasmq6b decodes to "\u03B2\u03CC\u03BB\u03BF\u03C2"
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_a_label("xn--nxasmq6b"));
 }
 
-TEST(IDNA_is_valid_a_label, deja_french) {
+TEST(deja_french) {
   // xn--dj-kia8a decodes to "d\u00E9j\u00E0"
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_a_label("xn--dj-kia8a"));
 }
 
-TEST(IDNA_is_valid_a_label, missing_prefix) {
+TEST(missing_prefix) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("abc"));
 }
 
-TEST(IDNA_is_valid_a_label, partial_prefix) {
+TEST(partial_prefix) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("xn-abc"));
 }
 
-TEST(IDNA_is_valid_a_label, empty_input) {
-  EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label(""));
-}
+TEST(empty_input) { EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("")); }
 
-TEST(IDNA_is_valid_a_label, only_prefix) {
+TEST(only_prefix) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("xn--"));
 }
 
-TEST(IDNA_is_valid_a_label, decodes_to_pure_ascii) {
+TEST(decodes_to_pure_ascii) {
   // The body "abc-" is a Punycode encoding whose result has no non-ASCII
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("xn--abc-"));
 }
 
-TEST(IDNA_is_valid_a_label, malformed_punycode_body) {
+TEST(malformed_punycode_body) {
   // A trailing hyphen with garbage extension chars is invalid Punycode
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("xn--abc-zzzzzzzz!"));
 }
 
-TEST(IDNA_is_valid_a_label, non_ascii_byte_in_input) {
+TEST(non_ascii_byte_in_input) {
   // U+00E4 ä is non-ASCII, so the whole input fails the ASCII requirement
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label("xn--\u00E4"));
 }
 
-TEST(IDNA_is_valid_a_label, uppercase_in_body) {
+TEST(uppercase_in_body) {
   // Punycode is case-insensitive but A-labels are conventionally lowercase.
   // An uppercase letter in the Punycode body is not the canonical
   // representation, so the round-trip check rejects it.
@@ -59,7 +57,7 @@ TEST(IDNA_is_valid_a_label, uppercase_in_body) {
 
 // RFC 5890 §2.3.2.1: a label in A-label form is at most 63 octets. A 64-octet
 // input is rejected on length alone, before any Punycode decoding
-TEST(IDNA_is_valid_a_label, exceeds_63_octets) {
+TEST(exceeds_63_octets) {
   const std::string label{"xn--" + std::string(60, 'a')};
   EXPECT_EQ(label.size(), 64);
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_a_label(label));

--- a/test/idna/idna_is_valid_u_label_test.cc
+++ b/test/idna/idna_is_valid_u_label_test.cc
@@ -1,147 +1,147 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
 #include <string> // std::u32string
 
-TEST(IDNA_is_valid_u_label, ascii_letters) {
+TEST(ascii_letters) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"abc"));
 }
 
-TEST(IDNA_is_valid_u_label, ascii_letters_and_digits) {
+TEST(ascii_letters_and_digits) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"abc123"));
 }
 
-TEST(IDNA_is_valid_u_label, ascii_with_internal_hyphen) {
+TEST(ascii_with_internal_hyphen) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"ab-cd"));
 }
 
-TEST(IDNA_is_valid_u_label, latin_with_diacritic) {
+TEST(latin_with_diacritic) {
   // d, e+acute, j, a+grave
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"d\u00E9j\u00E0"));
 }
 
-TEST(IDNA_is_valid_u_label, hebrew_label) {
+TEST(hebrew_label) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"\u05D0\u05D1\u05D2"));
 }
 
-TEST(IDNA_is_valid_u_label, arabic_label) {
+TEST(arabic_label) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"\u0627\u0628\u062A"));
 }
 
-TEST(IDNA_is_valid_u_label, devanagari_label) {
+TEST(devanagari_label) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"\u0905\u0915\u092E"));
 }
 
-TEST(IDNA_is_valid_u_label, devanagari_with_virama_zwj) {
+TEST(devanagari_with_virama_zwj) {
   // KA + VIRAMA + ZWJ + KA forms a valid ContextJ sequence
   EXPECT_TRUE(
       sourcemeta::core::idna_is_valid_u_label(U"\u0915\u094D\u200D\u0915"));
 }
 
-TEST(IDNA_is_valid_u_label, arabic_with_zwnj_context) {
+TEST(arabic_with_zwnj_context) {
   // Arabic BEH (D) + ZWNJ + Arabic ALEF (R) satisfies ContextJ A.1
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"\u0628\u200C\u0627"));
 }
 
-TEST(IDNA_is_valid_u_label, catalan_middle_dot) {
+TEST(catalan_middle_dot) {
   // l + U+00B7 + l satisfies ContextO A.3
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"l\u00B7l"));
 }
 
-TEST(IDNA_is_valid_u_label, single_letter) {
+TEST(single_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"a"));
 }
 
-TEST(IDNA_is_valid_u_label, empty_label) {
+TEST(empty_label) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U""));
 }
 
-TEST(IDNA_is_valid_u_label, leading_hyphen) {
+TEST(leading_hyphen) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"-abc"));
 }
 
-TEST(IDNA_is_valid_u_label, trailing_hyphen) {
+TEST(trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"abc-"));
 }
 
-TEST(IDNA_is_valid_u_label, double_hyphen_at_positions_3_and_4) {
+TEST(double_hyphen_at_positions_3_and_4) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"ab--cd"));
 }
 
-TEST(IDNA_is_valid_u_label, xn_prefix_pattern) {
+TEST(xn_prefix_pattern) {
   // The "xn--" pattern is the A-label prefix and must not appear in U-labels
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"xn--abc"));
 }
 
-TEST(IDNA_is_valid_u_label, exactly_four_chars_with_double_hyphen) {
+TEST(exactly_four_chars_with_double_hyphen) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"ab--"));
 }
 
-TEST(IDNA_is_valid_u_label, leading_nonspacing_combining_mark) {
+TEST(leading_nonspacing_combining_mark) {
   // U+0301 combining acute is general category Mn
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"\u0301abc"));
 }
 
-TEST(IDNA_is_valid_u_label, leading_spacing_combining_mark) {
+TEST(leading_spacing_combining_mark) {
   // U+093E Devanagari vowel sign Aa is general category Mc
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"\u093E\u0915"));
 }
 
-TEST(IDNA_is_valid_u_label, contains_uppercase_letter) {
+TEST(contains_uppercase_letter) {
   // Uppercase ASCII is DISALLOWED in IDNA2008
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"abcD"));
 }
 
-TEST(IDNA_is_valid_u_label, contains_full_stop) {
+TEST(contains_full_stop) {
   // ASCII full stop is DISALLOWED in a label
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"abc.def"));
 }
 
-TEST(IDNA_is_valid_u_label, contains_disallowed_control) {
+TEST(contains_disallowed_control) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u0007b"));
 }
 
-TEST(IDNA_is_valid_u_label, contains_disallowed_bidi_mark) {
+TEST(contains_disallowed_bidi_mark) {
   // U+200E LEFT-TO-RIGHT MARK is DISALLOWED
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u200Eb"));
 }
 
-TEST(IDNA_is_valid_u_label, contains_unassigned_codepoint) {
+TEST(contains_unassigned_codepoint) {
   // U+0E80 is unassigned in the Lao block
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u0E80b"));
 }
 
-TEST(IDNA_is_valid_u_label, zwj_without_virama_context_rejected) {
+TEST(zwj_without_virama_context_rejected) {
   // ZWJ between two non-virama letters fails ContextJ A.2
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u200Db"));
 }
 
-TEST(IDNA_is_valid_u_label, zwnj_with_no_joining_context_rejected) {
+TEST(zwnj_with_no_joining_context_rejected) {
   // ZWNJ between two ASCII letters fails ContextJ A.1
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u200Cb"));
 }
 
-TEST(IDNA_is_valid_u_label, middle_dot_not_flanked_by_l_rejected) {
+TEST(middle_dot_not_flanked_by_l_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u00B7b"));
 }
 
-TEST(IDNA_is_valid_u_label, greek_keraia_followed_by_non_greek_rejected) {
+TEST(greek_keraia_followed_by_non_greek_rejected) {
   // U+0375 must be followed by Greek script
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u0375b"));
 }
 
-TEST(IDNA_is_valid_u_label, arabic_indic_digit_mixed_with_extended_rejected) {
+TEST(arabic_indic_digit_mixed_with_extended_rejected) {
   // U+0660 and U+06F0 must not appear together
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"\u0627\u0660\u06F0"));
 }
 
-TEST(IDNA_is_valid_u_label, single_hyphen_in_position_3_only) {
+TEST(single_hyphen_in_position_3_only) {
   // Only position 3 is hyphen, position 4 is not, so allowed
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"ab-cdef"));
 }
 
-TEST(IDNA_is_valid_u_label, single_hyphen_in_position_4_only) {
+TEST(single_hyphen_in_position_4_only) {
   // Only position 4 is hyphen, position 3 is not, so allowed
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"abc-def"));
 }
@@ -150,36 +150,36 @@ TEST(IDNA_is_valid_u_label, single_hyphen_in_position_4_only) {
 // `a` (U+0061) and combining grave (U+0300) are both PVALID, so the only
 // reason this decomposed sequence is rejected is the missing NFC. The
 // precomposed `\u00E0` counterpart is accepted
-TEST(IDNA_is_valid_u_label, decomposed_lowercase_a_grave_rejected) {
+TEST(decomposed_lowercase_a_grave_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u0300"));
 }
 
-TEST(IDNA_is_valid_u_label, precomposed_lowercase_a_grave_accepted) {
+TEST(precomposed_lowercase_a_grave_accepted) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"\u00E0"));
 }
 
 // Out-of-order combining marks violate canonical CCC ordering, so the
 // label is not in NFC even though every codepoint is PVALID
-TEST(IDNA_is_valid_u_label, out_of_order_combining_marks_rejected) {
+TEST(out_of_order_combining_marks_rejected) {
   // a + U+0301 (CCC=230) + U+0316 (CCC=220)
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(U"a\u0301\u0316"));
 }
 
 // Hangul precomposed syllable is PVALID and already in NFC
-TEST(IDNA_is_valid_u_label, hangul_precomposed_syllable_accepted) {
+TEST(hangul_precomposed_syllable_accepted) {
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(U"\uAC00"));
 }
 
 // RFC 5890 \u00A72.3.2.1: the corresponding A-label must be at most 63 octets.
 // A pure-ASCII label of 58 "a" characters encodes to a 59-octet Punycode
 // body, which with the 4-octet "xn--" prefix is exactly 63 octets
-TEST(IDNA_is_valid_u_label, a_label_form_exactly_63_octets_accepted) {
+TEST(a_label_form_exactly_63_octets_accepted) {
   const std::u32string label(58, U'a');
   EXPECT_TRUE(sourcemeta::core::idna_is_valid_u_label(label));
 }
 
 // One additional character pushes the A-label form to 64 octets
-TEST(IDNA_is_valid_u_label, a_label_form_64_octets_rejected) {
+TEST(a_label_form_64_octets_rejected) {
   const std::u32string label(59, U'a');
   EXPECT_FALSE(sourcemeta::core::idna_is_valid_u_label(label));
 }

--- a/test/idna/idna_passes_bidi_rule_test.cc
+++ b/test/idna/idna_passes_bidi_rule_test.cc
@@ -1,153 +1,152 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
-TEST(IDNA_passes_bidi_rule, condition_1_first_char_latin_letter) {
+TEST(condition_1_first_char_latin_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"abc"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_1_first_char_hebrew_letter) {
+TEST(condition_1_first_char_hebrew_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_1_first_char_arabic_letter) {
+TEST(condition_1_first_char_arabic_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u0627"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_1_first_char_ascii_digit_rejected) {
+TEST(condition_1_first_char_ascii_digit_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"0abc"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_1_first_char_combining_mark_rejected) {
+TEST(condition_1_first_char_combining_mark_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u0301abc"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_1_first_char_punctuation_rejected) {
+TEST(condition_1_first_char_punctuation_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"@abc"));
 }
 
-TEST(IDNA_passes_bidi_rule,
-     condition_1_first_char_arabic_indic_digit_rejected) {
+TEST(condition_1_first_char_arabic_indic_digit_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u0660"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_2_rtl_with_allowed_mix) {
+TEST(condition_2_rtl_with_allowed_mix) {
   // Hebrew + ASCII digits + Hebrew
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0123\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_2_rtl_with_latin_letter_rejected) {
+TEST(condition_2_rtl_with_latin_letter_rejected) {
   // RTL label cannot contain L
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0a\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_2_rtl_with_paragraph_separator_rejected) {
+TEST(condition_2_rtl_with_paragraph_separator_rejected) {
   // U+2029 is bidi class B, not allowed
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0\u2029\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_2_rtl_with_lrm_isolate_rejected) {
+TEST(condition_2_rtl_with_lrm_isolate_rejected) {
   // U+2066 is LRI, not allowed
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0\u2066\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_hebrew) {
+TEST(condition_3_rtl_ends_with_hebrew) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_arabic) {
+TEST(condition_3_rtl_ends_with_arabic) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u0627\u0627"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_ascii_digit) {
+TEST(condition_3_rtl_ends_with_ascii_digit) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D01"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_arabic_indic_digit) {
+TEST(condition_3_rtl_ends_with_arabic_indic_digit) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u0627\u0660"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_trailing_nsm) {
+TEST(condition_3_rtl_ends_with_trailing_nsm) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0\u0301"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_multiple_trailing_nsms) {
+TEST(condition_3_rtl_ends_with_multiple_trailing_nsms) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0\u0301\u0301"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_punctuation_rejected) {
+TEST(condition_3_rtl_ends_with_punctuation_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0!"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_3_rtl_ends_with_comma_rejected) {
+TEST(condition_3_rtl_ends_with_comma_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0,"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_4_rtl_with_only_european_numbers) {
+TEST(condition_4_rtl_with_only_european_numbers) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D012"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_4_rtl_with_only_arabic_numbers) {
+TEST(condition_4_rtl_with_only_arabic_numbers) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u0627\u0660\u0661"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_4_rtl_with_both_en_and_an_rejected) {
+TEST(condition_4_rtl_with_both_en_and_an_rejected) {
   // Hebrew + ASCII digit + Arabic-Indic digit
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D01\u0660"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_5_ltr_with_allowed_mix) {
+TEST(condition_5_ltr_with_allowed_mix) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"abc123abc"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_5_ltr_with_hebrew_rejected) {
+TEST(condition_5_ltr_with_hebrew_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"abc\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_5_ltr_with_arabic_rejected) {
+TEST(condition_5_ltr_with_arabic_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"abc\u0627"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_5_ltr_with_arabic_indic_digit_rejected) {
+TEST(condition_5_ltr_with_arabic_indic_digit_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"abc\u0660"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_5_ltr_with_paragraph_separator_rejected) {
+TEST(condition_5_ltr_with_paragraph_separator_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"abc\u2029abc"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_6_ltr_ends_with_letter) {
+TEST(condition_6_ltr_ends_with_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"abc"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_6_ltr_ends_with_digit) {
+TEST(condition_6_ltr_ends_with_digit) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"abc123"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_6_ltr_ends_with_trailing_nsm) {
+TEST(condition_6_ltr_ends_with_trailing_nsm) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"abc\u0301"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_6_ltr_ends_with_punctuation_rejected) {
+TEST(condition_6_ltr_ends_with_punctuation_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"abc!"));
 }
 
-TEST(IDNA_passes_bidi_rule, condition_6_ltr_ends_with_comma_rejected) {
+TEST(condition_6_ltr_ends_with_comma_rejected) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U"abc,"));
 }
 
-TEST(IDNA_passes_bidi_rule, empty_label) {
+TEST(empty_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_bidi_rule(U""));
 }
 
-TEST(IDNA_passes_bidi_rule, single_latin_letter) {
+TEST(single_latin_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"a"));
 }
 
-TEST(IDNA_passes_bidi_rule, single_hebrew_letter) {
+TEST(single_hebrew_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u05D0"));
 }
 
-TEST(IDNA_passes_bidi_rule, single_arabic_letter) {
+TEST(single_arabic_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"\u0627"));
 }

--- a/test/idna/idna_passes_contextj_test.cc
+++ b/test/idna/idna_passes_contextj_test.cc
@@ -1,103 +1,103 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
-TEST(IDNA_passes_contextj, zwj_preceded_by_devanagari_virama) {
+TEST(zwj_preceded_by_devanagari_virama) {
   // Devanagari KA (U+0915) + VIRAMA (U+094D) + ZWJ (U+200D)
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"\u0915\u094D\u200D", 2));
 }
 
-TEST(IDNA_passes_contextj, zwj_preceded_by_bengali_virama) {
+TEST(zwj_preceded_by_bengali_virama) {
   // Bengali KA (U+0995) + VIRAMA (U+09CD) + ZWJ (U+200D)
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"\u0995\u09CD\u200D", 2));
 }
 
-TEST(IDNA_passes_contextj, zwj_preceded_by_non_virama_letter) {
+TEST(zwj_preceded_by_non_virama_letter) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"a\u200D", 1));
 }
 
-TEST(IDNA_passes_contextj, zwj_preceded_by_devanagari_letter_without_virama) {
+TEST(zwj_preceded_by_devanagari_letter_without_virama) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"\u0915\u200D", 1));
 }
 
-TEST(IDNA_passes_contextj, zwj_at_start_of_label) {
+TEST(zwj_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"\u200D", 0));
 }
 
-TEST(IDNA_passes_contextj, zwnj_preceded_by_devanagari_virama) {
+TEST(zwnj_preceded_by_devanagari_virama) {
   // Devanagari KA + VIRAMA + ZWNJ
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"\u0915\u094D\u200C", 2));
 }
 
-TEST(IDNA_passes_contextj, zwnj_between_arabic_dual_joining) {
+TEST(zwnj_between_arabic_dual_joining) {
   // Arabic BEH (D) + ZWNJ + Arabic BEH (D)
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"\u0628\u200C\u0628", 1));
 }
 
-TEST(IDNA_passes_contextj, zwnj_between_arabic_dual_and_right_joining) {
+TEST(zwnj_between_arabic_dual_and_right_joining) {
   // Arabic BEH (D) + ZWNJ + Arabic ALEF (R)
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"\u0628\u200C\u0627", 1));
 }
 
-TEST(IDNA_passes_contextj, zwnj_with_transparent_before) {
+TEST(zwnj_with_transparent_before) {
   // Arabic BEH (D) + COMBINING ACUTE (T) + ZWNJ + Arabic ALEF (R)
   EXPECT_TRUE(
       sourcemeta::core::idna_passes_contextj(U"\u0628\u0301\u200C\u0627", 2));
 }
 
-TEST(IDNA_passes_contextj, zwnj_with_transparent_after) {
+TEST(zwnj_with_transparent_after) {
   // Arabic BEH (D) + ZWNJ + COMBINING ACUTE (T) + Arabic ALEF (R)
   EXPECT_TRUE(
       sourcemeta::core::idna_passes_contextj(U"\u0628\u200C\u0301\u0627", 1));
 }
 
-TEST(IDNA_passes_contextj, zwnj_with_transparents_both_sides) {
+TEST(zwnj_with_transparents_both_sides) {
   // Arabic BEH (D) + COMBINING ACUTE (T) + ZWNJ + COMBINING ACUTE (T) + Arabic
   // ALEF (R)
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(
       U"\u0628\u0301\u200C\u0301\u0627", 2));
 }
 
-TEST(IDNA_passes_contextj, zwnj_with_no_joining_context) {
+TEST(zwnj_with_no_joining_context) {
   // ASCII letters have Non_Joining type, so no L|D before or R|D after.
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"a\u200Cb", 1));
 }
 
-TEST(IDNA_passes_contextj, zwnj_at_start_of_label) {
+TEST(zwnj_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"\u200C\u0627", 0));
 }
 
-TEST(IDNA_passes_contextj, zwnj_at_end_of_label) {
+TEST(zwnj_at_end_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"\u0628\u200C", 1));
 }
 
-TEST(IDNA_passes_contextj, zwnj_only_backward_joining_match) {
+TEST(zwnj_only_backward_joining_match) {
   // Arabic BEH (D) + ZWNJ + ASCII a (Non_Joining)
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"\u0628\u200Ca", 1));
 }
 
-TEST(IDNA_passes_contextj, zwnj_only_forward_joining_match) {
+TEST(zwnj_only_forward_joining_match) {
   // ASCII a (Non_Joining) + ZWNJ + Arabic ALEF (R)
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"a\u200C\u0627", 1));
 }
 
-TEST(IDNA_passes_contextj, ascii_letter_has_no_rule) {
+TEST(ascii_letter_has_no_rule) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"abc", 0));
 }
 
-TEST(IDNA_passes_contextj, devanagari_letter_has_no_rule) {
+TEST(devanagari_letter_has_no_rule) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"\u0905", 0));
 }
 
-TEST(IDNA_passes_contextj, middle_dot_has_no_contextj_rule) {
+TEST(middle_dot_has_no_contextj_rule) {
   // U+00B7 has a ContextO rule but not ContextJ
   EXPECT_TRUE(sourcemeta::core::idna_passes_contextj(U"l\u00B7l", 1));
 }
 
-TEST(IDNA_passes_contextj, position_out_of_range) {
+TEST(position_out_of_range) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"abc", 10));
 }
 
-TEST(IDNA_passes_contextj, empty_label) {
+TEST(empty_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contextj(U"", 0));
 }

--- a/test/idna/idna_passes_contexto_test.cc
+++ b/test/idna/idna_passes_contexto_test.cc
@@ -1,123 +1,123 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
-TEST(IDNA_passes_contexto, middle_dot_between_latin_l) {
+TEST(middle_dot_between_latin_l) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"l\u00B7l", 1));
 }
 
-TEST(IDNA_passes_contexto, middle_dot_not_flanked_by_l) {
+TEST(middle_dot_not_flanked_by_l) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"a\u00B7b", 1));
 }
 
-TEST(IDNA_passes_contexto, middle_dot_only_preceded_by_l) {
+TEST(middle_dot_only_preceded_by_l) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"l\u00B7a", 1));
 }
 
-TEST(IDNA_passes_contexto, middle_dot_only_followed_by_l) {
+TEST(middle_dot_only_followed_by_l) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"a\u00B7l", 1));
 }
 
-TEST(IDNA_passes_contexto, middle_dot_at_start_of_label) {
+TEST(middle_dot_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u00B7l", 0));
 }
 
-TEST(IDNA_passes_contexto, middle_dot_at_end_of_label) {
+TEST(middle_dot_at_end_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"l\u00B7", 1));
 }
 
-TEST(IDNA_passes_contexto, greek_keraia_followed_by_greek) {
+TEST(greek_keraia_followed_by_greek) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u0375\u0391", 0));
 }
 
-TEST(IDNA_passes_contexto, greek_keraia_followed_by_latin) {
+TEST(greek_keraia_followed_by_latin) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u0375a", 0));
 }
 
-TEST(IDNA_passes_contexto, greek_keraia_at_end_of_label) {
+TEST(greek_keraia_at_end_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"a\u0375", 1));
 }
 
-TEST(IDNA_passes_contexto, hebrew_geresh_preceded_by_hebrew) {
+TEST(hebrew_geresh_preceded_by_hebrew) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u05D0\u05F3", 1));
 }
 
-TEST(IDNA_passes_contexto, hebrew_geresh_preceded_by_latin) {
+TEST(hebrew_geresh_preceded_by_latin) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"a\u05F3", 1));
 }
 
-TEST(IDNA_passes_contexto, hebrew_geresh_at_start_of_label) {
+TEST(hebrew_geresh_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u05F3a", 0));
 }
 
-TEST(IDNA_passes_contexto, hebrew_gershayim_preceded_by_hebrew) {
+TEST(hebrew_gershayim_preceded_by_hebrew) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u05D0\u05F4", 1));
 }
 
-TEST(IDNA_passes_contexto, hebrew_gershayim_preceded_by_latin) {
+TEST(hebrew_gershayim_preceded_by_latin) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"a\u05F4", 1));
 }
 
-TEST(IDNA_passes_contexto, hebrew_gershayim_at_start_of_label) {
+TEST(hebrew_gershayim_at_start_of_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u05F4a", 0));
 }
 
-TEST(IDNA_passes_contexto, katakana_middle_dot_with_katakana) {
+TEST(katakana_middle_dot_with_katakana) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u30A2\u30FB\u30A4", 1));
 }
 
-TEST(IDNA_passes_contexto, katakana_middle_dot_with_hiragana) {
+TEST(katakana_middle_dot_with_hiragana) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u3042\u30FB\u3044", 1));
 }
 
-TEST(IDNA_passes_contexto, katakana_middle_dot_with_han) {
+TEST(katakana_middle_dot_with_han) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u6F22\u30FB\u5B57", 1));
 }
 
-TEST(IDNA_passes_contexto, katakana_middle_dot_with_only_latin) {
+TEST(katakana_middle_dot_with_only_latin) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"a\u30FBb", 1));
 }
 
-TEST(IDNA_passes_contexto, katakana_middle_dot_alone) {
+TEST(katakana_middle_dot_alone) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u30FB", 0));
 }
 
-TEST(IDNA_passes_contexto, arabic_indic_digits_only) {
+TEST(arabic_indic_digits_only) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u0660\u0661\u0662", 0));
 }
 
-TEST(IDNA_passes_contexto, arabic_indic_digit_mixed_with_extended) {
+TEST(arabic_indic_digit_mixed_with_extended) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u0660\u06F0", 0));
 }
 
-TEST(IDNA_passes_contexto, extended_arabic_indic_digits_only) {
+TEST(extended_arabic_indic_digits_only) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u06F0\u06F1\u06F2", 0));
 }
 
-TEST(IDNA_passes_contexto, extended_arabic_indic_mixed_with_standard) {
+TEST(extended_arabic_indic_mixed_with_standard) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"\u06F0\u0660", 0));
 }
 
-TEST(IDNA_passes_contexto, position_out_of_range) {
+TEST(position_out_of_range) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"abc", 10));
 }
 
-TEST(IDNA_passes_contexto, empty_label) {
+TEST(empty_label) {
   EXPECT_FALSE(sourcemeta::core::idna_passes_contexto(U"", 0));
 }
 
-TEST(IDNA_passes_contexto, ascii_letter_has_no_rule) {
+TEST(ascii_letter_has_no_rule) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"abc", 0));
 }
 
-TEST(IDNA_passes_contexto, ascii_digit_has_no_rule) {
+TEST(ascii_digit_has_no_rule) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"a0b", 1));
 }
 
-TEST(IDNA_passes_contexto, devanagari_letter_has_no_rule) {
+TEST(devanagari_letter_has_no_rule) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u0905", 0));
 }
 
-TEST(IDNA_passes_contexto, zero_width_joiner_has_no_contexto_rule) {
+TEST(zero_width_joiner_has_no_contexto_rule) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"\u200D", 0));
 }

--- a/test/idna/idna_property_test.cc
+++ b/test/idna/idna_property_test.cc
@@ -1,118 +1,118 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/idna.h>
 
-TEST(IDNA_property, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'a'),
             sourcemeta::core::IDNAProperty::PValid);
 }
 
-TEST(IDNA_property, ascii_digit) {
+TEST(ascii_digit) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'0'),
             sourcemeta::core::IDNAProperty::PValid);
 }
 
-TEST(IDNA_property, ascii_hyphen) {
+TEST(ascii_hyphen) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'-'),
             sourcemeta::core::IDNAProperty::PValid);
 }
 
-TEST(IDNA_property, ascii_uppercase_letter_disallowed) {
+TEST(ascii_uppercase_letter_disallowed) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'A'),
             sourcemeta::core::IDNAProperty::Disallowed);
 }
 
-TEST(IDNA_property, ascii_full_stop_disallowed) {
+TEST(ascii_full_stop_disallowed) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'.'),
             sourcemeta::core::IDNAProperty::Disallowed);
 }
 
-TEST(IDNA_property, control_character_disallowed) {
+TEST(control_character_disallowed) {
   EXPECT_EQ(sourcemeta::core::idna_property(0x0007),
             sourcemeta::core::IDNAProperty::Disallowed);
 }
 
-TEST(IDNA_property, hebrew_letter_alef_pvalid) {
+TEST(hebrew_letter_alef_pvalid) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u05D0'),
             sourcemeta::core::IDNAProperty::PValid);
 }
 
-TEST(IDNA_property, arabic_letter_alef_pvalid) {
+TEST(arabic_letter_alef_pvalid) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u0627'),
             sourcemeta::core::IDNAProperty::PValid);
 }
 
-TEST(IDNA_property, devanagari_letter_pvalid) {
+TEST(devanagari_letter_pvalid) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u0905'),
             sourcemeta::core::IDNAProperty::PValid);
 }
 
-TEST(IDNA_property, zero_width_joiner_contextj) {
+TEST(zero_width_joiner_contextj) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u200D'),
             sourcemeta::core::IDNAProperty::ContextJ);
 }
 
-TEST(IDNA_property, zero_width_non_joiner_contextj) {
+TEST(zero_width_non_joiner_contextj) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u200C'),
             sourcemeta::core::IDNAProperty::ContextJ);
 }
 
-TEST(IDNA_property, middle_dot_contexto) {
+TEST(middle_dot_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u00B7'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, greek_lower_numeral_sign_contexto) {
+TEST(greek_lower_numeral_sign_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u0375'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, hebrew_geresh_contexto) {
+TEST(hebrew_geresh_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u05F3'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, hebrew_gershayim_contexto) {
+TEST(hebrew_gershayim_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u05F4'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, katakana_middle_dot_contexto) {
+TEST(katakana_middle_dot_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u30FB'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, arabic_indic_digit_zero_contexto) {
+TEST(arabic_indic_digit_zero_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u0660'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, extended_arabic_indic_digit_zero_contexto) {
+TEST(extended_arabic_indic_digit_zero_contexto) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'\u06F0'),
             sourcemeta::core::IDNAProperty::ContextO);
 }
 
-TEST(IDNA_property, ltr_mark_disallowed) {
+TEST(ltr_mark_disallowed) {
   EXPECT_EQ(sourcemeta::core::idna_property(0x200E),
             sourcemeta::core::IDNAProperty::Disallowed);
 }
 
-TEST(IDNA_property, rtl_mark_disallowed) {
+TEST(rtl_mark_disallowed) {
   EXPECT_EQ(sourcemeta::core::idna_property(0x200F),
             sourcemeta::core::IDNAProperty::Disallowed);
 }
 
-TEST(IDNA_property, unassigned_in_lao_block) {
+TEST(unassigned_in_lao_block) {
   EXPECT_EQ(sourcemeta::core::idna_property(0x0E80),
             sourcemeta::core::IDNAProperty::Unassigned);
 }
 
-TEST(IDNA_property, max_codepoint_disallowed_noncharacter) {
+TEST(max_codepoint_disallowed_noncharacter) {
   EXPECT_EQ(sourcemeta::core::idna_property(0x10FFFF),
             sourcemeta::core::IDNAProperty::Disallowed);
 }
 
-TEST(IDNA_property, above_max_codepoint_unassigned) {
+TEST(above_max_codepoint_unassigned) {
   EXPECT_EQ(sourcemeta::core::idna_property(0x110000),
             sourcemeta::core::IDNAProperty::Unassigned);
 }

--- a/test/ip/CMakeLists.txt
+++ b/test/ip/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME ip
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME ip
   SOURCES ipv4_test.cc ipv6_test.cc)
 
 target_link_libraries(sourcemeta_core_ip_unit

--- a/test/ip/ipv4_test.cc
+++ b/test/ip/ipv4_test.cc
@@ -1,289 +1,263 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/ip.h>
 
-TEST(IP_ipv4, valid_all_zeros) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv4("0.0.0.0"));
-}
+TEST(valid_all_zeros) { EXPECT_TRUE(sourcemeta::core::is_ipv4("0.0.0.0")); }
 
-TEST(IP_ipv4, valid_all_max) {
+TEST(valid_all_max) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("255.255.255.255"));
 }
 
-TEST(IP_ipv4, valid_private_class_c) {
+TEST(valid_private_class_c) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("192.168.1.1"));
 }
 
-TEST(IP_ipv4, valid_private_class_a) {
+TEST(valid_private_class_a) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("10.0.0.1"));
 }
 
-TEST(IP_ipv4, valid_loopback) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv4("127.0.0.1"));
-}
+TEST(valid_loopback) { EXPECT_TRUE(sourcemeta::core::is_ipv4("127.0.0.1")); }
 
-TEST(IP_ipv4, valid_simple) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv4("1.2.3.4"));
-}
+TEST(valid_simple) { EXPECT_TRUE(sourcemeta::core::is_ipv4("1.2.3.4")); }
 
-TEST(IP_ipv4, valid_three_digit_octets) {
+TEST(valid_three_digit_octets) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("100.200.30.40"));
 }
 
-TEST(IP_ipv4, valid_high_octets) {
+TEST(valid_high_octets) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("249.249.249.249"));
 }
 
-TEST(IP_ipv4, valid_boundary_250s) {
+TEST(valid_boundary_250s) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("250.251.252.253"));
 }
 
-TEST(IP_ipv4, valid_first_octet_zero) {
+TEST(valid_first_octet_zero) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("0.0.0.1"));
 }
 
-TEST(IP_ipv4, valid_last_octets_zero) {
+TEST(valid_last_octets_zero) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("1.0.0.0"));
 }
 
-TEST(IP_ipv4, valid_single_digits) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv4("1.1.1.1"));
-}
+TEST(valid_single_digits) { EXPECT_TRUE(sourcemeta::core::is_ipv4("1.1.1.1")); }
 
-TEST(IP_ipv4, valid_two_digit_octets) {
+TEST(valid_two_digit_octets) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("99.88.77.66"));
 }
 
-TEST(IP_ipv4, valid_mixed_lengths) {
+TEST(valid_mixed_lengths) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("1.22.123.4"));
 }
 
-TEST(IP_ipv4, valid_254_boundary) {
+TEST(valid_254_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("254.254.254.254"));
 }
 
-TEST(IP_ipv4, valid_broadcast) {
+TEST(valid_broadcast) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("255.255.255.0"));
 }
 
-TEST(IP_ipv4, invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_ipv4("")); }
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_ipv4("")); }
 
-TEST(IP_ipv4, invalid_first_octet_overflow) {
+TEST(invalid_first_octet_overflow) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("256.0.0.0"));
 }
 
-TEST(IP_ipv4, invalid_last_octet_overflow) {
+TEST(invalid_last_octet_overflow) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0.0.0.256"));
 }
 
-TEST(IP_ipv4, invalid_five_octets) {
+TEST(invalid_five_octets) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4.5"));
 }
 
-TEST(IP_ipv4, invalid_three_octets) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3"));
-}
+TEST(invalid_three_octets) { EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3")); }
 
-TEST(IP_ipv4, invalid_two_octets) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2"));
-}
+TEST(invalid_two_octets) { EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2")); }
 
-TEST(IP_ipv4, invalid_one_octet) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("1"));
-}
+TEST(invalid_one_octet) { EXPECT_FALSE(sourcemeta::core::is_ipv4("1")); }
 
-TEST(IP_ipv4, invalid_leading_zeros_all) {
+TEST(invalid_leading_zeros_all) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("01.02.03.04"));
 }
 
-TEST(IP_ipv4, invalid_leading_zero_second_octet) {
+TEST(invalid_leading_zero_second_octet) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.02.3.4"));
 }
 
-TEST(IP_ipv4, invalid_double_leading_zero) {
+TEST(invalid_double_leading_zero) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("00.0.0.0"));
 }
 
-TEST(IP_ipv4, invalid_leading_dot) {
+TEST(invalid_leading_dot) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4(".1.2.3.4"));
 }
 
-TEST(IP_ipv4, invalid_trailing_dot) {
+TEST(invalid_trailing_dot) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4."));
 }
 
-TEST(IP_ipv4, invalid_empty_octet) {
+TEST(invalid_empty_octet) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1..2.3.4"));
 }
 
-TEST(IP_ipv4, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4 "));
 }
 
-TEST(IP_ipv4, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4(" 1.2.3.4"));
 }
 
-TEST(IP_ipv4, invalid_alpha_in_octet) {
+TEST(invalid_alpha_in_octet) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.a"));
 }
 
-TEST(IP_ipv4, invalid_hex_prefix) {
+TEST(invalid_hex_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0x1.0x2.0x3.0x4"));
 }
 
-TEST(IP_ipv4, invalid_all_overflow) {
+TEST(invalid_all_overflow) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("999.999.999.999"));
 }
 
-TEST(IP_ipv4, invalid_negative) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("-1.0.0.0"));
-}
+TEST(invalid_negative) { EXPECT_FALSE(sourcemeta::core::is_ipv4("-1.0.0.0")); }
 
-TEST(IP_ipv4, invalid_cidr_suffix) {
+TEST(invalid_cidr_suffix) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4/24"));
 }
 
-TEST(IP_ipv4, invalid_leading_zero_last_octet) {
+TEST(invalid_leading_zero_last_octet) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.04"));
 }
 
-TEST(IP_ipv4, invalid_three_digit_leading_zeros) {
+TEST(invalid_three_digit_leading_zeros) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("192.168.001.1"));
 }
 
-TEST(IP_ipv4, invalid_port_appended) {
+TEST(invalid_port_appended) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4:80"));
 }
 
-TEST(IP_ipv4, invalid_only_dots) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("..."));
-}
+TEST(invalid_only_dots) { EXPECT_FALSE(sourcemeta::core::is_ipv4("...")); }
 
-TEST(IP_ipv4, invalid_four_dots) {
+TEST(invalid_four_dots) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4.5."));
 }
 
-TEST(IP_ipv4, invalid_words) {
+TEST(invalid_words) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("one.two.three.four"));
 }
 
-TEST(IP_ipv4, invalid_octet_260) {
+TEST(invalid_octet_260) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("260.0.0.0"));
 }
 
-TEST(IP_ipv4, invalid_four_digit_octet) {
+TEST(invalid_four_digit_octet) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1000.0.0.0"));
 }
 
-TEST(IP_ipv4, invalid_just_dot) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("."));
-}
+TEST(invalid_just_dot) { EXPECT_FALSE(sourcemeta::core::is_ipv4(".")); }
 
-TEST(IP_ipv4, invalid_three_empty_dots) {
+TEST(invalid_three_empty_dots) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4(".."));
 }
 
-TEST(IP_ipv4, invalid_plus_sign) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4("+1.2.3.4"));
-}
+TEST(invalid_plus_sign) { EXPECT_FALSE(sourcemeta::core::is_ipv4("+1.2.3.4")); }
 
-TEST(IP_ipv4, invalid_leading_zero_first_octet_200) {
+TEST(invalid_leading_zero_first_octet_200) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0200.0.0.0"));
 }
 
-TEST(IP_ipv4, valid_boundary_199) {
+TEST(valid_boundary_199) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("199.199.199.199"));
 }
 
-TEST(IP_ipv4, valid_boundary_200) {
+TEST(valid_boundary_200) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("200.200.200.200"));
 }
 
-TEST(IP_ipv4, valid_boundary_9) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv4("9.9.9.9"));
-}
+TEST(valid_boundary_9) { EXPECT_TRUE(sourcemeta::core::is_ipv4("9.9.9.9")); }
 
-TEST(IP_ipv4, valid_boundary_10) {
+TEST(valid_boundary_10) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("10.10.10.10"));
 }
 
-TEST(IP_ipv4, valid_boundary_99) {
+TEST(valid_boundary_99) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("99.99.99.99"));
 }
 
-TEST(IP_ipv4, valid_boundary_100) {
+TEST(valid_boundary_100) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("100.100.100.100"));
 }
 
-TEST(IP_ipv4, valid_boundary_250) {
+TEST(valid_boundary_250) {
   EXPECT_TRUE(sourcemeta::core::is_ipv4("250.250.250.250"));
 }
 
-TEST(IP_ipv4, invalid_second_octet_overflow) {
+TEST(invalid_second_octet_overflow) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0.256.0.0"));
 }
 
-TEST(IP_ipv4, invalid_third_octet_overflow) {
+TEST(invalid_third_octet_overflow) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0.0.256.0"));
 }
 
-TEST(IP_ipv4, invalid_third_octet_300) {
+TEST(invalid_third_octet_300) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0.0.300.0"));
 }
 
-TEST(IP_ipv4, invalid_leading_zero_last_octet_double) {
+TEST(invalid_leading_zero_last_octet_double) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("0.0.0.00"));
 }
 
-TEST(IP_ipv4, invalid_trailing_tab) {
+TEST(invalid_trailing_tab) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4\t"));
 }
 
-TEST(IP_ipv4, invalid_leading_tab) {
+TEST(invalid_leading_tab) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("\t1.2.3.4"));
 }
 
-TEST(IP_ipv4, invalid_trailing_newline) {
+TEST(invalid_trailing_newline) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4\n"));
 }
 
-TEST(IP_ipv4, invalid_leading_newline) {
+TEST(invalid_leading_newline) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("\n1.2.3.4"));
 }
 
-TEST(IP_ipv4, invalid_trailing_crlf) {
+TEST(invalid_trailing_crlf) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2.3.4\r\n"));
 }
 
-TEST(IP_ipv4, invalid_space_after_dot) {
+TEST(invalid_space_after_dot) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1. 2.3.4"));
 }
 
-TEST(IP_ipv4, invalid_space_before_dot) {
+TEST(invalid_space_before_dot) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1.2 .3.4"));
 }
 
-TEST(IP_ipv4, invalid_comma_separators) {
+TEST(invalid_comma_separators) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1,2,3,4"));
 }
 
-TEST(IP_ipv4, invalid_semicolon_separators) {
+TEST(invalid_semicolon_separators) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1;2;3;4"));
 }
 
-TEST(IP_ipv4, invalid_colon_separators) {
+TEST(invalid_colon_separators) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("1:2:3:4"));
 }
 
-TEST(IP_ipv4, invalid_very_long_octet) {
+TEST(invalid_very_long_octet) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("12345678901234567890.0.0.0"));
 }
 
-TEST(IP_ipv4, invalid_eight_octets) {
+TEST(invalid_eight_octets) {
   EXPECT_FALSE(sourcemeta::core::is_ipv4("255.255.255.255.255.255.255.255"));
 }
 
-TEST(IP_ipv4, invalid_whitespace_only) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv4(" "));
-}
+TEST(invalid_whitespace_only) { EXPECT_FALSE(sourcemeta::core::is_ipv4(" ")); }

--- a/test/ip/ipv6_test.cc
+++ b/test/ip/ipv6_test.cc
@@ -1,374 +1,358 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/ip.h>
 
-TEST(IP_ipv6, valid_unspecified) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv6("::"));
-}
+TEST(valid_unspecified) { EXPECT_TRUE(sourcemeta::core::is_ipv6("::")); }
 
-TEST(IP_ipv6, valid_loopback) { EXPECT_TRUE(sourcemeta::core::is_ipv6("::1")); }
+TEST(valid_loopback) { EXPECT_TRUE(sourcemeta::core::is_ipv6("::1")); }
 
-TEST(IP_ipv6, valid_documentation_prefix) {
+TEST(valid_documentation_prefix) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("2001:db8::1"));
 }
 
-TEST(IP_ipv6, valid_full_form_leading_zeros) {
+TEST(valid_full_form_leading_zeros) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("2001:0db8:0000:0000:0000:0000:0000:0001"));
 }
 
-TEST(IP_ipv6, valid_mixed_elision) {
+TEST(valid_mixed_elision) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("2001:db8:85a3::8a2e:370:7334"));
 }
 
-TEST(IP_ipv6, valid_link_local) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv6("fe80::1"));
-}
+TEST(valid_link_local) { EXPECT_TRUE(sourcemeta::core::is_ipv6("fe80::1")); }
 
-TEST(IP_ipv6, valid_multicast) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv6("ff02::1"));
-}
+TEST(valid_multicast) { EXPECT_TRUE(sourcemeta::core::is_ipv6("ff02::1")); }
 
-TEST(IP_ipv6, valid_ipv4_mapped) {
+TEST(valid_ipv4_mapped) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:192.168.1.1"));
 }
 
-TEST(IP_ipv6, valid_ipv4_mapped_with_group) {
+TEST(valid_ipv4_mapped_with_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:0:192.168.1.1"));
 }
 
-TEST(IP_ipv6, valid_ipv4_mixed_with_compression) {
+TEST(valid_ipv4_mixed_with_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("2001:db8::192.168.1.1"));
 }
 
-TEST(IP_ipv6, valid_all_zeros_explicit) {
+TEST(valid_all_zeros_explicit) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("0:0:0:0:0:0:0:0"));
 }
 
-TEST(IP_ipv6, valid_loopback_explicit) {
+TEST(valid_loopback_explicit) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("0:0:0:0:0:0:0:1"));
 }
 
-TEST(IP_ipv6, valid_uppercase) {
+TEST(valid_uppercase) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("ABCD:EF01:2345:6789:ABCD:EF01:2345:6789"));
 }
 
-TEST(IP_ipv6, valid_lowercase) {
+TEST(valid_lowercase) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("abcd:ef01:2345:6789:abcd:ef01:2345:6789"));
 }
 
-TEST(IP_ipv6, valid_mixed_case) {
+TEST(valid_mixed_case) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("AbCd:eF01:2345:6789:aBcD:Ef01:2345:6789"));
 }
 
-TEST(IP_ipv6, valid_all_single_digit_groups) {
+TEST(valid_all_single_digit_groups) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_first_group) {
+TEST(valid_elide_first_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::2:3:4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_second_group) {
+TEST(valid_elide_second_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1::3:4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_third_group) {
+TEST(valid_elide_third_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_fourth_group) {
+TEST(valid_elide_fourth_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3::5:6:7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_fifth_group) {
+TEST(valid_elide_fifth_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4::6:7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_sixth_group) {
+TEST(valid_elide_sixth_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5::7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_seventh_group) {
+TEST(valid_elide_seventh_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6::8"));
 }
 
-TEST(IP_ipv6, valid_elide_last_group) {
+TEST(valid_elide_last_group) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7::"));
 }
 
-TEST(IP_ipv6, valid_elide_last_seven) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::"));
-}
+TEST(valid_elide_last_seven) { EXPECT_TRUE(sourcemeta::core::is_ipv6("1::")); }
 
-TEST(IP_ipv6, valid_elide_first_seven) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv6("::8"));
-}
+TEST(valid_elide_first_seven) { EXPECT_TRUE(sourcemeta::core::is_ipv6("::8")); }
 
-TEST(IP_ipv6, valid_ipv4_suffix_no_compression) {
+TEST(valid_ipv4_suffix_no_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_all_elided) {
+TEST(valid_ipv4_suffix_all_elided) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_ffff) {
+TEST(valid_ipv4_suffix_ffff) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::ffff:1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_with_one_group_and_compression) {
+TEST(valid_ipv4_suffix_with_one_group_and_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1::1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_with_four_groups_and_compression) {
+TEST(valid_ipv4_suffix_with_four_groups_and_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4::1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_all_max) {
+TEST(valid_all_max) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF"));
 }
 
-TEST(IP_ipv6, valid_all_zeros_leading_zeros) {
+TEST(valid_all_zeros_leading_zeros) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("0000:0000:0000:0000:0000:0000:0000:0000"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_max) {
+TEST(valid_ipv4_suffix_max) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:255.255.255.255"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_zeros) {
+TEST(valid_ipv4_suffix_zeros) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:0.0.0.0"));
 }
 
-TEST(IP_ipv6, valid_elide_multiple_middle) {
+TEST(valid_elide_multiple_middle) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::7:8"));
 }
 
-TEST(IP_ipv6, valid_elide_six_groups) {
-  EXPECT_TRUE(sourcemeta::core::is_ipv6("1::8"));
-}
+TEST(valid_elide_six_groups) { EXPECT_TRUE(sourcemeta::core::is_ipv6("1::8")); }
 
-TEST(IP_ipv6, valid_rfc2732_full) {
+TEST(valid_rfc2732_full) {
   EXPECT_TRUE(
       sourcemeta::core::is_ipv6("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210"));
 }
 
-TEST(IP_ipv6, valid_rfc2732_with_zeros) {
+TEST(valid_rfc2732_with_zeros) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1080:0:0:0:8:800:200C:417A"));
 }
 
-TEST(IP_ipv6, valid_rfc2732_compressed) {
+TEST(valid_rfc2732_compressed) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("3ffe:2a00:100:7031::1"));
 }
 
-TEST(IP_ipv6, valid_ipv4_compatible_deprecated) {
+TEST(valid_ipv4_compatible_deprecated) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::192.9.5.5"));
 }
 
-TEST(IP_ipv6, valid_ipv4_mapped_uppercase_ffff) {
+TEST(valid_ipv4_mapped_uppercase_ffff) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::FFFF:129.144.52.38"));
 }
 
-TEST(IP_ipv6, valid_two_groups_with_compression) {
+TEST(valid_two_groups_with_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("2010:836B:4179::836B:4179"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_two_groups_compressed) {
+TEST(valid_ipv4_suffix_two_groups_compressed) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2::5:6:1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_ipv4_suffix_three_groups_compressed) {
+TEST(valid_ipv4_suffix_three_groups_compressed) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1::4:5:6:1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_ipv6("")); }
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_ipv6("")); }
 
-TEST(IP_ipv6, invalid_nine_groups) {
+TEST(invalid_nine_groups) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:8:9"));
 }
 
-TEST(IP_ipv6, invalid_double_compression) {
+TEST(invalid_double_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1::2::3"));
 }
 
-TEST(IP_ipv6, invalid_seven_groups_no_compression) {
+TEST(invalid_seven_groups_no_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7"));
 }
 
-TEST(IP_ipv6, invalid_non_hex_character) {
+TEST(invalid_non_hex_character) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::gggg"));
 }
 
-TEST(IP_ipv6, invalid_five_hex_digits) {
+TEST(invalid_five_hex_digits) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:00001"));
 }
 
-TEST(IP_ipv6, invalid_leading_single_colon) {
+TEST(invalid_leading_single_colon) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6(":1:2:3:4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, invalid_trailing_single_colon) {
+TEST(invalid_trailing_single_colon) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:8:"));
 }
 
-TEST(IP_ipv6, invalid_triple_colon_start) {
+TEST(invalid_triple_colon_start) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6(":::1"));
 }
 
-TEST(IP_ipv6, invalid_triple_colon_middle) {
+TEST(invalid_triple_colon_middle) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:::2"));
 }
 
-TEST(IP_ipv6, invalid_plain_ipv4) {
+TEST(invalid_plain_ipv4) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("192.168.1.1"));
 }
 
-TEST(IP_ipv6, invalid_brackets_included) {
+TEST(invalid_brackets_included) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("[2001:db8::1]"));
 }
 
-TEST(IP_ipv6, invalid_zone_id) {
+TEST(invalid_zone_id) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("2001:db8::1%eth0"));
 }
 
-TEST(IP_ipv6, invalid_too_many_groups_with_ipv4) {
+TEST(invalid_too_many_groups_with_ipv4) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:8:1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_eight_groups_with_ipv4) {
+TEST(invalid_eight_groups_with_ipv4) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_ipv4_octet_overflow_in_mixed) {
+TEST(invalid_ipv4_octet_overflow_in_mixed) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::1.2.3.256"));
 }
 
-TEST(IP_ipv6, invalid_incomplete_ipv4_in_mixed) {
+TEST(invalid_incomplete_ipv4_in_mixed) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::1.2.3"));
 }
 
-TEST(IP_ipv6, invalid_five_groups_before_ipv4) {
+TEST(invalid_five_groups_before_ipv4) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_words) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv6("hello"));
-}
+TEST(invalid_words) { EXPECT_FALSE(sourcemeta::core::is_ipv6("hello")); }
 
-TEST(IP_ipv6, invalid_single_colon) {
-  EXPECT_FALSE(sourcemeta::core::is_ipv6(":"));
-}
+TEST(invalid_single_colon) { EXPECT_FALSE(sourcemeta::core::is_ipv6(":")); }
 
-TEST(IP_ipv6, invalid_trailing_colon_not_double) {
+TEST(invalid_trailing_colon_not_double) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7:"));
 }
 
-TEST(IP_ipv6, invalid_leading_colon_not_double) {
+TEST(invalid_leading_colon_not_double) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6(":1:2:3:4:5:6:7"));
 }
 
-TEST(IP_ipv6, invalid_ipv4_leading_zero_in_mixed) {
+TEST(invalid_ipv4_leading_zero_in_mixed) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:1.2.3.04"));
 }
 
-TEST(IP_ipv6, invalid_space_in_address) {
+TEST(invalid_space_in_address) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("2001:db8:: 1"));
 }
 
-TEST(IP_ipv6, invalid_empty_group) {
+TEST(invalid_empty_group) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3::5:6:7:8:9"));
 }
 
-TEST(IP_ipv6, invalid_too_many_with_compression) {
+TEST(invalid_too_many_with_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7::8:9"));
 }
 
-TEST(IP_ipv6, invalid_ipv4_five_octets_in_mixed) {
+TEST(invalid_ipv4_five_octets_in_mixed) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::1.2.3.4.5"));
 }
 
-TEST(IP_ipv6, invalid_hex_in_ipv4_suffix) {
+TEST(invalid_hex_in_ipv4_suffix) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:0x1.0x2.0x3.0x4"));
 }
 
-TEST(IP_ipv6, invalid_ipv4_negative_in_mixed) {
+TEST(invalid_ipv4_negative_in_mixed) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::ffff:-1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_slash_notation) {
+TEST(invalid_slash_notation) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("2001:db8::1/64"));
 }
 
-TEST(IP_ipv6, invalid_six_groups_no_compression) {
+TEST(invalid_six_groups_no_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6"));
 }
 
-TEST(IP_ipv6, invalid_five_groups_no_compression) {
+TEST(invalid_five_groups_no_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5"));
 }
 
-TEST(IP_ipv6, invalid_eight_groups_after_compression) {
+TEST(invalid_eight_groups_after_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::1:2:3:4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, invalid_seven_before_one_after_compression) {
+TEST(invalid_seven_before_one_after_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6:7::8"));
 }
 
-TEST(IP_ipv6, invalid_one_before_seven_after_compression) {
+TEST(invalid_one_before_seven_after_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1::2:3:4:5:6:7:8"));
 }
 
-TEST(IP_ipv6, invalid_six_hex_plus_ipv4_after_compression) {
+TEST(invalid_six_hex_plus_ipv4_after_compression) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::1:2:3:4:5:6:1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_six_hex_before_compression_plus_ipv4) {
+TEST(invalid_six_hex_before_compression_plus_ipv4) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5:6::1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_five_before_one_after_compression_plus_ipv4) {
+TEST(invalid_five_before_one_after_compression_plus_ipv4) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("1:2:3:4:5::6:1.2.3.4"));
 }
 
-TEST(IP_ipv6, invalid_trailing_content_after_ipv4_suffix) {
+TEST(invalid_trailing_content_after_ipv4_suffix) {
   EXPECT_FALSE(sourcemeta::core::is_ipv6("::1.2.3.4:0"));
 }
 
-TEST(IP_ipv6, valid_five_hex_after_compression_plus_ipv4) {
+TEST(valid_five_hex_after_compression_plus_ipv4) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::2:3:4:5:6:1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_five_hex_before_compression_plus_ipv4) {
+TEST(valid_five_hex_before_compression_plus_ipv4) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("1:2:3:4:5::1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_all_zero_hex_plus_ipv4_no_compression) {
+TEST(valid_all_zero_hex_plus_ipv4_no_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("0:0:0:0:0:0:1.2.3.4"));
 }
 
-TEST(IP_ipv6, valid_all_zero_ipv4_with_compression) {
+TEST(valid_all_zero_ipv4_with_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::0.0.0.0"));
 }
 
-TEST(IP_ipv6, valid_all_max_ipv4_with_compression) {
+TEST(valid_all_max_ipv4_with_compression) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("::255.255.255.255"));
 }
 
-TEST(IP_ipv6, valid_single_alpha_hex_groups) {
+TEST(valid_single_alpha_hex_groups) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("a:b:c:d:e:f:0:1"));
 }
 
-TEST(IP_ipv6, valid_two_digit_hex_groups_with_leading_zeros) {
+TEST(valid_two_digit_hex_groups_with_leading_zeros) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("01:02:03:04:05:06:07:08"));
 }
 
-TEST(IP_ipv6, valid_three_digit_hex_groups_with_leading_zeros) {
+TEST(valid_three_digit_hex_groups_with_leading_zeros) {
   EXPECT_TRUE(sourcemeta::core::is_ipv6("001:002:003:004:005:006:007:008"));
 }

--- a/test/jose/CMakeLists.txt
+++ b/test/jose/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jose
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jose
   SOURCES jose_algorithm_test.cc jose_jwk_test.cc jose_jwks_test.cc
           jose_jwks_provider_test.cc jose_jwt_test.cc
           jose_jwt_check_claims_test.cc jose_jws_verify_signature_test.cc
@@ -11,7 +11,7 @@ target_link_libraries(sourcemeta_core_jose_unit
 
 # IETF JOSE Cookbook (RFC 7520) JWS Examples
 # See https://github.com/ietf-jose/cookbook
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jose_cookbook
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jose_cookbook
   SOURCES jose_cookbook_test.cc)
 target_compile_definitions(sourcemeta_core_jose_cookbook_unit
   PRIVATE JOSE_COOKBOOK_PATH="${PROJECT_SOURCE_DIR}/vendor/jose-cookbook")

--- a/test/jose/jose_algorithm_test.cc
+++ b/test/jose/jose_algorithm_test.cc
@@ -1,43 +1,43 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jose.h>
 
-TEST(JOSE_algorithm, rs256) {
+TEST(rs256) {
   const auto result{sourcemeta::core::to_jws_algorithm("RS256")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::JWSAlgorithm::RS256);
 }
 
-TEST(JOSE_algorithm, ps384) {
+TEST(ps384) {
   const auto result{sourcemeta::core::to_jws_algorithm("PS384")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::JWSAlgorithm::PS384);
 }
 
-TEST(JOSE_algorithm, es512) {
+TEST(es512) {
   const auto result{sourcemeta::core::to_jws_algorithm("ES512")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::JWSAlgorithm::ES512);
 }
 
-TEST(JOSE_algorithm, eddsa) {
+TEST(eddsa) {
   const auto result{sourcemeta::core::to_jws_algorithm("EdDSA")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::JWSAlgorithm::EdDSA);
 }
 
-TEST(JOSE_algorithm, rejects_none) {
+TEST(rejects_none) {
   EXPECT_FALSE(sourcemeta::core::to_jws_algorithm("none").has_value());
 }
 
-TEST(JOSE_algorithm, rejects_hmac) {
+TEST(rejects_hmac) {
   EXPECT_FALSE(sourcemeta::core::to_jws_algorithm("HS256").has_value());
 }
 
-TEST(JOSE_algorithm, rejects_unknown) {
+TEST(rejects_unknown) {
   EXPECT_FALSE(sourcemeta::core::to_jws_algorithm("RS128").has_value());
 }
 
-TEST(JOSE_algorithm, rejects_empty) {
+TEST(rejects_empty) {
   EXPECT_FALSE(sourcemeta::core::to_jws_algorithm("").has_value());
 }

--- a/test/jose/jose_cookbook_test.cc
+++ b/test/jose/jose_cookbook_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
@@ -55,14 +55,14 @@ static auto verify_cookbook_signature(const std::string_view filename) -> bool {
              algorithm, signing_input, signature.value(), parsed_key.value());
 }
 
-TEST(JOSE_cookbook, rsa_pkcs1_v15_rs256) {
+TEST(rsa_pkcs1_v15_rs256) {
   EXPECT_TRUE(verify_cookbook_signature("4_1.rsa_v15_signature.json"));
 }
 
-TEST(JOSE_cookbook, rsa_pss_ps384) {
+TEST(rsa_pss_ps384) {
   EXPECT_TRUE(verify_cookbook_signature("4_2.rsa-pss_signature.json"));
 }
 
-TEST(JOSE_cookbook, ecdsa_es512) {
+TEST(ecdsa_es512) {
   EXPECT_TRUE(verify_cookbook_signature("4_3.ecdsa_signature.json"));
 }

--- a/test/jose/jose_jwk_test.cc
+++ b/test/jose/jose_jwk_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
@@ -7,77 +7,77 @@
 #include <string>   // std::string
 #include <utility>  // std::move
 
-TEST(JOSE_JWK, rsa_public_key) {
+TEST(rsa_public_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "RS256",
            "kid": "key-1" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key.value().key_id().has_value());
+  EXPECT_TRUE(key.value().key_id().has_value());
   EXPECT_EQ(key.value().key_id().value(), "key-1");
-  ASSERT_TRUE(key.value().algorithm().has_value());
+  EXPECT_TRUE(key.value().algorithm().has_value());
   EXPECT_EQ(key.value().algorithm().value(),
             sourcemeta::core::JWSAlgorithm::RS256);
 }
 
-TEST(JOSE_JWK, rsa_public_key_without_optional_metadata) {
+TEST(rsa_public_key_without_optional_metadata) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::RSA);
   EXPECT_FALSE(key.value().key_id().has_value());
   EXPECT_FALSE(key.value().algorithm().has_value());
 }
 
-TEST(JOSE_JWK, elliptic_curve_public_key) {
+TEST(elliptic_curve_public_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256",
            "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
            "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
            "use": "enc", "kid": "1" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::EllipticCurve);
   EXPECT_EQ(key.value().curve(), "P-256");
-  ASSERT_TRUE(key.value().key_id().has_value());
+  EXPECT_TRUE(key.value().key_id().has_value());
   EXPECT_EQ(key.value().key_id().value(), "1");
   EXPECT_FALSE(key.value().algorithm().has_value());
 }
 
-TEST(JOSE_JWK, unrecognized_algorithm_is_absent) {
+TEST(unrecognized_algorithm_is_absent) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "HS256" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(key.value().algorithm().has_value());
 }
 
-TEST(JOSE_JWK, rejects_non_object) {
+TEST(rejects_non_object) {
   const auto document{sourcemeta::core::parse_json(R"("not an object")")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_missing_key_type) {
+TEST(rejects_missing_key_type) {
   const auto document{
       sourcemeta::core::parse_json(R"({ "n": "dGVzdA", "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_unsupported_key_type) {
+TEST(rejects_unsupported_key_type) {
   const auto document{
       sourcemeta::core::parse_json(R"({ "kty": "oct", "k": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key) {
+TEST(rejects_rsa_private_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "d": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_elliptic_curve_private_key) {
+TEST(rejects_elliptic_curve_private_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256",
            "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
@@ -87,39 +87,39 @@ TEST(JOSE_JWK, rejects_elliptic_curve_private_key) {
 }
 
 // The Ed25519 key is the public key from RFC 8037 Appendix A.2
-TEST(JOSE_JWK, octet_key_pair_ed25519_public_key) {
+TEST(octet_key_pair_ed25519_public_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "OKP", "crv": "Ed25519",
            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::OctetKeyPair);
   EXPECT_EQ(key.value().curve(), "Ed25519");
 }
 
-TEST(JOSE_JWK, octet_key_pair_ed448_public_key) {
+TEST(octet_key_pair_ed448_public_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "OKP", "crv": "Ed448",
            "x": "E35kUtHOEUbcTPAayux0atDpqzE8jD1lGIdbrhR5I79Gm1bDz6JMUvrGk7zVusKM8FEDCWzJMjcA" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::OctetKeyPair);
   EXPECT_EQ(key.value().curve(), "Ed448");
 }
 
-TEST(JOSE_JWK, octet_key_pair_algorithm_eddsa) {
+TEST(octet_key_pair_algorithm_eddsa) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "OKP", "crv": "Ed25519",
            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
            "alg": "EdDSA" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
-  ASSERT_TRUE(key.value().algorithm().has_value());
+  EXPECT_TRUE(key.has_value());
+  EXPECT_TRUE(key.value().algorithm().has_value());
   EXPECT_EQ(key.value().algorithm().value(),
             sourcemeta::core::JWSAlgorithm::EdDSA);
 }
 
-TEST(JOSE_JWK, rejects_octet_key_pair_private_key) {
+TEST(rejects_octet_key_pair_private_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "OKP", "crv": "Ed25519",
            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
@@ -127,32 +127,32 @@ TEST(JOSE_JWK, rejects_octet_key_pair_private_key) {
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_octet_key_pair_unsupported_curve) {
+TEST(rejects_octet_key_pair_unsupported_curve) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "OKP", "crv": "X25519",
            "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_octet_key_pair_wrong_public_key_length) {
+TEST(rejects_octet_key_pair_wrong_public_key_length) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "OKP", "crv": "Ed25519", "x": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_missing_rsa_modulus) {
+TEST(rejects_missing_rsa_modulus) {
   const auto document{
       sourcemeta::core::parse_json(R"({ "kty": "RSA", "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_invalid_base64url) {
+TEST(rejects_invalid_base64url) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "not valid base64url", "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, constructor_throws_on_invalid_input) {
+TEST(constructor_throws_on_invalid_input) {
   const auto document{sourcemeta::core::parse_json(R"({ "kty": "oct" })")};
   try {
     sourcemeta::core::JWK{document};
@@ -162,15 +162,15 @@ TEST(JOSE_JWK, constructor_throws_on_invalid_input) {
   }
 }
 
-TEST(JOSE_JWK, from_accepts_rvalue) {
+TEST(from_accepts_rvalue) {
   auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB" })")};
   const auto key{sourcemeta::core::JWK::from(std::move(document))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::RSA);
 }
 
-TEST(JOSE_JWK, constructor_accepts_rvalue) {
+TEST(constructor_accepts_rvalue) {
   auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256",
            "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
@@ -180,7 +180,7 @@ TEST(JOSE_JWK, constructor_accepts_rvalue) {
   EXPECT_EQ(key.curve(), "P-256");
 }
 
-TEST(JOSE_JWK, owns_material_after_source_destroyed) {
+TEST(owns_material_after_source_destroyed) {
   std::optional<sourcemeta::core::JWK> key;
   {
     const auto document{sourcemeta::core::parse_json(
@@ -188,74 +188,74 @@ TEST(JOSE_JWK, owns_material_after_source_destroyed) {
     key = sourcemeta::core::JWK::from(document);
   }
 
-  ASSERT_TRUE(key.has_value());
-  ASSERT_TRUE(key.value().key_id().has_value());
+  EXPECT_TRUE(key.has_value());
+  EXPECT_TRUE(key.value().key_id().has_value());
   EXPECT_EQ(key.value().key_id().value(), "scoped");
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key_prime_p) {
+TEST(rejects_rsa_private_key_prime_p) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "p": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key_prime_q) {
+TEST(rejects_rsa_private_key_prime_q) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "q": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key_exponent_dp) {
+TEST(rejects_rsa_private_key_exponent_dp) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "dp": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key_exponent_dq) {
+TEST(rejects_rsa_private_key_exponent_dq) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "dq": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key_coefficient_qi) {
+TEST(rejects_rsa_private_key_coefficient_qi) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "qi": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_rsa_private_key_other_primes_oth) {
+TEST(rejects_rsa_private_key_other_primes_oth) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "oth": [] })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_empty_rsa_modulus) {
+TEST(rejects_empty_rsa_modulus) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "", "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_empty_rsa_exponent) {
+TEST(rejects_empty_rsa_exponent) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_unknown_curve) {
+TEST(rejects_unknown_curve) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "secp256k1", "x": "dGVzdA",
            "y": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_ec_coordinate_wrong_length) {
+TEST(rejects_ec_coordinate_wrong_length) {
   // "dGVzdA" decodes to 4 bytes, not the 32 a P-256 coordinate requires
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256", "x": "dGVzdA", "y": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, accepts_ec_p384) {
+TEST(accepts_ec_p384) {
   // 64 base64url characters decode to the 48 bytes a P-384 coordinate requires
   const std::string coordinate(64, 'A');
   auto document{sourcemeta::core::JSON::make_object()};
@@ -264,11 +264,11 @@ TEST(JOSE_JWK, accepts_ec_p384) {
   document.assign_assume_new("x", sourcemeta::core::JSON{coordinate});
   document.assign_assume_new("y", sourcemeta::core::JSON{coordinate});
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().curve(), "P-384");
 }
 
-TEST(JOSE_JWK, accepts_ec_p521) {
+TEST(accepts_ec_p521) {
   // 88 base64url characters decode to the 66 bytes a P-521 coordinate requires
   const std::string coordinate(88, 'A');
   auto document{sourcemeta::core::JSON::make_object()};
@@ -277,116 +277,116 @@ TEST(JOSE_JWK, accepts_ec_p521) {
   document.assign_assume_new("x", sourcemeta::core::JSON{coordinate});
   document.assign_assume_new("y", sourcemeta::core::JSON{coordinate});
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().curve(), "P-521");
 }
 
-TEST(JOSE_JWK, rejects_missing_rsa_exponent) {
+TEST(rejects_missing_rsa_exponent) {
   const auto document{
       sourcemeta::core::parse_json(R"({ "kty": "RSA", "n": "dGVzdA" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_missing_ec_curve) {
+TEST(rejects_missing_ec_curve) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
            "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_missing_ec_coordinate_x) {
+TEST(rejects_missing_ec_coordinate_x) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256",
            "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_missing_ec_coordinate_y) {
+TEST(rejects_missing_ec_coordinate_y) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256",
            "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_non_string_key_type) {
+TEST(rejects_non_string_key_type) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": 123, "n": "dGVzdA", "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_non_string_rsa_modulus) {
+TEST(rejects_non_string_rsa_modulus) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": 123, "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_lowercase_key_type) {
+TEST(rejects_lowercase_key_type) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "rsa", "n": "dGVzdA", "e": "AQAB" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_invalid_base64url_exponent) {
+TEST(rejects_invalid_base64url_exponent) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "not valid" })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_non_string_key_id) {
+TEST(rejects_non_string_key_id) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "kid": 123 })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, rejects_non_string_algorithm) {
+TEST(rejects_non_string_algorithm) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": 123 })")};
   EXPECT_FALSE(sourcemeta::core::JWK::from(document).has_value());
 }
 
-TEST(JOSE_JWK, ignores_unknown_members) {
+TEST(ignores_unknown_members) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "use": "sig",
            "key_ops": [ "verify" ], "x5t": "abc" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_EQ(key.value().type(), sourcemeta::core::JWK::Type::RSA);
 }
 
-TEST(JOSE_JWK, ignores_algorithm_inconsistent_with_key_type) {
+TEST(ignores_algorithm_inconsistent_with_key_type) {
   // An algorithm hint that contradicts the key type is not actionable, so it
   // is dropped while the otherwise valid key still parses
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "ES256" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(key.value().algorithm().has_value());
 }
 
-TEST(JOSE_JWK, tolerates_unsupported_algorithm) {
+TEST(tolerates_unsupported_algorithm) {
   // A valid but unsupported algorithm hint is advisory (RFC 7517 Section 4.4),
   // so it does not invalidate the key, it is simply not reported
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "EdDSA" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(key.value().algorithm().has_value());
 }
 
-TEST(JOSE_JWK, stores_algorithm_matching_curve) {
+TEST(stores_algorithm_matching_curve) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "kty": "EC", "crv": "P-256",
            "x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
            "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
            "alg": "ES256" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
-  ASSERT_TRUE(key.value().algorithm().has_value());
+  EXPECT_TRUE(key.has_value());
+  EXPECT_TRUE(key.value().algorithm().has_value());
   EXPECT_EQ(key.value().algorithm().value(),
             sourcemeta::core::JWSAlgorithm::ES256);
 }
 
-TEST(JOSE_JWK, ignores_algorithm_not_matching_curve) {
+TEST(ignores_algorithm_not_matching_curve) {
   // ES512 is defined over P-521, so the hint is not actionable for a P-256
   // key and is dropped while the key still parses
   const auto document{sourcemeta::core::parse_json(
@@ -395,6 +395,6 @@ TEST(JOSE_JWK, ignores_algorithm_not_matching_curve) {
            "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
            "alg": "ES512" })")};
   const auto key{sourcemeta::core::JWK::from(document)};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(key.value().algorithm().has_value());
 }

--- a/test/jose/jose_jwks_provider_test.cc
+++ b/test/jose/jose_jwks_provider_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jose.h>
 
@@ -56,7 +56,7 @@ constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> ALLOWED_RS256{
 
 } // namespace
 
-TEST(JOSE_jwks_provider, unreachable_issuer_denies) {
+TEST(unreachable_issuer_denies) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -69,16 +69,16 @@ TEST(JOSE_jwks_provider, unreachable_issuer_denies) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
   EXPECT_EQ(calls, std::size_t{1});
 }
 
-TEST(JOSE_jwks_provider, malformed_body_is_treated_as_failure) {
+TEST(malformed_body_is_treated_as_failure) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -90,15 +90,15 @@ TEST(JOSE_jwks_provider, malformed_body_is_treated_as_failure) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
 }
 
-TEST(JOSE_jwks_provider, cache_hit_does_not_refetch) {
+TEST(cache_hit_does_not_refetch) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -112,7 +112,7 @@ TEST(JOSE_jwks_provider, cache_hit_does_not_refetch) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -123,7 +123,7 @@ TEST(JOSE_jwks_provider, cache_hit_does_not_refetch) {
   EXPECT_EQ(calls, std::size_t{1});
 }
 
-TEST(JOSE_jwks_provider, cache_control_absent_uses_fallback) {
+TEST(cache_control_absent_uses_fallback) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -137,7 +137,7 @@ TEST(JOSE_jwks_provider, cache_control_absent_uses_fallback) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -156,7 +156,7 @@ TEST(JOSE_jwks_provider, cache_control_absent_uses_fallback) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, cache_control_above_maximum_clamps_down) {
+TEST(cache_control_above_maximum_clamps_down) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -170,7 +170,7 @@ TEST(JOSE_jwks_provider, cache_control_above_maximum_clamps_down) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -189,7 +189,7 @@ TEST(JOSE_jwks_provider, cache_control_above_maximum_clamps_down) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, cache_control_below_minimum_clamps_up) {
+TEST(cache_control_below_minimum_clamps_up) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -203,7 +203,7 @@ TEST(JOSE_jwks_provider, cache_control_below_minimum_clamps_up) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -222,7 +222,7 @@ TEST(JOSE_jwks_provider, cache_control_below_minimum_clamps_up) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, cache_control_zero_clamps_to_minimum) {
+TEST(cache_control_zero_clamps_to_minimum) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -237,7 +237,7 @@ TEST(JOSE_jwks_provider, cache_control_zero_clamps_to_minimum) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -257,7 +257,7 @@ TEST(JOSE_jwks_provider, cache_control_zero_clamps_to_minimum) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, unknown_key_triggers_one_guarded_refetch) {
+TEST(unknown_key_triggers_one_guarded_refetch) {
   std::size_t calls{0};
   // The issuer first publishes a set with no key able to verify the token, then
   // after rotation publishes the matching key
@@ -274,7 +274,7 @@ TEST(JOSE_jwks_provider, unknown_key_triggers_one_guarded_refetch) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
@@ -282,7 +282,7 @@ TEST(JOSE_jwks_provider, unknown_key_triggers_one_guarded_refetch) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, signature_failure_is_not_retried) {
+TEST(signature_failure_is_not_retried) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -300,16 +300,16 @@ TEST(JOSE_jwks_provider, signature_failure_is_not_retried) {
   // failure rather than an unknown key, and a signature failure is never
   // retried
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN_WITH_KEY_ID)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "joe", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Signature);
   EXPECT_EQ(calls, std::size_t{1});
 }
 
-TEST(JOSE_jwks_provider, unknown_key_refetch_is_bounded_by_cooldown) {
+TEST(unknown_key_refetch_is_bounded_by_cooldown) {
   std::size_t calls{0};
   // The published set never contains the token's key, so every verification
   // hits an unknown key
@@ -325,19 +325,19 @@ TEST(JOSE_jwks_provider, unknown_key_refetch_is_bounded_by_cooldown) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN_WITH_KEY_ID)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   // Cold fetch then one guarded refetch, and the named key is still absent
   const auto first{
       provider.verify(token.value(), ALLOWED_RS256, "joe", "client")};
-  ASSERT_TRUE(first.has_value());
+  EXPECT_TRUE(first.has_value());
   EXPECT_EQ(first.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
   EXPECT_EQ(calls, std::size_t{2});
 
   // Within the cooldown window no further refetch happens
   const auto second{
       provider.verify(token.value(), ALLOWED_RS256, "joe", "client")};
-  ASSERT_TRUE(second.has_value());
+  EXPECT_TRUE(second.has_value());
   EXPECT_EQ(second.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
   EXPECT_EQ(calls, std::size_t{2});
 
@@ -345,12 +345,12 @@ TEST(JOSE_jwks_provider, unknown_key_refetch_is_bounded_by_cooldown) {
   now = std::chrono::system_clock::from_time_t(1300000000 + 301);
   const auto third{
       provider.verify(token.value(), ALLOWED_RS256, "joe", "client")};
-  ASSERT_TRUE(third.has_value());
+  EXPECT_TRUE(third.has_value());
   EXPECT_EQ(third.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
   EXPECT_EQ(calls, std::size_t{3});
 }
 
-TEST(JOSE_jwks_provider, failed_refresh_serves_stale_keys) {
+TEST(failed_refresh_serves_stale_keys) {
   std::size_t calls{0};
   // Good keys first, then the issuer becomes unreachable on every later fetch
   const auto fetcher{
@@ -368,7 +368,7 @@ TEST(JOSE_jwks_provider, failed_refresh_serves_stale_keys) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -389,7 +389,7 @@ TEST(JOSE_jwks_provider, failed_refresh_serves_stale_keys) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, expected_type_is_forwarded) {
+TEST(expected_type_is_forwarded) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -401,18 +401,18 @@ TEST(JOSE_jwks_provider, expected_type_is_forwarded) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   // The token carries an access-token type, so pinning a different expected
   // type is rejected, proving that argument reaches the underlying verification
   const auto error{provider.verify(token.value(), ALLOWED_RS256, "acme",
                                    "client", std::nullopt,
                                    "application/example")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Type);
 }
 
-TEST(JOSE_jwks_provider, clock_skew_tolerates_recent_expiry) {
+TEST(clock_skew_tolerates_recent_expiry) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -428,13 +428,13 @@ TEST(JOSE_jwks_provider, clock_skew_tolerates_recent_expiry) {
                                                   std::chrono::seconds{60}},
       [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
 }
 
-TEST(JOSE_jwks_provider, fetcher_exception_is_treated_as_failure) {
+TEST(fetcher_exception_is_treated_as_failure) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -445,17 +445,17 @@ TEST(JOSE_jwks_provider, fetcher_exception_is_treated_as_failure) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   // A throwing fetcher must not escape verification, and it denies like any
   // failed fetch
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
 }
 
-TEST(JOSE_jwks_provider, fetcher_recovers_after_exception) {
+TEST(fetcher_recovers_after_exception) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -472,12 +472,12 @@ TEST(JOSE_jwks_provider, fetcher_recovers_after_exception) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   // The first fetch throws and denies, leaving the provider usable
   const auto first{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
-  ASSERT_TRUE(first.has_value());
+  EXPECT_TRUE(first.has_value());
   EXPECT_EQ(first.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
 
   // The next call obtains keys and verifies, proving no state was corrupted
@@ -486,7 +486,7 @@ TEST(JOSE_jwks_provider, fetcher_recovers_after_exception) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, fetcher_exception_serves_stale_keys) {
+TEST(fetcher_exception_serves_stale_keys) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -503,7 +503,7 @@ TEST(JOSE_jwks_provider, fetcher_exception_serves_stale_keys) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -517,7 +517,7 @@ TEST(JOSE_jwks_provider, fetcher_exception_serves_stale_keys) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, empty_key_set_is_treated_as_failure) {
+TEST(empty_key_set_is_treated_as_failure) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -529,15 +529,15 @@ TEST(JOSE_jwks_provider, empty_key_set_is_treated_as_failure) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
 }
 
-TEST(JOSE_jwks_provider, disallowed_algorithm_denies) {
+TEST(disallowed_algorithm_denies) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -551,20 +551,20 @@ TEST(JOSE_jwks_provider, disallowed_algorithm_denies) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   // The token's signing algorithm is absent from the allow-list
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const auto error{provider.verify(token.value(), allowed, "acme", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(),
             sourcemeta::core::JWTVerificationError::AlgorithmNotAllowed);
   // A rejected algorithm is final, so there is no unknown-key refetch
   EXPECT_EQ(calls, std::size_t{1});
 }
 
-TEST(JOSE_jwks_provider, expired_token_denies) {
+TEST(expired_token_denies) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -577,15 +577,15 @@ TEST(JOSE_jwks_provider, expired_token_denies) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Expiration);
 }
 
-TEST(JOSE_jwks_provider, wrong_audience_denies) {
+TEST(wrong_audience_denies) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -597,15 +597,15 @@ TEST(JOSE_jwks_provider, wrong_audience_denies) {
       "https://issuer.test/jwks", fetcher,
       sourcemeta::core::JWKSProvider::Options{}, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "unexpected")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Audience);
 }
 
-TEST(JOSE_jwks_provider, inverted_lifetime_bounds_stay_well_defined) {
+TEST(inverted_lifetime_bounds_stay_well_defined) {
   std::size_t calls{0};
   const auto fetcher{
       [&calls](const std::string_view)
@@ -623,7 +623,7 @@ TEST(JOSE_jwks_provider, inverted_lifetime_bounds_stay_well_defined) {
   sourcemeta::core::JWKSProvider provider{"https://issuer.test/jwks", fetcher,
                                           options, [&now] { return now; }};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   EXPECT_FALSE(provider.verify(token.value(), ALLOWED_RS256, "acme", "client")
                    .has_value());
@@ -642,7 +642,7 @@ TEST(JOSE_jwks_provider, inverted_lifetime_bounds_stay_well_defined) {
   EXPECT_EQ(calls, std::size_t{2});
 }
 
-TEST(JOSE_jwks_provider, empty_clock_falls_back_to_the_system_clock) {
+TEST(empty_clock_falls_back_to_the_system_clock) {
   const auto fetcher{
       [](const std::string_view)
           -> std::optional<sourcemeta::core::JWKSProvider::FetchResult> {
@@ -656,7 +656,7 @@ TEST(JOSE_jwks_provider, empty_clock_falls_back_to_the_system_clock) {
       sourcemeta::core::JWKSProvider::Options{},
       sourcemeta::core::JWKSProvider::Clock{}};
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
 
   const auto error{
       provider.verify(token.value(), ALLOWED_RS256, "acme", "client")};

--- a/test/jose/jose_jwks_test.cc
+++ b/test/jose/jose_jwks_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
@@ -7,25 +7,25 @@
 #include <string>   // std::string
 #include <utility>  // std::move
 
-TEST(JOSE_JWKS, parses_single_key) {
+TEST(parses_single_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [ { "kty": "RSA", "n": "dGVzdA", "e": "AQAB",
                        "alg": "RS256", "kid": "rsa-1" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 1);
   EXPECT_FALSE(keys.value().empty());
 
   const auto *key{keys.value().find("rsa-1")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "rsa-1");
 }
 
-TEST(JOSE_JWKS, parses_multiple_keys) {
+TEST(parses_multiple_keys) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [
              { "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "RS256",
@@ -35,133 +35,133 @@ TEST(JOSE_JWKS, parses_multiple_keys) {
                "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
                "alg": "ES256", "kid": "ec-1" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 2);
 
   const auto *rsa{keys.value().find("rsa-1")};
-  ASSERT_NE(rsa, nullptr);
+  EXPECT_NE(rsa, nullptr);
   EXPECT_EQ(rsa->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(rsa->algorithm().has_value());
+  EXPECT_TRUE(rsa->algorithm().has_value());
   EXPECT_EQ(rsa->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(rsa->key_id().has_value());
+  EXPECT_TRUE(rsa->key_id().has_value());
   EXPECT_EQ(rsa->key_id().value(), "rsa-1");
 
   const auto *ec{keys.value().find("ec-1")};
-  ASSERT_NE(ec, nullptr);
+  EXPECT_NE(ec, nullptr);
   EXPECT_EQ(ec->type(), sourcemeta::core::JWK::Type::EllipticCurve);
   EXPECT_EQ(ec->curve(), "P-256");
-  ASSERT_TRUE(ec->algorithm().has_value());
+  EXPECT_TRUE(ec->algorithm().has_value());
   EXPECT_EQ(ec->algorithm().value(), sourcemeta::core::JWSAlgorithm::ES256);
-  ASSERT_TRUE(ec->key_id().has_value());
+  EXPECT_TRUE(ec->key_id().has_value());
   EXPECT_EQ(ec->key_id().value(), "ec-1");
 }
 
-TEST(JOSE_JWKS, skips_unsupported_key) {
+TEST(skips_unsupported_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [
              { "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "RS256",
                "kid": "good" },
              { "kty": "oct", "k": "dGVzdA" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 1);
 
   const auto *key{keys.value().find("good")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "good");
 }
 
-TEST(JOSE_JWKS, skips_structurally_invalid_key) {
+TEST(skips_structurally_invalid_key) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [
              { "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "RS256",
                "kid": "good" },
              { "kty": "RSA", "n": "", "e": "AQAB", "kid": "bad" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 1);
   EXPECT_EQ(keys.value().find("bad"), nullptr);
 
   const auto *key{keys.value().find("good")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "good");
 }
 
-TEST(JOSE_JWKS, skips_non_object_entries) {
+TEST(skips_non_object_entries) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [ "not a key",
              { "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "RS256",
                "kid": "good" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 1);
 
   const auto *key{keys.value().find("good")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "good");
 }
 
-TEST(JOSE_JWKS, rejects_all_keys_unsupported) {
+TEST(rejects_all_keys_unsupported) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [ { "kty": "oct", "k": "dGVzdA" } ] })")};
   EXPECT_FALSE(sourcemeta::core::JWKS::from(document).has_value());
 }
 
-TEST(JOSE_JWKS, rejects_empty_key_array) {
+TEST(rejects_empty_key_array) {
   const auto document{sourcemeta::core::parse_json(R"({ "keys": [] })")};
   EXPECT_FALSE(sourcemeta::core::JWKS::from(document).has_value());
 }
 
-TEST(JOSE_JWKS, rejects_missing_keys) {
+TEST(rejects_missing_keys) {
   const auto document{sourcemeta::core::parse_json(R"({ "foo": "bar" })")};
   EXPECT_FALSE(sourcemeta::core::JWKS::from(document).has_value());
 }
 
-TEST(JOSE_JWKS, rejects_non_array_keys) {
+TEST(rejects_non_array_keys) {
   const auto document{
       sourcemeta::core::parse_json(R"({ "keys": "not an array" })")};
   EXPECT_FALSE(sourcemeta::core::JWKS::from(document).has_value());
 }
 
-TEST(JOSE_JWKS, rejects_non_object) {
+TEST(rejects_non_object) {
   const auto document{sourcemeta::core::parse_json(R"("not an object")")};
   EXPECT_FALSE(sourcemeta::core::JWKS::from(document).has_value());
 }
 
-TEST(JOSE_JWKS, find_returns_null_for_unknown_key_id) {
+TEST(find_returns_null_for_unknown_key_id) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [ { "kty": "RSA", "n": "dGVzdA", "e": "AQAB",
                        "alg": "RS256", "kid": "present" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().find("absent"), nullptr);
 
   const auto *key{keys.value().find("present")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "present");
 }
 
-TEST(JOSE_JWKS, find_ignores_keys_without_key_id) {
+TEST(find_ignores_keys_without_key_id) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [ { "kty": "RSA", "n": "dGVzdA", "e": "AQAB" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 1);
   EXPECT_EQ(keys.value().find(""), nullptr);
   EXPECT_EQ(keys.value().find("anything"), nullptr);
@@ -172,7 +172,7 @@ TEST(JOSE_JWKS, find_ignores_keys_without_key_id) {
   EXPECT_FALSE(key.key_id().has_value());
 }
 
-TEST(JOSE_JWKS, iterates_in_order) {
+TEST(iterates_in_order) {
   const auto document{sourcemeta::core::parse_json(
       R"({ "keys": [
              { "kty": "RSA", "n": "dGVzdA", "e": "AQAB", "alg": "RS256",
@@ -182,49 +182,49 @@ TEST(JOSE_JWKS, iterates_in_order) {
                "y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
                "alg": "ES256", "kid": "ec-1" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(document)};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
 
   auto iterator{keys.value().begin()};
-  ASSERT_NE(iterator, keys.value().end());
+  EXPECT_NE(iterator, keys.value().end());
   EXPECT_EQ(iterator->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(iterator->algorithm().has_value());
+  EXPECT_TRUE(iterator->algorithm().has_value());
   EXPECT_EQ(iterator->algorithm().value(),
             sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(iterator->key_id().has_value());
+  EXPECT_TRUE(iterator->key_id().has_value());
   EXPECT_EQ(iterator->key_id().value(), "rsa-1");
 
   ++iterator;
-  ASSERT_NE(iterator, keys.value().end());
+  EXPECT_NE(iterator, keys.value().end());
   EXPECT_EQ(iterator->type(), sourcemeta::core::JWK::Type::EllipticCurve);
   EXPECT_EQ(iterator->curve(), "P-256");
-  ASSERT_TRUE(iterator->algorithm().has_value());
+  EXPECT_TRUE(iterator->algorithm().has_value());
   EXPECT_EQ(iterator->algorithm().value(),
             sourcemeta::core::JWSAlgorithm::ES256);
-  ASSERT_TRUE(iterator->key_id().has_value());
+  EXPECT_TRUE(iterator->key_id().has_value());
   EXPECT_EQ(iterator->key_id().value(), "ec-1");
 
   ++iterator;
   EXPECT_EQ(iterator, keys.value().end());
 }
 
-TEST(JOSE_JWKS, from_accepts_rvalue) {
+TEST(from_accepts_rvalue) {
   auto document{sourcemeta::core::parse_json(
       R"({ "keys": [ { "kty": "RSA", "n": "dGVzdA", "e": "AQAB",
                        "alg": "RS256", "kid": "rsa-1" } ] })")};
   const auto keys{sourcemeta::core::JWKS::from(std::move(document))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   EXPECT_EQ(keys.value().size(), 1);
 
   const auto *key{keys.value().find("rsa-1")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "rsa-1");
 }
 
-TEST(JOSE_JWKS, constructor_throws_on_invalid_input) {
+TEST(constructor_throws_on_invalid_input) {
   const auto document{sourcemeta::core::parse_json(R"({ "keys": [] })")};
   try {
     sourcemeta::core::JWKS{document};
@@ -234,7 +234,7 @@ TEST(JOSE_JWKS, constructor_throws_on_invalid_input) {
   }
 }
 
-TEST(JOSE_JWKS, owns_keys_after_source_destroyed) {
+TEST(owns_keys_after_source_destroyed) {
   std::optional<sourcemeta::core::JWKS> keys;
   {
     const auto document{sourcemeta::core::parse_json(
@@ -243,12 +243,12 @@ TEST(JOSE_JWKS, owns_keys_after_source_destroyed) {
     keys = sourcemeta::core::JWKS::from(document);
   }
 
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const auto *key{keys.value().find("scoped")};
-  ASSERT_NE(key, nullptr);
+  EXPECT_NE(key, nullptr);
   EXPECT_EQ(key->type(), sourcemeta::core::JWK::Type::RSA);
-  ASSERT_TRUE(key->algorithm().has_value());
+  EXPECT_TRUE(key->algorithm().has_value());
   EXPECT_EQ(key->algorithm().value(), sourcemeta::core::JWSAlgorithm::RS256);
-  ASSERT_TRUE(key->key_id().has_value());
+  EXPECT_TRUE(key->key_id().has_value());
   EXPECT_EQ(key->key_id().value(), "scoped");
 }

--- a/test/jose/jose_jws_verify_signature_test.cc
+++ b/test/jose/jose_jws_verify_signature_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
@@ -51,129 +51,129 @@ constexpr std::string_view OKP_JWK{
     R"JSON({ "kty": "OKP", "crv": "Ed25519", "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo" })JSON"};
 } // namespace
 
-TEST(JOSE_jws_verify_signature, rs256_valid) {
+TEST(rs256_valid) {
   const auto signature{sourcemeta::core::base64url_decode(RSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::RS256, RS256_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, es256_valid) {
+TEST(es256_valid) {
   const auto signature{sourcemeta::core::base64url_decode(ECDSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::ES256, ES256_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, arbitrary_signing_input) {
+TEST(arbitrary_signing_input) {
   const auto signature{
       sourcemeta::core::base64url_decode(RSA_ARBITRARY_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::RS256, ARBITRARY_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, unrecognized_algorithm) {
+TEST(unrecognized_algorithm) {
   const auto signature{sourcemeta::core::base64url_decode(RSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       std::nullopt, RS256_SIGNING_INPUT, signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, contradicting_key_algorithm) {
+TEST(contradicting_key_algorithm) {
   const auto signature{sourcemeta::core::base64url_decode(RSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{sourcemeta::core::JWK::from(
       sourcemeta::core::parse_json(RSA_JWK_OTHER_ALGORITHM))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::RS256, RS256_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, key_type_mismatch) {
+TEST(key_type_mismatch) {
   const auto signature{sourcemeta::core::base64url_decode(RSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::RS256, RS256_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, curve_mismatch) {
+TEST(curve_mismatch) {
   const auto signature{sourcemeta::core::base64url_decode(ECDSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::ES512, ES256_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, tampered_signature) {
+TEST(tampered_signature) {
   const auto signature{sourcemeta::core::base64url_decode(RSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   std::string tampered{signature.value()};
   tampered.front() =
       static_cast<char>(static_cast<unsigned char>(tampered.front()) ^ 0x80U);
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::RS256, RS256_SIGNING_INPUT, tampered,
       key.value()));
 }
 
 // The Ed25519 signature is the worked example from RFC 8037 Appendix A.4
-TEST(JOSE_jws_verify_signature, eddsa_ed25519_valid) {
+TEST(eddsa_ed25519_valid) {
   const auto signature{sourcemeta::core::base64url_decode(EDDSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(OKP_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::EdDSA, EDDSA_SIGNING_INPUT,
       signature.value(), key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, eddsa_tampered_signature) {
+TEST(eddsa_tampered_signature) {
   const auto signature{sourcemeta::core::base64url_decode(EDDSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   std::string tampered{signature.value()};
   tampered.front() =
       static_cast<char>(static_cast<unsigned char>(tampered.front()) ^ 0x80U);
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(OKP_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::EdDSA, EDDSA_SIGNING_INPUT, tampered,
       key.value()));
 }
 
-TEST(JOSE_jws_verify_signature, eddsa_key_type_mismatch) {
+TEST(eddsa_key_type_mismatch) {
   const auto signature{sourcemeta::core::base64url_decode(EDDSA_SIGNATURE)};
-  ASSERT_TRUE(signature.has_value());
+  EXPECT_TRUE(signature.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(sourcemeta::core::jws_verify_signature(
       sourcemeta::core::JWSAlgorithm::EdDSA, EDDSA_SIGNING_INPUT,
       signature.value(), key.value()));

--- a/test/jose/jose_jwt_check_claims_test.cc
+++ b/test/jose/jose_jwt_check_claims_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
@@ -17,88 +17,88 @@ static auto make_token(const std::string_view header,
          sourcemeta::core::base64url_encode(signature);
 }
 
-TEST(JOSE_jwt_check_claims, valid) {
+TEST(valid) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "client", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, missing_issuer) {
+TEST(missing_issuer) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "aud": "client", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Issuer);
 }
 
-TEST(JOSE_jwt_check_claims, wrong_issuer) {
+TEST(wrong_issuer) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "evil", "aud": "client", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Issuer);
 }
 
-TEST(JOSE_jwt_check_claims, missing_audience) {
+TEST(missing_audience) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "iss": "acme", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Audience);
 }
 
-TEST(JOSE_jwt_check_claims, wrong_audience) {
+TEST(wrong_audience) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "other", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Audience);
 }
 
-TEST(JOSE_jwt_check_claims, audience_array_contains) {
+TEST(audience_array_contains) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": [ "a", "client", "b" ], "exp": 2000 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, valid_with_subject) {
+TEST(valid_with_subject) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "sub": "user", "aud": "client", "exp": 2000 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{0},
@@ -106,144 +106,144 @@ TEST(JOSE_jwt_check_claims, valid_with_subject) {
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, wrong_subject) {
+TEST(wrong_subject) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "sub": "user", "aud": "client", "exp": 2000 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{0},
       "other")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Subject);
 }
 
-TEST(JOSE_jwt_check_claims, missing_subject_when_expected) {
+TEST(missing_subject_when_expected) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "client", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{0},
       "user")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Subject);
 }
 
-TEST(JOSE_jwt_check_claims, subject_ignored_when_not_pinned) {
+TEST(subject_ignored_when_not_pinned) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "sub": "user", "aud": "client", "exp": 2000 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, missing_expiration) {
+TEST(missing_expiration) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "iss": "acme", "aud": "client" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Expiration);
 }
 
-TEST(JOSE_jwt_check_claims, malformed_expiration) {
+TEST(malformed_expiration) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": "soon" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Expiration);
 }
 
-TEST(JOSE_jwt_check_claims, expired) {
+TEST(expired) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "client", "exp": 500 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Expiration);
 }
 
-TEST(JOSE_jwt_check_claims, expired_within_skew) {
+TEST(expired_within_skew) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "client", "exp": 900 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{200})};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, expired_beyond_skew) {
+TEST(expired_beyond_skew) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "client", "exp": 900 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{50})};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Expiration);
 }
 
-TEST(JOSE_jwt_check_claims, not_before_satisfied) {
+TEST(not_before_satisfied) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "nbf": 500 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, not_yet_valid) {
+TEST(not_yet_valid) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "nbf": 1500 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::NotBefore);
 }
 
-TEST(JOSE_jwt_check_claims, not_yet_valid_within_skew) {
+TEST(not_yet_valid_within_skew) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "nbf": 1100 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{200})};
@@ -253,95 +253,95 @@ TEST(JOSE_jwt_check_claims, not_yet_valid_within_skew) {
 // A present but malformed not-before fails closed rather than being ignored.
 // Borrowed in spirit from jwt-cpp's claim handling
 // (https://github.com/Thalhammer/jwt-cpp)
-TEST(JOSE_jwt_check_claims, malformed_not_before) {
+TEST(malformed_not_before) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "nbf": "soon" })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::NotBefore);
 }
 
-TEST(JOSE_jwt_check_claims, issued_in_the_past) {
+TEST(issued_in_the_past) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "iat": 500 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, issued_in_the_future) {
+TEST(issued_in_the_future) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "iat": 1500 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::IssuedAt);
 }
 
-TEST(JOSE_jwt_check_claims, issued_in_the_future_within_skew) {
+TEST(issued_in_the_future_within_skew) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "iat": 1100 })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{200})};
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_check_claims, malformed_issued_at) {
+TEST(malformed_issued_at) {
   const auto input{make_token(
       R"({ "alg": "RS256" })",
       R"({ "iss": "acme", "aud": "client", "exp": 2000, "iat": "soon" })",
       "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::IssuedAt);
 }
 
-TEST(JOSE_jwt_check_claims, issuer_checked_before_audience) {
+TEST(issuer_checked_before_audience) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "evil", "aud": "other", "exp": 2000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Issuer);
 }
 
-TEST(JOSE_jwt_check_claims, audience_checked_before_expiration) {
+TEST(audience_checked_before_expiration) {
   const auto input{
       make_token(R"({ "alg": "RS256" })",
                  R"({ "iss": "acme", "aud": "other", "exp": 500 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto error{sourcemeta::core::jwt_check_claims(
       token.value(), "acme", "client",
       std::chrono::system_clock::from_time_t(1000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Audience);
 }

--- a/test/jose/jose_jwt_test.cc
+++ b/test/jose/jose_jwt_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
@@ -17,11 +17,11 @@ static auto make_token(const std::string_view header,
          sourcemeta::core::base64url_encode(signature);
 }
 
-TEST(JOSE_JWT, parses_minimal_token) {
+TEST(parses_minimal_token) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().algorithm().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().algorithm().has_value());
   EXPECT_EQ(token.value().algorithm().value(),
             sourcemeta::core::JWSAlgorithm::RS256);
   EXPECT_TRUE(token.value().header().is_object());
@@ -29,272 +29,272 @@ TEST(JOSE_JWT, parses_minimal_token) {
   EXPECT_EQ(token.value().signature(), "sig");
 }
 
-TEST(JOSE_JWT, signing_input_is_verbatim) {
+TEST(signing_input_is_verbatim) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "iss": "acme" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto expected{
       sourcemeta::core::base64url_encode(R"({ "alg": "RS256" })") + "." +
       sourcemeta::core::base64url_encode(R"({ "iss": "acme" })")};
   EXPECT_EQ(token.value().signing_input(), expected);
 }
 
-TEST(JOSE_JWT, unrecognized_algorithm_still_parses) {
+TEST(unrecognized_algorithm_still_parses) {
   const auto input{make_token(R"({ "alg": "HS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().algorithm().has_value());
 }
 
-TEST(JOSE_JWT, key_id) {
+TEST(key_id) {
   const auto input{
       make_token(R"({ "alg": "RS256", "kid": "key-1" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().key_id().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().key_id().has_value());
   EXPECT_EQ(token.value().key_id().value(), "key-1");
 }
 
-TEST(JOSE_JWT, absent_key_id) {
+TEST(absent_key_id) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().key_id().has_value());
 }
 
-TEST(JOSE_JWT, type) {
+TEST(type) {
   const auto input{
       make_token(R"({ "alg": "RS256", "typ": "at+jwt" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().type().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().type().has_value());
   EXPECT_EQ(token.value().type().value(), "at+jwt");
 }
 
-TEST(JOSE_JWT, absent_type) {
+TEST(absent_type) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().type().has_value());
 }
 
-TEST(JOSE_JWT, issuer) {
+TEST(issuer) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "iss": "acme" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().issuer().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().issuer().has_value());
   EXPECT_EQ(token.value().issuer().value(), "acme");
 }
 
-TEST(JOSE_JWT, subject) {
+TEST(subject) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "sub": "user-1" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().subject().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().subject().has_value());
   EXPECT_EQ(token.value().subject().value(), "user-1");
 }
 
-TEST(JOSE_JWT, token_id) {
+TEST(token_id) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "jti": "abc" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().token_id().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().token_id().has_value());
   EXPECT_EQ(token.value().token_id().value(), "abc");
 }
 
-TEST(JOSE_JWT, absent_string_claim) {
+TEST(absent_string_claim) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().issuer().has_value());
   EXPECT_FALSE(token.value().subject().has_value());
   EXPECT_FALSE(token.value().token_id().has_value());
 }
 
-TEST(JOSE_JWT, non_string_claim_is_absent) {
+TEST(non_string_claim_is_absent) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "iss": 123 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().issuer().has_value());
 }
 
-TEST(JOSE_JWT, has_audience_string) {
+TEST(has_audience_string) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "aud": "api" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(token.value().has_audience("api"));
   EXPECT_FALSE(token.value().has_audience("other"));
 }
 
-TEST(JOSE_JWT, has_audience_array) {
+TEST(has_audience_array) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "aud": [ "api", "web" ] })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_TRUE(token.value().has_audience("api"));
   EXPECT_TRUE(token.value().has_audience("web"));
   EXPECT_FALSE(token.value().has_audience("other"));
 }
 
-TEST(JOSE_JWT, has_audience_absent) {
+TEST(has_audience_absent) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().has_audience("api"));
 }
 
-TEST(JOSE_JWT, expires_at_integer) {
+TEST(expires_at_integer) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "exp": 1700000000 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().expires_at().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().expires_at().has_value());
   EXPECT_EQ(token.value().expires_at().value(),
             std::chrono::system_clock::from_time_t(1700000000));
 }
 
-TEST(JOSE_JWT, expires_at_fractional) {
+TEST(expires_at_fractional) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "exp": 1700000000.5 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().expires_at().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().expires_at().has_value());
   EXPECT_EQ(token.value().expires_at().value(),
             std::chrono::system_clock::from_time_t(1700000000) +
                 std::chrono::milliseconds{500});
 }
 
-TEST(JOSE_JWT, not_before_and_issued_at) {
+TEST(not_before_and_issued_at) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "nbf": 1700000000, "iat": 1699999999 })",
                               "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().not_before().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().not_before().has_value());
   EXPECT_EQ(token.value().not_before().value(),
             std::chrono::system_clock::from_time_t(1700000000));
-  ASSERT_TRUE(token.value().issued_at().has_value());
+  EXPECT_TRUE(token.value().issued_at().has_value());
   EXPECT_EQ(token.value().issued_at().value(),
             std::chrono::system_clock::from_time_t(1699999999));
 }
 
-TEST(JOSE_JWT, expires_at_exponent_form) {
+TEST(expires_at_exponent_form) {
   // Exponent notation parses to a decimal-backed number, which must still
   // yield the correct timestamp (1e9 seconds since the epoch)
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "exp": 1e9 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().expires_at().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().expires_at().has_value());
   EXPECT_EQ(token.value().expires_at().value(),
             std::chrono::system_clock::from_time_t(1000000000));
 }
 
-TEST(JOSE_JWT, expires_at_high_precision_decimal) {
+TEST(expires_at_high_precision_decimal) {
   // More than fifteen significant digits parses to a decimal-backed number
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "exp": 1700000000.000000001 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().expires_at().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().expires_at().has_value());
   EXPECT_EQ(token.value().expires_at().value(),
             std::chrono::system_clock::from_time_t(1700000000));
 }
 
-TEST(JOSE_JWT, expires_at_out_of_range_decimal_is_absent) {
+TEST(expires_at_out_of_range_decimal_is_absent) {
   // A decimal beyond the range of a double cannot represent a timestamp
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "exp": 1e400 })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().expires_at().has_value());
 }
 
-TEST(JOSE_JWT, absent_date_claim) {
+TEST(absent_date_claim) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"({})", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().expires_at().has_value());
 }
 
-TEST(JOSE_JWT, non_numeric_date_claim_is_absent) {
+TEST(non_numeric_date_claim_is_absent) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "exp": "soon" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   EXPECT_FALSE(token.value().expires_at().has_value());
 }
 
-TEST(JOSE_JWT, payload_exposes_unregistered_claims) {
+TEST(payload_exposes_unregistered_claims) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "scope": "read write" })", "sig")};
   const auto token{sourcemeta::core::JWT::from(input)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto *scope{token.value().payload().try_at(
       sourcemeta::core::JSON::StringView{"scope"})};
-  ASSERT_NE(scope, nullptr);
-  ASSERT_TRUE(scope->is_string());
+  EXPECT_NE(scope, nullptr);
+  EXPECT_TRUE(scope->is_string());
   EXPECT_EQ(scope->to_string(), "read write");
 }
 
-TEST(JOSE_JWT, rejects_one_segment) {
+TEST(rejects_one_segment) {
   EXPECT_FALSE(sourcemeta::core::JWT::from("abc").has_value());
 }
 
-TEST(JOSE_JWT, rejects_two_segments) {
+TEST(rejects_two_segments) {
   EXPECT_FALSE(sourcemeta::core::JWT::from("abc.def").has_value());
 }
 
-TEST(JOSE_JWT, rejects_four_segments) {
+TEST(rejects_four_segments) {
   EXPECT_FALSE(sourcemeta::core::JWT::from("a.b.c.d").has_value());
 }
 
-TEST(JOSE_JWT, rejects_invalid_base64url_header) {
+TEST(rejects_invalid_base64url_header) {
   const std::string input{"!!!." + sourcemeta::core::base64url_encode(R"({})") +
                           "." + sourcemeta::core::base64url_encode("sig")};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, rejects_invalid_base64url_signature) {
+TEST(rejects_invalid_base64url_signature) {
   const std::string input{
       sourcemeta::core::base64url_encode(R"({ "alg": "RS256" })") + "." +
       sourcemeta::core::base64url_encode(R"({})") + ".!!!"};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, rejects_non_object_header) {
+TEST(rejects_non_object_header) {
   const auto input{make_token(R"([])", R"({})", "sig")};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, rejects_non_object_payload) {
+TEST(rejects_non_object_payload) {
   const auto input{make_token(R"({ "alg": "RS256" })", R"([])", "sig")};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, rejects_missing_algorithm) {
+TEST(rejects_missing_algorithm) {
   const auto input{make_token(R"({})", R"({})", "sig")};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, rejects_non_string_algorithm) {
+TEST(rejects_non_string_algorithm) {
   const auto input{make_token(R"({ "alg": 123 })", R"({})", "sig")};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, rejects_critical_header) {
+TEST(rejects_critical_header) {
   const auto input{
       make_token(R"({ "alg": "RS256", "crit": [ "exp" ] })", R"({})", "sig")};
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
-TEST(JOSE_JWT, constructor_throws_on_invalid_input) {
+TEST(constructor_throws_on_invalid_input) {
   try {
     sourcemeta::core::JWT{"abc.def"};
     FAIL();
@@ -303,7 +303,7 @@ TEST(JOSE_JWT, constructor_throws_on_invalid_input) {
   }
 }
 
-TEST(JOSE_JWT, owns_decoded_data) {
+TEST(owns_decoded_data) {
   std::optional<sourcemeta::core::JWT> token;
   {
     const auto scoped{
@@ -313,8 +313,8 @@ TEST(JOSE_JWT, owns_decoded_data) {
 
   // The decoded header, payload, and signature are owned, so they survive the
   // destruction of the buffers they were parsed from
-  ASSERT_TRUE(token.has_value());
-  ASSERT_TRUE(token.value().issuer().has_value());
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().issuer().has_value());
   EXPECT_EQ(token.value().issuer().value(), "acme");
   EXPECT_EQ(token.value().signature(), "sig");
 }

--- a/test/jose/jose_jwt_verify_signature_test.cc
+++ b/test/jose/jose_jwt_verify_signature_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
@@ -84,98 +84,98 @@ constexpr std::string_view EDDSA_ED448_JWK{
     R"JSON({ "kty": "OKP", "crv": "Ed448", "x": "E35kUtHOEUbcTPAayux0atDpqzE8jD1lGIdbrhR5I79Gm1bDz6JMUvrGk7zVusKM8FEDCWzJMjcA" })JSON"};
 } // namespace
 
-TEST(JOSE_jwt_verify_signature, rs256_valid) {
+TEST(rs256_valid) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, rs256_tampered_signature) {
+TEST(rs256_tampered_signature) {
   std::string tampered{RS256_TOKEN};
   const auto signature_start{tampered.rfind('.') + 1};
   tampered[signature_start] = (tampered[signature_start] == 'A') ? 'B' : 'A';
   const auto token{sourcemeta::core::JWT::from(tampered)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, es256_valid) {
+TEST(es256_valid) {
   const auto token{sourcemeta::core::JWT::from(ES256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, es256_tampered_signature) {
+TEST(es256_tampered_signature) {
   std::string tampered{ES256_TOKEN};
   const auto signature_start{tampered.rfind('.') + 1};
   tampered[signature_start] = (tampered[signature_start] == 'A') ? 'B' : 'A';
   const auto token{sourcemeta::core::JWT::from(tampered)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, rsa_token_with_elliptic_curve_key) {
+TEST(rsa_token_with_elliptic_curve_key) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, elliptic_curve_token_with_rsa_key) {
+TEST(elliptic_curve_token_with_rsa_key) {
   const auto token{sourcemeta::core::JWT::from(ES256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(RSA_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, elliptic_curve_algorithm_curve_mismatch) {
+TEST(elliptic_curve_algorithm_curve_mismatch) {
   const auto token{sourcemeta::core::JWT::from(ES512_TOKEN_CURVE_GUARD)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, unrecognized_algorithm) {
+TEST(unrecognized_algorithm) {
   const auto token{sourcemeta::core::JWT::from(HS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, contradicting_key_algorithm) {
+TEST(contradicting_key_algorithm) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{sourcemeta::core::JWK::from(
       sourcemeta::core::parse_json(RSA_JWK_OTHER_ALGORITHM))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_FALSE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
@@ -185,54 +185,54 @@ TEST(JOSE_jwt_verify_signature, contradicting_key_algorithm) {
 // and P-384 / P-521 mappings. No RFC worked example covers these as a JWT: RFC
 // 7515 only provides RS256 and ES256, and the RFC 7520 cookbook signs a
 // non-JSON payload that is not a valid JWT
-TEST(JOSE_jwt_verify_signature, ps256_valid) {
+TEST(ps256_valid) {
   const auto token{sourcemeta::core::JWT::from(PS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(PS256_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, es384_valid) {
+TEST(es384_valid) {
   const auto token{sourcemeta::core::JWT::from(ES384_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(ES384_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, es512_valid) {
+TEST(es512_valid) {
   const auto token{sourcemeta::core::JWT::from(ES512_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{
       sourcemeta::core::JWK::from(sourcemeta::core::parse_json(ES512_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
 // Self-signed with OpenSSL, since no RFC worked example provides an EdDSA token
 // with a JSON object payload (RFC 8037 signs plain text)
-TEST(JOSE_jwt_verify_signature, eddsa_ed25519) {
+TEST(eddsa_ed25519) {
   const auto token{sourcemeta::core::JWT::from(EDDSA_ED25519_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{sourcemeta::core::JWK::from(
       sourcemeta::core::parse_json(EDDSA_ED25519_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }
 
-TEST(JOSE_jwt_verify_signature, eddsa_ed448) {
+TEST(eddsa_ed448) {
   const auto token{sourcemeta::core::JWT::from(EDDSA_ED448_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto key{sourcemeta::core::JWK::from(
       sourcemeta::core::parse_json(EDDSA_ED448_JWK))};
-  ASSERT_TRUE(key.has_value());
+  EXPECT_TRUE(key.has_value());
   EXPECT_TRUE(
       sourcemeta::core::jwt_verify_signature(token.value(), key.value()));
 }

--- a/test/jose/jose_jwt_verify_test.cc
+++ b/test/jose/jose_jwt_verify_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
@@ -56,122 +56,122 @@ constexpr std::string_view SIGNED_KEYS{
     R"JSON({ "keys": [ { "kty": "RSA", "n": "oHTpl-jfNfBuXmBp58sW8s_77UP6j2jA0mjjKjhDkxhp7Agk-xLNGgfPCS_bjdZ6YU6FGeab8uVjkSgo9_0OCJUaF4vzEGwXmNuGawANxnZtiYjWvbJlq-2mn_L7rsqGQcSkMmyM0g4aX7dF8wB6DVrXShJ78fcrNtpeoU72YGEdjehA8qVclDFwBdpCGynxxnWJePk72lQb6gkVMqKMc3jBF8GkWf8oP_sjss-fpOjSUMR1c8_0JlTYWO46KWOZa0EO2t8H1V3imMyzbhoxRd_qZHmo46gJkG-ZdebjX0vGQllaCwu0z4kLcXIfAZhqPEkdssDGhC_txwJuhaPDFQ", "e": "AQAB" } ] })JSON"};
 } // namespace
 
-TEST(JOSE_jwt_verify, algorithm_not_allowed) {
+TEST(algorithm_not_allowed) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(RSA_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::ES256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "joe", "client",
       std::chrono::system_clock::from_time_t(1300000000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(),
             sourcemeta::core::JWTVerificationError::AlgorithmNotAllowed);
 }
 
-TEST(JOSE_jwt_verify, unknown_key_by_identifier) {
+TEST(unknown_key_by_identifier) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN_WITH_KEY_ID)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(RSA_KEYS_KEY_ID_OTHER))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "joe", "client",
       std::chrono::system_clock::from_time_t(1300000000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
 }
 
-TEST(JOSE_jwt_verify, unknown_key_no_compatible_key) {
+TEST(unknown_key_no_compatible_key) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(ELLIPTIC_CURVE_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "joe", "client",
       std::chrono::system_clock::from_time_t(1300000000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::UnknownKey);
 }
 
-TEST(JOSE_jwt_verify, signature_failure) {
+TEST(signature_failure) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN_WITH_KEY_ID)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(RSA_KEYS_KEY_ID_K1))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "joe", "client",
       std::chrono::system_clock::from_time_t(1300000000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Signature);
 }
 
-TEST(JOSE_jwt_verify, valid_signature_reaches_audience_check) {
+TEST(valid_signature_reaches_audience_check) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(RSA_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "joe", "client",
       std::chrono::system_clock::from_time_t(1300000000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Audience);
 }
 
-TEST(JOSE_jwt_verify, issuer_mismatch_after_valid_signature) {
+TEST(issuer_mismatch_after_valid_signature) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(RSA_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "wrong", "client",
       std::chrono::system_clock::from_time_t(1300000000))};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Issuer);
 }
 
-TEST(JOSE_jwt_verify, type_required_but_absent) {
+TEST(type_required_but_absent) {
   const auto token{sourcemeta::core::JWT::from(RS256_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(RSA_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "joe", "client",
       std::chrono::system_clock::from_time_t(1300000000),
       std::chrono::seconds{0}, std::nullopt, "at+jwt")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Type);
 }
 
 // The signed token below is generated locally with OpenSSL (RS256, header
 // typ "at+jwt", unexpired issuer and audience claims), since no RFC worked
 // example pairs a valid signature with verifiable claims and an explicit type
-TEST(JOSE_jwt_verify, valid) {
+TEST(valid) {
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(SIGNED_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
@@ -180,12 +180,12 @@ TEST(JOSE_jwt_verify, valid) {
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_verify, type_compact_form_matches) {
+TEST(type_compact_form_matches) {
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(SIGNED_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
@@ -195,12 +195,12 @@ TEST(JOSE_jwt_verify, type_compact_form_matches) {
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_verify, type_application_prefix_matches) {
+TEST(type_application_prefix_matches) {
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(SIGNED_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
@@ -210,18 +210,18 @@ TEST(JOSE_jwt_verify, type_application_prefix_matches) {
   EXPECT_FALSE(error.has_value());
 }
 
-TEST(JOSE_jwt_verify, type_mismatch) {
+TEST(type_mismatch) {
   const auto token{sourcemeta::core::JWT::from(SIGNED_TOKEN)};
-  ASSERT_TRUE(token.has_value());
+  EXPECT_TRUE(token.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(SIGNED_KEYS))};
-  ASSERT_TRUE(keys.has_value());
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::RS256}};
   const auto error{sourcemeta::core::jwt_verify(
       token.value(), keys.value(), allowed, "acme", "client",
       std::chrono::system_clock::from_time_t(1000000000),
       std::chrono::seconds{0}, std::nullopt, "application/example")};
-  ASSERT_TRUE(error.has_value());
+  EXPECT_TRUE(error.has_value());
   EXPECT_EQ(error.value(), sourcemeta::core::JWTVerificationError::Type);
 }

--- a/test/json/CMakeLists.txt
+++ b/test/json/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME json
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME json
   SOURCES
     json_array_test.cc
     json_boolean_test.cc

--- a/test/json/json_array_test.cc
+++ b/test/json/json_array_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
@@ -9,7 +9,7 @@
 #include <utility>
 #include <vector>
 
-TEST(JSON_array, general_traits) {
+TEST(general_traits) {
   EXPECT_TRUE(
       std::is_default_constructible<sourcemeta::core::JSON::Array>::value);
   EXPECT_FALSE(std::is_nothrow_default_constructible<
@@ -19,7 +19,7 @@ TEST(JSON_array, general_traits) {
       std::is_nothrow_destructible<sourcemeta::core::JSON::Array>::value);
 }
 
-TEST(JSON_array, copy_traits) {
+TEST(copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::JSON::Array>::value);
   EXPECT_TRUE(std::is_copy_constructible<sourcemeta::core::JSON::Array>::value);
   EXPECT_FALSE(
@@ -28,7 +28,7 @@ TEST(JSON_array, copy_traits) {
       std::is_nothrow_copy_constructible<sourcemeta::core::JSON::Array>::value);
 }
 
-TEST(JSON_array, move_traits) {
+TEST(move_traits) {
   EXPECT_TRUE(std::is_move_assignable<sourcemeta::core::JSON::Array>::value);
   EXPECT_TRUE(std::is_move_constructible<sourcemeta::core::JSON::Array>::value);
   EXPECT_TRUE(
@@ -37,7 +37,7 @@ TEST(JSON_array, move_traits) {
       std::is_nothrow_move_constructible<sourcemeta::core::JSON::Array>::value);
 }
 
-TEST(JSON_array, initializer_list_2_booleans) {
+TEST(initializer_list_2_booleans) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON{false},
                                         sourcemeta::core::JSON{true}};
 
@@ -50,13 +50,13 @@ TEST(JSON_array, initializer_list_2_booleans) {
   EXPECT_TRUE(document.at(1).to_boolean());
 }
 
-TEST(JSON_array, type) {
+TEST(type) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON{false},
                                         sourcemeta::core::JSON{true}};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Array);
 }
 
-TEST(JSON_array, empty_with_copy_constructor) {
+TEST(empty_with_copy_constructor) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
 
   EXPECT_TRUE(document.is_array());
@@ -64,14 +64,14 @@ TEST(JSON_array, empty_with_copy_constructor) {
   EXPECT_EQ(document.array_size(), 0);
 }
 
-TEST(JSON_array, empty_with_make_array) {
+TEST(empty_with_make_array) {
   const sourcemeta::core::JSON document = sourcemeta::core::JSON::make_array();
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 0);
   EXPECT_EQ(document.array_size(), 0);
 }
 
-TEST(JSON_array, push_back_booleans) {
+TEST(push_back_booleans) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   EXPECT_TRUE(document.is_array());
   document.push_back(sourcemeta::core::JSON{false});
@@ -84,7 +84,7 @@ TEST(JSON_array, push_back_booleans) {
   EXPECT_TRUE(document.at(1).to_boolean());
 }
 
-TEST(JSON_array, boolean_iterator) {
+TEST(boolean_iterator) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON{true},
                                         sourcemeta::core::JSON{false},
                                         sourcemeta::core::JSON{false}};
@@ -100,7 +100,7 @@ TEST(JSON_array, boolean_iterator) {
   EXPECT_FALSE(result.at(2));
 }
 
-TEST(JSON_array, reverse_boolean_iterator) {
+TEST(reverse_boolean_iterator) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON{true},
                                         sourcemeta::core::JSON{false},
                                         sourcemeta::core::JSON{false}};
@@ -117,7 +117,7 @@ TEST(JSON_array, reverse_boolean_iterator) {
   EXPECT_TRUE(result.at(2));
 }
 
-TEST(JSON_array, push_back_json_copy) {
+TEST(push_back_json_copy) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON{1},
                                   sourcemeta::core::JSON{2}};
 
@@ -138,7 +138,7 @@ TEST(JSON_array, push_back_json_copy) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, push_back_json_move) {
+TEST(push_back_json_move) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON{1},
                                   sourcemeta::core::JSON{2}};
 
@@ -159,7 +159,7 @@ TEST(JSON_array, push_back_json_move) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, modify_array_after_copy) {
+TEST(modify_array_after_copy) {
   // Original document
   sourcemeta::core::JSON document{sourcemeta::core::JSON{1},
                                   sourcemeta::core::JSON{2},
@@ -189,7 +189,7 @@ TEST(JSON_array, modify_array_after_copy) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, const_iterator_for_each) {
+TEST(const_iterator_for_each) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   std::vector<std::int64_t> result;
@@ -203,7 +203,7 @@ TEST(JSON_array, const_iterator_for_each) {
   EXPECT_EQ(result.at(2), 3);
 }
 
-TEST(JSON_array, iterator_for_each) {
+TEST(iterator_for_each) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   std::vector<std::int64_t> result;
   std::for_each(
@@ -215,7 +215,7 @@ TEST(JSON_array, iterator_for_each) {
   EXPECT_EQ(result.at(2), 3);
 }
 
-TEST(JSON_array, reverse_const_iterator_for_each) {
+TEST(reverse_const_iterator_for_each) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   std::vector<std::int64_t> result;
@@ -229,7 +229,7 @@ TEST(JSON_array, reverse_const_iterator_for_each) {
   EXPECT_EQ(result.at(2), 1);
 }
 
-TEST(JSON_array, reverse_iterator_for_each) {
+TEST(reverse_iterator_for_each) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   std::vector<std::int64_t> result;
   std::for_each(
@@ -241,7 +241,7 @@ TEST(JSON_array, reverse_iterator_for_each) {
   EXPECT_EQ(result.at(2), 1);
 }
 
-TEST(JSON_array, const_iterator) {
+TEST(const_iterator) {
   std::vector<std::int64_t> result;
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ 1, 2, 3 ]");
@@ -255,7 +255,7 @@ TEST(JSON_array, const_iterator) {
   EXPECT_EQ(result.at(2), 3);
 }
 
-TEST(JSON_array, simple_iterator) {
+TEST(simple_iterator) {
   std::vector<std::int64_t> result;
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   for (auto &element : document.as_array()) {
@@ -268,7 +268,7 @@ TEST(JSON_array, simple_iterator) {
   EXPECT_EQ(result.at(2), 3);
 }
 
-TEST(JSON_array, int_standard_sort) {
+TEST(int_standard_sort) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[3,2,1]");
   EXPECT_EQ(document.size(), 3);
   EXPECT_EQ(document.array_size(), 3);
@@ -281,7 +281,7 @@ TEST(JSON_array, int_standard_sort) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, object_standard_sort) {
+TEST(object_standard_sort) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(
       R"JSON([{"a":9,"b":1},{"a":1,"b":9},{"a":5,"b":5},{"a":1,"b":1}])JSON");
   std::sort(document.as_array().begin(), document.as_array().end());
@@ -296,7 +296,7 @@ TEST(JSON_array, object_standard_sort) {
   EXPECT_EQ(document.at(3).at("b").to_integer(), 1);
 }
 
-TEST(JSON_array, move_assignment_from_own_element) {
+TEST(move_assignment_from_own_element) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[[1,2,3]]");
   document = std::move(document.at(0));
   EXPECT_TRUE(document.is_array());
@@ -306,7 +306,7 @@ TEST(JSON_array, move_assignment_from_own_element) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, erase_many_full) {
+TEST(erase_many_full) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 3);
@@ -317,7 +317,7 @@ TEST(JSON_array, erase_many_full) {
   EXPECT_EQ(document.array_size(), 0);
 }
 
-TEST(JSON_array, erase_many_partial) {
+TEST(erase_many_partial) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 3);
@@ -330,7 +330,7 @@ TEST(JSON_array, erase_many_partial) {
   EXPECT_EQ(document.at(0).to_integer(), 1);
 }
 
-TEST(JSON_array, erase_many_full_const) {
+TEST(erase_many_full_const) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 3);
@@ -341,59 +341,59 @@ TEST(JSON_array, erase_many_full_const) {
   EXPECT_EQ(document.array_size(), 0);
 }
 
-TEST(JSON_array, contains_string_key_true) {
+TEST(contains_string_key_true) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ \"foo\", \"bar\" ]");
   EXPECT_TRUE(document.contains(sourcemeta::core::JSON{"bar"}));
 }
 
-TEST(JSON_array, contains_string_key_false) {
+TEST(contains_string_key_false) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ \"foo\", \"bar\" ]");
   EXPECT_FALSE(document.contains(sourcemeta::core::JSON{"baz"}));
 }
 
-TEST(JSON_array, contains_string_literal_true) {
+TEST(contains_string_literal_true) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar", "baz" ])JSON");
   EXPECT_TRUE(document.contains("bar"));
 }
 
-TEST(JSON_array, contains_string_literal_false) {
+TEST(contains_string_literal_false) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar", "baz" ])JSON");
   EXPECT_FALSE(document.contains("qux"));
 }
 
-TEST(JSON_array, contains_string_view_true) {
+TEST(contains_string_view_true) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar", "baz" ])JSON");
   const sourcemeta::core::JSON::StringView element{"bar"};
   EXPECT_TRUE(document.contains(element));
 }
 
-TEST(JSON_array, contains_string_view_false) {
+TEST(contains_string_view_false) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar", "baz" ])JSON");
   const sourcemeta::core::JSON::StringView element{"qux"};
   EXPECT_FALSE(document.contains(element));
 }
 
-TEST(JSON_array, contains_string_from_std_string) {
+TEST(contains_string_from_std_string) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar", "baz" ])JSON");
   const std::string element{"bar"};
   EXPECT_TRUE(document.contains(element));
 }
 
-TEST(JSON_array, contains_string_in_mixed_array) {
+TEST(contains_string_in_mixed_array) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, "bar", true, null ])JSON");
   EXPECT_TRUE(document.contains("bar"));
   EXPECT_FALSE(document.contains("foo"));
 }
 
-TEST(JSON_array, defines_any_with_iterators_has_one) {
+TEST(defines_any_with_iterators_has_one) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -405,7 +405,7 @@ TEST(JSON_array, defines_any_with_iterators_has_one) {
   EXPECT_TRUE(document.defines_any(keys.cbegin(), keys.cend()));
 }
 
-TEST(JSON_array, defines_any_with_iterators_has_two) {
+TEST(defines_any_with_iterators_has_two) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -414,7 +414,7 @@ TEST(JSON_array, defines_any_with_iterators_has_two) {
   EXPECT_TRUE(document.defines_any(keys.cbegin(), keys.cend()));
 }
 
-TEST(JSON_array, defines_any_with_iterators_has_none) {
+TEST(defines_any_with_iterators_has_none) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -423,7 +423,7 @@ TEST(JSON_array, defines_any_with_iterators_has_none) {
   EXPECT_FALSE(document.defines_any(keys.cbegin(), keys.cend()));
 }
 
-TEST(JSON_array, defines_any_with_initializer_list_has_one) {
+TEST(defines_any_with_initializer_list_has_one) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -431,7 +431,7 @@ TEST(JSON_array, defines_any_with_initializer_list_has_one) {
   EXPECT_TRUE(document.defines_any({"foo", "qux"}));
 }
 
-TEST(JSON_array, defines_any_with_initializer_list_has_two) {
+TEST(defines_any_with_initializer_list_has_two) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -439,7 +439,7 @@ TEST(JSON_array, defines_any_with_initializer_list_has_two) {
   EXPECT_TRUE(document.defines_any({"foo", "baz"}));
 }
 
-TEST(JSON_array, defines_any_with_initializer_list_has_none) {
+TEST(defines_any_with_initializer_list_has_none) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -447,7 +447,7 @@ TEST(JSON_array, defines_any_with_initializer_list_has_none) {
   EXPECT_FALSE(document.defines_any({"qux", "test"}));
 }
 
-TEST(JSON_array, into_array) {
+TEST(into_array) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into_array();
@@ -456,7 +456,7 @@ TEST(JSON_array, into_array) {
   EXPECT_EQ(document.array_size(), 0);
 }
 
-TEST(JSON_array, clear) {
+TEST(clear) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 3);
@@ -467,31 +467,31 @@ TEST(JSON_array, clear) {
   EXPECT_EQ(document.array_size(), 0);
 }
 
-TEST(JSON_array, estimated_byte_size_integers) {
+TEST(estimated_byte_size_integers) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_EQ(document.estimated_byte_size(), 24);
 }
 
-TEST(JSON_array, estimated_byte_size_nested) {
+TEST(estimated_byte_size_nested) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[1,[\"foo\"],[[true]]]");
   EXPECT_EQ(document.estimated_byte_size(), 12);
 }
 
-TEST(JSON_array, fast_hash_integers) {
+TEST(fast_hash_integers) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_EQ(document.fast_hash(), 27);
 }
 
-TEST(JSON_array, fast_hash_nested) {
+TEST(fast_hash_nested) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[1,[\"foo\"],[[true]]]");
   EXPECT_EQ(document.fast_hash(), 42);
 }
 
-TEST(JSON_array, push_back_if_unique_copy_exists) {
+TEST(push_back_if_unique_copy_exists) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
 
   const sourcemeta::core::JSON element{2};
@@ -509,7 +509,7 @@ TEST(JSON_array, push_back_if_unique_copy_exists) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, push_back_if_unique_copy_not_exist) {
+TEST(push_back_if_unique_copy_not_exist) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
 
   const sourcemeta::core::JSON element{4};
@@ -528,7 +528,7 @@ TEST(JSON_array, push_back_if_unique_copy_not_exist) {
   EXPECT_EQ(document.at(3).to_integer(), 4);
 }
 
-TEST(JSON_array, push_back_if_unique_move_exists) {
+TEST(push_back_if_unique_move_exists) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
 
   sourcemeta::core::JSON element{2};
@@ -546,7 +546,7 @@ TEST(JSON_array, push_back_if_unique_move_exists) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_array, push_back_if_unique_move_not_exist) {
+TEST(push_back_if_unique_move_not_exist) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[1,2,3]");
 
   sourcemeta::core::JSON element{4};
@@ -565,24 +565,24 @@ TEST(JSON_array, push_back_if_unique_move_not_exist) {
   EXPECT_EQ(document.at(3).to_integer(), 4);
 }
 
-TEST(JSON_array, unique_empty) {
+TEST(unique_empty) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("[]");
   EXPECT_TRUE(document.unique());
 }
 
-TEST(JSON_array, unique_true) {
+TEST(unique_true) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ 1, 2, {} ]");
   EXPECT_TRUE(document.unique());
 }
 
-TEST(JSON_array, unique_false) {
+TEST(unique_false) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ [2], 1, [2] ]");
   EXPECT_FALSE(document.unique());
 }
 
-TEST(JSON_array, sort_object_items) {
+TEST(sort_object_items) {
   auto document = sourcemeta::core::parse_json(R"JSON([
     { "type": "string" },
     { "type": "integer" },
@@ -600,7 +600,7 @@ TEST(JSON_array, sort_object_items) {
   EXPECT_EQ(document, expected);
 }
 
-TEST(JSON_array, erase_if_some) {
+TEST(erase_if_some) {
   auto document = sourcemeta::core::parse_json(R"JSON([
     1, 2, 3, 4, 5
   ])JSON");
@@ -616,7 +616,7 @@ TEST(JSON_array, erase_if_some) {
   EXPECT_EQ(document, expected);
 }
 
-TEST(JSON_array, erase_if_none) {
+TEST(erase_if_none) {
   auto document = sourcemeta::core::parse_json(R"JSON([
     1, 2, 3, 4, 5
   ])JSON");
@@ -630,7 +630,7 @@ TEST(JSON_array, erase_if_none) {
   EXPECT_EQ(document, expected);
 }
 
-TEST(JSON_array, erase_if_all) {
+TEST(erase_if_all) {
   auto document = sourcemeta::core::parse_json(R"JSON([
     1, 2, 3, 4, 5
   ])JSON");

--- a/test/json/json_auto_test.cc
+++ b/test/json/json_auto_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <bitset>
 #include <filesystem>
@@ -31,7 +31,7 @@ struct ClassWithCustomMethod {
 
 enum class SampleEnum { Foo = 0, Bar = 1, Baz };
 
-TEST(JSON_auto, class_with_custom_method) {
+TEST(class_with_custom_method) {
   const ClassWithCustomMethod value;
   const auto result{sourcemeta::core::to_json(value)};
   const sourcemeta::core::JSON expected{42};
@@ -41,7 +41,7 @@ TEST(JSON_auto, class_with_custom_method) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, object_hash) {
+TEST(object_hash) {
   const auto value{sourcemeta::core::JSON::Object::hash("foo")};
   const auto result{sourcemeta::core::to_json(value)};
   EXPECT_TRUE(result.is_array());
@@ -53,7 +53,7 @@ TEST(JSON_auto, object_hash) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, json) {
+TEST(json) {
   const sourcemeta::core::JSON value{true};
   const auto result{sourcemeta::core::to_json(value)};
   const sourcemeta::core::JSON expected{true};
@@ -63,7 +63,7 @@ TEST(JSON_auto, json) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, from_constructor) {
+TEST(from_constructor) {
   const auto value{"foo bar"};
   const auto result{sourcemeta::core::to_json(value)};
   const sourcemeta::core::JSON expected{"foo bar"};
@@ -73,7 +73,7 @@ TEST(JSON_auto, from_constructor) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, enum_class) {
+TEST(enum_class) {
   const SampleEnum value{SampleEnum::Bar};
   const auto result{sourcemeta::core::to_json(value)};
   const sourcemeta::core::JSON expected{1};
@@ -83,7 +83,7 @@ TEST(JSON_auto, enum_class) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_with_value) {
+TEST(optional_with_value) {
   const std::optional<std::string> value{"foo bar"};
   const auto result{sourcemeta::core::to_json(value)};
   const sourcemeta::core::JSON expected{"foo bar"};
@@ -94,7 +94,7 @@ TEST(JSON_auto, optional_with_value) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_without_value_1) {
+TEST(optional_without_value_1) {
   const std::optional<std::string> value;
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::parse_json(R"JSON(null)JSON")};
@@ -105,7 +105,7 @@ TEST(JSON_auto, optional_without_value_1) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_without_value_2) {
+TEST(optional_without_value_2) {
   const std::optional<std::size_t> value;
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::parse_json(R"JSON(null)JSON")};
@@ -116,7 +116,7 @@ TEST(JSON_auto, optional_without_value_2) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_tuple_1) {
+TEST(optional_tuple_1) {
   using Type =
       std::optional<std::tuple<std::uint64_t, std::uint64_t, std::uint64_t>>;
   const Type value{
@@ -129,7 +129,7 @@ TEST(JSON_auto, optional_tuple_1) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_tuple_2) {
+TEST(optional_tuple_2) {
   using Type =
       std::optional<std::tuple<std::uint64_t, std::uint64_t, std::uint64_t>>;
   const Type value;
@@ -141,7 +141,7 @@ TEST(JSON_auto, optional_tuple_2) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_strings_without_iterators) {
+TEST(vector_strings_without_iterators) {
   const std::vector<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -156,7 +156,7 @@ TEST(JSON_auto, vector_strings_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_paths_without_iterators) {
+TEST(vector_paths_without_iterators) {
   const std::vector<std::filesystem::path> value{TEST_DIRECTORY};
   const auto result{sourcemeta::core::to_json(value)};
   EXPECT_EQ(result.size(), 1);
@@ -166,7 +166,7 @@ TEST(JSON_auto, vector_paths_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_with_iterators) {
+TEST(vector_with_iterators) {
   const std::vector<std::string> value{"foo", "bar", "baz"};
   const auto result{
       sourcemeta::core::to_json<decltype(value)>(value.cbegin(), value.cend())};
@@ -182,7 +182,7 @@ TEST(JSON_auto, vector_with_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_with_iterators_and_transform) {
+TEST(vector_with_iterators_and_transform) {
   const std::vector<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json<decltype(value)>(
       value.cbegin(), value.cend(), [](const auto &subvalue) {
@@ -201,7 +201,7 @@ TEST(JSON_auto, vector_with_iterators_and_transform) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_without_iterators) {
+TEST(vector_without_iterators) {
   const std::vector<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -216,7 +216,7 @@ TEST(JSON_auto, vector_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_without_iterators_and_transform) {
+TEST(vector_without_iterators_and_transform) {
   const std::vector<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(value, [](const auto &subvalue) {
     return sourcemeta::core::JSON{std::string{"$"} + subvalue};
@@ -234,7 +234,7 @@ TEST(JSON_auto, vector_without_iterators_and_transform) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_of_pairs) {
+TEST(vector_of_pairs) {
   const std::vector<std::pair<std::string, std::size_t>> value{
       {"foo", 1}, {"bar", 2}, {"baz", 3}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -252,7 +252,7 @@ TEST(JSON_auto, vector_of_pairs) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_with_iterators) {
+TEST(map_with_iterators) {
   const std::map<std::string, std::size_t> value{
       {"foo", 1}, {"bar", 2}, {"baz", 3}};
   const auto result{
@@ -271,7 +271,7 @@ TEST(JSON_auto, map_with_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_without_iterators) {
+TEST(map_without_iterators) {
   const std::map<std::string, std::size_t> value{
       {"foo", 1}, {"bar", 2}, {"baz", 3}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -289,7 +289,7 @@ TEST(JSON_auto, map_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_of_map) {
+TEST(map_of_map) {
   const std::map<std::string, std::map<std::string, std::size_t>> value{
       {"foo", {{"bar", 1}, {"baz", 2}}}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -308,7 +308,7 @@ TEST(JSON_auto, map_of_map) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_without_iterators_and_transform) {
+TEST(map_without_iterators_and_transform) {
   const std::map<std::string, std::size_t> value{
       {"foo", 1}, {"bar", 2}, {"baz", 3}};
   const auto result{sourcemeta::core::to_json(value, [](const auto subvalue) {
@@ -330,7 +330,7 @@ TEST(JSON_auto, map_without_iterators_and_transform) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, set_without_iterators) {
+TEST(set_without_iterators) {
   const std::set<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -344,7 +344,7 @@ TEST(JSON_auto, set_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, unordered_set_without_iterators) {
+TEST(unordered_set_without_iterators) {
   const std::unordered_set<std::string> value{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -359,7 +359,7 @@ TEST(JSON_auto, unordered_set_without_iterators) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, unsigned_long_long) {
+TEST(unsigned_long_long) {
   const unsigned long long value{15};
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::JSON{15}};
@@ -369,7 +369,7 @@ TEST(JSON_auto, unsigned_long_long) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, pair) {
+TEST(pair) {
   const std::pair<std::string, std::size_t> value{"foo", 1};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -384,7 +384,7 @@ TEST(JSON_auto, pair) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, pair_with_pair) {
+TEST(pair_with_pair) {
   const std::pair<sourcemeta::core::JSON::Type,
                   std::pair<sourcemeta::core::JSON::Type, std::size_t>>
       value{sourcemeta::core::JSON::Type::String,
@@ -402,7 +402,7 @@ TEST(JSON_auto, pair_with_pair) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, tuple_1) {
+TEST(tuple_1) {
   const std::tuple<std::string> value{"foo"};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -416,7 +416,7 @@ TEST(JSON_auto, tuple_1) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, tuple_2) {
+TEST(tuple_2) {
   const std::tuple<std::string, std::size_t> value{"foo", 1};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -432,7 +432,7 @@ TEST(JSON_auto, tuple_2) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, tuple_3) {
+TEST(tuple_3) {
   const std::tuple<std::string, std::size_t, bool> value{"foo", 1, true};
   const auto result{sourcemeta::core::to_json(value)};
 
@@ -448,7 +448,7 @@ TEST(JSON_auto, tuple_3) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, tuple_4) {
+TEST(tuple_4) {
   const std::tuple<std::size_t, std::optional<std::size_t>, bool> value{
       1, {}, false};
   const auto result{sourcemeta::core::to_json(value)};
@@ -464,7 +464,7 @@ TEST(JSON_auto, tuple_4) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, file_time_1) {
+TEST(file_time_1) {
   const std::filesystem::path file{std::filesystem::path{TEST_DIRECTORY} /
                                    "stub_valid.json"};
   EXPECT_TRUE(std::filesystem::exists(file));
@@ -477,7 +477,7 @@ TEST(JSON_auto, file_time_1) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, file_time_2) {
+TEST(file_time_2) {
   const std::filesystem::path file{std::filesystem::path{TEST_DIRECTORY} /
                                    "stub_invalid_1.json"};
   EXPECT_TRUE(std::filesystem::exists(file));
@@ -490,7 +490,7 @@ TEST(JSON_auto, file_time_2) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, file_time_3) {
+TEST(file_time_3) {
   const std::filesystem::path file{std::filesystem::path{TEST_DIRECTORY} /
                                    "stub_invalid_2.json"};
   EXPECT_TRUE(std::filesystem::exists(file));
@@ -503,7 +503,7 @@ TEST(JSON_auto, file_time_3) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, file_time_4) {
+TEST(file_time_4) {
   const std::filesystem::path file{std::filesystem::path{TEST_DIRECTORY} /
                                    "stub_bigint.json"};
   EXPECT_TRUE(std::filesystem::exists(file));
@@ -516,7 +516,7 @@ TEST(JSON_auto, file_time_4) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, file_time_idempotency) {
+TEST(file_time_idempotency) {
   const std::filesystem::path file{std::filesystem::path{TEST_DIRECTORY} /
                                    "stub_valid.json"};
   EXPECT_TRUE(std::filesystem::exists(file));
@@ -535,7 +535,7 @@ TEST(JSON_auto, file_time_idempotency) {
   EXPECT_EQ(result_3, result_1);
 }
 
-TEST(JSON_auto, filesystem_path) {
+TEST(filesystem_path) {
   const std::filesystem::path value{TEST_DIRECTORY};
   const auto result{sourcemeta::core::to_json(value)};
   EXPECT_TRUE(result.is_string());
@@ -544,19 +544,19 @@ TEST(JSON_auto, filesystem_path) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, from_json_invalid_bool) {
+TEST(from_json_invalid_bool) {
   const sourcemeta::core::JSON document{42};
   const auto result{sourcemeta::core::from_json<bool>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_integer) {
+TEST(from_json_invalid_integer) {
   const sourcemeta::core::JSON document{true};
   const auto result{sourcemeta::core::from_json<int>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_hash_1) {
+TEST(from_json_invalid_hash_1) {
   const sourcemeta::core::JSON document{true};
   const auto result{
       sourcemeta::core::from_json<sourcemeta::core::JSON::Object::hash_type>(
@@ -564,7 +564,7 @@ TEST(JSON_auto, from_json_invalid_hash_1) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_hash_2) {
+TEST(from_json_invalid_hash_2) {
   const auto document{sourcemeta::core::parse_json(R"JSON([
     "foo", "bar", "baz"
   ])JSON")};
@@ -575,7 +575,7 @@ TEST(JSON_auto, from_json_invalid_hash_2) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_hash_3) {
+TEST(from_json_invalid_hash_3) {
   const auto document{sourcemeta::core::parse_json(R"JSON([
     "foo", "bar", "baz", "qux"
   ])JSON")};
@@ -586,31 +586,31 @@ TEST(JSON_auto, from_json_invalid_hash_3) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_string) {
+TEST(from_json_invalid_string) {
   const sourcemeta::core::JSON document{true};
   const auto result{sourcemeta::core::from_json<std::string>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_enum) {
+TEST(from_json_invalid_enum) {
   const sourcemeta::core::JSON document{true};
   const auto result{sourcemeta::core::from_json<SampleEnum>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_optional) {
+TEST(from_json_invalid_optional) {
   const sourcemeta::core::JSON document{true};
   const auto result{sourcemeta::core::from_json<std::optional<int>>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_vector) {
+TEST(from_json_invalid_vector) {
   const sourcemeta::core::JSON document{true};
   const auto result{sourcemeta::core::from_json<std::vector<bool>>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_vector_transform) {
+TEST(from_json_invalid_vector_transform) {
   const auto document{sourcemeta::core::parse_json(R"JSON([
     "foo", "bar", "baz", true
   ])JSON")};
@@ -623,14 +623,14 @@ TEST(JSON_auto, from_json_invalid_vector_transform) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_map) {
+TEST(from_json_invalid_map) {
   const sourcemeta::core::JSON document{true};
   const auto result{
       sourcemeta::core::from_json<std::map<std::string, bool>>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_map_transform) {
+TEST(from_json_invalid_map_transform) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": 1,
     "bar": true
@@ -644,7 +644,7 @@ TEST(JSON_auto, from_json_invalid_map_transform) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_pair_type) {
+TEST(from_json_invalid_pair_type) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "foo": "bar", "baz": 2 })JSON")};
   const auto result{
@@ -652,21 +652,21 @@ TEST(JSON_auto, from_json_invalid_pair_type) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_pair_size) {
+TEST(from_json_invalid_pair_size) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 1 ])JSON")};
   const auto result{
       sourcemeta::core::from_json<std::pair<std::string, int>>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_pair_first) {
+TEST(from_json_invalid_pair_first) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2 ])JSON")};
   const auto result{
       sourcemeta::core::from_json<std::pair<std::string, int>>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_pair_second) {
+TEST(from_json_invalid_pair_second) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar" ])JSON")};
   const auto result{
@@ -674,7 +674,7 @@ TEST(JSON_auto, from_json_invalid_pair_second) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_tuple_mono_type) {
+TEST(from_json_invalid_tuple_mono_type) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "foo": "bar" })JSON")};
   const auto result{
@@ -682,7 +682,7 @@ TEST(JSON_auto, from_json_invalid_tuple_mono_type) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_tuple_mono_size) {
+TEST(from_json_invalid_tuple_mono_size) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON([ "foo", "bar" ])JSON")};
   const auto result{
@@ -690,13 +690,13 @@ TEST(JSON_auto, from_json_invalid_tuple_mono_size) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_tuple_mono_element) {
+TEST(from_json_invalid_tuple_mono_element) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ "foo" ])JSON")};
   const auto result{sourcemeta::core::from_json<std::tuple<int>>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_tuple_poly_type) {
+TEST(from_json_invalid_tuple_poly_type) {
   const auto document{sourcemeta::core::parse_json(
       R"JSON({ "foo": "bar", "baz": "qux" })JSON")};
   const auto result{
@@ -705,7 +705,7 @@ TEST(JSON_auto, from_json_invalid_tuple_poly_type) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_tuple_poly_size) {
+TEST(from_json_invalid_tuple_poly_size) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ "foo" ])JSON")};
   const auto result{
       sourcemeta::core::from_json<std::tuple<std::string, std::string>>(
@@ -713,7 +713,7 @@ TEST(JSON_auto, from_json_invalid_tuple_poly_size) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, from_json_invalid_tuple_poly_element) {
+TEST(from_json_invalid_tuple_poly_element) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ "foo", 1 ])JSON")};
   const auto result{
       sourcemeta::core::from_json<std::tuple<std::string, std::string>>(
@@ -721,7 +721,7 @@ TEST(JSON_auto, from_json_invalid_tuple_poly_element) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, optional_pair) {
+TEST(optional_pair) {
   using Type = std::optional<std::pair<std::string, std::size_t>>;
   const Type value{std::make_pair("foo", 42)};
   const auto result{sourcemeta::core::to_json(value)};
@@ -732,7 +732,7 @@ TEST(JSON_auto, optional_pair) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_map) {
+TEST(optional_map) {
   using Type = std::optional<std::map<std::string, std::size_t>>;
   const Type value{std::map<std::string, std::size_t>{{"foo", 1}, {"bar", 2}}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -744,7 +744,7 @@ TEST(JSON_auto, optional_map) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_of_tuples) {
+TEST(vector_of_tuples) {
   const std::vector<std::tuple<std::string, std::size_t, bool>> value{
       {"foo", 1, true}, {"bar", 2, false}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -759,7 +759,7 @@ TEST(JSON_auto, vector_of_tuples) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_of_tuples) {
+TEST(map_of_tuples) {
   const std::map<std::string, std::tuple<std::size_t, bool>> value{
       {"foo", {1, true}}, {"bar", {2, false}}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -774,7 +774,7 @@ TEST(JSON_auto, map_of_tuples) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_of_pairs) {
+TEST(map_of_pairs) {
   const std::map<std::string, std::pair<std::size_t, bool>> value{
       {"foo", {1, true}}, {"bar", {2, false}}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -789,7 +789,7 @@ TEST(JSON_auto, map_of_pairs) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_vector_of_tuples) {
+TEST(optional_vector_of_tuples) {
   using Type = std::optional<std::vector<std::tuple<std::string, std::size_t>>>;
   const Type value{std::vector<std::tuple<std::string, std::size_t>>{
       {"foo", 1}, {"bar", 2}}};
@@ -804,7 +804,7 @@ TEST(JSON_auto, optional_vector_of_tuples) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, pair_with_optional) {
+TEST(pair_with_optional) {
   using Type = std::pair<std::string, std::optional<std::size_t>>;
   const Type value{"foo", 42};
   const auto result{sourcemeta::core::to_json(value)};
@@ -815,7 +815,7 @@ TEST(JSON_auto, pair_with_optional) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, tuple_with_pair) {
+TEST(tuple_with_pair) {
   using Type = std::tuple<std::string, std::pair<std::size_t, bool>>;
   const Type value{"foo", {42, true}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -827,7 +827,7 @@ TEST(JSON_auto, tuple_with_pair) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, decimal) {
+TEST(decimal) {
   const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
   const auto result{sourcemeta::core::to_json(value)};
   const sourcemeta::core::JSON expected{
@@ -840,7 +840,7 @@ TEST(JSON_auto, decimal) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_decimal_with_value) {
+TEST(optional_decimal_with_value) {
   const std::optional<sourcemeta::core::Decimal> value{
       sourcemeta::core::Decimal{"987654321098765432109876543210"}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -855,7 +855,7 @@ TEST(JSON_auto, optional_decimal_with_value) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_decimal_without_value) {
+TEST(optional_decimal_without_value) {
   const std::optional<sourcemeta::core::Decimal> value;
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::parse_json(R"JSON(null)JSON")};
@@ -867,7 +867,7 @@ TEST(JSON_auto, optional_decimal_without_value) {
   EXPECT_FALSE(back.value().has_value());
 }
 
-TEST(JSON_auto, vector_of_decimals) {
+TEST(vector_of_decimals) {
   const std::vector<sourcemeta::core::Decimal> value{
       sourcemeta::core::Decimal{"123456789012345678901234567890"}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -884,7 +884,7 @@ TEST(JSON_auto, vector_of_decimals) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, map_of_decimals) {
+TEST(map_of_decimals) {
   const std::map<std::string, sourcemeta::core::Decimal> value{
       {"large", sourcemeta::core::Decimal{"999999999999999999999999999999"}}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -900,7 +900,7 @@ TEST(JSON_auto, map_of_decimals) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, vector_of_optional_decimals) {
+TEST(vector_of_optional_decimals) {
   const std::vector<std::optional<sourcemeta::core::Decimal>> value{
       sourcemeta::core::Decimal{"123456789012345678901234567890"},
       std::nullopt};
@@ -918,7 +918,7 @@ TEST(JSON_auto, vector_of_optional_decimals) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_8) {
+TEST(bitset_8) {
   const std::bitset<8> value{"10110101"};
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::JSON{181}};
@@ -929,7 +929,7 @@ TEST(JSON_auto, bitset_8) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_16) {
+TEST(bitset_16) {
   const std::bitset<16> value{"1011010110110101"};
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::JSON{46517}};
@@ -940,7 +940,7 @@ TEST(JSON_auto, bitset_16) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_32) {
+TEST(bitset_32) {
   const std::bitset<32> value{"10110101101101011011010110110101"};
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{
@@ -952,7 +952,7 @@ TEST(JSON_auto, bitset_32) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_8_all_zeros) {
+TEST(bitset_8_all_zeros) {
   const std::bitset<8> value{"00000000"};
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::JSON{0}};
@@ -963,7 +963,7 @@ TEST(JSON_auto, bitset_8_all_zeros) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_8_all_ones) {
+TEST(bitset_8_all_ones) {
   const std::bitset<8> value{"11111111"};
   const auto result{sourcemeta::core::to_json(value)};
   const auto expected{sourcemeta::core::JSON{255}};
@@ -974,7 +974,7 @@ TEST(JSON_auto, bitset_8_all_ones) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_64) {
+TEST(bitset_64) {
   const std::bitset<64> value{
       "1011010110110101101101011011010110110101101101011011010110110101"};
   const auto result{sourcemeta::core::to_json(value)};
@@ -984,7 +984,7 @@ TEST(JSON_auto, bitset_64) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, bitset_128) {
+TEST(bitset_128) {
   const std::bitset<128> value{
       "1011010110110101101101011011010110110101101101011011010110110101101101"
       "0110110101101101011011010110110101101101011011010110110101"};
@@ -995,7 +995,7 @@ TEST(JSON_auto, bitset_128) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, variant_first_alternative) {
+TEST(variant_first_alternative) {
   using Type = std::variant<std::string, int, bool>;
   const Type value{"hello"};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1010,7 +1010,7 @@ TEST(JSON_auto, variant_first_alternative) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, variant_second_alternative) {
+TEST(variant_second_alternative) {
   using Type = std::variant<std::string, int, bool>;
   const Type value{42};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1025,7 +1025,7 @@ TEST(JSON_auto, variant_second_alternative) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, variant_third_alternative) {
+TEST(variant_third_alternative) {
   using Type = std::variant<std::string, int, bool>;
   const Type value{true};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1040,7 +1040,7 @@ TEST(JSON_auto, variant_third_alternative) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, variant_with_enum) {
+TEST(variant_with_enum) {
   using Type = std::variant<SampleEnum, std::string>;
   const Type value{SampleEnum::Baz};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1055,14 +1055,14 @@ TEST(JSON_auto, variant_with_enum) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, variant_from_json_invalid_type) {
+TEST(variant_from_json_invalid_type) {
   using Type = std::variant<std::string, int>;
   const sourcemeta::core::JSON document{"not-an-array"};
   const auto result{sourcemeta::core::from_json<Type>(document)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, variant_from_json_invalid_size) {
+TEST(variant_from_json_invalid_size) {
   using Type = std::variant<std::string, int>;
   auto document{sourcemeta::core::JSON::make_array()};
   document.push_back(sourcemeta::core::JSON{0});
@@ -1070,7 +1070,7 @@ TEST(JSON_auto, variant_from_json_invalid_size) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, variant_from_json_invalid_index_type) {
+TEST(variant_from_json_invalid_index_type) {
   using Type = std::variant<std::string, int>;
   auto document{sourcemeta::core::JSON::make_array()};
   document.push_back(sourcemeta::core::JSON{"not-an-index"});
@@ -1079,7 +1079,7 @@ TEST(JSON_auto, variant_from_json_invalid_index_type) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, variant_from_json_index_out_of_range) {
+TEST(variant_from_json_index_out_of_range) {
   using Type = std::variant<std::string, int>;
   auto document{sourcemeta::core::JSON::make_array()};
   document.push_back(sourcemeta::core::JSON{99});
@@ -1088,7 +1088,7 @@ TEST(JSON_auto, variant_from_json_index_out_of_range) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, variant_from_json_data_type_mismatch) {
+TEST(variant_from_json_data_type_mismatch) {
   using Type = std::variant<std::string, int>;
   auto document{sourcemeta::core::JSON::make_array()};
   document.push_back(sourcemeta::core::JSON{0});
@@ -1097,7 +1097,7 @@ TEST(JSON_auto, variant_from_json_data_type_mismatch) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSON_auto, optional_variant) {
+TEST(optional_variant) {
   using Type = std::optional<std::variant<std::string, int>>;
   const Type value{std::variant<std::string, int>{42}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1108,7 +1108,7 @@ TEST(JSON_auto, optional_variant) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, optional_variant_nullopt) {
+TEST(optional_variant_nullopt) {
   using Type = std::optional<std::variant<std::string, int>>;
   const Type value{std::nullopt};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1118,7 +1118,7 @@ TEST(JSON_auto, optional_variant_nullopt) {
   EXPECT_FALSE(back.value().has_value());
 }
 
-TEST(JSON_auto, vector_of_variants) {
+TEST(vector_of_variants) {
   using Type = std::vector<std::variant<std::string, int>>;
   const Type value{std::string{"hello"}, 42, std::string{"world"}};
   const auto result{sourcemeta::core::to_json(value)};
@@ -1129,14 +1129,14 @@ TEST(JSON_auto, vector_of_variants) {
   EXPECT_EQ(value, back.value());
 }
 
-TEST(JSON_auto, to_json_string_view) {
+TEST(to_json_string_view) {
   const std::string_view value{"hello"};
   const auto result{sourcemeta::core::to_json(value)};
   EXPECT_TRUE(result.is_string());
   EXPECT_EQ(result.to_string(), "hello");
 }
 
-TEST(JSON_auto, to_json_string_view_subview) {
+TEST(to_json_string_view_subview) {
   const std::string buffer{"prefix-hello-suffix"};
   const std::string_view value{buffer.data() + 7, 5};
   const auto result{sourcemeta::core::to_json(value)};

--- a/test/json/json_boolean_test.cc
+++ b/test/json/json_boolean_test.cc
@@ -1,30 +1,30 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
-TEST(JSON_boolean, true_value) {
+TEST(true_value) {
   const sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   EXPECT_TRUE(document.to_boolean());
 }
 
-TEST(JSON_boolean, false_value) {
+TEST(false_value) {
   const sourcemeta::core::JSON document{false};
   EXPECT_TRUE(document.is_boolean());
   EXPECT_FALSE(document.to_boolean());
 }
 
-TEST(JSON_boolean, type_false) {
+TEST(type_false) {
   const sourcemeta::core::JSON document{false};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Boolean);
 }
 
-TEST(JSON_boolean, type_true) {
+TEST(type_true) {
   const sourcemeta::core::JSON document{true};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Boolean);
 }
 
-TEST(JSON_boolean, literal_equality_false) {
+TEST(literal_equality_false) {
   const sourcemeta::core::JSON left{false};
   const sourcemeta::core::JSON right{false};
   const sourcemeta::core::JSON extra{true};
@@ -36,7 +36,7 @@ TEST(JSON_boolean, literal_equality_false) {
   EXPECT_FALSE(right == extra);
 }
 
-TEST(JSON_boolean, literal_equality_true) {
+TEST(literal_equality_true) {
   const sourcemeta::core::JSON left{true};
   const sourcemeta::core::JSON right{true};
   const sourcemeta::core::JSON extra{false};
@@ -48,22 +48,22 @@ TEST(JSON_boolean, literal_equality_true) {
   EXPECT_FALSE(right == extra);
 }
 
-TEST(JSON_boolean, estimated_byte_size_false) {
+TEST(estimated_byte_size_false) {
   const sourcemeta::core::JSON document{false};
   EXPECT_EQ(document.estimated_byte_size(), 1);
 }
 
-TEST(JSON_boolean, estimated_byte_size_true) {
+TEST(estimated_byte_size_true) {
   const sourcemeta::core::JSON document{true};
   EXPECT_EQ(document.estimated_byte_size(), 1);
 }
 
-TEST(JSON_boolean, fast_hash_false) {
+TEST(fast_hash_false) {
   const sourcemeta::core::JSON document{false};
   EXPECT_EQ(document.fast_hash(), 0);
 }
 
-TEST(JSON_boolean, fast_hash_true) {
+TEST(fast_hash_true) {
   const sourcemeta::core::JSON document{true};
   EXPECT_EQ(document.fast_hash(), 1);
 }

--- a/test/json/json_decimal_test.cc
+++ b/test/json/json_decimal_test.cc
@@ -1,35 +1,35 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
-TEST(JSON_decimal, positive) {
+TEST(positive) {
   const sourcemeta::core::Decimal value{42};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_int64(), 42);
 }
 
-TEST(JSON_decimal, type) {
+TEST(type) {
   const sourcemeta::core::Decimal value{5};
   const sourcemeta::core::JSON document{value};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Decimal);
 }
 
-TEST(JSON_decimal, negative) {
+TEST(negative) {
   const sourcemeta::core::Decimal value{-10};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_int64(), -10);
 }
 
-TEST(JSON_decimal, zero) {
+TEST(zero) {
   const sourcemeta::core::Decimal value{0};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_int64(), 0);
 }
 
-TEST(JSON_decimal, copy_constructor_from_json) {
+TEST(copy_constructor_from_json) {
   const sourcemeta::core::Decimal value{123};
   const sourcemeta::core::JSON decimal{value};
   const sourcemeta::core::JSON document{decimal};
@@ -37,21 +37,21 @@ TEST(JSON_decimal, copy_constructor_from_json) {
   EXPECT_EQ(document.to_decimal().to_int64(), 123);
 }
 
-TEST(JSON_decimal, copy_constructor_from_decimal) {
+TEST(copy_constructor_from_decimal) {
   const sourcemeta::core::Decimal value{789};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_int64(), 789);
 }
 
-TEST(JSON_decimal, move_constructor) {
+TEST(move_constructor) {
   sourcemeta::core::Decimal value{456};
   const sourcemeta::core::JSON document{std::move(value)};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_int64(), 456);
 }
 
-TEST(JSON_decimal, copy_assignment) {
+TEST(copy_assignment) {
   const sourcemeta::core::Decimal value{999};
   const sourcemeta::core::JSON source{value};
   sourcemeta::core::JSON document{5};
@@ -60,7 +60,7 @@ TEST(JSON_decimal, copy_assignment) {
   EXPECT_EQ(document.to_decimal().to_int64(), 999);
 }
 
-TEST(JSON_decimal, move_assignment) {
+TEST(move_assignment) {
   sourcemeta::core::Decimal value{777};
   sourcemeta::core::JSON source{value};
   sourcemeta::core::JSON document{10};
@@ -69,7 +69,7 @@ TEST(JSON_decimal, move_assignment) {
   EXPECT_EQ(document.to_decimal().to_int64(), 777);
 }
 
-TEST(JSON_decimal, large_positive) {
+TEST(large_positive) {
   const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
@@ -77,7 +77,7 @@ TEST(JSON_decimal, large_positive) {
             "123456789012345678901234567890");
 }
 
-TEST(JSON_decimal, large_negative) {
+TEST(large_negative) {
   const sourcemeta::core::Decimal value{"-987654321098765432109876543210"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
@@ -85,63 +85,63 @@ TEST(JSON_decimal, large_negative) {
             "-987654321098765432109876543210");
 }
 
-TEST(JSON_decimal, fractional) {
+TEST(fractional) {
   const sourcemeta::core::Decimal value{"3.14159265358979323846"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "3.14159265358979323846");
 }
 
-TEST(JSON_decimal, negative_fractional) {
+TEST(negative_fractional) {
   const sourcemeta::core::Decimal value{"-2.71828182845904523536"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "-2.71828182845904523536");
 }
 
-TEST(JSON_decimal, is_not_integer) {
+TEST(is_not_integer) {
   const sourcemeta::core::Decimal value{42};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_integer());
 }
 
-TEST(JSON_decimal, is_not_real) {
+TEST(is_not_real) {
   const sourcemeta::core::Decimal value{"3.14"};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_real());
 }
 
-TEST(JSON_decimal, is_not_string) {
+TEST(is_not_string) {
   const sourcemeta::core::Decimal value{100};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_string());
 }
 
-TEST(JSON_decimal, is_not_boolean) {
+TEST(is_not_boolean) {
   const sourcemeta::core::Decimal value{1};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_boolean());
 }
 
-TEST(JSON_decimal, is_not_null) {
+TEST(is_not_null) {
   const sourcemeta::core::Decimal value{0};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_null());
 }
 
-TEST(JSON_decimal, is_not_array) {
+TEST(is_not_array) {
   const sourcemeta::core::Decimal value{42};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_array());
 }
 
-TEST(JSON_decimal, is_not_object) {
+TEST(is_not_object) {
   const sourcemeta::core::Decimal value{42};
   const sourcemeta::core::JSON document{value};
   EXPECT_FALSE(document.is_object());
 }
 
-TEST(JSON_decimal, to_decimal_returns_reference) {
+TEST(to_decimal_returns_reference) {
   const sourcemeta::core::Decimal value{555};
   const sourcemeta::core::JSON document{value};
   const sourcemeta::core::Decimal &reference{document.to_decimal()};
@@ -149,7 +149,7 @@ TEST(JSON_decimal, to_decimal_returns_reference) {
   EXPECT_EQ(&reference, &document.to_decimal());
 }
 
-TEST(JSON_decimal, copy_preserves_precision) {
+TEST(copy_preserves_precision) {
   const sourcemeta::core::Decimal value{
       "12345678901234567890.123456789012345678901234567890"};
   const sourcemeta::core::JSON original{value};
@@ -157,7 +157,7 @@ TEST(JSON_decimal, copy_preserves_precision) {
   EXPECT_EQ(copy.to_decimal().to_string(), original.to_decimal().to_string());
 }
 
-TEST(JSON_decimal, assignment_from_other_type) {
+TEST(assignment_from_other_type) {
   const sourcemeta::core::Decimal value{888};
   const sourcemeta::core::JSON decimal{value};
   sourcemeta::core::JSON document{true};
@@ -167,7 +167,7 @@ TEST(JSON_decimal, assignment_from_other_type) {
   EXPECT_EQ(document.to_decimal().to_int64(), 888);
 }
 
-TEST(JSON_decimal, assignment_to_other_type) {
+TEST(assignment_to_other_type) {
   const sourcemeta::core::Decimal value{333};
   sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
@@ -176,28 +176,28 @@ TEST(JSON_decimal, assignment_to_other_type) {
   EXPECT_FALSE(document.is_decimal());
 }
 
-TEST(JSON_decimal, very_small_fractional) {
+TEST(very_small_fractional) {
   const sourcemeta::core::Decimal value{"0.000000000000000000000000000001"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "1e-30");
 }
 
-TEST(JSON_decimal, scientific_notation) {
+TEST(scientific_notation) {
   const sourcemeta::core::Decimal value{"1.23e10"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "12.3e+9");
 }
 
-TEST(JSON_decimal, negative_scientific_notation) {
+TEST(negative_scientific_notation) {
   const sourcemeta::core::Decimal value{"-4.56e-5"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "-0.0000456");
 }
 
-TEST(JSON_decimal, unsigned_integer_construction) {
+TEST(unsigned_integer_construction) {
   const sourcemeta::core::Decimal value{
       static_cast<std::uint64_t>(18446744073709551615ULL)};
   const sourcemeta::core::JSON document{value};
@@ -205,7 +205,7 @@ TEST(JSON_decimal, unsigned_integer_construction) {
   EXPECT_EQ(document.to_decimal().to_uint64(), 18446744073709551615ULL);
 }
 
-TEST(JSON_decimal, multiple_copies) {
+TEST(multiple_copies) {
   const sourcemeta::core::Decimal value{111};
   const sourcemeta::core::JSON first{value};
   const sourcemeta::core::JSON second{first};
@@ -214,7 +214,7 @@ TEST(JSON_decimal, multiple_copies) {
   EXPECT_EQ(third.to_decimal().to_int64(), 111);
 }
 
-TEST(JSON_decimal, negative_in_object) {
+TEST(negative_in_object) {
   const sourcemeta::core::Decimal value{"-67.89"};
   const sourcemeta::core::JSON document{
       {"test", sourcemeta::core::JSON{value}}};
@@ -222,7 +222,7 @@ TEST(JSON_decimal, negative_in_object) {
   EXPECT_EQ(document.at("test").to_decimal().to_string(), "-67.89");
 }
 
-TEST(JSON_decimal, negative_copy_into_array) {
+TEST(negative_copy_into_array) {
   const sourcemeta::core::Decimal value{"-67.89"};
   const sourcemeta::core::JSON decimal_json{value};
   sourcemeta::core::JSON document{sourcemeta::core::JSON::make_array()};
@@ -231,7 +231,7 @@ TEST(JSON_decimal, negative_copy_into_array) {
   EXPECT_EQ(document.at(0).to_decimal().to_string(), "-67.89");
 }
 
-TEST(JSON_decimal, less_than_decimal_decimal) {
+TEST(less_than_decimal_decimal) {
   const sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"5.7"}};
   EXPECT_TRUE(value1 < value2);
@@ -239,7 +239,7 @@ TEST(JSON_decimal, less_than_decimal_decimal) {
   EXPECT_FALSE(value1 < value1);
 }
 
-TEST(JSON_decimal, less_than_or_equal_decimal_decimal) {
+TEST(less_than_or_equal_decimal_decimal) {
   const sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON value3{sourcemeta::core::Decimal{"3.2"}};
@@ -248,7 +248,7 @@ TEST(JSON_decimal, less_than_or_equal_decimal_decimal) {
   EXPECT_TRUE(value1 <= value3);
 }
 
-TEST(JSON_decimal, greater_than_decimal_decimal) {
+TEST(greater_than_decimal_decimal) {
   const sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"3.2"}};
   EXPECT_TRUE(value1 > value2);
@@ -256,7 +256,7 @@ TEST(JSON_decimal, greater_than_decimal_decimal) {
   EXPECT_FALSE(value1 > value1);
 }
 
-TEST(JSON_decimal, greater_than_or_equal_decimal_decimal) {
+TEST(greater_than_or_equal_decimal_decimal) {
   const sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON value3{sourcemeta::core::Decimal{"5.7"}};
@@ -265,14 +265,14 @@ TEST(JSON_decimal, greater_than_or_equal_decimal_decimal) {
   EXPECT_TRUE(value1 >= value3);
 }
 
-TEST(JSON_decimal, less_than_decimal_integer) {
+TEST(less_than_decimal_integer) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON integer{5};
   EXPECT_TRUE(decimal < integer);
   EXPECT_FALSE(integer < decimal);
 }
 
-TEST(JSON_decimal, less_than_or_equal_decimal_integer) {
+TEST(less_than_or_equal_decimal_integer) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"5"}};
@@ -281,14 +281,14 @@ TEST(JSON_decimal, less_than_or_equal_decimal_integer) {
   EXPECT_TRUE(equal <= integer);
 }
 
-TEST(JSON_decimal, greater_than_decimal_integer) {
+TEST(greater_than_decimal_integer) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON integer{3};
   EXPECT_TRUE(decimal > integer);
   EXPECT_FALSE(integer > decimal);
 }
 
-TEST(JSON_decimal, greater_than_or_equal_decimal_integer) {
+TEST(greater_than_or_equal_decimal_integer) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON integer{3};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"3"}};
@@ -297,14 +297,14 @@ TEST(JSON_decimal, greater_than_or_equal_decimal_integer) {
   EXPECT_TRUE(equal >= integer);
 }
 
-TEST(JSON_decimal, less_than_decimal_real) {
+TEST(less_than_decimal_real) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON real{5.5};
   EXPECT_TRUE(decimal < real);
   EXPECT_FALSE(real < decimal);
 }
 
-TEST(JSON_decimal, less_than_or_equal_decimal_real) {
+TEST(less_than_or_equal_decimal_real) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON real{5.5};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"5.5"}};
@@ -313,14 +313,14 @@ TEST(JSON_decimal, less_than_or_equal_decimal_real) {
   EXPECT_TRUE(equal <= real);
 }
 
-TEST(JSON_decimal, greater_than_decimal_real) {
+TEST(greater_than_decimal_real) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON real{3.5};
   EXPECT_TRUE(decimal > real);
   EXPECT_FALSE(real > decimal);
 }
 
-TEST(JSON_decimal, greater_than_or_equal_decimal_real) {
+TEST(greater_than_or_equal_decimal_real) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON real{3.5};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"3.5"}};
@@ -329,7 +329,7 @@ TEST(JSON_decimal, greater_than_or_equal_decimal_real) {
   EXPECT_TRUE(equal >= real);
 }
 
-TEST(JSON_decimal, addition_decimal_decimal) {
+TEST(addition_decimal_decimal) {
   const sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON result{value1 + value2};
@@ -337,7 +337,7 @@ TEST(JSON_decimal, addition_decimal_decimal) {
   EXPECT_EQ(result.to_decimal().to_string(), "8.9");
 }
 
-TEST(JSON_decimal, subtraction_decimal_decimal) {
+TEST(subtraction_decimal_decimal) {
   const sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON result{value1 - value2};
@@ -345,7 +345,7 @@ TEST(JSON_decimal, subtraction_decimal_decimal) {
   EXPECT_EQ(result.to_decimal().to_string(), "2.5");
 }
 
-TEST(JSON_decimal, addition_assignment_decimal_decimal) {
+TEST(addition_assignment_decimal_decimal) {
   sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"5.7"}};
   value1 += value2;
@@ -353,7 +353,7 @@ TEST(JSON_decimal, addition_assignment_decimal_decimal) {
   EXPECT_EQ(value1.to_decimal().to_string(), "8.9");
 }
 
-TEST(JSON_decimal, subtraction_assignment_decimal_decimal) {
+TEST(subtraction_assignment_decimal_decimal) {
   sourcemeta::core::JSON value1{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON value2{sourcemeta::core::Decimal{"3.2"}};
   value1 -= value2;
@@ -361,7 +361,7 @@ TEST(JSON_decimal, subtraction_assignment_decimal_decimal) {
   EXPECT_EQ(value1.to_decimal().to_string(), "2.5");
 }
 
-TEST(JSON_decimal, addition_decimal_integer) {
+TEST(addition_decimal_integer) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON result{decimal + integer};
@@ -369,7 +369,7 @@ TEST(JSON_decimal, addition_decimal_integer) {
   EXPECT_EQ(result.to_decimal().to_string(), "8.2");
 }
 
-TEST(JSON_decimal, subtraction_decimal_integer) {
+TEST(subtraction_decimal_integer) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON integer{3};
   const sourcemeta::core::JSON result{decimal - integer};
@@ -377,7 +377,7 @@ TEST(JSON_decimal, subtraction_decimal_integer) {
   EXPECT_EQ(result.to_decimal().to_string(), "2.7");
 }
 
-TEST(JSON_decimal, addition_assignment_decimal_integer) {
+TEST(addition_assignment_decimal_integer) {
   sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON integer{5};
   decimal += integer;
@@ -385,7 +385,7 @@ TEST(JSON_decimal, addition_assignment_decimal_integer) {
   EXPECT_EQ(decimal.to_decimal().to_string(), "8.2");
 }
 
-TEST(JSON_decimal, subtraction_assignment_decimal_integer) {
+TEST(subtraction_assignment_decimal_integer) {
   sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON integer{3};
   decimal -= integer;
@@ -393,7 +393,7 @@ TEST(JSON_decimal, subtraction_assignment_decimal_integer) {
   EXPECT_EQ(decimal.to_decimal().to_string(), "2.7");
 }
 
-TEST(JSON_decimal, addition_decimal_real) {
+TEST(addition_decimal_real) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON real{5.5};
   const sourcemeta::core::JSON result{decimal + real};
@@ -401,7 +401,7 @@ TEST(JSON_decimal, addition_decimal_real) {
   EXPECT_EQ(result.to_decimal().to_string(), "8.7");
 }
 
-TEST(JSON_decimal, subtraction_decimal_real) {
+TEST(subtraction_decimal_real) {
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON real{3.5};
   const sourcemeta::core::JSON result{decimal - real};
@@ -409,7 +409,7 @@ TEST(JSON_decimal, subtraction_decimal_real) {
   EXPECT_EQ(result.to_decimal().to_string(), "2.2");
 }
 
-TEST(JSON_decimal, addition_assignment_decimal_real) {
+TEST(addition_assignment_decimal_real) {
   sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON real{5.5};
   decimal += real;
@@ -417,7 +417,7 @@ TEST(JSON_decimal, addition_assignment_decimal_real) {
   EXPECT_EQ(decimal.to_decimal().to_string(), "8.7");
 }
 
-TEST(JSON_decimal, subtraction_assignment_decimal_real) {
+TEST(subtraction_assignment_decimal_real) {
   sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON real{3.5};
   decimal -= real;
@@ -425,109 +425,109 @@ TEST(JSON_decimal, subtraction_assignment_decimal_real) {
   EXPECT_EQ(decimal.to_decimal().to_string(), "2.2");
 }
 
-TEST(JSON_decimal, is_number_positive) {
+TEST(is_number_positive) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"5.7"}};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_decimal, is_number_negative) {
+TEST(is_number_negative) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"-3.2"}};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_decimal, is_number_zero) {
+TEST(is_number_zero) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"0"}};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_decimal, is_number_very_large) {
+TEST(is_number_very_large) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"123456789012345678901234567890.5"}};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_decimal, is_positive_positive) {
+TEST(is_positive_positive) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"5.7"}};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_decimal, is_positive_negative) {
+TEST(is_positive_negative) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"-3.2"}};
   EXPECT_FALSE(document.is_positive());
 }
 
-TEST(JSON_decimal, is_positive_zero) {
+TEST(is_positive_zero) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"0"}};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_decimal, is_positive_very_small_positive) {
+TEST(is_positive_very_small_positive) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"0.0000000001"}};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_decimal, is_positive_very_small_negative) {
+TEST(is_positive_very_small_negative) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"-0.0000000001"}};
   EXPECT_FALSE(document.is_positive());
 }
 
-TEST(JSON_decimal, is_integral_positive_integer) {
+TEST(is_integral_positive_integer) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"1234567890123456789012345678900000"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_zero) {
+TEST(is_integral_zero) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{0}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_negative_integer) {
+TEST(is_integral_negative_integer) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"-1234567890123456789012345678900000"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_positive_real_with_zero_fractional) {
+TEST(is_integral_positive_real_with_zero_fractional) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"1234567890123456789012345678900000.0"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_negative_real_with_zero_fractional) {
+TEST(is_integral_negative_real_with_zero_fractional) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"-1234567890123456789012345678900000.0"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_positive_real) {
+TEST(is_integral_positive_real) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"1234567890123456789012345678900000.1"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_negative_real) {
+TEST(is_integral_negative_real) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"-1234567890123456789012345678900000.1"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_decimal, is_integral_zero_real) {
+TEST(is_integral_zero_real) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"0.1"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_decimal, construction_rejects_nan) {
+TEST(construction_rejects_nan) {
   const sourcemeta::core::Decimal value{sourcemeta::core::Decimal::nan()};
   try {
     sourcemeta::core::JSON{value};
@@ -537,7 +537,7 @@ TEST(JSON_decimal, construction_rejects_nan) {
   }
 }
 
-TEST(JSON_decimal, construction_rejects_positive_infinity) {
+TEST(construction_rejects_positive_infinity) {
   const sourcemeta::core::Decimal value{sourcemeta::core::Decimal::infinity()};
   try {
     sourcemeta::core::JSON{value};
@@ -547,7 +547,7 @@ TEST(JSON_decimal, construction_rejects_positive_infinity) {
   }
 }
 
-TEST(JSON_decimal, construction_rejects_negative_infinity) {
+TEST(construction_rejects_negative_infinity) {
   const sourcemeta::core::Decimal value{
       sourcemeta::core::Decimal::negative_infinity()};
   try {
@@ -558,7 +558,7 @@ TEST(JSON_decimal, construction_rejects_negative_infinity) {
   }
 }
 
-TEST(JSON_decimal, construction_move_rejects_nan) {
+TEST(construction_move_rejects_nan) {
   sourcemeta::core::Decimal value{sourcemeta::core::Decimal::nan()};
   try {
     sourcemeta::core::JSON{std::move(value)};
@@ -568,7 +568,7 @@ TEST(JSON_decimal, construction_move_rejects_nan) {
   }
 }
 
-TEST(JSON_decimal, construction_move_rejects_positive_infinity) {
+TEST(construction_move_rejects_positive_infinity) {
   sourcemeta::core::Decimal value{sourcemeta::core::Decimal::infinity()};
   try {
     sourcemeta::core::JSON{std::move(value)};
@@ -578,7 +578,7 @@ TEST(JSON_decimal, construction_move_rejects_positive_infinity) {
   }
 }
 
-TEST(JSON_decimal, construction_move_rejects_negative_infinity) {
+TEST(construction_move_rejects_negative_infinity) {
   sourcemeta::core::Decimal value{
       sourcemeta::core::Decimal::negative_infinity()};
   try {
@@ -589,7 +589,7 @@ TEST(JSON_decimal, construction_move_rejects_negative_infinity) {
   }
 }
 
-TEST(JSON_decimal, copy_constructor_cannot_create_invalid_json) {
+TEST(copy_constructor_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON source{sourcemeta::core::Decimal::nan()};
     const sourcemeta::core::JSON copy{source};
@@ -599,7 +599,7 @@ TEST(JSON_decimal, copy_constructor_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, move_constructor_cannot_create_invalid_json) {
+TEST(move_constructor_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON source{sourcemeta::core::Decimal::infinity()};
     const sourcemeta::core::JSON moved{std::move(source)};
@@ -609,7 +609,7 @@ TEST(JSON_decimal, move_constructor_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, copy_assignment_cannot_create_invalid_json) {
+TEST(copy_assignment_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON source{sourcemeta::core::Decimal::nan()};
     sourcemeta::core::JSON target{sourcemeta::core::Decimal{1}};
@@ -620,7 +620,7 @@ TEST(JSON_decimal, copy_assignment_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, move_assignment_cannot_create_invalid_json) {
+TEST(move_assignment_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON source{sourcemeta::core::Decimal::infinity()};
     sourcemeta::core::JSON target{sourcemeta::core::Decimal{1}};
@@ -631,7 +631,7 @@ TEST(JSON_decimal, move_assignment_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, addition_operator_cannot_create_invalid_json) {
+TEST(addition_operator_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON left{sourcemeta::core::Decimal::infinity()};
     const sourcemeta::core::JSON right{sourcemeta::core::Decimal{1}};
@@ -642,7 +642,7 @@ TEST(JSON_decimal, addition_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, subtraction_operator_cannot_create_invalid_json) {
+TEST(subtraction_operator_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON left{
         sourcemeta::core::Decimal::negative_infinity()};
@@ -654,7 +654,7 @@ TEST(JSON_decimal, subtraction_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, addition_assignment_operator_cannot_create_invalid_json) {
+TEST(addition_assignment_operator_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON document{sourcemeta::core::Decimal::infinity()};
     const sourcemeta::core::JSON addend{sourcemeta::core::Decimal{1}};
@@ -665,7 +665,7 @@ TEST(JSON_decimal, addition_assignment_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, subtraction_assignment_operator_cannot_create_invalid_json) {
+TEST(subtraction_assignment_operator_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON document{
         sourcemeta::core::Decimal::negative_infinity()};
@@ -677,500 +677,497 @@ TEST(JSON_decimal, subtraction_assignment_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_decimal_integer_true) {
+TEST(divisible_by_decimal_integer_decimal_integer_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{10}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_decimal_integer_false) {
+TEST(divisible_by_decimal_integer_decimal_integer_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{11}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{5}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_decimal_real_true) {
+TEST(divisible_by_decimal_integer_decimal_real_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{6}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_decimal_real_false) {
+TEST(divisible_by_decimal_integer_decimal_real_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{7}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_decimal_integer_true) {
+TEST(divisible_by_decimal_real_decimal_integer_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"6.0"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{2}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_decimal_integer_false) {
+TEST(divisible_by_decimal_real_decimal_integer_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"6.5"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{2}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_decimal_real_true) {
+TEST(divisible_by_decimal_real_decimal_real_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"4.5"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_decimal_real_false) {
+TEST(divisible_by_decimal_real_decimal_real_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"4.7"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_integer_true) {
+TEST(divisible_by_decimal_integer_integer_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{10}};
   const sourcemeta::core::JSON divisor{5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_integer_false) {
+TEST(divisible_by_decimal_integer_integer_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{11}};
   const sourcemeta::core::JSON divisor{5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_integer_true) {
+TEST(divisible_by_decimal_real_integer_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"6.0"}};
   const sourcemeta::core::JSON divisor{2};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_integer_false) {
+TEST(divisible_by_decimal_real_integer_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"6.5"}};
   const sourcemeta::core::JSON divisor{2};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_real_true) {
+TEST(divisible_by_decimal_integer_real_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{6}};
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_real_false) {
+TEST(divisible_by_decimal_integer_real_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{7}};
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_real_true) {
+TEST(divisible_by_decimal_real_real_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"4.5"}};
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_real_false) {
+TEST(divisible_by_decimal_real_real_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"4.7"}};
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_integer_true) {
+TEST(divisible_by_integer_decimal_integer_true) {
   const sourcemeta::core::JSON dividend{10};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_integer_false) {
+TEST(divisible_by_integer_decimal_integer_false) {
   const sourcemeta::core::JSON dividend{11};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{5}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_real_true) {
+TEST(divisible_by_integer_decimal_real_true) {
   const sourcemeta::core::JSON dividend{6};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_real_false) {
+TEST(divisible_by_integer_decimal_real_false) {
   const sourcemeta::core::JSON dividend{7};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_integer_true) {
+TEST(divisible_by_real_decimal_integer_true) {
   const sourcemeta::core::JSON dividend{6.0};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{2}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_integer_false) {
+TEST(divisible_by_real_decimal_integer_false) {
   const sourcemeta::core::JSON dividend{6.5};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{2}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_real_true) {
+TEST(divisible_by_real_decimal_real_true) {
   const sourcemeta::core::JSON dividend{4.5};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_real_false) {
+TEST(divisible_by_real_decimal_real_false) {
   const sourcemeta::core::JSON dividend{4.7};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_zero) {
+TEST(divisible_by_decimal_integer_zero) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{10}};
   const sourcemeta::core::JSON divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_zero) {
+TEST(divisible_by_decimal_real_zero) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"3.5"}};
   const sourcemeta::core::JSON divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_zero_decimal_integer) {
+TEST(divisible_by_zero_decimal_integer) {
   const sourcemeta::core::JSON dividend{0};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_zero_decimal_real) {
+TEST(divisible_by_zero_decimal_real) {
   const sourcemeta::core::JSON dividend{0};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_zero_decimal_integer) {
+TEST(divisible_by_decimal_zero_decimal_integer) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{0}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_zero_decimal_real) {
+TEST(divisible_by_decimal_zero_decimal_real) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{0}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1.5"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_integer_decimal_zero) {
+TEST(divisible_by_decimal_integer_decimal_zero) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{10}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{0}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_zero_decimal_zero) {
+TEST(divisible_by_decimal_zero_decimal_zero) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{0}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{0}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal,
-     divisible_by_very_large_decimal_by_real_not_divisible_false) {
+TEST(divisible_by_very_large_decimal_by_real_not_divisible_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e308"}};
   const sourcemeta::core::JSON divisor{0.123456789};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal,
-     divisible_by_very_large_decimal_by_decimal_not_divisible_false) {
+TEST(divisible_by_very_large_decimal_by_decimal_not_divisible_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e308"}};
   const sourcemeta::core::JSON divisor{
       sourcemeta::core::Decimal{"0.123456789"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_very_large_decimal_by_decimal_divisible_true) {
+TEST(divisible_by_very_large_decimal_by_decimal_divisible_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e308"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"1e154"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal,
-     divisible_by_very_large_decimal_by_integer_not_divisible_false) {
+TEST(divisible_by_very_large_decimal_by_integer_not_divisible_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e308"}};
   const sourcemeta::core::JSON divisor{3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_very_large_decimal_by_integer_divisible_true) {
+TEST(divisible_by_very_large_decimal_by_integer_divisible_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e308"}};
   const sourcemeta::core::JSON divisor{2};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_mixed_scale_decimal_real_not_divisible_false) {
+TEST(divisible_by_mixed_scale_decimal_real_not_divisible_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e100"}};
   const sourcemeta::core::JSON divisor{0.3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_mixed_scale_decimal_real_divisible_true) {
+TEST(divisible_by_mixed_scale_decimal_real_divisible_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1e100"}};
   const sourcemeta::core::JSON divisor{0.5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_01_true) {
+TEST(divisible_by_decimal_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1280.32"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_01_false) {
+TEST(divisible_by_decimal_decimal_0_01_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1280.325"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_1_true) {
+TEST(divisible_by_decimal_decimal_0_1_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"100.3"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.1"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_1_false) {
+TEST(divisible_by_decimal_decimal_0_1_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"100.35"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.1"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_001_true) {
+TEST(divisible_by_decimal_decimal_0_001_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"25.123"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_001_false) {
+TEST(divisible_by_decimal_decimal_0_001_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"25.1235"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.001"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_0001_true) {
+TEST(divisible_by_decimal_decimal_0_0001_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"99.9999"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.0001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_0001_false) {
+TEST(divisible_by_decimal_decimal_0_0001_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"99.99995"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.0001"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_01_true) {
+TEST(divisible_by_decimal_real_0_01_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1280.32"}};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_01_false) {
+TEST(divisible_by_decimal_real_0_01_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1280.325"}};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_1_true) {
+TEST(divisible_by_decimal_real_0_1_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"100.3"}};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_1_false) {
+TEST(divisible_by_decimal_real_0_1_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"100.35"}};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_001_true) {
+TEST(divisible_by_decimal_real_0_001_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"25.123"}};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_001_false) {
+TEST(divisible_by_decimal_real_0_001_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"25.1235"}};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_0001_true) {
+TEST(divisible_by_decimal_real_0_0001_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"99.9999"}};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_real_0_0001_false) {
+TEST(divisible_by_decimal_real_0_0001_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"99.99995"}};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_01_true) {
+TEST(divisible_by_real_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{1280.32};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_01_false) {
+TEST(divisible_by_real_decimal_0_01_false) {
   const sourcemeta::core::JSON dividend{1280.325};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_1_true) {
+TEST(divisible_by_real_decimal_0_1_true) {
   const sourcemeta::core::JSON dividend{100.3};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.1"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_1_false) {
+TEST(divisible_by_real_decimal_0_1_false) {
   const sourcemeta::core::JSON dividend{100.35};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.1"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_001_true) {
+TEST(divisible_by_real_decimal_0_001_true) {
   const sourcemeta::core::JSON dividend{25.123};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_001_false) {
+TEST(divisible_by_real_decimal_0_001_false) {
   const sourcemeta::core::JSON dividend{25.1235};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.001"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_0001_true) {
+TEST(divisible_by_real_decimal_0_0001_true) {
   const sourcemeta::core::JSON dividend{99.9999};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.0001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_real_decimal_0_0001_false) {
+TEST(divisible_by_real_decimal_0_0001_false) {
   const sourcemeta::core::JSON dividend{99.99995};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.0001"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_0_01_true) {
+TEST(divisible_by_integer_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{100};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_0_1_true) {
+TEST(divisible_by_integer_decimal_0_1_true) {
   const sourcemeta::core::JSON dividend{10};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.1"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_0_001_true) {
+TEST(divisible_by_integer_decimal_0_001_true) {
   const sourcemeta::core::JSON dividend{1};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_integer_decimal_0_0001_true) {
+TEST(divisible_by_integer_decimal_0_0001_true) {
   const sourcemeta::core::JSON dividend{1};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.0001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_negative_decimal_decimal_0_01_true) {
+TEST(divisible_by_negative_decimal_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"-1280.32"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_negative_decimal_real_0_01_true) {
+TEST(divisible_by_negative_decimal_real_0_01_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"-1280.32"}};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_negative_real_decimal_0_01_true) {
+TEST(divisible_by_negative_real_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{-1280.32};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_negative_integer_decimal_0_01_true) {
+TEST(divisible_by_negative_integer_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{-100};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_3_true) {
+TEST(divisible_by_decimal_decimal_0_3_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"0.9"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.3"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_3_false) {
+TEST(divisible_by_decimal_decimal_0_3_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"1.0"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.3"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_7_true) {
+TEST(divisible_by_decimal_decimal_0_7_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"2.1"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.7"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_decimal_decimal_0_7_false) {
+TEST(divisible_by_decimal_decimal_0_7_false) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"2.0"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.7"}};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_large_decimal_decimal_0_01_true) {
+TEST(divisible_by_large_decimal_decimal_0_01_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"999999.99"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.01"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_large_decimal_real_0_01_true) {
+TEST(divisible_by_large_decimal_real_0_01_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"999999.99"}};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, divisible_by_large_decimal_decimal_0_001_true) {
+TEST(divisible_by_large_decimal_decimal_0_001_true) {
   const sourcemeta::core::JSON dividend{sourcemeta::core::Decimal{"12345.678"}};
   const sourcemeta::core::JSON divisor{sourcemeta::core::Decimal{"0.001"}};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_decimal, fast_hash_positive) {
+TEST(fast_hash_positive) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"3.14"}};
   EXPECT_EQ(document.fast_hash(), 8);
 }
 
-TEST(JSON_decimal, fast_hash_negative) {
+TEST(fast_hash_negative) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"-3.14"}};
   EXPECT_EQ(document.fast_hash(), 8);
 }
 
-TEST(JSON_decimal, fast_hash_zero) {
+TEST(fast_hash_zero) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{0}};
   EXPECT_EQ(document.fast_hash(), 8);
 }
 
-TEST(JSON_decimal, fast_hash_large) {
+TEST(fast_hash_large) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"123456789012345678901234567890"}};
   EXPECT_EQ(document.fast_hash(), 8);
 }
 
-TEST(JSON_decimal, lexical_bignum_integer) {
+TEST(lexical_bignum_integer) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{
       "12345678910111213141516171819202122232425262728293031"}};
   EXPECT_TRUE(document.is_decimal());
@@ -1180,7 +1177,7 @@ TEST(JSON_decimal, lexical_bignum_integer) {
   EXPECT_TRUE(document.to_decimal().is_integral());
 }
 
-TEST(JSON_decimal, exponent_form_integer_valued) {
+TEST(exponent_form_integer_valued) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"1e2"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integer());
@@ -1189,7 +1186,7 @@ TEST(JSON_decimal, exponent_form_integer_valued) {
   EXPECT_TRUE(document.to_decimal().is_integral());
 }
 
-TEST(JSON_decimal, exponent_zero_form) {
+TEST(exponent_zero_form) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"5e0"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integer());
@@ -1198,7 +1195,7 @@ TEST(JSON_decimal, exponent_zero_form) {
   EXPECT_TRUE(document.to_decimal().is_integral());
 }
 
-TEST(JSON_decimal, dot_zero_fraction_high_precision) {
+TEST(dot_zero_fraction_high_precision) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"1234567890123456789012.0"}};
   EXPECT_TRUE(document.is_decimal());
@@ -1208,7 +1205,7 @@ TEST(JSON_decimal, dot_zero_fraction_high_precision) {
   EXPECT_TRUE(document.to_decimal().is_integral());
 }
 
-TEST(JSON_decimal, negative_exponent_non_integral) {
+TEST(negative_exponent_non_integral) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"1e-2"}};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integer());

--- a/test/json/json_error_test.cc
+++ b/test/json/json_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
@@ -6,7 +6,7 @@
 #include <string>      // std::string
 #include <type_traits> // std::is_base_of_v
 
-TEST(JSON_error, parse_error) {
+TEST(parse_error) {
   static_assert(
       std::is_base_of_v<std::exception, sourcemeta::core::JSONParseError>,
       "Must subclass std::exception");

--- a/test/json/json_format_test.cc
+++ b/test/json/json_format_test.cc
@@ -1,87 +1,87 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <format> // std::format
 #include <string> // std::string
 
-TEST(JSON_format, null_value) {
+TEST(null_value) {
   const sourcemeta::core::JSON value{nullptr};
   const std::string result{std::format("{}", value)};
   EXPECT_EQ(result, "null");
 }
 
-TEST(JSON_format, boolean_true) {
+TEST(boolean_true) {
   const sourcemeta::core::JSON value{true};
   EXPECT_EQ(std::format("{}", value), "true");
 }
 
-TEST(JSON_format, boolean_false) {
+TEST(boolean_false) {
   const sourcemeta::core::JSON value{false};
   EXPECT_EQ(std::format("{}", value), "false");
 }
 
-TEST(JSON_format, integer_positive) {
+TEST(integer_positive) {
   const sourcemeta::core::JSON value{42};
   EXPECT_EQ(std::format("{}", value), "42");
 }
 
-TEST(JSON_format, integer_negative) {
+TEST(integer_negative) {
   const sourcemeta::core::JSON value{-10};
   EXPECT_EQ(std::format("{}", value), "-10");
 }
 
-TEST(JSON_format, integer_zero) {
+TEST(integer_zero) {
   const sourcemeta::core::JSON value{0};
   EXPECT_EQ(std::format("{}", value), "0");
 }
 
-TEST(JSON_format, real_value) {
+TEST(real_value) {
   const sourcemeta::core::JSON value{3.14};
   EXPECT_EQ(std::format("{}", value), "3.14");
 }
 
-TEST(JSON_format, string_value) {
+TEST(string_value) {
   const sourcemeta::core::JSON value{"hello"};
   EXPECT_EQ(std::format("{}", value), "\"hello\"");
 }
 
-TEST(JSON_format, string_empty) {
+TEST(string_empty) {
   const sourcemeta::core::JSON value{""};
   EXPECT_EQ(std::format("{}", value), "\"\"");
 }
 
-TEST(JSON_format, type_null) {
+TEST(type_null) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Null), "null");
 }
 
-TEST(JSON_format, type_boolean) {
+TEST(type_boolean) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Boolean),
             "boolean");
 }
 
-TEST(JSON_format, type_integer) {
+TEST(type_integer) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Integer),
             "integer");
 }
 
-TEST(JSON_format, type_real) {
+TEST(type_real) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Real), "real");
 }
 
-TEST(JSON_format, type_decimal) {
+TEST(type_decimal) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Decimal),
             "decimal");
 }
 
-TEST(JSON_format, type_string) {
+TEST(type_string) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::String), "string");
 }
 
-TEST(JSON_format, type_array) {
+TEST(type_array) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Array), "array");
 }
 
-TEST(JSON_format, type_object) {
+TEST(type_object) {
   EXPECT_EQ(std::format("{}", sourcemeta::core::JSON::Type::Object), "object");
 }

--- a/test/json/json_hash_test.cc
+++ b/test/json/json_hash_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
-TEST(JSON_key_hash, hash_empty) {
+TEST(hash_empty) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{""};
@@ -14,7 +14,7 @@ TEST(JSON_key_hash, hash_empty) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_f) {
+TEST(hash_f) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"f"};
@@ -26,7 +26,7 @@ TEST(JSON_key_hash, hash_f) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fo) {
+TEST(hash_fo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fo"};
@@ -38,7 +38,7 @@ TEST(JSON_key_hash, hash_fo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foo) {
+TEST(hash_foo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foo"};
@@ -50,7 +50,7 @@ TEST(JSON_key_hash, hash_foo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooo) {
+TEST(hash_fooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooo"};
@@ -62,7 +62,7 @@ TEST(JSON_key_hash, hash_fooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foooo) {
+TEST(hash_foooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooo"};
@@ -74,7 +74,7 @@ TEST(JSON_key_hash, hash_foooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooooo) {
+TEST(hash_fooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooo"};
@@ -86,7 +86,7 @@ TEST(JSON_key_hash, hash_fooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foooooo) {
+TEST(hash_foooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooo"};
@@ -98,7 +98,7 @@ TEST(JSON_key_hash, hash_foooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooooooo) {
+TEST(hash_fooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooo"};
@@ -110,7 +110,7 @@ TEST(JSON_key_hash, hash_fooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foooooooo) {
+TEST(hash_foooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooo"};
@@ -122,7 +122,7 @@ TEST(JSON_key_hash, hash_foooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooooooooo) {
+TEST(hash_fooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooo"};
@@ -134,7 +134,7 @@ TEST(JSON_key_hash, hash_fooooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foooooooooo) {
+TEST(hash_foooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooo"};
@@ -146,7 +146,7 @@ TEST(JSON_key_hash, hash_foooooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooo) {
+TEST(hash_fooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooo"};
@@ -158,7 +158,7 @@ TEST(JSON_key_hash, hash_fooooooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooo) {
+TEST(hash_foooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooo"};
@@ -170,7 +170,7 @@ TEST(JSON_key_hash, hash_foooooooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooo) {
+TEST(hash_fooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooo"};
@@ -182,7 +182,7 @@ TEST(JSON_key_hash, hash_fooooooooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooo) {
+TEST(hash_foooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooo"};
@@ -194,7 +194,7 @@ TEST(JSON_key_hash, hash_foooooooooooooo) {
                         0x0000000000000000);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooo) {
+TEST(hash_fooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooo"};
@@ -206,7 +206,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooo) {
                         0x000000000000006f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooo) {
+TEST(hash_foooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooo"};
@@ -218,7 +218,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooo) {
                         0x0000000000006f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooo) {
+TEST(hash_fooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooo"};
@@ -230,7 +230,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooo) {
                         0x00000000006f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooo) {
+TEST(hash_foooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooo"};
@@ -242,7 +242,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooo) {
                         0x000000006f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooooo"};
@@ -254,7 +254,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooo) {
                         0x0000006f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooooo) {
+TEST(hash_foooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooooo"};
@@ -266,7 +266,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooo) {
                         0x00006f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooooooo"};
@@ -278,7 +278,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooo) {
                         0x006f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooooooo) {
+TEST(hash_foooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooooooo"};
@@ -290,7 +290,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooooooooo"};
@@ -302,7 +302,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooooooooo) {
+TEST(hash_foooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooooooooo"};
@@ -314,7 +314,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooooooooooo"};
@@ -326,7 +326,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooooooooooo) {
+TEST(hash_foooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooooooooooo"};
@@ -338,7 +338,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooooooooooooo"};
@@ -350,7 +350,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooo) {
+TEST(hash_foooooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooooooooooooo"};
@@ -362,7 +362,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"fooooooooooooooooooooooooooooo"};
@@ -374,7 +374,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooooo) {
+TEST(hash_foooooooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{"foooooooooooooooooooooooooooooo"};
@@ -386,7 +386,7 @@ TEST(JSON_key_hash, hash_foooooooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooooo) {
+TEST(hash_fooooooooooooooooooooooooooooooo) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{
@@ -399,7 +399,7 @@ TEST(JSON_key_hash, hash_fooooooooooooooooooooooooooooooo) {
                         0x6f6f6f6f6f6f6f6f);
 }
 
-TEST(JSON_key_hash, hash_no_collision) {
+TEST(hash_no_collision) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>
       hasher;
   const sourcemeta::core::JSON::String value{

--- a/test/json/json_integer_test.cc
+++ b/test/json/json_integer_test.cc
@@ -1,25 +1,25 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
-TEST(JSON_integer, positive) {
+TEST(positive) {
   const sourcemeta::core::JSON document{10};
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 10);
 }
 
-TEST(JSON_integer, type) {
+TEST(type) {
   const sourcemeta::core::JSON document{5};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Integer);
 }
 
-TEST(JSON_integer, negative) {
+TEST(negative) {
   const sourcemeta::core::JSON document{-10};
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), -10);
 }
 
-TEST(JSON_integer, zero) {
+TEST(zero) {
   const sourcemeta::core::JSON document{0};
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 0);
@@ -27,61 +27,61 @@ TEST(JSON_integer, zero) {
 
 // We have seen GCC getting confused about this one,
 // creating an array with a single integer item instead.
-TEST(JSON_integer, copy_constructor) {
+TEST(copy_constructor) {
   const sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON document{integer};
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 5);
 }
 
-TEST(JSON_integer, estimated_byte_size_5) {
+TEST(estimated_byte_size_5) {
   const sourcemeta::core::JSON document{5};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_integer, estimated_byte_size_minus_5) {
+TEST(estimated_byte_size_minus_5) {
   const sourcemeta::core::JSON document{-5};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_integer, estimated_byte_size_0) {
+TEST(estimated_byte_size_0) {
   const sourcemeta::core::JSON document{0};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_integer, estimated_byte_size_1234567) {
+TEST(estimated_byte_size_1234567) {
   const sourcemeta::core::JSON document{1234567};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_integer, fast_hash_5) {
+TEST(fast_hash_5) {
   const sourcemeta::core::JSON document{5};
   EXPECT_EQ(document.fast_hash(), 9);
 }
 
-TEST(JSON_integer, fast_hash_minus_5) {
+TEST(fast_hash_minus_5) {
   const sourcemeta::core::JSON document{-5};
   EXPECT_EQ(document.fast_hash(), 255);
 }
 
-TEST(JSON_integer, fast_hash_0) {
+TEST(fast_hash_0) {
   const sourcemeta::core::JSON document{0};
   EXPECT_EQ(document.fast_hash(), 4);
 }
 
-TEST(JSON_integer, fast_hash_1234567) {
+TEST(fast_hash_1234567) {
   const sourcemeta::core::JSON document{1234567};
   EXPECT_EQ(document.fast_hash(), 139);
 }
 
-TEST(JSON_integer, less_than_integer_decimal) {
+TEST(less_than_integer_decimal) {
   const sourcemeta::core::JSON integer{3};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   EXPECT_TRUE(integer < decimal);
   EXPECT_FALSE(decimal < integer);
 }
 
-TEST(JSON_integer, less_than_or_equal_integer_decimal) {
+TEST(less_than_or_equal_integer_decimal) {
   const sourcemeta::core::JSON integer{3};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"3"}};
@@ -90,14 +90,14 @@ TEST(JSON_integer, less_than_or_equal_integer_decimal) {
   EXPECT_TRUE(integer <= equal);
 }
 
-TEST(JSON_integer, greater_than_integer_decimal) {
+TEST(greater_than_integer_decimal) {
   const sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   EXPECT_TRUE(integer > decimal);
   EXPECT_FALSE(decimal > integer);
 }
 
-TEST(JSON_integer, greater_than_or_equal_integer_decimal) {
+TEST(greater_than_or_equal_integer_decimal) {
   const sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"5"}};
@@ -106,7 +106,7 @@ TEST(JSON_integer, greater_than_or_equal_integer_decimal) {
   EXPECT_TRUE(integer >= equal);
 }
 
-TEST(JSON_integer, addition_integer_decimal) {
+TEST(addition_integer_decimal) {
   const sourcemeta::core::JSON integer{3};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON result{integer + decimal};
@@ -114,7 +114,7 @@ TEST(JSON_integer, addition_integer_decimal) {
   EXPECT_EQ(result.to_decimal().to_string(), "8.7");
 }
 
-TEST(JSON_integer, subtraction_integer_decimal) {
+TEST(subtraction_integer_decimal) {
   const sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON result{integer - decimal};
@@ -122,7 +122,7 @@ TEST(JSON_integer, subtraction_integer_decimal) {
   EXPECT_EQ(result.to_decimal().to_string(), "1.8");
 }
 
-TEST(JSON_integer, addition_assignment_integer_decimal) {
+TEST(addition_assignment_integer_decimal) {
   sourcemeta::core::JSON integer{3};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   integer += decimal;
@@ -130,7 +130,7 @@ TEST(JSON_integer, addition_assignment_integer_decimal) {
   EXPECT_EQ(integer.to_decimal().to_string(), "8.7");
 }
 
-TEST(JSON_integer, subtraction_assignment_integer_decimal) {
+TEST(subtraction_assignment_integer_decimal) {
   sourcemeta::core::JSON integer{5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   integer -= decimal;

--- a/test/json/json_null_test.cc
+++ b/test/json/json_null_test.cc
@@ -1,18 +1,18 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
-TEST(JSON_null, nullptr_value) {
+TEST(nullptr_value) {
   const sourcemeta::core::JSON document{nullptr};
   EXPECT_TRUE(document.is_null());
 }
 
-TEST(JSON_null, type) {
+TEST(type) {
   const sourcemeta::core::JSON document{nullptr};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Null);
 }
 
-TEST(JSON_null, literal_equality) {
+TEST(literal_equality) {
   const sourcemeta::core::JSON left{nullptr};
   const sourcemeta::core::JSON right{false};
   EXPECT_EQ(left, left);
@@ -20,12 +20,12 @@ TEST(JSON_null, literal_equality) {
   EXPECT_FALSE(right == left);
 }
 
-TEST(JSON_null, estimated_byte_size) {
+TEST(estimated_byte_size) {
   const sourcemeta::core::JSON document{nullptr};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_null, fast_hash) {
+TEST(fast_hash) {
   const sourcemeta::core::JSON document{nullptr};
   EXPECT_EQ(document.fast_hash(), 2);
 }

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -1,80 +1,80 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <stdexcept> // std::out_of_range
 
-TEST(JSON_number, is_number_zero) {
+TEST(is_number_zero) {
   const sourcemeta::core::JSON document{0};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_number, is_number_zero_real) {
+TEST(is_number_zero_real) {
   const sourcemeta::core::JSON document{0.0};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_number, is_number_positive_integer) {
+TEST(is_number_positive_integer) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_number, is_number_positive_real) {
+TEST(is_number_positive_real) {
   const sourcemeta::core::JSON document{5.3};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_number, is_number_negative_integer) {
+TEST(is_number_negative_integer) {
   const sourcemeta::core::JSON document{-5};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_number, is_number_negative_real) {
+TEST(is_number_negative_real) {
   const sourcemeta::core::JSON document{-5.3};
   EXPECT_TRUE(document.is_number());
 }
 
-TEST(JSON_number, is_number_string) {
+TEST(is_number_string) {
   const sourcemeta::core::JSON document{"0"};
   EXPECT_FALSE(document.is_number());
 }
 
-TEST(JSON_number, is_number_null) {
+TEST(is_number_null) {
   const sourcemeta::core::JSON document{nullptr};
   EXPECT_FALSE(document.is_number());
 }
 
-TEST(JSON_number, is_positive_negative_integer) {
+TEST(is_positive_negative_integer) {
   const sourcemeta::core::JSON document{-3};
   EXPECT_FALSE(document.is_positive());
 }
 
-TEST(JSON_number, is_positive_zero_integer) {
+TEST(is_positive_zero_integer) {
   const sourcemeta::core::JSON document{0};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_number, is_positive_positive_integer) {
+TEST(is_positive_positive_integer) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_number, is_positive_negative_real) {
+TEST(is_positive_negative_real) {
   const sourcemeta::core::JSON document{-3.2};
   EXPECT_FALSE(document.is_positive());
 }
 
-TEST(JSON_number, is_positive_zero_real) {
+TEST(is_positive_zero_real) {
   const sourcemeta::core::JSON document{0.0};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_number, is_positive_positive_real) {
+TEST(is_positive_positive_real) {
   const sourcemeta::core::JSON document{5.1};
   EXPECT_TRUE(document.is_positive());
 }
 
-TEST(JSON_number, add_integer_integer) {
+TEST(add_integer_integer) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{3};
   const sourcemeta::core::JSON document{left + right};
@@ -82,7 +82,7 @@ TEST(JSON_number, add_integer_integer) {
   EXPECT_EQ(document.to_integer(), 8);
 }
 
-TEST(JSON_number, add_integer_real) {
+TEST(add_integer_real) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{3.2};
   const sourcemeta::core::JSON document{left + right};
@@ -90,7 +90,7 @@ TEST(JSON_number, add_integer_real) {
   EXPECT_EQ(document.to_real(), 8.2);
 }
 
-TEST(JSON_number, add_real_integer) {
+TEST(add_real_integer) {
   const sourcemeta::core::JSON left{3.2};
   const sourcemeta::core::JSON right{2};
   const sourcemeta::core::JSON document{left + right};
@@ -98,7 +98,7 @@ TEST(JSON_number, add_real_integer) {
   EXPECT_EQ(document.to_real(), 5.2);
 }
 
-TEST(JSON_number, add_real_real) {
+TEST(add_real_real) {
   const sourcemeta::core::JSON left{3.2};
   const sourcemeta::core::JSON right{2.0};
   const sourcemeta::core::JSON document{left + right};
@@ -106,7 +106,7 @@ TEST(JSON_number, add_real_real) {
   EXPECT_EQ(document.to_real(), 5.2);
 }
 
-TEST(JSON_number, substract_integer_integer) {
+TEST(substract_integer_integer) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{3};
   const sourcemeta::core::JSON document{left - right};
@@ -114,7 +114,7 @@ TEST(JSON_number, substract_integer_integer) {
   EXPECT_EQ(document.to_integer(), 2);
 }
 
-TEST(JSON_number, substract_integer_real) {
+TEST(substract_integer_real) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{3.2};
   const sourcemeta::core::JSON document{left - right};
@@ -122,7 +122,7 @@ TEST(JSON_number, substract_integer_real) {
   EXPECT_DOUBLE_EQ(document.to_real(), 1.8);
 }
 
-TEST(JSON_number, substract_real_integer) {
+TEST(substract_real_integer) {
   const sourcemeta::core::JSON left{3.2};
   const sourcemeta::core::JSON right{2};
   const sourcemeta::core::JSON document{left - right};
@@ -130,7 +130,7 @@ TEST(JSON_number, substract_real_integer) {
   EXPECT_DOUBLE_EQ(document.to_real(), 1.2);
 }
 
-TEST(JSON_number, substract_real_real) {
+TEST(substract_real_real) {
   const sourcemeta::core::JSON left{3.2};
   const sourcemeta::core::JSON right{2.0};
   const sourcemeta::core::JSON document{left - right};
@@ -138,7 +138,7 @@ TEST(JSON_number, substract_real_real) {
   EXPECT_DOUBLE_EQ(document.to_real(), 1.2);
 }
 
-TEST(JSON_number, increment_integer_integer) {
+TEST(increment_integer_integer) {
   sourcemeta::core::JSON document{5};
   const sourcemeta::core::JSON value{3};
   document += value;
@@ -146,7 +146,7 @@ TEST(JSON_number, increment_integer_integer) {
   EXPECT_EQ(document.to_integer(), 8);
 }
 
-TEST(JSON_number, increment_integer_real) {
+TEST(increment_integer_real) {
   sourcemeta::core::JSON document{5};
   const sourcemeta::core::JSON value{3.2};
   document += value;
@@ -154,7 +154,7 @@ TEST(JSON_number, increment_integer_real) {
   EXPECT_EQ(document.to_real(), 8.2);
 }
 
-TEST(JSON_number, increment_real_integer) {
+TEST(increment_real_integer) {
   sourcemeta::core::JSON document{3.2};
   const sourcemeta::core::JSON value{2};
   document += value;
@@ -162,7 +162,7 @@ TEST(JSON_number, increment_real_integer) {
   EXPECT_EQ(document.to_real(), 5.2);
 }
 
-TEST(JSON_number, increment_real_real) {
+TEST(increment_real_real) {
   sourcemeta::core::JSON document{3.2};
   const sourcemeta::core::JSON value{2.0};
   document += value;
@@ -170,7 +170,7 @@ TEST(JSON_number, increment_real_real) {
   EXPECT_EQ(document.to_real(), 5.2);
 }
 
-TEST(JSON_number, decrement_integer_integer) {
+TEST(decrement_integer_integer) {
   sourcemeta::core::JSON document{5};
   const sourcemeta::core::JSON value{3};
   document -= value;
@@ -178,7 +178,7 @@ TEST(JSON_number, decrement_integer_integer) {
   EXPECT_EQ(document.to_integer(), 2);
 }
 
-TEST(JSON_number, decrement_integer_real) {
+TEST(decrement_integer_real) {
   sourcemeta::core::JSON document{5};
   const sourcemeta::core::JSON value{3.2};
   document -= value;
@@ -186,7 +186,7 @@ TEST(JSON_number, decrement_integer_real) {
   EXPECT_DOUBLE_EQ(document.to_real(), 1.8);
 }
 
-TEST(JSON_number, decrement_real_integer) {
+TEST(decrement_real_integer) {
   sourcemeta::core::JSON document{3.2};
   const sourcemeta::core::JSON value{2};
   document -= value;
@@ -194,7 +194,7 @@ TEST(JSON_number, decrement_real_integer) {
   EXPECT_DOUBLE_EQ(document.to_real(), 1.2);
 }
 
-TEST(JSON_number, decrement_real_real) {
+TEST(decrement_real_real) {
   sourcemeta::core::JSON document{3.2};
   const sourcemeta::core::JSON value{2.0};
   document -= value;
@@ -202,7 +202,7 @@ TEST(JSON_number, decrement_real_real) {
   EXPECT_DOUBLE_EQ(document.to_real(), 1.2);
 }
 
-TEST(JSON_number, add_integer_integer_within_object) {
+TEST(add_integer_integer_within_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\": 5}");
   const sourcemeta::core::JSON value{3};
@@ -211,7 +211,7 @@ TEST(JSON_number, add_integer_integer_within_object) {
   EXPECT_EQ(document.at("foo").to_integer(), 8);
 }
 
-TEST(JSON_number, add_integer_real_within_object) {
+TEST(add_integer_real_within_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\": 5}");
   const sourcemeta::core::JSON value{3.2};
@@ -220,7 +220,7 @@ TEST(JSON_number, add_integer_real_within_object) {
   EXPECT_EQ(document.at("foo").to_real(), 8.2);
 }
 
-TEST(JSON_number, add_real_integer_within_object) {
+TEST(add_real_integer_within_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\": 3.5}");
   const sourcemeta::core::JSON value{2};
@@ -229,7 +229,7 @@ TEST(JSON_number, add_real_integer_within_object) {
   EXPECT_EQ(document.at("foo").to_real(), 5.5);
 }
 
-TEST(JSON_number, add_real_real_within_object) {
+TEST(add_real_real_within_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\": 3.5}");
   const sourcemeta::core::JSON value{2.0};
@@ -238,365 +238,365 @@ TEST(JSON_number, add_real_real_within_object) {
   EXPECT_EQ(document.at("foo").to_real(), 5.5);
 }
 
-TEST(JSON_number, divisible_by_integer_integer_true) {
+TEST(divisible_by_integer_integer_true) {
   const sourcemeta::core::JSON dividend{10};
   const sourcemeta::core::JSON divisor{5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_integer_false) {
+TEST(divisible_by_integer_integer_false) {
   const sourcemeta::core::JSON dividend{11};
   const sourcemeta::core::JSON divisor{5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_true) {
+TEST(divisible_by_integer_real_true) {
   const sourcemeta::core::JSON dividend{6};
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_false) {
+TEST(divisible_by_integer_real_false) {
   const sourcemeta::core::JSON dividend{7};
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_integer_true) {
+TEST(divisible_by_real_integer_true) {
   const sourcemeta::core::JSON dividend{6.0};
   EXPECT_TRUE(dividend.is_real());
   const sourcemeta::core::JSON divisor{2};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_integer_false) {
+TEST(divisible_by_real_integer_false) {
   const sourcemeta::core::JSON dividend{6.0};
   EXPECT_TRUE(dividend.is_real());
   const sourcemeta::core::JSON divisor{2.5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_real_true) {
+TEST(divisible_by_real_real_true) {
   const sourcemeta::core::JSON dividend{4.5};
   EXPECT_TRUE(dividend.is_real());
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_real_false) {
+TEST(divisible_by_real_real_false) {
   const sourcemeta::core::JSON dividend{4.7};
   EXPECT_TRUE(dividend.is_real());
   const sourcemeta::core::JSON divisor{1.5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_infinity) {
+TEST(divisible_by_infinity) {
   const sourcemeta::core::JSON dividend{1e308};
   const sourcemeta::core::JSON divisor{0.123456789};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_tiny_true) {
+TEST(divisible_by_tiny_true) {
   const sourcemeta::core::JSON dividend{0.0075};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_tiny_false) {
+TEST(divisible_by_tiny_false) {
   const sourcemeta::core::JSON dividend{0.00751};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_zero) {
+TEST(divisible_by_real_zero) {
   const sourcemeta::core::JSON dividend{0.00751};
   const sourcemeta::core::JSON divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_zero) {
+TEST(divisible_by_integer_zero) {
   const sourcemeta::core::JSON dividend{5};
   const sourcemeta::core::JSON divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_zero_zero) {
+TEST(divisible_by_zero_zero) {
   const sourcemeta::core::JSON dividend{0};
   const sourcemeta::core::JSON divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_zero_interger) {
+TEST(divisible_by_zero_interger) {
   const sourcemeta::core::JSON dividend{0};
   const sourcemeta::core::JSON divisor{5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_zero_real_zero_real) {
+TEST(divisible_by_zero_real_zero_real) {
   const sourcemeta::core::JSON dividend{0.0};
   const sourcemeta::core::JSON divisor{0.0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_float_overflow_integer_0_5) {
+TEST(divisible_by_float_overflow_integer_0_5) {
   const sourcemeta::core::JSON document{1e308};
   const sourcemeta::core::JSON divisor{0.5};
   EXPECT_TRUE(document.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_float_overflow_integer_1) {
+TEST(divisible_by_float_overflow_integer_1) {
   const sourcemeta::core::JSON document{1e308};
   const sourcemeta::core::JSON divisor{1};
   EXPECT_TRUE(document.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_float_overflow_integer_1_0) {
+TEST(divisible_by_float_overflow_integer_1_0) {
   const sourcemeta::core::JSON document{1e308};
   const sourcemeta::core::JSON divisor{1.0};
   EXPECT_TRUE(document.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_1_true_1) {
+TEST(divisible_by_real_0_1_true_1) {
   const sourcemeta::core::JSON dividend{3.5};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_1_true_2) {
+TEST(divisible_by_real_0_1_true_2) {
   const sourcemeta::core::JSON dividend{10.0};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_1_true_3) {
+TEST(divisible_by_real_0_1_true_3) {
   const sourcemeta::core::JSON dividend{100.3};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_1_true_4) {
+TEST(divisible_by_real_0_1_true_4) {
   const sourcemeta::core::JSON dividend{0.5};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_1_false) {
+TEST(divisible_by_real_0_1_false) {
   const sourcemeta::core::JSON dividend{3.55};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_01_true_1) {
+TEST(divisible_by_real_0_01_true_1) {
   const sourcemeta::core::JSON dividend{1280.32};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_01_true_2) {
+TEST(divisible_by_real_0_01_true_2) {
   const sourcemeta::core::JSON dividend{99.99};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_01_true_3) {
+TEST(divisible_by_real_0_01_true_3) {
   const sourcemeta::core::JSON dividend{0.01};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_01_true_4) {
+TEST(divisible_by_real_0_01_true_4) {
   const sourcemeta::core::JSON dividend{0.5};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_01_true_5) {
+TEST(divisible_by_real_0_01_true_5) {
   const sourcemeta::core::JSON dividend{1.0};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_01_false) {
+TEST(divisible_by_real_0_01_false) {
   const sourcemeta::core::JSON dividend{1.005};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_001_true_1) {
+TEST(divisible_by_real_0_001_true_1) {
   const sourcemeta::core::JSON dividend{1.001};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_001_true_2) {
+TEST(divisible_by_real_0_001_true_2) {
   const sourcemeta::core::JSON dividend{0.5};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_001_true_3) {
+TEST(divisible_by_real_0_001_true_3) {
   const sourcemeta::core::JSON dividend{25.123};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_001_false) {
+TEST(divisible_by_real_0_001_false) {
   const sourcemeta::core::JSON dividend{1.0005};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_0001_true_1) {
+TEST(divisible_by_real_0_0001_true_1) {
   const sourcemeta::core::JSON dividend{1.0001};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_0001_true_2) {
+TEST(divisible_by_real_0_0001_true_2) {
   const sourcemeta::core::JSON dividend{99.9999};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_0001_false) {
+TEST(divisible_by_real_0_0001_false) {
   const sourcemeta::core::JSON dividend{1.00005};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_0_1_true) {
+TEST(divisible_by_integer_real_0_1_true) {
   const sourcemeta::core::JSON dividend{10};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_0_1_true_2) {
+TEST(divisible_by_integer_real_0_1_true_2) {
   const sourcemeta::core::JSON dividend{1};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_0_01_true) {
+TEST(divisible_by_integer_real_0_01_true) {
   const sourcemeta::core::JSON dividend{1};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_0_01_true_2) {
+TEST(divisible_by_integer_real_0_01_true_2) {
   const sourcemeta::core::JSON dividend{100};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_0_001_true) {
+TEST(divisible_by_integer_real_0_001_true) {
   const sourcemeta::core::JSON dividend{1};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_integer_real_0_0001_true) {
+TEST(divisible_by_integer_real_0_0001_true) {
   const sourcemeta::core::JSON dividend{1};
   const sourcemeta::core::JSON divisor{0.0001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_3_true) {
+TEST(divisible_by_real_0_3_true) {
   const sourcemeta::core::JSON dividend{0.9};
   const sourcemeta::core::JSON divisor{0.3};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_3_false) {
+TEST(divisible_by_real_0_3_false) {
   const sourcemeta::core::JSON dividend{1.0};
   const sourcemeta::core::JSON divisor{0.3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_7_true) {
+TEST(divisible_by_real_0_7_true) {
   const sourcemeta::core::JSON dividend{2.1};
   const sourcemeta::core::JSON divisor{0.7};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_real_0_7_false) {
+TEST(divisible_by_real_0_7_false) {
   const sourcemeta::core::JSON dividend{2.0};
   const sourcemeta::core::JSON divisor{0.7};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_negative_real_0_01_true) {
+TEST(divisible_by_negative_real_0_01_true) {
   const sourcemeta::core::JSON dividend{-1280.32};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_negative_real_0_1_true) {
+TEST(divisible_by_negative_real_0_1_true) {
   const sourcemeta::core::JSON dividend{-5.5};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_negative_real_0_001_true) {
+TEST(divisible_by_negative_real_0_001_true) {
   const sourcemeta::core::JSON dividend{-3.141};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_negative_real_0_01_false) {
+TEST(divisible_by_negative_real_0_01_false) {
   const sourcemeta::core::JSON dividend{-1.005};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_large_real_0_01_true) {
+TEST(divisible_by_large_real_0_01_true) {
   const sourcemeta::core::JSON dividend{999999.99};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_large_real_0_001_true) {
+TEST(divisible_by_large_real_0_001_true) {
   const sourcemeta::core::JSON dividend{12345.678};
   const sourcemeta::core::JSON divisor{0.001};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_large_real_0_1_true) {
+TEST(divisible_by_large_real_0_1_true) {
   const sourcemeta::core::JSON dividend{99999.9};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_negative_integer_real_0_1_true) {
+TEST(divisible_by_negative_integer_real_0_1_true) {
   const sourcemeta::core::JSON dividend{-10};
   const sourcemeta::core::JSON divisor{0.1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, divisible_by_negative_integer_real_0_01_true) {
+TEST(divisible_by_negative_integer_real_0_01_true) {
   const sourcemeta::core::JSON dividend{-5};
   const sourcemeta::core::JSON divisor{0.01};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(JSON_number, as_real_real) {
+TEST(as_real_real) {
   const sourcemeta::core::JSON document{4.7};
   EXPECT_DOUBLE_EQ(document.as_real(), 4.7);
 }
 
-TEST(JSON_number, as_real_integer) {
+TEST(as_real_integer) {
   const sourcemeta::core::JSON document{4};
   EXPECT_DOUBLE_EQ(document.as_real(), 4.0);
 }
 
-TEST(JSON_number, as_real_decimal) {
+TEST(as_real_decimal) {
   const auto document{sourcemeta::core::parse_json("1e9")};
-  ASSERT_TRUE(document.is_decimal());
+  EXPECT_TRUE(document.is_decimal());
   EXPECT_DOUBLE_EQ(document.as_real(), 1e9);
 }
 
-TEST(JSON_number, as_real_decimal_out_of_range_throws) {
+TEST(as_real_decimal_out_of_range_throws) {
   const auto document{sourcemeta::core::parse_json("1e400")};
-  ASSERT_TRUE(document.is_decimal());
+  EXPECT_TRUE(document.is_decimal());
   try {
     [[maybe_unused]] const auto value = document.as_real();
     FAIL();
@@ -605,7 +605,7 @@ TEST(JSON_number, as_real_decimal_out_of_range_throws) {
   }
 }
 
-TEST(JSON_number, compare_int_real_equal) {
+TEST(compare_int_real_equal) {
   const sourcemeta::core::JSON left{300};
   const sourcemeta::core::JSON right{300.0};
   EXPECT_TRUE(left.is_integer());
@@ -616,7 +616,7 @@ TEST(JSON_number, compare_int_real_equal) {
   EXPECT_TRUE(right >= left);
 }
 
-TEST(JSON_number, big_real) {
+TEST(big_real) {
   const sourcemeta::core::JSON document{1e308};
   EXPECT_TRUE(document.is_number());
   EXPECT_FALSE(document.is_integer());
@@ -624,56 +624,56 @@ TEST(JSON_number, big_real) {
   EXPECT_EQ(document.to_real(), 1e308);
 }
 
-TEST(JSON_number, is_integral_integer) {
+TEST(is_integral_integer) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_number, is_integral_non_integer_real) {
+TEST(is_integral_non_integer_real) {
   const sourcemeta::core::JSON document{5.3};
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_number, is_integral_integer_real) {
+TEST(is_integral_integer_real) {
   const sourcemeta::core::JSON document{5.0};
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_number, is_integral_non_number) {
+TEST(is_integral_non_number) {
   const sourcemeta::core::JSON document{true};
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_number, as_integer_integer) {
+TEST(as_integer_integer) {
   const sourcemeta::core::JSON document{5};
   EXPECT_EQ(document.as_integer(), 5);
 }
 
-TEST(JSON_number, as_integer_integer_real) {
+TEST(as_integer_integer_real) {
   const sourcemeta::core::JSON document{5.0};
   EXPECT_EQ(document.as_integer(), 5);
 }
 
-TEST(JSON_number, as_integer_non_integer_real) {
+TEST(as_integer_non_integer_real) {
   const sourcemeta::core::JSON document{5.5};
   EXPECT_EQ(document.as_integer(), 5);
 }
 
-TEST(JSON_number, as_integer_decimal) {
+TEST(as_integer_decimal) {
   const auto document{sourcemeta::core::parse_json("1e9")};
-  ASSERT_TRUE(document.is_decimal());
+  EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.as_integer(), 1000000000);
 }
 
-TEST(JSON_number, as_integer_decimal_fractional) {
+TEST(as_integer_decimal_fractional) {
   const auto document{sourcemeta::core::parse_json("1700000000.000000001")};
-  ASSERT_TRUE(document.is_decimal());
+  EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.as_integer(), 1700000000);
 }
 
-TEST(JSON_number, as_integer_decimal_out_of_range_throws) {
+TEST(as_integer_decimal_out_of_range_throws) {
   const auto document{sourcemeta::core::parse_json("10000000000000000000")};
-  ASSERT_TRUE(document.is_decimal());
+  EXPECT_TRUE(document.is_decimal());
   try {
     [[maybe_unused]] const auto value = document.as_integer();
     FAIL();
@@ -683,9 +683,9 @@ TEST(JSON_number, as_integer_decimal_out_of_range_throws) {
   }
 }
 
-TEST(JSON_number, as_integer_real_out_of_range_throws) {
+TEST(as_integer_real_out_of_range_throws) {
   const sourcemeta::core::JSON document{1e300};
-  ASSERT_TRUE(document.is_real());
+  EXPECT_TRUE(document.is_real());
   try {
     [[maybe_unused]] const auto value = document.as_integer();
     FAIL();
@@ -695,17 +695,17 @@ TEST(JSON_number, as_integer_real_out_of_range_throws) {
   }
 }
 
-TEST(JSON_number, is_integer_int_storage) {
+TEST(is_integer_int_storage) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_integer());
 }
 
-TEST(JSON_number, is_integer_real_storage_integer_valued) {
+TEST(is_integer_real_storage_integer_valued) {
   const sourcemeta::core::JSON document{5.0};
   EXPECT_FALSE(document.is_integer());
 }
 
-TEST(JSON_number, is_integer_real_storage_fractional) {
+TEST(is_integer_real_storage_fractional) {
   const sourcemeta::core::JSON document{3.14};
   EXPECT_FALSE(document.is_integer());
 }

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
@@ -9,7 +9,7 @@
 #include <type_traits>
 #include <utility>
 
-TEST(JSON_object, general_traits) {
+TEST(general_traits) {
   EXPECT_TRUE(
       std::is_default_constructible<sourcemeta::core::JSON::Object>::value);
   EXPECT_TRUE(std::is_nothrow_default_constructible<
@@ -19,7 +19,7 @@ TEST(JSON_object, general_traits) {
       std::is_nothrow_destructible<sourcemeta::core::JSON::Object>::value);
 }
 
-TEST(JSON_object, copy_traits) {
+TEST(copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::JSON::Object>::value);
   EXPECT_TRUE(
       std::is_copy_constructible<sourcemeta::core::JSON::Object>::value);
@@ -29,7 +29,7 @@ TEST(JSON_object, copy_traits) {
                sourcemeta::core::JSON::Object>::value);
 }
 
-TEST(JSON_object, move_traits) {
+TEST(move_traits) {
   EXPECT_TRUE(std::is_move_assignable<sourcemeta::core::JSON::Object>::value);
   EXPECT_TRUE(
       std::is_move_constructible<sourcemeta::core::JSON::Object>::value);
@@ -37,13 +37,13 @@ TEST(JSON_object, move_traits) {
       std::is_nothrow_move_assignable<sourcemeta::core::JSON::Object>::value);
 }
 
-TEST(JSON_object, type) {
+TEST(type) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                         {"bar", sourcemeta::core::JSON{true}}};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Object);
 }
 
-TEST(JSON_object, initializer_list_2_booleans) {
+TEST(initializer_list_2_booleans) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                         {"bar", sourcemeta::core::JSON{true}}};
   EXPECT_TRUE(document.is_object());
@@ -55,7 +55,7 @@ TEST(JSON_object, initializer_list_2_booleans) {
   EXPECT_TRUE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_object, empty_with_copy_constructor) {
+TEST(empty_with_copy_constructor) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON::Object{}};
 
   EXPECT_TRUE(document.is_object());
@@ -63,14 +63,14 @@ TEST(JSON_object, empty_with_copy_constructor) {
   EXPECT_EQ(document.object_size(), 0);
 }
 
-TEST(JSON_object, empty_with_make_object) {
+TEST(empty_with_make_object) {
   const sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 0);
   EXPECT_EQ(document.object_size(), 0);
 }
 
-TEST(JSON_object, assign_booleans) {
+TEST(assign_booleans) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   EXPECT_TRUE(document.is_object());
   document.assign("foo", sourcemeta::core::JSON{false});
@@ -83,7 +83,7 @@ TEST(JSON_object, assign_booleans) {
   EXPECT_TRUE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_object, must_delete_one_existent_key) {
+TEST(must_delete_one_existent_key) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
 
@@ -101,7 +101,7 @@ TEST(JSON_object, must_delete_one_existent_key) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, must_delete_one_non_existent_key) {
+TEST(must_delete_one_non_existent_key) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
 
@@ -119,7 +119,7 @@ TEST(JSON_object, must_delete_one_non_existent_key) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, modify_after_copy) {
+TEST(modify_after_copy) {
   // Original document
   sourcemeta::core::JSON document{{"x", sourcemeta::core::JSON{1}},
                                   {"y", sourcemeta::core::JSON{2}}};
@@ -155,7 +155,7 @@ TEST(JSON_object, modify_after_copy) {
   EXPECT_EQ(document.at("y").to_integer(), 2);
 }
 
-TEST(JSON_object, nested_object_clear) {
+TEST(nested_object_clear) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}}};
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 1);
@@ -166,7 +166,7 @@ TEST(JSON_object, nested_object_clear) {
   EXPECT_EQ(document.object_size(), 0);
 }
 
-TEST(JSON_object, const_all_of_false) {
+TEST(const_all_of_false) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                         {"bar", sourcemeta::core::JSON{"2"}}};
   const bool result =
@@ -175,7 +175,7 @@ TEST(JSON_object, const_all_of_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSON_object, const_all_of_true) {
+TEST(const_all_of_true) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                         {"bar", sourcemeta::core::JSON{2}}};
   const bool result =
@@ -184,7 +184,7 @@ TEST(JSON_object, const_all_of_true) {
   EXPECT_TRUE(result);
 }
 
-TEST(JSON_object, assign_literal_lvalue_string) {
+TEST(assign_literal_lvalue_string) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}}};
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 1);
@@ -202,7 +202,7 @@ TEST(JSON_object, assign_literal_lvalue_string) {
   EXPECT_EQ(document.at("bar").to_string(), "baz");
 }
 
-TEST(JSON_object, assign_literal_rvalue_string) {
+TEST(assign_literal_rvalue_string) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}}};
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 1);
@@ -219,7 +219,7 @@ TEST(JSON_object, assign_literal_rvalue_string) {
   EXPECT_EQ(document.at("bar").to_string(), "baz");
 }
 
-TEST(JSON_object, key_copy_assignment_same_type) {
+TEST(key_copy_assignment_same_type) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{"bar"}}};
   EXPECT_EQ(document.size(), 1);
   EXPECT_EQ(document.object_size(), 1);
@@ -237,7 +237,7 @@ TEST(JSON_object, key_copy_assignment_same_type) {
   EXPECT_EQ(document.at("foo").to_string(), "baz");
 }
 
-TEST(JSON_object, key_move_assignment_same_type) {
+TEST(key_move_assignment_same_type) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{"bar"}}};
   EXPECT_EQ(document.size(), 1);
   EXPECT_EQ(document.object_size(), 1);
@@ -255,7 +255,7 @@ TEST(JSON_object, key_move_assignment_same_type) {
   EXPECT_EQ(document.at("foo").to_string(), "baz");
 }
 
-TEST(JSON_object, key_copy_assignment_different_type) {
+TEST(key_copy_assignment_different_type) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{"bar"}}};
   EXPECT_EQ(document.size(), 1);
   EXPECT_EQ(document.object_size(), 1);
@@ -273,7 +273,7 @@ TEST(JSON_object, key_copy_assignment_different_type) {
   EXPECT_EQ(document.at("foo").to_integer(), 1);
 }
 
-TEST(JSON_object, key_move_assignment_different_type) {
+TEST(key_move_assignment_different_type) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{"bar"}}};
   EXPECT_EQ(document.size(), 1);
   EXPECT_EQ(document.object_size(), 1);
@@ -291,7 +291,7 @@ TEST(JSON_object, key_move_assignment_different_type) {
   EXPECT_EQ(document.at("foo").to_integer(), 1);
 }
 
-TEST(JSON_object, all_of_true) {
+TEST(all_of_true) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
   const bool result =
@@ -300,7 +300,7 @@ TEST(JSON_object, all_of_true) {
   EXPECT_TRUE(result);
 }
 
-TEST(JSON_object, all_of_with_key_true) {
+TEST(all_of_with_key_true) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
   const bool result =
@@ -309,7 +309,7 @@ TEST(JSON_object, all_of_with_key_true) {
   EXPECT_TRUE(result);
 }
 
-TEST(JSON_object, all_of_with_key_false) {
+TEST(all_of_with_key_false) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"f\": 1, \"bar\": 2 }");
   const bool result =
@@ -318,7 +318,7 @@ TEST(JSON_object, all_of_with_key_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSON, const_object_iterator) {
+TEST(const_object_iterator) {
   std::map<std::string, std::int64_t> result;
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
@@ -331,7 +331,7 @@ TEST(JSON, const_object_iterator) {
   EXPECT_EQ(result.at("bar"), 2);
 }
 
-TEST(JSON_object, iterator) {
+TEST(iterator) {
   std::map<std::string, std::int64_t> result;
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
@@ -344,7 +344,7 @@ TEST(JSON_object, iterator) {
   EXPECT_EQ(result.at("bar"), 2);
 }
 
-TEST(JSON_object, into_object) {
+TEST(into_object) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into_object();
@@ -353,7 +353,7 @@ TEST(JSON_object, into_object) {
   EXPECT_EQ(document.object_size(), 0);
 }
 
-TEST(JSON_object, erase_with_initializer_list) {
+TEST(erase_with_initializer_list) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -368,7 +368,7 @@ TEST(JSON_object, erase_with_initializer_list) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, erase_with_vector_iterators) {
+TEST(erase_with_vector_iterators) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -384,7 +384,7 @@ TEST(JSON_object, erase_with_vector_iterators) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, erase_non_existent) {
+TEST(erase_non_existent) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false,\"baz\":true}");
   EXPECT_TRUE(document.is_object());
@@ -401,14 +401,14 @@ TEST(JSON_object, erase_non_existent) {
   EXPECT_TRUE(document.defines("baz"));
 }
 
-TEST(JSON_object, assign_move_empty_object) {
+TEST(assign_move_empty_object) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   EXPECT_TRUE(document.empty());
   document.assign("foo", sourcemeta::core::JSON{true});
   EXPECT_TRUE(document.defines("foo"));
 }
 
-TEST(JSON_object, long_key_assign) {
+TEST(long_key_assign) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 0);
@@ -422,7 +422,7 @@ TEST(JSON_object, long_key_assign) {
   EXPECT_TRUE(value.to_boolean());
 }
 
-TEST(JSON_object, long_key_assign_rvalue) {
+TEST(long_key_assign_rvalue) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 0);
@@ -436,7 +436,7 @@ TEST(JSON_object, long_key_assign_rvalue) {
   EXPECT_EQ(document.at(key).to_string(), "value");
 }
 
-TEST(JSON_object, long_key_move_assignment_same_type) {
+TEST(long_key_move_assignment_same_type) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   const std::string key(32, 'x');
   document.assign(key, sourcemeta::core::JSON{"before"});
@@ -456,7 +456,7 @@ TEST(JSON_object, long_key_move_assignment_same_type) {
   EXPECT_EQ(document.at(key).to_string(), "after");
 }
 
-TEST(JSON_object, long_key_move_assignment_hash_collision) {
+TEST(long_key_move_assignment_hash_collision) {
   const std::string prefix(31, 'x');
   const std::string first_key{prefix + "ay"};
   const std::string second_key{prefix + "by"};
@@ -482,7 +482,7 @@ TEST(JSON_object, long_key_move_assignment_hash_collision) {
   EXPECT_EQ(document.at(second_key).to_integer(), 3);
 }
 
-TEST(JSON_object, clear_except_one_key_initializer_list) {
+TEST(clear_except_one_key_initializer_list) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false}");
   EXPECT_TRUE(document.is_object());
@@ -497,7 +497,7 @@ TEST(JSON_object, clear_except_one_key_initializer_list) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, clear_except_extra_key_initializer_list) {
+TEST(clear_except_extra_key_initializer_list) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":true,\"bar\":false}");
   EXPECT_TRUE(document.is_object());
@@ -509,7 +509,7 @@ TEST(JSON_object, clear_except_extra_key_initializer_list) {
   EXPECT_TRUE(document.empty());
 }
 
-TEST(JSON_object, clear_except_multiple_intersection_initializer_list) {
+TEST(clear_except_multiple_intersection_initializer_list) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2,\"baz\":3,\"qux\":4}");
   EXPECT_TRUE(document.is_object());
@@ -528,7 +528,7 @@ TEST(JSON_object, clear_except_multiple_intersection_initializer_list) {
   EXPECT_FALSE(document.defines("qux"));
 }
 
-TEST(JSON_object, at_index_using_integer) {
+TEST(at_index_using_integer) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"0\":1,\"1\":2,\"2\":3}");
   EXPECT_TRUE(document.is_object());
@@ -545,7 +545,7 @@ TEST(JSON_object, at_index_using_integer) {
   EXPECT_EQ(document.at("2").to_integer(), 3);
 }
 
-TEST(JSON_object, at_index_using_integer_non_const) {
+TEST(at_index_using_integer_non_const) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"0\":1,\"1\":2,\"2\":3}");
   EXPECT_TRUE(document.is_object());
@@ -562,7 +562,7 @@ TEST(JSON_object, at_index_using_integer_non_const) {
   EXPECT_EQ(document.at("2").to_integer(), 3);
 }
 
-TEST(JSON_object, defines_property_using_integer) {
+TEST(defines_property_using_integer) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"0\":1,\"1\":2,\"2\":3}");
   EXPECT_TRUE(document.is_object());
@@ -573,7 +573,7 @@ TEST(JSON_object, defines_property_using_integer) {
   EXPECT_TRUE(document.defines(2));
 }
 
-TEST(JSON_object, assign_if_missing_not_missing_lvalue) {
+TEST(assign_if_missing_not_missing_lvalue) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
 
@@ -596,7 +596,7 @@ TEST(JSON_object, assign_if_missing_not_missing_lvalue) {
   EXPECT_TRUE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_object, assign_if_missing_missing_lvalue) {
+TEST(assign_if_missing_missing_lvalue) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
 
@@ -621,7 +621,7 @@ TEST(JSON_object, assign_if_missing_missing_lvalue) {
   EXPECT_EQ(document.at("baz").to_integer(), 1);
 }
 
-TEST(JSON_object, assign_if_missing_not_missing_rvalue) {
+TEST(assign_if_missing_not_missing_rvalue) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
 
@@ -643,7 +643,7 @@ TEST(JSON_object, assign_if_missing_not_missing_rvalue) {
   EXPECT_TRUE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_object, assign_if_missing_missing_rvalue) {
+TEST(assign_if_missing_missing_rvalue) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
 
@@ -667,7 +667,7 @@ TEST(JSON_object, assign_if_missing_missing_rvalue) {
   EXPECT_EQ(document.at("baz").to_integer(), 1);
 }
 
-TEST(JSON_object, assign_assume_new_rvalue) {
+TEST(assign_assume_new_rvalue) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
 
   EXPECT_TRUE(document.is_object());
@@ -684,7 +684,7 @@ TEST(JSON_object, assign_assume_new_rvalue) {
   EXPECT_EQ(document.at("bar").to_integer(), 42);
 }
 
-TEST(JSON_object, assign_assume_new_rvalue_key) {
+TEST(assign_assume_new_rvalue_key) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
 
   EXPECT_TRUE(document.is_object());
@@ -703,7 +703,7 @@ TEST(JSON_object, assign_assume_new_rvalue_key) {
   EXPECT_EQ(document.at("bar").to_integer(), 42);
 }
 
-TEST(JSON_object, assign_assume_new_multiple_types) {
+TEST(assign_assume_new_multiple_types) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
 
   document.assign_assume_new("string", sourcemeta::core::JSON{"hello"});
@@ -718,7 +718,7 @@ TEST(JSON_object, assign_assume_new_multiple_types) {
   EXPECT_TRUE(document.at("null").is_null());
 }
 
-TEST(JSON_object, assign_assume_new_rvalue_key_with_hash) {
+TEST(assign_assume_new_rvalue_key_with_hash) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
 
   EXPECT_TRUE(document.is_object());
@@ -742,31 +742,31 @@ TEST(JSON_object, assign_assume_new_rvalue_key_with_hash) {
   EXPECT_EQ(document.at("foo").at("bar").to_integer(), 42);
 }
 
-TEST(JSON_object, estimated_byte_size_integers) {
+TEST(estimated_byte_size_integers) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
   EXPECT_EQ(document.estimated_byte_size(), 22);
 }
 
-TEST(JSON_object, estimated_byte_size_nested) {
+TEST(estimated_byte_size_nested) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(
       "{ \"foo\": 1, \"bar\": { \"bar\": true } }");
   EXPECT_EQ(document.estimated_byte_size(), 18);
 }
 
-TEST(JSON_object, fast_hash_integers) {
+TEST(fast_hash_integers) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2 }");
   EXPECT_EQ(document.fast_hash(), 26);
 }
 
-TEST(JSON_object, fast_hash_nested) {
+TEST(fast_hash_nested) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(
       "{ \"foo\": 1, \"bar\": { \"bar\": true } }");
   EXPECT_EQ(document.fast_hash(), 32);
 }
 
-TEST(JSON_object, find) {
+TEST(find) {
   const auto document{sourcemeta::core::parse_json("{\"foo\":5}")};
   EXPECT_NE(document.as_object().find("foo"), document.as_object().cend());
   EXPECT_EQ(document.as_object().find("foo")->first, "foo");
@@ -775,7 +775,7 @@ TEST(JSON_object, find) {
   EXPECT_EQ(document.as_object().find("bar"), document.as_object().cend());
 }
 
-TEST(JSON_object, at_hash_const) {
+TEST(at_hash_const) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                         {"bar", sourcemeta::core::JSON{true}}};
   EXPECT_TRUE(document.is_object());
@@ -791,7 +791,7 @@ TEST(JSON_object, at_hash_const) {
   EXPECT_TRUE(document.at("bar", hash_bar).to_boolean());
 }
 
-TEST(JSON_object, at_hash_non_const) {
+TEST(at_hash_non_const) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                   {"bar", sourcemeta::core::JSON{true}}};
   EXPECT_TRUE(document.is_object());
@@ -807,7 +807,7 @@ TEST(JSON_object, at_hash_non_const) {
   EXPECT_TRUE(document.at("bar", hash_bar).to_boolean());
 }
 
-TEST(JSON_object, defines_hash_const) {
+TEST(defines_hash_const) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                         {"bar", sourcemeta::core::JSON{true}}};
   EXPECT_TRUE(document.is_object());
@@ -819,7 +819,7 @@ TEST(JSON_object, defines_hash_const) {
   EXPECT_FALSE(document.defines("baz", document.as_object().hash("baz")));
 }
 
-TEST(JSON_object, iterator_hash) {
+TEST(iterator_hash) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                         {"bar", sourcemeta::core::JSON{true}}};
   EXPECT_TRUE(document.is_object());
@@ -831,19 +831,19 @@ TEST(JSON_object, iterator_hash) {
   }
 }
 
-TEST(JSON_object, as_object_defines) {
+TEST(as_object_defines) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{"bar"}}};
   for (const auto &entry : document.as_object()) {
     EXPECT_TRUE(document.as_object().defines(entry.first, entry.hash));
   }
 }
 
-TEST(JSON_object, as_object_size) {
+TEST(as_object_size) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{"bar"}}};
   EXPECT_EQ(document.as_object().size(), 1);
 }
 
-TEST(JSON_object, at_index) {
+TEST(at_index) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{false}},
                                         {"bar", sourcemeta::core::JSON{true}}};
 
@@ -859,7 +859,7 @@ TEST(JSON_object, at_index) {
   EXPECT_EQ(entry_2.hash, document.as_object().hash("bar"));
 }
 
-TEST(JSON_object, rename_match) {
+TEST(rename_match) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}}};
   document.rename("foo", "bar");
 
@@ -870,7 +870,7 @@ TEST(JSON_object, rename_match) {
   EXPECT_TRUE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_object, rename_no_match) {
+TEST(rename_no_match) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}}};
   document.rename("xxx", "bar");
 
@@ -880,7 +880,7 @@ TEST(JSON_object, rename_no_match) {
   EXPECT_TRUE(document.at("foo").to_boolean());
 }
 
-TEST(JSON_object, rename_match_destination_exists) {
+TEST(rename_match_destination_exists) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
                                   {"bar", sourcemeta::core::JSON{1}}};
   document.rename("foo", "bar");
@@ -892,7 +892,7 @@ TEST(JSON_object, rename_match_destination_exists) {
   EXPECT_TRUE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_object, merge_with_overlap) {
+TEST(merge_with_overlap) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
                                   {"bar", sourcemeta::core::JSON{1}}};
 
@@ -916,7 +916,7 @@ TEST(JSON_object, merge_with_overlap) {
   EXPECT_EQ(document.at("baz").to_integer(), 9);
 }
 
-TEST(JSON_object, merge_deep_object) {
+TEST(merge_deep_object) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": {
@@ -957,7 +957,7 @@ TEST(JSON_object, merge_deep_object) {
   EXPECT_EQ(document, expected);
 }
 
-TEST(JSON_object, merge_with_own_object) {
+TEST(merge_with_own_object) {
   auto document{
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "bar": 2 })JSON")};
   document.merge(document.as_object());
@@ -966,7 +966,7 @@ TEST(JSON_object, merge_with_own_object) {
   EXPECT_EQ(document.at("bar").to_integer(), 2);
 }
 
-TEST(JSON_object, copy_assignment_from_own_member) {
+TEST(copy_assignment_from_own_member) {
   auto document{
       sourcemeta::core::parse_json(R"JSON({ "foo": { "bar": 42 } })JSON")};
   document = document.at("foo");
@@ -976,7 +976,7 @@ TEST(JSON_object, copy_assignment_from_own_member) {
   EXPECT_EQ(document.at("bar").to_integer(), 42);
 }
 
-TEST(JSON_object, ordering_is_asymmetric) {
+TEST(ordering_is_asymmetric) {
   const auto left{
       sourcemeta::core::parse_json(R"JSON({ "a": 1, "b": 9 })JSON")};
   const auto right{
@@ -987,7 +987,7 @@ TEST(JSON_object, ordering_is_asymmetric) {
   EXPECT_NE(left < right, right < left);
 }
 
-TEST(JSON_object, ordering_with_distinct_keys) {
+TEST(ordering_with_distinct_keys) {
   const auto left{
       sourcemeta::core::parse_json(R"JSON({ "a": 1, "b": 1 })JSON")};
   const auto right{
@@ -997,7 +997,7 @@ TEST(JSON_object, ordering_with_distinct_keys) {
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_object, ordering_key_difference_outranks_value_difference) {
+TEST(ordering_key_difference_outranks_value_difference) {
   const auto left{
       sourcemeta::core::parse_json(R"JSON({ "a": 9, "b": 1 })JSON")};
   const auto right{
@@ -1007,7 +1007,7 @@ TEST(JSON_object, ordering_key_difference_outranks_value_difference) {
   EXPECT_TRUE(right < left);
 }
 
-TEST(JSON_object, at_or_defined) {
+TEST(at_or_defined) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
                                         {"bar", sourcemeta::core::JSON{1}}};
   const sourcemeta::core::JSON default_value{99};
@@ -1017,7 +1017,7 @@ TEST(JSON_object, at_or_defined) {
   EXPECT_TRUE(result.to_boolean());
 }
 
-TEST(JSON_object, at_or_defined_with_hash) {
+TEST(at_or_defined_with_hash) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
                                         {"bar", sourcemeta::core::JSON{1}}};
   const sourcemeta::core::JSON default_value{99};
@@ -1028,7 +1028,7 @@ TEST(JSON_object, at_or_defined_with_hash) {
   EXPECT_TRUE(result.to_boolean());
 }
 
-TEST(JSON_object, at_or_not_defined) {
+TEST(at_or_not_defined) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
                                         {"bar", sourcemeta::core::JSON{1}}};
   const sourcemeta::core::JSON default_value{99};
@@ -1038,7 +1038,7 @@ TEST(JSON_object, at_or_not_defined) {
   EXPECT_EQ(result.to_integer(), 99);
 }
 
-TEST(JSON_object, at_or_not_defined_with_hash) {
+TEST(at_or_not_defined_with_hash) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{true}},
                                         {"bar", sourcemeta::core::JSON{1}}};
   const sourcemeta::core::JSON default_value{99};
@@ -1049,7 +1049,7 @@ TEST(JSON_object, at_or_not_defined_with_hash) {
   EXPECT_EQ(result.to_integer(), 99);
 }
 
-TEST(JSON_object, try_assign_before_exists) {
+TEST(try_assign_before_exists) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}}};
 
@@ -1070,7 +1070,7 @@ TEST(JSON_object, try_assign_before_exists) {
   EXPECT_EQ(document.at("baz").to_integer(), 99);
 }
 
-TEST(JSON_object, try_assign_before_not_exists) {
+TEST(try_assign_before_not_exists) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}}};
 
@@ -1091,7 +1091,7 @@ TEST(JSON_object, try_assign_before_not_exists) {
   EXPECT_EQ(document.at("baz").to_integer(), 99);
 }
 
-TEST(JSON_object, try_assign_before_exists_front) {
+TEST(try_assign_before_exists_front) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}}};
 
@@ -1112,7 +1112,7 @@ TEST(JSON_object, try_assign_before_exists_front) {
   EXPECT_EQ(document.at("baz").to_integer(), 99);
 }
 
-TEST(JSON_object, try_assign_before_empty) {
+TEST(try_assign_before_empty) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::make_object()};
 
   document.try_assign_before("baz", sourcemeta::core::JSON{99}, "foo");
@@ -1127,7 +1127,7 @@ TEST(JSON_object, try_assign_before_empty) {
   EXPECT_EQ(document.at("baz").to_integer(), 99);
 }
 
-TEST(JSON_object, erase_must_not_affect_ordering) {
+TEST(erase_must_not_affect_ordering) {
   sourcemeta::core::JSON document{{"x", sourcemeta::core::JSON{1}},
                                   {"y", sourcemeta::core::JSON{2}},
                                   {"z", sourcemeta::core::JSON{2}}};
@@ -1147,7 +1147,7 @@ TEST(JSON_object, erase_must_not_affect_ordering) {
   EXPECT_EQ(after_iterator->first, "z");
 }
 
-TEST(JSON_object, reorder_empty) {
+TEST(reorder_empty) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   document.reorder(
       [](const auto &left, const auto &right) { return left < right; });
@@ -1155,7 +1155,7 @@ TEST(JSON_object, reorder_empty) {
   EXPECT_EQ(document.size(), 0);
 }
 
-TEST(JSON_object, reorder_single_element) {
+TEST(reorder_single_element) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   document.assign("apple", sourcemeta::core::JSON{1});
   document.reorder(
@@ -1166,7 +1166,7 @@ TEST(JSON_object, reorder_single_element) {
   EXPECT_EQ(iterator->second.to_integer(), 1);
 }
 
-TEST(JSON_object, reorder_ascending) {
+TEST(reorder_ascending) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   document.assign("zebra", sourcemeta::core::JSON{1});
   document.assign("apple", sourcemeta::core::JSON{2});
@@ -1187,7 +1187,7 @@ TEST(JSON_object, reorder_ascending) {
   EXPECT_EQ(iterator->second.to_integer(), 1);
 }
 
-TEST(JSON_object, reorder_descending) {
+TEST(reorder_descending) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   document.assign("apple", sourcemeta::core::JSON{1});
   document.assign("zebra", sourcemeta::core::JSON{2});
@@ -1208,7 +1208,7 @@ TEST(JSON_object, reorder_descending) {
   EXPECT_EQ(iterator->second.to_integer(), 1);
 }
 
-TEST(JSON_object, reorder_already_ordered) {
+TEST(reorder_already_ordered) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   document.assign("apple", sourcemeta::core::JSON{1});
   document.assign("banana", sourcemeta::core::JSON{2});
@@ -1229,7 +1229,7 @@ TEST(JSON_object, reorder_already_ordered) {
   EXPECT_EQ(iterator->second.to_integer(), 3);
 }
 
-TEST(JSON_object, try_at_start_hit) {
+TEST(try_at_start_hit) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2,\"baz\":3}");
   const auto &object{document.as_object()};
@@ -1254,7 +1254,7 @@ TEST(JSON_object, try_at_start_hit) {
   EXPECT_EQ(start, 3);
 }
 
-TEST(JSON_object, try_at_start_miss) {
+TEST(try_at_start_miss) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const auto &object{document.as_object()};
@@ -1266,7 +1266,7 @@ TEST(JSON_object, try_at_start_miss) {
   EXPECT_EQ(start, 0);
 }
 
-TEST(JSON_object, try_at_start_reverse_order) {
+TEST(try_at_start_reverse_order) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2,\"baz\":3}");
   const auto &object{document.as_object()};
@@ -1291,7 +1291,7 @@ TEST(JSON_object, try_at_start_reverse_order) {
   EXPECT_EQ(start, 1);
 }
 
-TEST(JSON_object, try_at_start_single_property) {
+TEST(try_at_start_single_property) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"only\":42}");
   const auto &object{document.as_object()};
@@ -1304,7 +1304,7 @@ TEST(JSON_object, try_at_start_single_property) {
   EXPECT_EQ(start, 1);
 }
 
-TEST(JSON_object, try_at_start_wraparound) {
+TEST(try_at_start_wraparound) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2,\"baz\":3}");
   const auto &object{document.as_object()};
@@ -1317,7 +1317,7 @@ TEST(JSON_object, try_at_start_wraparound) {
   EXPECT_EQ(start, 1);
 }
 
-TEST(JSON_object, try_at_start_sequential_advances) {
+TEST(try_at_start_sequential_advances) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"a\":1,\"b\":2,\"c\":3,\"d\":4}");
   const auto &object{document.as_object()};
@@ -1346,7 +1346,7 @@ TEST(JSON_object, try_at_start_sequential_advances) {
   EXPECT_EQ(start, object.size());
 }
 
-TEST(JSON_object, defines_with_string_view) {
+TEST(defines_with_string_view) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string_view foo{"foo"};
@@ -1357,7 +1357,7 @@ TEST(JSON_object, defines_with_string_view) {
   EXPECT_FALSE(document.defines(qux));
 }
 
-TEST(JSON_object, defines_with_string_view_subview) {
+TEST(defines_with_string_view_subview) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string buffer{"foobar"};
@@ -1367,7 +1367,7 @@ TEST(JSON_object, defines_with_string_view_subview) {
   EXPECT_TRUE(document.defines(bar_view));
 }
 
-TEST(JSON_object, defines_with_string_view_and_hash) {
+TEST(defines_with_string_view_and_hash) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const auto &object{document.as_object()};
@@ -1376,7 +1376,7 @@ TEST(JSON_object, defines_with_string_view_and_hash) {
   EXPECT_TRUE(document.defines(foo, foo_hash));
 }
 
-TEST(JSON_object, at_const_with_string_view) {
+TEST(at_const_with_string_view) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string_view foo{"foo"};
@@ -1385,7 +1385,7 @@ TEST(JSON_object, at_const_with_string_view) {
   EXPECT_EQ(document.at(bar).to_integer(), 2);
 }
 
-TEST(JSON_object, at_const_with_string_view_subview) {
+TEST(at_const_with_string_view_subview) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string buffer{"foobar"};
@@ -1395,7 +1395,7 @@ TEST(JSON_object, at_const_with_string_view_subview) {
   EXPECT_EQ(document.at(bar_view).to_integer(), 2);
 }
 
-TEST(JSON_object, at_mutable_with_string_view) {
+TEST(at_mutable_with_string_view) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string_view foo{"foo"};
@@ -1403,7 +1403,7 @@ TEST(JSON_object, at_mutable_with_string_view) {
   EXPECT_EQ(document.at("foo").to_integer(), 42);
 }
 
-TEST(JSON_object, at_const_with_string_view_and_hash) {
+TEST(at_const_with_string_view_and_hash) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const auto &object{document.as_object()};
@@ -1412,7 +1412,7 @@ TEST(JSON_object, at_const_with_string_view_and_hash) {
   EXPECT_EQ(document.at(foo, foo_hash).to_integer(), 1);
 }
 
-TEST(JSON_object, defines_with_string_view_long_key) {
+TEST(defines_with_string_view_long_key) {
   const std::string_view long_key{
       "this_is_a_long_key_more_than_thirty_one_characters"};
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
@@ -1421,7 +1421,7 @@ TEST(JSON_object, defines_with_string_view_long_key) {
   EXPECT_EQ(document.at(long_key).to_integer(), 1);
 }
 
-TEST(JSON_object, assign_lvalue_with_string_view_key) {
+TEST(assign_lvalue_with_string_view_key) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   const std::string_view key{"foo"};
   const sourcemeta::core::JSON value{42};
@@ -1430,7 +1430,7 @@ TEST(JSON_object, assign_lvalue_with_string_view_key) {
   EXPECT_EQ(document.at("foo").to_integer(), 42);
 }
 
-TEST(JSON_object, assign_rvalue_with_string_view_key) {
+TEST(assign_rvalue_with_string_view_key) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   const std::string_view key{"foo"};
   document.assign(key, sourcemeta::core::JSON{42});
@@ -1438,7 +1438,7 @@ TEST(JSON_object, assign_rvalue_with_string_view_key) {
   EXPECT_EQ(document.at("foo").to_integer(), 42);
 }
 
-TEST(JSON_object, assign_with_string_view_subview_key) {
+TEST(assign_with_string_view_subview_key) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   const std::string buffer{"foobar"};
   const std::string_view foo_view{buffer.data(), 3};
@@ -1449,7 +1449,7 @@ TEST(JSON_object, assign_with_string_view_subview_key) {
   EXPECT_EQ(document.at("bar").to_integer(), 2);
 }
 
-TEST(JSON_object, erase_with_string_view) {
+TEST(erase_with_string_view) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string_view foo{"foo"};
@@ -1458,7 +1458,7 @@ TEST(JSON_object, erase_with_string_view) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, erase_with_string_view_subview) {
+TEST(erase_with_string_view_subview) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":1,\"bar\":2}");
   const std::string buffer{"foobar"};
@@ -1468,7 +1468,7 @@ TEST(JSON_object, erase_with_string_view_subview) {
   EXPECT_TRUE(document.defines("bar"));
 }
 
-TEST(JSON_object, assign_if_missing_with_string_view) {
+TEST(assign_if_missing_with_string_view) {
   sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   document.assign("foo", sourcemeta::core::JSON{1});
   const std::string_view foo{"foo"};
@@ -1479,21 +1479,21 @@ TEST(JSON_object, assign_if_missing_with_string_view) {
   EXPECT_EQ(document.at("bar").to_integer(), 2);
 }
 
-TEST(JSON_object, entry_key_equals_perfect_match) {
+TEST(entry_key_equals_perfect_match) {
   const auto document{sourcemeta::core::parse_json(R"({ "foo": 1 })")};
   const auto &entry{*document.as_object().cbegin()};
   EXPECT_TRUE(
       entry.key_equals("foo", sourcemeta::core::JSON::Object::hash("foo")));
 }
 
-TEST(JSON_object, entry_key_equals_perfect_mismatch) {
+TEST(entry_key_equals_perfect_mismatch) {
   const auto document{sourcemeta::core::parse_json(R"({ "foo": 1 })")};
   const auto &entry{*document.as_object().cbegin()};
   EXPECT_FALSE(
       entry.key_equals("bar", sourcemeta::core::JSON::Object::hash("bar")));
 }
 
-TEST(JSON_object, entry_key_equals_imperfect_match) {
+TEST(entry_key_equals_imperfect_match) {
   const std::string key(40, 'a');
   sourcemeta::core::JSON document{sourcemeta::core::JSON::make_object()};
   document.assign(key, sourcemeta::core::JSON{1});
@@ -1503,7 +1503,7 @@ TEST(JSON_object, entry_key_equals_imperfect_match) {
   EXPECT_TRUE(entry.key_equals(key, sourcemeta::core::JSON::Object::hash(key)));
 }
 
-TEST(JSON_object, entry_key_equals_imperfect_collision_is_rejected) {
+TEST(entry_key_equals_imperfect_collision_is_rejected) {
   const std::string stored{std::string(31, 'a') + "11111110" + "z"};
   const std::string other{std::string(31, 'a') + "22222220" + "z"};
   sourcemeta::core::JSON document{sourcemeta::core::JSON::make_object()};

--- a/test/json/json_parse_callback_test.cc
+++ b/test/json/json_parse_callback_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
@@ -60,70 +60,70 @@
   EXPECT_EQ(std::get<5>(traces.at(index)), expected_index);                    \
   EXPECT_EQ(std::get<6>(traces.at(index)), expected_property)
 
-TEST(JSON_parse_callback, true) {
+TEST(true) {
   const auto input{"true"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Boolean, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Boolean, 1, 4, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, true_with_padding) {
+TEST(true_with_padding) {
   const auto input{"  true  "};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Boolean, 1, 3, Root, 0, "");
   EXPECT_TRACE(1, Post, Boolean, 1, 6, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, false) {
+TEST(false) {
   const auto input{"false"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Boolean, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Boolean, 1, 5, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, null) {
+TEST(null) {
   const auto input{"null"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Null, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Null, 1, 4, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, empty_string) {
+TEST(empty_string) {
   const auto input{"\"\""};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, String, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, String, 1, 2, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, non_empty_string) {
+TEST(non_empty_string) {
   const auto input{"\"foo\""};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, String, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, String, 1, 5, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, integer) {
+TEST(integer) {
   const auto input{"1234"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Integer, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Integer, 1, 4, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, real) {
+TEST(real) {
   const auto input{"3.5"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Real, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Real, 1, 3, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, empty_array) {
+TEST(empty_array) {
   const auto input{"[]"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Array, 1, 2, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_booleans) {
+TEST(array_booleans) {
   const auto input{"[\n  true,\n  false\n]"};
 
   PARSE_WITH_TRACES(document, input, 6);
@@ -135,7 +135,7 @@ TEST(JSON_parse_callback, array_booleans) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_nulls) {
+TEST(array_nulls) {
   const auto input{"[\n  null,\n  null\n]"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -146,7 +146,7 @@ TEST(JSON_parse_callback, array_nulls) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_strings) {
+TEST(array_strings) {
   const auto input{"[\n  \"foo\",\n  \"bar\"\n]"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -157,7 +157,7 @@ TEST(JSON_parse_callback, array_strings) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_integers) {
+TEST(array_integers) {
   const auto input{"[\n  1,\n  234\n]"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -168,7 +168,7 @@ TEST(JSON_parse_callback, array_integers) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_reals) {
+TEST(array_reals) {
   const auto input{"[\n  1.0,\n  2.5\n]"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -179,7 +179,7 @@ TEST(JSON_parse_callback, array_reals) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_empty_objects) {
+TEST(array_empty_objects) {
   const auto input{"[\n  {},\n  {}\n]"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -190,7 +190,7 @@ TEST(JSON_parse_callback, array_empty_objects) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, array_empty_arrays) {
+TEST(array_empty_arrays) {
   const auto input{"[\n  [],\n  []\n]"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -201,14 +201,14 @@ TEST(JSON_parse_callback, array_empty_arrays) {
   EXPECT_TRACE(5, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, empty_object) {
+TEST(empty_object) {
   const auto input{"{}"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Object, 1, 2, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_booleans) {
+TEST(object_booleans) {
   const auto input{"{\n  \"foo\": true,\n  \"bar\": false\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -219,7 +219,7 @@ TEST(JSON_parse_callback, object_booleans) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_nulls) {
+TEST(object_nulls) {
   const auto input{"{\n  \"foo\": null,\n  \"bar\": null\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -230,7 +230,7 @@ TEST(JSON_parse_callback, object_nulls) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_strings) {
+TEST(object_strings) {
   const auto input{"{\n  \"foo\": \"baz\",\n  \"bar\": \"qux\"\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -241,7 +241,7 @@ TEST(JSON_parse_callback, object_strings) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_integers) {
+TEST(object_integers) {
   const auto input{"{\n  \"foo\": 1,\n  \"bar\": 234\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -252,7 +252,7 @@ TEST(JSON_parse_callback, object_integers) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_reals) {
+TEST(object_reals) {
   const auto input{"{\n  \"foo\": 1.0,\n  \"bar\": 2.5\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -263,7 +263,7 @@ TEST(JSON_parse_callback, object_reals) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_empty_arrays) {
+TEST(object_empty_arrays) {
   const auto input{"{\n  \"foo\": [],\n  \"bar\": []\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -274,7 +274,7 @@ TEST(JSON_parse_callback, object_empty_arrays) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, object_empty_objects) {
+TEST(object_empty_objects) {
   const auto input{"{\n  \"foo\": {},\n  \"bar\": {}\n}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -285,7 +285,7 @@ TEST(JSON_parse_callback, object_empty_objects) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, complex_1) {
+TEST(complex_1) {
   const auto input{R"JSON([
   {
     "foo": {
@@ -305,7 +305,7 @@ TEST(JSON_parse_callback, complex_1) {
   EXPECT_TRACE(7, Post, Array, 7, 1, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, read_json_stub_valid) {
+TEST(read_json_stub_valid) {
   const auto input{std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json"};
   READ_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -314,21 +314,21 @@ TEST(JSON_parse_callback, read_json_stub_valid) {
   EXPECT_TRACE(3, Post, Object, 1, 12, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, decimal_simple) {
+TEST(decimal_simple) {
   const auto input{"9223372036854776000"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Decimal, 1, 19, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, decimal_negative) {
+TEST(decimal_negative) {
   const auto input{"-9223372036854776000"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Decimal, 1, 20, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, decimal_in_array) {
+TEST(decimal_in_array) {
   const auto input{"[1, 9223372036854776000, 3]"};
   PARSE_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -341,7 +341,7 @@ TEST(JSON_parse_callback, decimal_in_array) {
   EXPECT_TRACE(7, Post, Array, 1, 27, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, decimal_in_object) {
+TEST(decimal_in_object) {
   const auto input{"{\"big\":9223372036854776000}"};
   PARSE_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -350,7 +350,7 @@ TEST(JSON_parse_callback, decimal_in_object) {
   EXPECT_TRACE(3, Post, Object, 1, 27, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, decimals_mixed_in_object) {
+TEST(decimals_mixed_in_object) {
   const auto input{"{\"big\":9223372036854776000,\"small\":42}"};
   PARSE_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -361,14 +361,14 @@ TEST(JSON_parse_callback, decimals_mixed_in_object) {
   EXPECT_TRACE(5, Post, Object, 1, 38, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, decimal_big_real) {
+TEST(decimal_big_real) {
   const auto input{"3.14159265358979323846264338327950288419716939937510"};
   PARSE_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Decimal, 1, 52, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, nested_decimals) {
+TEST(nested_decimals) {
   const auto input{"{\"data\":[{\"big_int\":9223372036854776000}]}"};
   PARSE_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -381,7 +381,7 @@ TEST(JSON_parse_callback, nested_decimals) {
   EXPECT_TRACE(7, Post, Object, 1, 42, Root, 0, "");
 }
 
-TEST(JSON_parse_callback, read_json_stub_bigint) {
+TEST(read_json_stub_bigint) {
   const auto input{std::filesystem::path{TEST_DIRECTORY} / "stub_bigint.json"};
   READ_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
@@ -23,32 +23,32 @@
   __EXPECT_PARSE_ERROR(input, expected_line, expected_column, JSONParseError,  \
                        "Failed to parse the JSON document");
 
-TEST(JSON_parse_error, boolean_true_invalid) {
+TEST(boolean_true_invalid) {
   std::istringstream input{"trrue"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, new_lines_before_invalid_true) {
+TEST(new_lines_before_invalid_true) {
   std::istringstream input{"\n\n\n\ntrrue"};
   EXPECT_PARSE_ERROR(input, 5, 3);
 }
 
-TEST(JSON_parse_error, whitespace_before_invalid_true) {
+TEST(whitespace_before_invalid_true) {
   std::istringstream input{" \t\rtrrue"};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, invalid_start_character) {
+TEST(invalid_start_character) {
   std::istringstream input{"xxxxxxx"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, boolean_true_invalid_with_spaces) {
+TEST(boolean_true_invalid_with_spaces) {
   std::istringstream input{"   trrue   "};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, invalid_object_delimiter) {
+TEST(invalid_object_delimiter) {
   std::istringstream input{R"EOF({
     "foo": {
       "bar" "baz"
@@ -57,277 +57,277 @@ TEST(JSON_parse_error, invalid_object_delimiter) {
   EXPECT_PARSE_ERROR(input, 3, 13);
 }
 
-TEST(JSON_parse_error, array_comma_before_element) {
+TEST(array_comma_before_element) {
   std::istringstream input{"[,]"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, array_without_end) {
+TEST(array_without_end) {
   std::istringstream input{"["};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, empty_array_incomplete_right_with_inner_space) {
+TEST(empty_array_incomplete_right_with_inner_space) {
   std::istringstream input{"[  "};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, array_empty_with_comma_and_no_right_bracket) {
+TEST(array_empty_with_comma_and_no_right_bracket) {
   std::istringstream input{"[,"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, array_empty_with_comma_and_spacing) {
+TEST(array_empty_with_comma_and_spacing) {
   std::istringstream input{"[   ,   ]"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, array_boolean_incomplete) {
+TEST(array_boolean_incomplete) {
   std::istringstream input{"[true"};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, array_incomplete_boolean) {
+TEST(array_incomplete_boolean) {
   std::istringstream input{"[tru]"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, array_without_comma_after_element) {
+TEST(array_without_comma_after_element) {
   std::istringstream input{"[1[2]]"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, array_unclosed_string_element) {
+TEST(array_unclosed_string_element) {
   std::istringstream input{"[\"foo]"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, array_single_element_trailing_comma) {
+TEST(array_single_element_trailing_comma) {
   std::istringstream input{"[true,]"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, array_single_element_trailing_commas) {
+TEST(array_single_element_trailing_commas) {
   std::istringstream input{"[true,,,]"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, array_single_element_middle_comma) {
+TEST(array_single_element_middle_comma) {
   std::istringstream input{"[true,,true]"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, array_single_element_leading_comma) {
+TEST(array_single_element_leading_comma) {
   std::istringstream input{"[,true]"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, array_single_element_leading_commas) {
+TEST(array_single_element_leading_commas) {
   std::istringstream input{"[,,,true]"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, concat_array_middle_unbalanced_right) {
+TEST(concat_array_middle_unbalanced_right) {
   std::istringstream input{"[true,[false]"};
   EXPECT_PARSE_ERROR(input, 1, 14);
 }
 
-TEST(JSON_parse_error, true_incomplete_1) {
+TEST(true_incomplete_1) {
   std::istringstream input{"tru"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, true_incomplete_2) {
+TEST(true_incomplete_2) {
   std::istringstream input{"tr"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, true_incomplete_3) {
+TEST(true_incomplete_3) {
   std::istringstream input{"t"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, false_incomplete_1) {
+TEST(false_incomplete_1) {
   std::istringstream input{"fals"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, false_incomplete_2) {
+TEST(false_incomplete_2) {
   std::istringstream input{"fal"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, false_incomplete_3) {
+TEST(false_incomplete_3) {
   std::istringstream input{"fa"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, false_incomplete_4) {
+TEST(false_incomplete_4) {
   std::istringstream input{"f"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, null_incomplete_1) {
+TEST(null_incomplete_1) {
   std::istringstream input{"nul"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, null_incomplete_2) {
+TEST(null_incomplete_2) {
   std::istringstream input{"nu"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, null_incomplete_3) {
+TEST(null_incomplete_3) {
   std::istringstream input{"n"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, empty_object_missing_left_curly) {
+TEST(empty_object_missing_left_curly) {
   std::istringstream input{"}"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, empty_object_missing_right_curly) {
+TEST(empty_object_missing_right_curly) {
   std::istringstream input{"{"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, object_missing_closing_curly) {
+TEST(object_missing_closing_curly) {
   std::istringstream input{"{\"foo\":{}"};
   EXPECT_PARSE_ERROR(input, 1, 10);
 }
 
-TEST(JSON_parse_error, object_integer_key) {
+TEST(object_integer_key) {
   std::istringstream input{"{1:false}"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, object_colon_but_no_key) {
+TEST(object_colon_but_no_key) {
   std::istringstream input{"{:false}"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, object_colon_but_no_key_with_space) {
+TEST(object_colon_but_no_key_with_space) {
   std::istringstream input{"{  :  false  }"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, object_colon_but_no_value) {
+TEST(object_colon_but_no_value) {
   std::istringstream input{"{\"x\":}"};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, object_colon_but_no_value_with_space) {
+TEST(object_colon_but_no_value_with_space) {
   std::istringstream input{"{   \"x\"   :   }"};
   EXPECT_PARSE_ERROR(input, 1, 15);
 }
 
-TEST(JSON_parse_error, object_missing_key_left_quote) {
+TEST(object_missing_key_left_quote) {
   std::istringstream input{"{foo\":true}"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, object_missing_key_right_quote) {
+TEST(object_missing_key_right_quote) {
   std::istringstream input{"{\"foo:true}"};
   EXPECT_PARSE_ERROR(input, 1, 12);
 }
 
-TEST(JSON_parse_error, object_missing_key_both_quotes) {
+TEST(object_missing_key_both_quotes) {
   std::istringstream input{"{foo:true}"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, object_missing_colon) {
+TEST(object_missing_colon) {
   std::istringstream input{"{\"foo\" true}"};
   EXPECT_PARSE_ERROR(input, 1, 8);
 }
 
-TEST(JSON_parse_error, object_multiple_colons) {
+TEST(object_multiple_colons) {
   std::istringstream input{"{\"foo\"::true}"};
   EXPECT_PARSE_ERROR(input, 1, 8);
 }
 
-TEST(JSON_parse_error, object_no_right_curly_bracket) {
+TEST(object_no_right_curly_bracket) {
   std::istringstream input{"{\"foo\":true"};
   EXPECT_PARSE_ERROR(input, 1, 12);
 }
 
-TEST(JSON_parse_error, object_incomplete_boolean) {
+TEST(object_incomplete_boolean) {
   std::istringstream input{"{\"foo\":tru}"};
   EXPECT_PARSE_ERROR(input, 1, 11);
 }
 
-TEST(JSON_parse_error, object_key_without_value) {
+TEST(object_key_without_value) {
   std::istringstream input{"{\"foo\"}"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, object_key_without_value_after_valid_key) {
+TEST(object_key_without_value_after_valid_key) {
   std::istringstream input{"{\"foo\": 1,\"bar\"}"};
   EXPECT_PARSE_ERROR(input, 1, 16);
 }
 
-TEST(JSON_parse_error, object_trailing_comma_after_element) {
+TEST(object_trailing_comma_after_element) {
   std::istringstream input{"{\"foo\": 1,\"bar\":0,}"};
   EXPECT_PARSE_ERROR(input, 1, 19);
 }
 
-TEST(JSON_parse_error, object_trailing_comma) {
+TEST(object_trailing_comma) {
   std::istringstream input{"{\"foo\": 1,}"};
   EXPECT_PARSE_ERROR(input, 1, 11);
 }
 
-TEST(JSON_parse_error, object_trailing_comma_with_spacing) {
+TEST(object_trailing_comma_with_spacing) {
   std::istringstream input{"{\"foo\": 1  ,   } "};
   EXPECT_PARSE_ERROR(input, 1, 16);
 }
 
-TEST(JSON_parse_error, object_trailing_comma_with_left_spacing) {
+TEST(object_trailing_comma_with_left_spacing) {
   std::istringstream input{"{\"foo\": 1  ,}"};
   EXPECT_PARSE_ERROR(input, 1, 13);
 }
 
-TEST(JSON_parse_error, object_multiple_commas) {
+TEST(object_multiple_commas) {
   std::istringstream input{"{\"foo\": 1,,,,,}"};
   EXPECT_PARSE_ERROR(input, 1, 11);
 }
 
-TEST(JSON_parse_error, object_multiple_commas_with_spacing) {
+TEST(object_multiple_commas_with_spacing) {
   std::istringstream input{"{\"foo\": 1 ,  ,  , , }"};
   EXPECT_PARSE_ERROR(input, 1, 14);
 }
 
-TEST(JSON_parse_error, string_no_right_quote) {
+TEST(string_no_right_quote) {
   std::istringstream input{"\"foo"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, string_no_left_quote) {
+TEST(string_no_left_quote) {
   std::istringstream input{"foo\""};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, string_single_quotes) {
+TEST(string_single_quotes) {
   std::istringstream input{"'foo'"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, string_only_quote) {
+TEST(string_only_quote) {
   std::istringstream input{"\""};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, string_escaped_invalid) {
+TEST(string_escaped_invalid) {
   std::istringstream input{"\"foo\\xbar\""};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, string_escaped_incomplete) {
+TEST(string_escaped_incomplete) {
   std::istringstream input{"\"foo\\\""};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, string_invalid_control_characters) {
+TEST(string_invalid_control_characters) {
   std::istringstream input00{"\"foo \u0000 bar\""};
   std::istringstream input01{"\"foo \u0001 bar\""};
   std::istringstream input02{"\"foo \u0002 bar\""};
@@ -395,273 +395,272 @@ TEST(JSON_parse_error, string_invalid_control_characters) {
   EXPECT_PARSE_ERROR(input1F, 1, 6);
 }
 
-TEST(JSON_parse_error, string_invalid_code_point) {
+TEST(string_invalid_code_point) {
   std::istringstream input{"\"\\uXXXX\""};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, string_invalid_lowercase_code_point) {
+TEST(string_invalid_lowercase_code_point) {
   std::istringstream input{"\"\\uqqqq\""};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, string_incomplete_code_point_0) {
+TEST(string_incomplete_code_point_0) {
   std::istringstream input{"\"\\u\""};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, string_incomplete_code_point_1) {
+TEST(string_incomplete_code_point_1) {
   std::istringstream input{"\"\\u6\""};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, string_incomplete_code_point_2) {
+TEST(string_incomplete_code_point_2) {
   std::istringstream input{"\"\\u2F\""};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, string_incomplete_code_point_3) {
+TEST(string_incomplete_code_point_3) {
   std::istringstream input{"\"\\u02F\""};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, string_incomplete_code_point_space) {
+TEST(string_incomplete_code_point_space) {
   std::istringstream input{"\"\\u0F 2F\""};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, invalid_integer_trailing_minus) {
+TEST(invalid_integer_trailing_minus) {
   std::istringstream input{"[-0-]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, invalid_integer_trailing_character) {
+TEST(invalid_integer_trailing_character) {
   std::istringstream input{"[-0x]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, invalid_minus_in_between_integer) {
+TEST(invalid_minus_in_between_integer) {
   std::istringstream input{"[123-45]"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, integer_invalid_double_minus) {
+TEST(integer_invalid_double_minus) {
   std::istringstream input{"--123"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, integer_two_zeroes) {
+TEST(integer_two_zeroes) {
   std::istringstream input{"[00]"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, integer_multiple_zeroes) {
+TEST(integer_multiple_zeroes) {
   std::istringstream input{"[000]"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, leading_zero_with_one_digit_integer) {
+TEST(leading_zero_with_one_digit_integer) {
   std::istringstream input{"[01]"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, leading_zero_with_two_digits_integer) {
+TEST(leading_zero_with_two_digits_integer) {
   std::istringstream input{"[012]"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, real_leading_period) {
+TEST(real_leading_period) {
   std::istringstream input{".0"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, real_trailing_period) {
+TEST(real_trailing_period) {
   std::istringstream input{"0."};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, real_trailing_period_and_minus) {
+TEST(real_trailing_period_and_minus) {
   std::istringstream input{"[0.-]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, integer_double_minus_at_start) {
+TEST(integer_double_minus_at_start) {
   std::istringstream input{"--5"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, integer_leading_minus_and_period) {
+TEST(integer_leading_minus_and_period) {
   std::istringstream input{"-.0"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, integer_multiple_leading_plus) {
+TEST(integer_multiple_leading_plus) {
   std::istringstream input{"++5"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, real_multiple_sibling_periods) {
+TEST(real_multiple_sibling_periods) {
   std::istringstream input{"123..56"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, real_multiple_separate_periods) {
+TEST(real_multiple_separate_periods) {
   std::istringstream input{"[12.34.56]"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSON_parse_error, integer_with_plus) {
+TEST(integer_with_plus) {
   std::istringstream input{"+5"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, integer_string_zero_with_plus) {
+TEST(integer_string_zero_with_plus) {
   std::istringstream input{"+0"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, integer_negative_with_leading_zero) {
+TEST(integer_negative_with_leading_zero) {
   std::istringstream input{"-05"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, integer_negative_with_leading_zero_and_space) {
+TEST(integer_negative_with_leading_zero_and_space) {
   std::istringstream input{"[-0 5]"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, leading_zero_positive_integer_number) {
+TEST(leading_zero_positive_integer_number) {
   std::istringstream input{"[02]"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, leading_zero_negative_integer_number) {
+TEST(leading_zero_negative_integer_number) {
   std::istringstream input{"[-02]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, two_leading_zeroes_real_number) {
+TEST(two_leading_zeroes_real_number) {
   std::istringstream input{"[-00.2]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, multiple_leading_zeroes_real_number) {
+TEST(multiple_leading_zeroes_real_number) {
   std::istringstream input{"[-00000.2]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, decimal_invalid_standalone_exponent) {
+TEST(decimal_invalid_standalone_exponent) {
   std::istringstream input{"e10"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, decimal_invalid_standalone_negative_sign) {
+TEST(decimal_invalid_standalone_negative_sign) {
   std::istringstream input{"-"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, decimal_invalid_standalone_decimal_point) {
+TEST(decimal_invalid_standalone_decimal_point) {
   std::istringstream input{"."};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, decimal_exponent_no_digits) {
+TEST(decimal_exponent_no_digits) {
   std::istringstream input{"1e"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, decimal_exponent_sign_no_digits) {
+TEST(decimal_exponent_sign_no_digits) {
   std::istringstream input{"1e+"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_double_upper_e) {
+TEST(exponential_notation_error_double_upper_e) {
   std::istringstream input{"3EE2"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_double_lower_e) {
+TEST(exponential_notation_error_double_lower_e) {
   std::istringstream input{"3ee2"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_double_mixed_e) {
+TEST(exponential_notation_error_double_mixed_e) {
   std::istringstream input{"3eE2"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_trailing_upper_e) {
+TEST(exponential_notation_error_trailing_upper_e) {
   std::istringstream input{"3E"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_trailing_lower_e) {
+TEST(exponential_notation_error_trailing_lower_e) {
   std::istringstream input{"3e"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_trailing_upper_e_minus) {
+TEST(exponential_notation_error_trailing_upper_e_minus) {
   std::istringstream input{"3E-"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_trailing_lower_e_minus) {
+TEST(exponential_notation_error_trailing_lower_e_minus) {
   std::istringstream input{"3e-"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_leading_upper_e) {
+TEST(exponential_notation_error_leading_upper_e) {
   std::istringstream input{"E2"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_leading_lower_e) {
+TEST(exponential_notation_error_leading_lower_e) {
   std::istringstream input{"e2"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_minus_leading_upper_e) {
+TEST(exponential_notation_error_minus_leading_upper_e) {
   std::istringstream input{"-E2"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_minus_leading_lower_e) {
+TEST(exponential_notation_error_minus_leading_lower_e) {
   std::istringstream input{"-e2"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_double_e_with_digits) {
+TEST(exponential_notation_error_double_e_with_digits) {
   std::istringstream input{"[3E1E2]"};
   EXPECT_PARSE_ERROR(input, 1, 5);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_left_e_space) {
+TEST(exponential_notation_error_left_e_space) {
   std::istringstream input{"[3 E2]"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_right_e_space) {
+TEST(exponential_notation_error_right_e_space) {
   std::istringstream input{"3E 2"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSON_parse_error, exponential_notation_error_double_minus_after_e) {
+TEST(exponential_notation_error_double_minus_after_e) {
   std::istringstream input{"3E--2"};
   EXPECT_PARSE_ERROR(input, 1, 4);
 }
 
-TEST(JSON_parse_error,
-     exponential_notation_error_double_minus_with_digits_after_e) {
+TEST(exponential_notation_error_double_minus_with_digits_after_e) {
   std::istringstream input{"[3E-2-2]"};
   EXPECT_PARSE_ERROR(input, 1, 6);
 }
 
-TEST(JSON_parse_error, backspace_is_not_whitespace) {
+TEST(backspace_is_not_whitespace) {
   std::istringstream input{"\bfalse\b"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, read_json_invalid_1) {
+TEST(read_json_invalid_1) {
   try {
     sourcemeta::core::read_json(std::filesystem::path{TEST_DIRECTORY} /
                                 "stub_invalid_1.json");
@@ -676,7 +675,7 @@ TEST(JSON_parse_error, read_json_invalid_1) {
   }
 }
 
-TEST(JSON_parse_error, read_json_invalid_2) {
+TEST(read_json_invalid_2) {
   try {
     sourcemeta::core::read_json(std::filesystem::path{TEST_DIRECTORY} /
                                 "stub_invalid_2.json");
@@ -691,7 +690,7 @@ TEST(JSON_parse_error, read_json_invalid_2) {
   }
 }
 
-TEST(JSON_parse_error, read_json_invalid_bigint) {
+TEST(read_json_invalid_bigint) {
   try {
     sourcemeta::core::read_json(std::filesystem::path{TEST_DIRECTORY} /
                                 "stub_bigint.json");
@@ -708,7 +707,7 @@ TEST(JSON_parse_error, read_json_invalid_bigint) {
   }
 }
 
-TEST(JSON_parse_error, read_json_directory) {
+TEST(read_json_directory) {
   const std::filesystem::path path{TEST_DIRECTORY};
   try {
     sourcemeta::core::read_json(path);
@@ -720,7 +719,7 @@ TEST(JSON_parse_error, read_json_directory) {
   }
 }
 
-TEST(JSON_parse_error, read_json_non_existent) {
+TEST(read_json_non_existent) {
   const auto path{std::filesystem::path{TEST_DIRECTORY} / "i-dont-exist"};
   try {
     sourcemeta::core::read_json(path);
@@ -732,17 +731,17 @@ TEST(JSON_parse_error, read_json_non_existent) {
   }
 }
 
-TEST(JSON_parse_error, parsing_infinity_keyword_fails) {
+TEST(parsing_infinity_keyword_fails) {
   std::istringstream input{"Infinity"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
 
-TEST(JSON_parse_error, parsing_negative_infinity_keyword_fails) {
+TEST(parsing_negative_infinity_keyword_fails) {
   std::istringstream input{"-Infinity"};
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSON_parse_error, parsing_nan_keyword_fails) {
+TEST(parsing_nan_keyword_fails) {
   std::istringstream input{"NaN"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }

--- a/test/json/json_parse_roundtrip_test.cc
+++ b/test/json/json_parse_roundtrip_test.cc
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <sstream>
 
-TEST(JSON_parse_roundtrip, decimal_large_integer) {
+TEST(decimal_large_integer) {
   const sourcemeta::core::JSON original{
       sourcemeta::core::Decimal{"123456789012345678901234567890"}};
   std::ostringstream stream;
@@ -15,7 +15,7 @@ TEST(JSON_parse_roundtrip, decimal_large_integer) {
   EXPECT_EQ(parsed.to_decimal().to_string(), "123456789012345678901234567890");
 }
 
-TEST(JSON_parse_roundtrip, decimal_exponential_overflow_positive) {
+TEST(decimal_exponential_overflow_positive) {
   const sourcemeta::core::JSON original{
       sourcemeta::core::Decimal{"1.23456789012345678901234567890e309"}};
   std::ostringstream stream;
@@ -25,7 +25,7 @@ TEST(JSON_parse_roundtrip, decimal_exponential_overflow_positive) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_exponential_overflow_large) {
+TEST(decimal_exponential_overflow_large) {
   const sourcemeta::core::JSON original{
       sourcemeta::core::Decimal{"9.87654321098765432109876543210e320"}};
   std::ostringstream stream;
@@ -35,7 +35,7 @@ TEST(JSON_parse_roundtrip, decimal_exponential_overflow_large) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_exponential_very_large_exponent) {
+TEST(decimal_exponential_very_large_exponent) {
   const sourcemeta::core::JSON original{sourcemeta::core::Decimal{"1.5e400"}};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -44,7 +44,7 @@ TEST(JSON_parse_roundtrip, decimal_exponential_very_large_exponent) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_exponential_negative_overflow) {
+TEST(decimal_exponential_negative_overflow) {
   const sourcemeta::core::JSON original{
       sourcemeta::core::Decimal{"-2.718281828459045235360287471352e310"}};
   std::ostringstream stream;
@@ -54,8 +54,7 @@ TEST(JSON_parse_roundtrip, decimal_exponential_negative_overflow) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip,
-     decimal_exponential_small_coefficient_large_exponent) {
+TEST(decimal_exponential_small_coefficient_large_exponent) {
   const sourcemeta::core::JSON original{sourcemeta::core::Decimal{"3.14e350"}};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -64,7 +63,7 @@ TEST(JSON_parse_roundtrip,
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_small_1) {
+TEST(decimal_small_1) {
   const sourcemeta::core::JSON original{sourcemeta::core::Decimal{"1e-05"}};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -73,7 +72,7 @@ TEST(JSON_parse_roundtrip, decimal_small_1) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_small_2) {
+TEST(decimal_small_2) {
   const sourcemeta::core::JSON original{sourcemeta::core::Decimal{"1e-06"}};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -82,7 +81,7 @@ TEST(JSON_parse_roundtrip, decimal_small_2) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_small_3) {
+TEST(decimal_small_3) {
   const sourcemeta::core::JSON original{sourcemeta::core::Decimal{"5e-05"}};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -91,7 +90,7 @@ TEST(JSON_parse_roundtrip, decimal_small_3) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, decimal_small_4) {
+TEST(decimal_small_4) {
   const sourcemeta::core::JSON original{
       sourcemeta::core::Decimal{"6.10352e-05"}};
   std::ostringstream stream;
@@ -101,7 +100,7 @@ TEST(JSON_parse_roundtrip, decimal_small_4) {
   EXPECT_TRUE(parsed.is_decimal());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_1) {
+TEST(real_number_precision_1) {
   const auto original{sourcemeta::core::parse_json("10.213854")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -110,7 +109,7 @@ TEST(JSON_parse_roundtrip, real_number_precision_1) {
   EXPECT_TRUE(parsed.is_real());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_2) {
+TEST(real_number_precision_2) {
   const auto original{sourcemeta::core::parse_json("52.273577")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -119,7 +118,7 @@ TEST(JSON_parse_roundtrip, real_number_precision_2) {
   EXPECT_TRUE(parsed.is_real());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_3) {
+TEST(real_number_precision_3) {
   const auto original{sourcemeta::core::parse_json("10.107058")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -128,7 +127,7 @@ TEST(JSON_parse_roundtrip, real_number_precision_3) {
   EXPECT_TRUE(parsed.is_real());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_4) {
+TEST(real_number_precision_4) {
   const auto original{sourcemeta::core::parse_json("52.148044")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -137,7 +136,7 @@ TEST(JSON_parse_roundtrip, real_number_precision_4) {
   EXPECT_TRUE(parsed.is_real());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_negative) {
+TEST(real_number_precision_negative) {
   const auto original{sourcemeta::core::parse_json("-52.273577")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -146,7 +145,7 @@ TEST(JSON_parse_roundtrip, real_number_precision_negative) {
   EXPECT_TRUE(parsed.is_real());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_small_fractional) {
+TEST(real_number_precision_small_fractional) {
   const auto original{sourcemeta::core::parse_json("0.00123456789")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);
@@ -155,7 +154,7 @@ TEST(JSON_parse_roundtrip, real_number_precision_small_fractional) {
   EXPECT_TRUE(parsed.is_real());
 }
 
-TEST(JSON_parse_roundtrip, real_number_precision_15_significant_digits) {
+TEST(real_number_precision_15_significant_digits) {
   const auto original{sourcemeta::core::parse_json("1.23456789012345")};
   std::ostringstream stream;
   sourcemeta::core::stringify(original, stream);

--- a/test/json/json_parse_test.cc
+++ b/test/json/json_parse_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
@@ -6,21 +6,21 @@
 #include <sstream>
 #include <string>
 
-TEST(JSON_parse, true) {
+TEST(true) {
   std::istringstream input{"true"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_boolean());
   EXPECT_TRUE(document.to_boolean());
 }
 
-TEST(JSON_parse, false) {
+TEST(false) {
   std::istringstream input{"false"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_boolean());
   EXPECT_FALSE(document.to_boolean());
 }
 
-TEST(JSON_parse, true_equality) {
+TEST(true_equality) {
   std::istringstream input_1{"true"};
   std::istringstream input_2{"   true    "};
   std::istringstream input_3{"false"};
@@ -35,7 +35,7 @@ TEST(JSON_parse, true_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, false_equality) {
+TEST(false_equality) {
   std::istringstream input_1{"false"};
   std::istringstream input_2{"   false    "};
   std::istringstream input_3{"true"};
@@ -50,33 +50,33 @@ TEST(JSON_parse, false_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, true_with_spacing) {
+TEST(true_with_spacing) {
   std::istringstream input{"   true   "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_boolean());
   EXPECT_TRUE(document.to_boolean());
 }
 
-TEST(JSON_parse, false_with_spacing) {
+TEST(false_with_spacing) {
   std::istringstream input{"   false   "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_boolean());
   EXPECT_FALSE(document.to_boolean());
 }
 
-TEST(JSON_parse, null) {
+TEST(null) {
   std::istringstream input{"null"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_null());
 }
 
-TEST(JSON_parse, null_with_spacing) {
+TEST(null_with_spacing) {
   std::istringstream input{"   null   "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_null());
 }
 
-TEST(JSON_parse, null_equality) {
+TEST(null_equality) {
   std::istringstream input_1{"null"};
   std::istringstream input_2{"   null    "};
   std::istringstream input_3{"true"};
@@ -91,7 +91,7 @@ TEST(JSON_parse, null_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, string_empty) {
+TEST(string_empty) {
   std::istringstream input{"\"\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -100,7 +100,7 @@ TEST(JSON_parse, string_empty) {
   EXPECT_EQ(document.to_string(), "");
 }
 
-TEST(JSON_parse, string_with_null) {
+TEST(string_with_null) {
   std::istringstream input{"\"foo \\u0000 bar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -112,7 +112,7 @@ TEST(JSON_parse, string_with_null) {
   EXPECT_EQ(document.to_string(), "foo \0 bar"s);
 }
 
-TEST(JSON_parse, string_foo) {
+TEST(string_foo) {
   std::istringstream input{"\"foo\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -121,7 +121,7 @@ TEST(JSON_parse, string_foo) {
   EXPECT_EQ(document.to_string(), "foo");
 }
 
-TEST(JSON_parse, string_foo_with_spacing) {
+TEST(string_foo_with_spacing) {
   std::istringstream input{"      \"foo\"     "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -130,7 +130,7 @@ TEST(JSON_parse, string_foo_with_spacing) {
   EXPECT_EQ(document.to_string(), "foo");
 }
 
-TEST(JSON_parse, string_foo_padded) {
+TEST(string_foo_padded) {
   std::istringstream input{"\"   foo   \""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -139,7 +139,7 @@ TEST(JSON_parse, string_foo_padded) {
   EXPECT_EQ(document.to_string(), "   foo   ");
 }
 
-TEST(JSON_parse, string_escape_quote) {
+TEST(string_escape_quote) {
   std::istringstream input{"\"foo\\\"bar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -148,21 +148,21 @@ TEST(JSON_parse, string_escape_quote) {
   EXPECT_EQ(document.to_string(), "foo\"bar");
 }
 
-TEST(JSON_parse, empty_array) {
+TEST(empty_array) {
   std::istringstream input{"[]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 0);
 }
 
-TEST(JSON_parse, empty_array_with_inner_space) {
+TEST(empty_array_with_inner_space) {
   std::istringstream input{"[            ]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 0);
 }
 
-TEST(JSON_parse, array_one_null_item) {
+TEST(array_one_null_item) {
   std::istringstream input{"[null]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -170,7 +170,7 @@ TEST(JSON_parse, array_one_null_item) {
   EXPECT_TRUE(document.at(0).is_null());
 }
 
-TEST(JSON_parse, array_one_boolean_item) {
+TEST(array_one_boolean_item) {
   std::istringstream input{"[true]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -179,7 +179,7 @@ TEST(JSON_parse, array_one_boolean_item) {
   EXPECT_TRUE(document.at(0).to_boolean());
 }
 
-TEST(JSON_parse, array_one_boolean_item_with_inner_space) {
+TEST(array_one_boolean_item_with_inner_space) {
   std::istringstream input{"[   true     ]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -188,7 +188,7 @@ TEST(JSON_parse, array_one_boolean_item_with_inner_space) {
   EXPECT_TRUE(document.at(0).to_boolean());
 }
 
-TEST(JSON_parse, array_one_boolean_item_with_padding) {
+TEST(array_one_boolean_item_with_padding) {
   std::istringstream input{"   [ true  ]   "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -197,7 +197,7 @@ TEST(JSON_parse, array_one_boolean_item_with_padding) {
   EXPECT_TRUE(document.at(0).to_boolean());
 }
 
-TEST(JSON_parse, array_one_nested_null_item) {
+TEST(array_one_nested_null_item) {
   std::istringstream input{"[[null]]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -207,7 +207,7 @@ TEST(JSON_parse, array_one_nested_null_item) {
   EXPECT_TRUE(document.at(0).at(0).is_null());
 }
 
-TEST(JSON_parse, array_one_nested_nested_null_item) {
+TEST(array_one_nested_nested_null_item) {
   std::istringstream input{"[[[null]]]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -219,7 +219,7 @@ TEST(JSON_parse, array_one_nested_nested_null_item) {
   EXPECT_TRUE(document.at(0).at(0).at(0).is_null());
 }
 
-TEST(JSON_parse, array_nested_nested_string) {
+TEST(array_nested_nested_string) {
   std::istringstream input{"[[[\"nested\"]]]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -232,7 +232,7 @@ TEST(JSON_parse, array_nested_nested_string) {
   EXPECT_EQ(document.at(0).at(0).at(0).to_string(), "nested");
 }
 
-TEST(JSON_parse, array_false_true_false) {
+TEST(array_false_true_false) {
   std::istringstream input{"[false,true,false]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -245,7 +245,7 @@ TEST(JSON_parse, array_false_true_false) {
   EXPECT_FALSE(document.at(2).to_boolean());
 }
 
-TEST(JSON_parse, array_foo_bar_baz) {
+TEST(array_foo_bar_baz) {
   std::istringstream input{"[\"foo\",\"bar\",\"baz\"]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -258,7 +258,7 @@ TEST(JSON_parse, array_foo_bar_baz) {
   EXPECT_EQ(document.at(2).to_string(), "baz");
 }
 
-TEST(JSON_parse, array_mixed_boolean_nested) {
+TEST(array_mixed_boolean_nested) {
   std::istringstream input{"[false,[true],false]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -273,7 +273,7 @@ TEST(JSON_parse, array_mixed_boolean_nested) {
   EXPECT_FALSE(document.at(2).to_boolean());
 }
 
-TEST(JSON_parse, array_nested_double) {
+TEST(array_nested_double) {
   std::istringstream input{"[true,[false,[true]]]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -290,7 +290,7 @@ TEST(JSON_parse, array_nested_double) {
   EXPECT_TRUE(document.at(1).at(1).at(0).to_boolean());
 }
 
-TEST(JSON_parse, array_nested_double_with_spacing) {
+TEST(array_nested_double_with_spacing) {
   std::istringstream input{"   [   true  ,  [ false  ,  [ true] ] ]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -307,7 +307,7 @@ TEST(JSON_parse, array_nested_double_with_spacing) {
   EXPECT_TRUE(document.at(1).at(1).at(0).to_boolean());
 }
 
-TEST(JSON_parse, array_mixed_boolean_nested_with_spaces) {
+TEST(array_mixed_boolean_nested_with_spaces) {
   std::istringstream input{"  [   false  ,  [ true]    ,   false ]   "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -322,7 +322,7 @@ TEST(JSON_parse, array_mixed_boolean_nested_with_spaces) {
   EXPECT_FALSE(document.at(2).to_boolean());
 }
 
-TEST(JSON_parse, array_one_string_item) {
+TEST(array_one_string_item) {
   std::istringstream input{"[\"foo\"]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -331,7 +331,7 @@ TEST(JSON_parse, array_one_string_item) {
   EXPECT_EQ(document.at(0).to_string(), "foo");
 }
 
-TEST(JSON_parse, array_one_positive_integer_item) {
+TEST(array_one_positive_integer_item) {
   std::istringstream input{"[5]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -340,7 +340,7 @@ TEST(JSON_parse, array_one_positive_integer_item) {
   EXPECT_EQ(document.at(0).to_integer(), 5);
 }
 
-TEST(JSON_parse, array_one_negative_integer_item) {
+TEST(array_one_negative_integer_item) {
   std::istringstream input{"[-5]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -349,7 +349,7 @@ TEST(JSON_parse, array_one_negative_integer_item) {
   EXPECT_EQ(document.at(0).to_integer(), -5);
 }
 
-TEST(JSON_parse, array_one_positive_real_item) {
+TEST(array_one_positive_real_item) {
   std::istringstream input{"[5.5]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -358,7 +358,7 @@ TEST(JSON_parse, array_one_positive_real_item) {
   EXPECT_EQ(document.at(0).to_real(), 5.5);
 }
 
-TEST(JSON_parse, array_one_negative_real_item) {
+TEST(array_one_negative_real_item) {
   std::istringstream input{"[-5.5]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -367,7 +367,7 @@ TEST(JSON_parse, array_one_negative_real_item) {
   EXPECT_EQ(document.at(0).to_real(), -5.5);
 }
 
-TEST(JSON_parse, array_comma_within_string) {
+TEST(array_comma_within_string) {
   std::istringstream input{"[\"foo,bar\"]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -376,7 +376,7 @@ TEST(JSON_parse, array_comma_within_string) {
   EXPECT_EQ(document.at(0).to_string(), "foo,bar");
 }
 
-TEST(JSON_parse, array_with_stringified_array) {
+TEST(array_with_stringified_array) {
   std::istringstream input{"[\"[false,true]\"]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -385,7 +385,7 @@ TEST(JSON_parse, array_with_stringified_array) {
   EXPECT_EQ(document.at(0).to_string(), "[false,true]");
 }
 
-TEST(JSON_parse, array_equality) {
+TEST(array_equality) {
   std::istringstream input_1{"[ 1, 2, 3 ]"};
   std::istringstream input_2{"    [   1, 2    ,3]    "};
   std::istringstream input_3{"   [1,2,2]"};
@@ -400,7 +400,7 @@ TEST(JSON_parse, array_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, single_exponential_number_element) {
+TEST(single_exponential_number_element) {
   std::istringstream input{"[3e2]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -409,7 +409,7 @@ TEST(JSON_parse, single_exponential_number_element) {
   EXPECT_EQ(document.at(0).to_decimal(), sourcemeta::core::Decimal{"300"});
 }
 
-TEST(JSON_parse, object_equality) {
+TEST(object_equality) {
   std::istringstream input_1{"{\"foo\":1}"};
   std::istringstream input_2{"   {   \"foo\"   :  1  }    "};
   std::istringstream input_3{"{\"foo\":2}"};
@@ -424,7 +424,7 @@ TEST(JSON_parse, object_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, object_single_null) {
+TEST(object_single_null) {
   std::istringstream input{"{\"foo\":null}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -433,7 +433,7 @@ TEST(JSON_parse, object_single_null) {
   EXPECT_TRUE(document.at("foo").is_null());
 }
 
-TEST(JSON_parse, object_single_null_with_spaces) {
+TEST(object_single_null_with_spaces) {
   std::istringstream input{"   {   \"foo\"   :   null  }  "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -442,7 +442,7 @@ TEST(JSON_parse, object_single_null_with_spaces) {
   EXPECT_TRUE(document.at("foo").is_null());
 }
 
-TEST(JSON_parse, object_multiple_null) {
+TEST(object_multiple_null) {
   std::istringstream input{"{\"foo\":null,\"bar\":null,\"baz\":null}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -455,7 +455,7 @@ TEST(JSON_parse, object_multiple_null) {
   EXPECT_TRUE(document.at("baz").is_null());
 }
 
-TEST(JSON_parse, array_with_object_size_1) {
+TEST(array_with_object_size_1) {
   std::istringstream input{"[ { \"foo\": null } ]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -465,7 +465,7 @@ TEST(JSON_parse, array_with_object_size_1) {
   EXPECT_TRUE(document.at(0).at("foo").is_null());
 }
 
-TEST(JSON_parse, array_with_object_size_2) {
+TEST(array_with_object_size_2) {
   std::istringstream input{"[ { \"foo\": false, \"bar\": true } ]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -480,7 +480,7 @@ TEST(JSON_parse, array_with_object_size_2) {
   EXPECT_TRUE(document.at(0).at("bar").to_boolean());
 }
 
-TEST(JSON_parse, array_with_empty_object) {
+TEST(array_with_empty_object) {
   std::istringstream input{"[{}]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -489,7 +489,7 @@ TEST(JSON_parse, array_with_empty_object) {
   EXPECT_EQ(document.at(0).size(), 0);
 }
 
-TEST(JSON_parse, array_escaped_quote_within_string_element) {
+TEST(array_escaped_quote_within_string_element) {
   std::istringstream input{"[\"foo\\\"bar\"]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -498,7 +498,7 @@ TEST(JSON_parse, array_escaped_quote_within_string_element) {
   EXPECT_EQ(document.at(0).to_string(), "foo\"bar");
 }
 
-TEST(JSON_parse, object_with_array) {
+TEST(object_with_array) {
   std::istringstream input{"{ \"foo\": [null] }"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -509,7 +509,7 @@ TEST(JSON_parse, object_with_array) {
   EXPECT_TRUE(document.at("foo").at(0).is_null());
 }
 
-TEST(JSON_parse, object_with_array_two_elements) {
+TEST(object_with_array_two_elements) {
   std::istringstream input{"{ \"foo\": [false, true] }"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -523,7 +523,7 @@ TEST(JSON_parse, object_with_array_two_elements) {
   EXPECT_TRUE(document.at("foo").at(1).to_boolean());
 }
 
-TEST(JSON_parse, object_with_object) {
+TEST(object_with_object) {
   std::istringstream input{"{ \"foo\": { \"bar\": null } }"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -535,7 +535,7 @@ TEST(JSON_parse, object_with_object) {
   EXPECT_TRUE(document.at("foo").at("bar").is_null());
 }
 
-TEST(JSON_parse, object_with_positive_integer) {
+TEST(object_with_positive_integer) {
   std::istringstream input{"{ \"foo\": 5 }"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -545,21 +545,21 @@ TEST(JSON_parse, object_with_positive_integer) {
   EXPECT_EQ(document.at("foo").to_integer(), 5);
 }
 
-TEST(JSON_parse, empty_object) {
+TEST(empty_object) {
   std::istringstream input{"{}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 0);
 }
 
-TEST(JSON_parse, empty_object_with_spacing) {
+TEST(empty_object_with_spacing) {
   std::istringstream input{"{      }"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
   EXPECT_EQ(document.size(), 0);
 }
 
-TEST(JSON_parse, object_string_value_with_comma) {
+TEST(object_string_value_with_comma) {
   std::istringstream input{"{\"foo\":\"bar,baz\"}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -569,7 +569,7 @@ TEST(JSON_parse, object_string_value_with_comma) {
   EXPECT_EQ(document.at("foo").to_string(), "bar,baz");
 }
 
-TEST(JSON_parse, object_string_value_with_escaped_quote) {
+TEST(object_string_value_with_escaped_quote) {
   std::istringstream input{"{\"foo\":\"bar\\\"baz\"}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -579,7 +579,7 @@ TEST(JSON_parse, object_string_value_with_escaped_quote) {
   EXPECT_EQ(document.at("foo").to_string(), "bar\"baz");
 }
 
-TEST(JSON_parse, object_empty_string_key) {
+TEST(object_empty_string_key) {
   std::istringstream input{"{\"\":\"foo\"}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -589,7 +589,7 @@ TEST(JSON_parse, object_empty_string_key) {
   EXPECT_EQ(document.at("").to_string(), "foo");
 }
 
-TEST(JSON_parse, object_string_key_with_comma) {
+TEST(object_string_key_with_comma) {
   std::istringstream input{"{\"foo,bar\":\"baz\"}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -599,7 +599,7 @@ TEST(JSON_parse, object_string_key_with_comma) {
   EXPECT_EQ(document.at("foo,bar").to_string(), "baz");
 }
 
-TEST(JSON_parse, object_string_key_with_space) {
+TEST(object_string_key_with_space) {
   std::istringstream input{"{\"foo bar\":\"baz\"}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -609,7 +609,7 @@ TEST(JSON_parse, object_string_key_with_space) {
   EXPECT_EQ(document.at("foo bar").to_string(), "baz");
 }
 
-TEST(JSON_parse, object_string_value_with_stringified) {
+TEST(object_string_value_with_stringified) {
   std::istringstream input{"{\"foo\":\"{\\\"x\\\":1}\"}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -619,7 +619,7 @@ TEST(JSON_parse, object_string_value_with_stringified) {
   EXPECT_EQ(document.at("foo").to_string(), "{\"x\":1}");
 }
 
-TEST(JSON_parse, object_one_true_boolean_element_with_space) {
+TEST(object_one_true_boolean_element_with_space) {
   std::istringstream input{"    {   \"foo\"   :   true  }    "};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -629,7 +629,7 @@ TEST(JSON_parse, object_one_true_boolean_element_with_space) {
   EXPECT_TRUE(document.at("foo").to_boolean());
 }
 
-TEST(JSON_parse, object_two_boolean_values_with_space) {
+TEST(object_two_boolean_values_with_space) {
   std::istringstream input{
       "{   \"foo\"  :   true    ,     \"bar\"   :   false}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
@@ -643,7 +643,7 @@ TEST(JSON_parse, object_two_boolean_values_with_space) {
   EXPECT_FALSE(document.at("bar").to_boolean());
 }
 
-TEST(JSON_parse, object_one_array_element_with_space) {
+TEST(object_one_array_element_with_space) {
   std::istringstream input{"{   \"foo\"   :  [  true  ,  false   ]   }"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -657,7 +657,7 @@ TEST(JSON_parse, object_one_array_element_with_space) {
   EXPECT_FALSE(document.at("foo").at(1).to_boolean());
 }
 
-TEST(JSON_parse, object_minified_nested) {
+TEST(object_minified_nested) {
   std::istringstream input{"{\"foo\":{\"bar\":true}}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -668,7 +668,7 @@ TEST(JSON_parse, object_minified_nested) {
   EXPECT_TRUE(document.at("foo").defines("bar"));
 }
 
-TEST(JSON_parse, object_empty_nested_with_new_line_before_end) {
+TEST(object_empty_nested_with_new_line_before_end) {
   std::istringstream input("{\"x\":{}\n}");
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -678,84 +678,84 @@ TEST(JSON_parse, object_empty_nested_with_new_line_before_end) {
   EXPECT_EQ(document.at("x").size(), 0);
 }
 
-TEST(JSON_parse, zero_integer) {
+TEST(zero_integer) {
   std::istringstream input{"0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 0);
 }
 
-TEST(JSON_parse, minus_zero_integer) {
+TEST(minus_zero_integer) {
   std::istringstream input{"-0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 0);
 }
 
-TEST(JSON_parse, positive_single_digit_positive_integer) {
+TEST(positive_single_digit_positive_integer) {
   std::istringstream input{"1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 1);
 }
 
-TEST(JSON_parse, positive_multi_digit_positive_integer) {
+TEST(positive_multi_digit_positive_integer) {
   std::istringstream input{"1234"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 1234);
 }
 
-TEST(JSON_parse, positive_single_digit_negative_integer) {
+TEST(positive_single_digit_negative_integer) {
   std::istringstream input{"-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), -1);
 }
 
-TEST(JSON_parse, positive_multi_digit_negative_integer) {
+TEST(positive_multi_digit_negative_integer) {
   std::istringstream input{"-1234"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), -1234);
 }
 
-TEST(JSON_parse, positive_large_integer) {
+TEST(positive_large_integer) {
   std::istringstream input{"12391239123"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 12391239123);
 }
 
-TEST(JSON_parse, positive_real_trailing_zeroes) {
+TEST(positive_real_trailing_zeroes) {
   std::istringstream input{"1.50000"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1.5);
 }
 
-TEST(JSON_parse, negative_real_trailing_zeroes) {
+TEST(negative_real_trailing_zeroes) {
   std::istringstream input{"-1.50000"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -1.5);
 }
 
-TEST(JSON_parse, positive_real) {
+TEST(positive_real) {
   std::istringstream input{"1.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1.5);
 }
 
-TEST(JSON_parse, negative_real) {
+TEST(negative_real) {
   std::istringstream input{"-1.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -1.5);
 }
 
-TEST(JSON_parse, real_long_small_decimal) {
+TEST(real_long_small_decimal) {
   std::istringstream input{
       "0.00000000000000000000000000000000000000000000000000000000000000000000"
       "1"};
@@ -764,14 +764,14 @@ TEST(JSON_parse, real_long_small_decimal) {
   EXPECT_EQ(document.to_real(), 1e-69);
 }
 
-TEST(JSON_parse, real_subnormal_decimal) {
+TEST(real_subnormal_decimal) {
   std::istringstream input{"0." + std::string(309, '0') + "5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 5e-310);
 }
 
-TEST(JSON_parse, decimal_underflowing_decimal) {
+TEST(decimal_underflowing_decimal) {
   std::istringstream input{"0." + std::string(400, '0') + "1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
@@ -779,252 +779,252 @@ TEST(JSON_parse, decimal_underflowing_decimal) {
             sourcemeta::core::Decimal{"0." + std::string(400, '0') + "1"});
 }
 
-TEST(JSON_parse, real_leading_decimal_zero) {
+TEST(real_leading_decimal_zero) {
   std::istringstream input{"1.125"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1.125);
 }
 
-TEST(JSON_parse, real_multi_left_digit_positive_real) {
+TEST(real_multi_left_digit_positive_real) {
   std::istringstream input{"1234.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1234.5);
 }
 
-TEST(JSON_parse, real_multi_left_digit_negative_real) {
+TEST(real_multi_left_digit_negative_real) {
   std::istringstream input{"-1234.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -1234.5);
 }
 
-TEST(JSON_parse, real_long_positive_real) {
+TEST(real_long_positive_real) {
   std::istringstream input{"1234.56789"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1234.56789);
 }
 
-TEST(JSON_parse, real_long_negative_real) {
+TEST(real_long_negative_real) {
   std::istringstream input{"-1234.56789"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -1234.56789);
 }
 
-TEST(JSON_parse, single_digit_positive_real_integer) {
+TEST(single_digit_positive_real_integer) {
   std::istringstream input{"1.0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1.0);
 }
 
-TEST(JSON_parse, single_digit_positive_real_integer_trailing_zero) {
+TEST(single_digit_positive_real_integer_trailing_zero) {
   std::istringstream input{"1.0000000"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 1.0);
 }
 
-TEST(JSON_parse, single_digit_negative_real_integer) {
+TEST(single_digit_negative_real_integer) {
   std::istringstream input{"-1.0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -1.0);
 }
 
-TEST(JSON_parse, single_digit_negative_real_integer_trailing_zero) {
+TEST(single_digit_negative_real_integer_trailing_zero) {
   std::istringstream input{"-1.0000000"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -1.0);
 }
 
-TEST(JSON_parse, leading_zero_real_number) {
+TEST(leading_zero_real_number) {
   std::istringstream input{"-0.125"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -0.125);
 }
 
-TEST(JSON_parse, zero_integer_with_exponent) {
+TEST(zero_integer_with_exponent) {
   std::istringstream input{"0e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"0e2"});
 }
 
-TEST(JSON_parse, zero_real_with_exponent) {
+TEST(zero_real_with_exponent) {
   std::istringstream input{"0.0e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"0.0e2"});
 }
 
-TEST(JSON_parse, large_negative_exponential_number) {
+TEST(large_negative_exponential_number) {
   std::istringstream input{"-1.0e10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-1.0e10"});
 }
 
-TEST(JSON_parse, large_positive_exponential_number_with_plus_exponent) {
+TEST(large_positive_exponential_number_with_plus_exponent) {
   std::istringstream input{"1.0e+10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.0e+10"});
 }
 
-TEST(JSON_parse, large_negative_exponential_number_with_plus_exponent) {
+TEST(large_negative_exponential_number_with_plus_exponent) {
   std::istringstream input{"-1.0e+10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-1.0e+10"});
 }
 
-TEST(JSON_parse, number_exponential_notation_plus_after_e) {
+TEST(number_exponential_notation_plus_after_e) {
   std::istringstream input{"3E+2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3E+2"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_1_upper) {
+TEST(exponential_notation_integer_1_upper) {
   std::istringstream input{"2E0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"2E0"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_2_upper) {
+TEST(exponential_notation_integer_2_upper) {
   std::istringstream input{"3E2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3E2"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_3_upper) {
+TEST(exponential_notation_integer_3_upper) {
   std::istringstream input{"4.321768E3"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"4.321768E3"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_4_upper) {
+TEST(exponential_notation_integer_4_upper) {
   std::istringstream input{"-5.3E4"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-5.3E4"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_5_upper) {
+TEST(exponential_notation_integer_5_upper) {
   std::istringstream input{"6.72E9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"6.72E9"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_6_upper) {
+TEST(exponential_notation_integer_6_upper) {
   std::istringstream input{"5E-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5E-1"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_7_upper) {
+TEST(exponential_notation_integer_7_upper) {
   std::istringstream input{"9.5E2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"9.5E2"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_8_upper) {
+TEST(exponential_notation_integer_8_upper) {
   std::istringstream input{"5E-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5E-1"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_1_lower) {
+TEST(exponential_notation_integer_1_lower) {
   std::istringstream input{"2e0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"2e0"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_2_lower) {
+TEST(exponential_notation_integer_2_lower) {
   std::istringstream input{"3e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3e2"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_3_lower) {
+TEST(exponential_notation_integer_3_lower) {
   std::istringstream input{"4.321768e3"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"4.321768e3"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_4_lower) {
+TEST(exponential_notation_integer_4_lower) {
   std::istringstream input{"-5.3e4"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"-5.3e4"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_5_lower) {
+TEST(exponential_notation_integer_5_lower) {
   std::istringstream input{"6.72e9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"6.72e9"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_6_lower) {
+TEST(exponential_notation_integer_6_lower) {
   std::istringstream input{"5e-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5e-1"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_7_lower) {
+TEST(exponential_notation_integer_7_lower) {
   std::istringstream input{"9.5e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"9.5e2"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_8_lower) {
+TEST(exponential_notation_integer_8_lower) {
   std::istringstream input{"5e-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5e-1"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_1_real) {
+TEST(exponential_notation_integer_1_real) {
   std::istringstream input{"2.0e0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"2.0e0"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_2_real) {
+TEST(exponential_notation_integer_2_real) {
   std::istringstream input{"3.0e2"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"3.0e2"});
 }
 
-TEST(JSON_parse, exponential_notation_integer_3_real) {
+TEST(exponential_notation_integer_3_real) {
   std::istringstream input{"5.0e-1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"5.0e-1"});
 }
 
-TEST(JSON_parse, integer_equality) {
+TEST(integer_equality) {
   std::istringstream input_1{"5"};
   std::istringstream input_2{"   5    "};
   std::istringstream input_3{" 5.1 "};
@@ -1039,7 +1039,7 @@ TEST(JSON_parse, integer_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, real_equality) {
+TEST(real_equality) {
   std::istringstream input_1{"5.1"};
   std::istringstream input_2{"   5.1    "};
   std::istringstream input_3{" 5 "};
@@ -1054,7 +1054,7 @@ TEST(JSON_parse, real_equality) {
   EXPECT_FALSE(document_2 == document_3);
 }
 
-TEST(JSON_parse, integer_real_equal) {
+TEST(integer_real_equal) {
   std::istringstream left{"1"};
   std::istringstream right{"1.0"};
   const sourcemeta::core::JSON document_1 = sourcemeta::core::parse_json(left);
@@ -1065,7 +1065,7 @@ TEST(JSON_parse, integer_real_equal) {
   EXPECT_FALSE(document_2 != document_1);
 }
 
-TEST(JSON_parse, string_escaped_quotes) {
+TEST(string_escaped_quotes) {
   std::istringstream input{"\"\\\"foo\\\"\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1073,7 +1073,7 @@ TEST(JSON_parse, string_escaped_quotes) {
   EXPECT_EQ(document.to_string(), "\"foo\"");
 }
 
-TEST(JSON_parse, string_escaped_reverse_solidus) {
+TEST(string_escaped_reverse_solidus) {
   std::istringstream input{"\"foo\\\\bar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1081,7 +1081,7 @@ TEST(JSON_parse, string_escaped_reverse_solidus) {
   EXPECT_EQ(document.to_string(), "foo\\bar");
 }
 
-TEST(JSON_parse, string_escaped_solidus) {
+TEST(string_escaped_solidus) {
   std::istringstream input{"\"foo\\/bar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1089,7 +1089,7 @@ TEST(JSON_parse, string_escaped_solidus) {
   EXPECT_EQ(document.to_string(), "foo/bar");
 }
 
-TEST(JSON_parse, string_escaped_backspace) {
+TEST(string_escaped_backspace) {
   std::istringstream input{"\"foo\\bbar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1097,7 +1097,7 @@ TEST(JSON_parse, string_escaped_backspace) {
   EXPECT_EQ(document.to_string(), "foo\bbar");
 }
 
-TEST(JSON_parse, string_escaped_form_feed) {
+TEST(string_escaped_form_feed) {
   std::istringstream input{"\"foo\\fbar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1105,7 +1105,7 @@ TEST(JSON_parse, string_escaped_form_feed) {
   EXPECT_EQ(document.to_string(), "foo\fbar");
 }
 
-TEST(JSON_parse, string_escaped_line_feed) {
+TEST(string_escaped_line_feed) {
   std::istringstream input{"\"foo\\nbar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1113,7 +1113,7 @@ TEST(JSON_parse, string_escaped_line_feed) {
   EXPECT_EQ(document.to_string(), "foo\nbar");
 }
 
-TEST(JSON_parse, string_escaped_carriage_return) {
+TEST(string_escaped_carriage_return) {
   std::istringstream input{"\"foo\\rbar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1121,7 +1121,7 @@ TEST(JSON_parse, string_escaped_carriage_return) {
   EXPECT_EQ(document.to_string(), "foo\rbar");
 }
 
-TEST(JSON_parse, string_escaped_tab) {
+TEST(string_escaped_tab) {
   std::istringstream input{"\"foo\\tbar\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1129,7 +1129,7 @@ TEST(JSON_parse, string_escaped_tab) {
   EXPECT_EQ(document.to_string(), "foo\tbar");
 }
 
-TEST(JSON_parse, string_unicode_code_points) {
+TEST(string_unicode_code_points) {
   std::istringstream input{"\"\\u002F\""};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_string());
@@ -1137,7 +1137,7 @@ TEST(JSON_parse, string_unicode_code_points) {
   EXPECT_EQ(document.to_string(), "\u002F");
 }
 
-TEST(JSON_parse, string_unicode_length_surrogates) {
+TEST(string_unicode_length_surrogates) {
   // See https://en.wikipedia.org/wiki/UTF-8#Surrogates
   // https://unicodeplus.com/U+D83D
   // https://unicodeplus.com/U+DCA9
@@ -1148,7 +1148,7 @@ TEST(JSON_parse, string_unicode_length_surrogates) {
   EXPECT_EQ(document.byte_size(), 4);
 }
 
-TEST(JSON_parse, string_unicode_code_point_equality) {
+TEST(string_unicode_code_point_equality) {
   std::istringstream input_1{"\"\\u002F\""};
   std::istringstream input_2{"\"\\u002f\""};
   std::istringstream input_3{"\"\\/\""};
@@ -1168,7 +1168,7 @@ TEST(JSON_parse, string_unicode_code_point_equality) {
   EXPECT_EQ(document_3.to_string(), document_4.to_string());
 }
 
-TEST(JSON_parse, string_equality) {
+TEST(string_equality) {
   std::istringstream input_1{"\"foo\""};
   std::istringstream input_2{"   \"foo\"    "};
   std::istringstream input_3{"\"fo\""};
@@ -1184,7 +1184,7 @@ TEST(JSON_parse, string_equality) {
 }
 
 // https://datatracker.ietf.org/doc/html/rfc8259#section-13
-TEST(JSON_parse, rfc8259_example_1) {
+TEST(rfc8259_example_1) {
   std::istringstream input{
       "{\n"
       "\"Image\": {\n"
@@ -1254,7 +1254,7 @@ TEST(JSON_parse, rfc8259_example_1) {
 }
 
 // https://datatracker.ietf.org/doc/html/rfc8259#section-13
-TEST(JSON_parse, rfc8259_example_2) {
+TEST(rfc8259_example_2) {
   std::istringstream input{"[\n"
                            "{\n"
                            "\"precision\": \"zip\",\n"
@@ -1355,7 +1355,7 @@ TEST(JSON_parse, rfc8259_example_2) {
   EXPECT_EQ(value.at(1).at("Country").to_string(), "US");
 }
 
-TEST(JSON_parse, custom_line_column_from_string_stream) {
+TEST(custom_line_column_from_string_stream) {
   std::istringstream input{"[\n  false,\n  true\n]"};
   std::uint64_t line{5};
   std::uint64_t column{2};
@@ -1374,7 +1374,7 @@ TEST(JSON_parse, custom_line_column_from_string_stream) {
   EXPECT_TRUE(document.at(1).to_boolean());
 }
 
-TEST(JSON_parse, read_json) {
+TEST(read_json) {
   const sourcemeta::core::JSON document{sourcemeta::core::read_json(
       std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json")};
   EXPECT_TRUE(document.is_object());
@@ -1384,7 +1384,7 @@ TEST(JSON_parse, read_json) {
   EXPECT_EQ(document.at("foo").to_integer(), 1);
 }
 
-TEST(JSON_parse, read_file) {
+TEST(read_file) {
   auto stream{sourcemeta::core::read_file(
       std::filesystem::path{TEST_DIRECTORY} / "stub_valid.json")};
   const auto document{sourcemeta::core::parse_json(stream)};
@@ -1395,21 +1395,21 @@ TEST(JSON_parse, read_file) {
   EXPECT_EQ(document.at("foo").to_integer(), 1);
 }
 
-TEST(JSON_parse, big_integer_beyond_64_bit) {
+TEST(big_integer_beyond_64_bit) {
   std::istringstream input{"9223372036854776000"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "9223372036854776000");
 }
 
-TEST(JSON_parse, big_negative_integer_beyond_64_bit) {
+TEST(big_negative_integer_beyond_64_bit) {
   std::istringstream input{"-9223372036854776000"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "-9223372036854776000");
 }
 
-TEST(JSON_parse, very_large_integer) {
+TEST(very_large_integer) {
   std::istringstream input{"123456789012345678901234567890"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
@@ -1417,7 +1417,7 @@ TEST(JSON_parse, very_large_integer) {
             "123456789012345678901234567890");
 }
 
-TEST(JSON_parse, big_integer_in_array) {
+TEST(big_integer_in_array) {
   std::istringstream input{"[1, 9223372036854776000, 3]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
@@ -1430,7 +1430,7 @@ TEST(JSON_parse, big_integer_in_array) {
   EXPECT_EQ(document.at(2).to_integer(), 3);
 }
 
-TEST(JSON_parse, big_integer_in_object) {
+TEST(big_integer_in_object) {
   std::istringstream input{"{\"big\":9223372036854776000,\"small\":42}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_object());
@@ -1441,20 +1441,20 @@ TEST(JSON_parse, big_integer_in_object) {
   EXPECT_EQ(document.at("small").to_integer(), 42);
 }
 
-TEST(JSON_parse, big_real_number) {
+TEST(big_real_number) {
   std::istringstream input{"1.234567890123456789012345678901234567890"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
 }
 
-TEST(JSON_parse, very_small_real_number) {
+TEST(very_small_real_number) {
   std::istringstream input{"0.000000000000000000000000000001"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 0.000000000000000000000000000001);
 }
 
-TEST(JSON_parse, big_real_in_array) {
+TEST(big_real_in_array) {
   std::istringstream input{
       "[1.5, 1.234567890123456789012345678901234567890, 2.5]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
@@ -1467,7 +1467,7 @@ TEST(JSON_parse, big_real_in_array) {
   EXPECT_EQ(document.at(2).to_real(), 2.5);
 }
 
-TEST(JSON_parse, big_real_in_object) {
+TEST(big_real_in_object) {
   std::istringstream input{
       "{\"pi\":3.14159265358979323846264338327950288419716939937510}"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
@@ -1476,49 +1476,49 @@ TEST(JSON_parse, big_real_in_object) {
   EXPECT_TRUE(document.at("pi").is_decimal());
 }
 
-TEST(JSON_parse, big_number_with_exponent) {
+TEST(big_number_with_exponent) {
   std::istringstream input{"1.5e10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.5e10"});
 }
 
-TEST(JSON_parse, big_number_with_negative_exponent) {
+TEST(big_number_with_negative_exponent) {
   std::istringstream input{"1.5e-10"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.5e-10"});
 }
 
-TEST(JSON_parse, scientific_constant_planck) {
+TEST(scientific_constant_planck) {
   std::istringstream input{"6.62607E-34"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"6.62607E-34"});
 }
 
-TEST(JSON_parse, scientific_constant_elementary_charge) {
+TEST(scientific_constant_elementary_charge) {
   std::istringstream input{"1.60218E-19"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.60218E-19"});
 }
 
-TEST(JSON_parse, scientific_constant_boltzmann) {
+TEST(scientific_constant_boltzmann) {
   std::istringstream input{"1.38065E-23"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal(), sourcemeta::core::Decimal{"1.38065E-23"});
 }
 
-TEST(JSON_parse, read_json_stub_bigint) {
+TEST(read_json_stub_bigint) {
   const sourcemeta::core::JSON document{sourcemeta::core::read_json(
       std::filesystem::path{TEST_DIRECTORY} / "stub_bigint.json")};
   EXPECT_TRUE(document.is_decimal());
   EXPECT_EQ(document.to_decimal().to_string(), "9223372036854776000");
 }
 
-TEST(JSON_parse, nested_big_integers_and_reals) {
+TEST(nested_big_integers_and_reals) {
   std::istringstream input{
       "{\"data\":[{\"big_int\":9223372036854776000,"
       "\"big_real\":3.14159265358979323846264338327950288419716939937510}]}"};
@@ -1534,154 +1534,154 @@ TEST(JSON_parse, nested_big_integers_and_reals) {
   EXPECT_TRUE(document.at("data").at(0).at("big_real").is_decimal());
 }
 
-TEST(JSON_parse, double_precision_below_2_53_with_fraction_point_1) {
+TEST(double_precision_below_2_53_with_fraction_point_1) {
   std::istringstream input{"9007199254740991.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_below_2_53_with_fraction_point_5) {
+TEST(double_precision_below_2_53_with_fraction_point_5) {
   std::istringstream input{"9007199254740991.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_below_2_53_with_fraction_point_9) {
+TEST(double_precision_below_2_53_with_fraction_point_9) {
   std::istringstream input{"9007199254740991.9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_at_2_53_with_fraction_point_1) {
+TEST(double_precision_at_2_53_with_fraction_point_1) {
   std::istringstream input{"9007199254740992.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_at_2_53_with_fraction_point_5) {
+TEST(double_precision_at_2_53_with_fraction_point_5) {
   std::istringstream input{"9007199254740992.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_at_2_53_with_fraction_point_9) {
+TEST(double_precision_at_2_53_with_fraction_point_9) {
   std::istringstream input{"9007199254740992.9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_above_2_53_with_fraction_point_1) {
+TEST(double_precision_above_2_53_with_fraction_point_1) {
   std::istringstream input{"9007199254740993.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_above_2_53_with_fraction_point_5) {
+TEST(double_precision_above_2_53_with_fraction_point_5) {
   std::istringstream input{"9007199254740993.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_above_2_53_with_fraction_point_9) {
+TEST(double_precision_above_2_53_with_fraction_point_9) {
   std::istringstream input{"9007199254740993.9"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_16_with_fraction_point_1) {
+TEST(double_precision_10_16_with_fraction_point_1) {
   std::istringstream input{"10000000000000000.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_16_with_fraction_point_5) {
+TEST(double_precision_10_16_with_fraction_point_5) {
   std::istringstream input{"10000000000000000.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_16_with_many_fractional_digits) {
+TEST(double_precision_10_16_with_many_fractional_digits) {
   std::istringstream input{"10000000000000000.123456789"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_17_with_fraction) {
+TEST(double_precision_10_17_with_fraction) {
   std::istringstream input{"100000000000000000.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_20_with_fraction) {
+TEST(double_precision_10_20_with_fraction) {
   std::istringstream input{"100000000000000000000.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_35_with_fraction) {
+TEST(double_precision_10_35_with_fraction) {
   std::istringstream input{"99999999999999999999999999999999999.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_9e15_with_fraction) {
+TEST(double_precision_9e15_with_fraction) {
   std::istringstream input{"9000000000000000.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_5e16_with_fraction) {
+TEST(double_precision_5e16_with_fraction) {
   std::istringstream input{"50000000000000000.1"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_below_2_53_with_point_0) {
+TEST(double_precision_below_2_53_with_point_0) {
   std::istringstream input{"123456789012345.0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_at_2_53_with_point_0) {
+TEST(double_precision_at_2_53_with_point_0) {
   std::istringstream input{"9007199254740992.0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_above_2_53_with_point_0) {
+TEST(double_precision_above_2_53_with_point_0) {
   std::istringstream input{"10000000000000000.0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_20_with_point_0) {
+TEST(double_precision_10_20_with_point_0) {
   std::istringstream input{"100000000000000000000.0"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_TRUE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_small_number_with_fraction) {
+TEST(double_precision_small_number_with_fraction) {
   std::istringstream input{"123.456"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
@@ -1689,7 +1689,7 @@ TEST(JSON_parse, double_precision_small_number_with_fraction) {
   EXPECT_EQ(document.to_real(), 123.456);
 }
 
-TEST(JSON_parse, double_precision_medium_number_with_fraction) {
+TEST(double_precision_medium_number_with_fraction) {
   std::istringstream input{"123456789.123"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_real());
@@ -1697,28 +1697,28 @@ TEST(JSON_parse, double_precision_medium_number_with_fraction) {
   EXPECT_EQ(document.to_real(), 123456789.123);
 }
 
-TEST(JSON_parse, double_precision_10_14_with_fraction) {
+TEST(double_precision_10_14_with_fraction) {
   std::istringstream input{"100000000000000.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, double_precision_10_15_with_fraction) {
+TEST(double_precision_10_15_with_fraction) {
   std::istringstream input{"1000000000000000.5"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_decimal());
   EXPECT_FALSE(document.is_integral());
 }
 
-TEST(JSON_parse, parse_string_view) {
+TEST(parse_string_view) {
   const std::string_view input{"[ 1, 2, 3 ]"};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(input);
   EXPECT_TRUE(document.is_array());
   EXPECT_EQ(document.size(), 3);
 }
 
-TEST(JSON_parse, parse_string_view_subview) {
+TEST(parse_string_view_subview) {
   const std::string buffer{"prefix[ 1, 2, 3 ]suffix"};
   const std::string_view view{buffer.data() + 6, 11};
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(view);
@@ -1726,7 +1726,7 @@ TEST(JSON_parse, parse_string_view_subview) {
   EXPECT_EQ(document.size(), 3);
 }
 
-TEST(JSON_parse, parse_string_view_with_line_column) {
+TEST(parse_string_view_with_line_column) {
   const std::string_view input{"[ 1, 2, 3 ]"};
   std::uint64_t line{1};
   std::uint64_t column{0};
@@ -1735,7 +1735,7 @@ TEST(JSON_parse, parse_string_view_with_line_column) {
   EXPECT_TRUE(document.is_array());
 }
 
-TEST(JSON_parse, parse_default_string_view_does_not_invoke_ub) {
+TEST(parse_default_string_view_does_not_invoke_ub) {
   const std::string_view input{};
   EXPECT_EQ(input.data(), nullptr);
   try {
@@ -1747,8 +1747,7 @@ TEST(JSON_parse, parse_default_string_view_does_not_invoke_ub) {
   }
 }
 
-TEST(JSON_parse,
-     parse_default_string_view_with_line_column_does_not_invoke_ub) {
+TEST(parse_default_string_view_with_line_column_does_not_invoke_ub) {
   const std::string_view input{};
   std::uint64_t line{1};
   std::uint64_t column{0};

--- a/test/json/json_prettify_test.cc
+++ b/test/json/json_prettify_test.cc
@@ -1,101 +1,101 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <sstream>
 
-TEST(JSON_prettify, boolean_false) {
+TEST(boolean_false) {
   const sourcemeta::core::JSON document{false};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "false");
 }
 
-TEST(JSON_prettify, boolean_true) {
+TEST(boolean_true) {
   const sourcemeta::core::JSON document{true};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "true");
 }
 
-TEST(JSON_prettify, null) {
+TEST(null) {
   const sourcemeta::core::JSON document{nullptr};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "null");
 }
 
-TEST(JSON_prettify, integer_positive) {
+TEST(integer_positive) {
   const sourcemeta::core::JSON document{1234};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "1234");
 }
 
-TEST(JSON_prettify, integer_negative) {
+TEST(integer_negative) {
   const sourcemeta::core::JSON document{-1234};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "-1234");
 }
 
-TEST(JSON_prettify, integer_zero) {
+TEST(integer_zero) {
   const sourcemeta::core::JSON document{0};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "0");
 }
 
-TEST(JSON_prettify, integer_minus_zero) {
+TEST(integer_minus_zero) {
   const sourcemeta::core::JSON document{-0};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "0");
 }
 
-TEST(JSON_prettify, real_positive) {
+TEST(real_positive) {
   const sourcemeta::core::JSON document{12.34};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "12.34");
 }
 
-TEST(JSON_prettify, real_negative) {
+TEST(real_negative) {
   const sourcemeta::core::JSON document{-12.34};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "-12.34");
 }
 
-TEST(JSON_prettify, real_zero) {
+TEST(real_zero) {
   const sourcemeta::core::JSON document{0.0};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "0.0");
 }
 
-TEST(JSON_prettify, real_minus_zero) {
+TEST(real_minus_zero) {
   const sourcemeta::core::JSON document{-0.0};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "0.0");
 }
 
-TEST(JSON_prettify, empty_string) {
+TEST(empty_string) {
   const sourcemeta::core::JSON document{""};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"\"");
 }
 
-TEST(JSON_prettify, small_string) {
+TEST(small_string) {
   const sourcemeta::core::JSON document{"foo"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\"");
 }
 
-TEST(JSON_prettify, array_integers) {
+TEST(array_integers) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
@@ -104,7 +104,7 @@ TEST(JSON_prettify, array_integers) {
   EXPECT_EQ(stream.str(), "[ 1, 2, 3, 4 ]");
 }
 
-TEST(JSON_prettify, array_strings_almost_long) {
+TEST(array_strings_almost_long) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON{"aaaaaaaaaa"},
                                         sourcemeta::core::JSON{"bbbbbbbbbb"},
                                         sourcemeta::core::JSON{"cccccccccc"},
@@ -116,7 +116,7 @@ TEST(JSON_prettify, array_strings_almost_long) {
                           "\"dddddddddd\", \"eeeeeeeeee\" ]");
 }
 
-TEST(JSON_prettify, array_strings_almost_long_with_indentation) {
+TEST(array_strings_almost_long_with_indentation) {
   auto document{sourcemeta::core::JSON::make_object()};
   document.assign("1", sourcemeta::core::JSON::make_object());
   document.at("1").assign("2", sourcemeta::core::JSON::make_object());
@@ -161,7 +161,7 @@ TEST(JSON_prettify, array_strings_almost_long_with_indentation) {
   EXPECT_EQ(stream.str(), expected);
 }
 
-TEST(JSON_prettify, array_strings_almost_long_with_long_property) {
+TEST(array_strings_almost_long_with_long_property) {
   auto document{sourcemeta::core::JSON::make_object()};
   // Key has 40 characters (plus 2 for quotes + 1 for semicolon + 1 for space) =
   // 44
@@ -192,7 +192,7 @@ TEST(JSON_prettify, array_strings_almost_long_with_long_property) {
   EXPECT_EQ(stream.str(), expected);
 }
 
-TEST(JSON_prettify, array_strings_long) {
+TEST(array_strings_long) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON{"aaaaaaaaaa"},
                                         sourcemeta::core::JSON{"bbbbbbbbbb"},
                                         sourcemeta::core::JSON{"cccccccccc"},
@@ -209,7 +209,7 @@ TEST(JSON_prettify, array_strings_long) {
             "\"gggggggggg\",\n  \"hhhhhhhhhh\"\n]");
 }
 
-TEST(JSON_prettify, array_nested_1) {
+TEST(array_nested_1) {
   sourcemeta::core::JSON array{
       sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
@@ -220,7 +220,7 @@ TEST(JSON_prettify, array_nested_1) {
   EXPECT_EQ(stream.str(), "[\n  [ 1, 2, 3, 4 ]\n]");
 }
 
-TEST(JSON_prettify, array_nested_2) {
+TEST(array_nested_2) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
@@ -232,14 +232,14 @@ TEST(JSON_prettify, array_nested_2) {
   EXPECT_EQ(stream.str(), "[\n  1,\n  [ 2, 3 ],\n  4\n]");
 }
 
-TEST(JSON_prettify, array_empty) {
+TEST(array_empty) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "[]");
 }
 
-TEST(JSON_prettify, object_integers) {
+TEST(object_integers) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                         {"bar", sourcemeta::core::JSON{2}}};
   std::ostringstream stream;
@@ -250,7 +250,7 @@ TEST(JSON_prettify, object_integers) {
   EXPECT_TRUE(matches);
 }
 
-TEST(JSON_prettify, object_integers_order_1) {
+TEST(object_integers_order_1) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}},
                                   {"baz", sourcemeta::core::JSON{3}}};
@@ -261,7 +261,7 @@ TEST(JSON_prettify, object_integers_order_1) {
   EXPECT_EQ(stream.str(), "{\n  \"bar\": 2,\n  \"baz\": 3,\n  \"foo\": 1\n}");
 }
 
-TEST(JSON_prettify, object_integers_order_2) {
+TEST(object_integers_order_2) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}},
                                   {"baz", sourcemeta::core::JSON{3}}};
@@ -272,14 +272,14 @@ TEST(JSON_prettify, object_integers_order_2) {
   EXPECT_EQ(stream.str(), "{\n  \"foo\": 1,\n  \"baz\": 3,\n  \"bar\": 2\n}");
 }
 
-TEST(JSON_prettify, object_empty) {
+TEST(object_empty) {
   const sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "{}");
 }
 
-TEST(JSON_prettify, object_with_array) {
+TEST(object_with_array) {
   sourcemeta::core::JSON array{sourcemeta::core::JSON::Array{}};
   array.push_back(sourcemeta::core::JSON{1});
   array.push_back(sourcemeta::core::JSON{2});
@@ -289,7 +289,7 @@ TEST(JSON_prettify, object_with_array) {
   EXPECT_EQ(stream.str(), "{\n  \"foo\": [ 1, 2 ]\n}");
 }
 
-TEST(JSON_prettify, object_nested) {
+TEST(object_nested) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("bar", sourcemeta::core::JSON{1});
   const sourcemeta::core::JSON document{{"foo", std::move(object)}};
@@ -298,7 +298,7 @@ TEST(JSON_prettify, object_nested) {
   EXPECT_EQ(stream.str(), "{\n  \"foo\": {\n    \"bar\": 1\n  }\n}");
 }
 
-TEST(JSON_prettify, array_with_object) {
+TEST(array_with_object) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("foo", sourcemeta::core::JSON{1});
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
@@ -308,77 +308,77 @@ TEST(JSON_prettify, array_with_object) {
   EXPECT_EQ(stream.str(), "[\n  {\n    \"foo\": 1\n  }\n]");
 }
 
-TEST(JSON_prettify, simple_object) {
+TEST(simple_object) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}}};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "{\n  \"foo\": 1\n}");
 }
 
-TEST(JSON_prettify, prettify_quote) {
+TEST(prettify_quote) {
   const sourcemeta::core::JSON document{"\""};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"\\\"\"");
 }
 
-TEST(JSON_prettify, prettify_escape) {
+TEST(prettify_escape) {
   const sourcemeta::core::JSON document{"\\"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"\\\\\"");
 }
 
-TEST(JSON_prettify, prettify_solidus) {
+TEST(prettify_solidus) {
   const sourcemeta::core::JSON document{"/"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"/\"");
 }
 
-TEST(JSON_prettify, prettify_backspace) {
+TEST(prettify_backspace) {
   const sourcemeta::core::JSON document{"foo\bbar"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\bbar\"");
 }
 
-TEST(JSON_prettify, prettify_formfeed) {
+TEST(prettify_formfeed) {
   const sourcemeta::core::JSON document{"foo\fbar"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\fbar\"");
 }
 
-TEST(JSON_prettify, prettify_newline) {
+TEST(prettify_newline) {
   const sourcemeta::core::JSON document{"foo\nbar"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\nbar\"");
 }
 
-TEST(JSON_prettify, prettify_carriage_return) {
+TEST(prettify_carriage_return) {
   const sourcemeta::core::JSON document{"foo\rbar"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\rbar\"");
 }
 
-TEST(JSON_prettify, prettify_tabulation) {
+TEST(prettify_tabulation) {
   const sourcemeta::core::JSON document{"foo\tbar"};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\tbar\"");
 }
 
-TEST(JSON_prettify, prettify_scientific_real) {
+TEST(prettify_scientific_real) {
   const sourcemeta::core::JSON document{4.321768E3};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream);
   EXPECT_EQ(stream.str(), "4321.768");
 }
 
-TEST(JSON_prettify, object_nested_with_0_spaces) {
+TEST(object_nested_with_0_spaces) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("bar", sourcemeta::core::JSON{1});
   const sourcemeta::core::JSON document{{"foo", std::move(object)}};
@@ -387,7 +387,7 @@ TEST(JSON_prettify, object_nested_with_0_spaces) {
   EXPECT_EQ(stream.str(), "{\n\"foo\": {\n\"bar\": 1\n}\n}");
 }
 
-TEST(JSON_prettify, object_nested_with_1_space) {
+TEST(object_nested_with_1_space) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("bar", sourcemeta::core::JSON{1});
   const sourcemeta::core::JSON document{{"foo", std::move(object)}};
@@ -396,7 +396,7 @@ TEST(JSON_prettify, object_nested_with_1_space) {
   EXPECT_EQ(stream.str(), "{\n \"foo\": {\n  \"bar\": 1\n }\n}");
 }
 
-TEST(JSON_prettify, object_nested_with_2_spaces) {
+TEST(object_nested_with_2_spaces) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("bar", sourcemeta::core::JSON{1});
   const sourcemeta::core::JSON document{{"foo", std::move(object)}};
@@ -405,7 +405,7 @@ TEST(JSON_prettify, object_nested_with_2_spaces) {
   EXPECT_EQ(stream.str(), "{\n  \"foo\": {\n    \"bar\": 1\n  }\n}");
 }
 
-TEST(JSON_prettify, object_nested_with_3_spaces) {
+TEST(object_nested_with_3_spaces) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("bar", sourcemeta::core::JSON{1});
   const sourcemeta::core::JSON document{{"foo", std::move(object)}};
@@ -414,7 +414,7 @@ TEST(JSON_prettify, object_nested_with_3_spaces) {
   EXPECT_EQ(stream.str(), "{\n   \"foo\": {\n      \"bar\": 1\n   }\n}");
 }
 
-TEST(JSON_prettify, object_nested_with_4_spaces) {
+TEST(object_nested_with_4_spaces) {
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
   object.assign("bar", sourcemeta::core::JSON{1});
   const sourcemeta::core::JSON document{{"foo", std::move(object)}};
@@ -423,7 +423,7 @@ TEST(JSON_prettify, object_nested_with_4_spaces) {
   EXPECT_EQ(stream.str(), "{\n    \"foo\": {\n        \"bar\": 1\n    }\n}");
 }
 
-TEST(JSON_prettify, array_nested_with_0_spaces) {
+TEST(array_nested_with_0_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
@@ -435,7 +435,7 @@ TEST(JSON_prettify, array_nested_with_0_spaces) {
   EXPECT_EQ(stream.str(), "[\n1,\n[ 2, 3 ],\n4\n]");
 }
 
-TEST(JSON_prettify, array_nested_with_1_space) {
+TEST(array_nested_with_1_space) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
@@ -447,7 +447,7 @@ TEST(JSON_prettify, array_nested_with_1_space) {
   EXPECT_EQ(stream.str(), "[\n 1,\n [ 2, 3 ],\n 4\n]");
 }
 
-TEST(JSON_prettify, array_nested_with_2_spaces) {
+TEST(array_nested_with_2_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
@@ -459,7 +459,7 @@ TEST(JSON_prettify, array_nested_with_2_spaces) {
   EXPECT_EQ(stream.str(), "[\n  1,\n  [ 2, 3 ],\n  4\n]");
 }
 
-TEST(JSON_prettify, array_nested_with_3_spaces) {
+TEST(array_nested_with_3_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
@@ -471,7 +471,7 @@ TEST(JSON_prettify, array_nested_with_3_spaces) {
   EXPECT_EQ(stream.str(), "[\n   1,\n   [ 2, 3 ],\n   4\n]");
 }
 
-TEST(JSON_prettify, array_nested_with_4_spaces) {
+TEST(array_nested_with_4_spaces) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON nested{sourcemeta::core::JSON{2},
@@ -483,14 +483,14 @@ TEST(JSON_prettify, array_nested_with_4_spaces) {
   EXPECT_EQ(stream.str(), "[\n    1,\n    [ 2, 3 ],\n    4\n]");
 }
 
-TEST(JSON_prettify, boolean_false_with_4_spaces) {
+TEST(boolean_false_with_4_spaces) {
   const sourcemeta::core::JSON document{false};
   std::ostringstream stream;
   sourcemeta::core::prettify(document, stream, 4);
   EXPECT_EQ(stream.str(), "false");
 }
 
-TEST(JSON_prettify, object_reorder_with_4_spaces) {
+TEST(object_reorder_with_4_spaces) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}},
                                   {"baz", sourcemeta::core::JSON{3}}};
@@ -502,7 +502,7 @@ TEST(JSON_prettify, object_reorder_with_4_spaces) {
             "{\n    \"bar\": 2,\n    \"baz\": 3,\n    \"foo\": 1\n}");
 }
 
-TEST(JSON_prettify, decimal_positive_integer) {
+TEST(decimal_positive_integer) {
   const sourcemeta::core::Decimal value{12345};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -510,7 +510,7 @@ TEST(JSON_prettify, decimal_positive_integer) {
   EXPECT_EQ(stream.str(), "1.2345e+4");
 }
 
-TEST(JSON_prettify, decimal_negative_integer) {
+TEST(decimal_negative_integer) {
   const sourcemeta::core::Decimal value{-67890};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -518,7 +518,7 @@ TEST(JSON_prettify, decimal_negative_integer) {
   EXPECT_EQ(stream.str(), "-6.7890e+4");
 }
 
-TEST(JSON_prettify, decimal_zero) {
+TEST(decimal_zero) {
   const sourcemeta::core::Decimal value{0};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -526,7 +526,7 @@ TEST(JSON_prettify, decimal_zero) {
   EXPECT_EQ(stream.str(), "0e+0");
 }
 
-TEST(JSON_prettify, decimal_fractional) {
+TEST(decimal_fractional) {
   const sourcemeta::core::Decimal value{"3.14159"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -534,7 +534,7 @@ TEST(JSON_prettify, decimal_fractional) {
   EXPECT_EQ(stream.str(), "3.14159e+0");
 }
 
-TEST(JSON_prettify, decimal_negative_fractional) {
+TEST(decimal_negative_fractional) {
   const sourcemeta::core::Decimal value{"-2.71828"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -542,7 +542,7 @@ TEST(JSON_prettify, decimal_negative_fractional) {
   EXPECT_EQ(stream.str(), "-2.71828e+0");
 }
 
-TEST(JSON_prettify, decimal_large_integer) {
+TEST(decimal_large_integer) {
   const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -550,7 +550,7 @@ TEST(JSON_prettify, decimal_large_integer) {
   EXPECT_EQ(stream.str(), "1.23456789012345678901234567890e+29");
 }
 
-TEST(JSON_prettify, decimal_large_negative_integer) {
+TEST(decimal_large_negative_integer) {
   const sourcemeta::core::Decimal value{"-987654321098765432109876543210"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -558,7 +558,7 @@ TEST(JSON_prettify, decimal_large_negative_integer) {
   EXPECT_EQ(stream.str(), "-9.87654321098765432109876543210e+29");
 }
 
-TEST(JSON_prettify, decimal_high_precision_fractional) {
+TEST(decimal_high_precision_fractional) {
   const sourcemeta::core::Decimal value{
       "3.141592653589793238462643383279502884197"};
   const sourcemeta::core::JSON document{value};
@@ -567,7 +567,7 @@ TEST(JSON_prettify, decimal_high_precision_fractional) {
   EXPECT_EQ(stream.str(), "3.141592653589793238462643383279502884197e+0");
 }
 
-TEST(JSON_prettify, decimal_very_small_fractional) {
+TEST(decimal_very_small_fractional) {
   const sourcemeta::core::Decimal value{"0.000000000000000000000000000001"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -575,7 +575,7 @@ TEST(JSON_prettify, decimal_very_small_fractional) {
   EXPECT_EQ(stream.str(), "1e-30");
 }
 
-TEST(JSON_prettify, decimal_scientific_notation) {
+TEST(decimal_scientific_notation) {
   const sourcemeta::core::Decimal value{"1.23e10"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -583,7 +583,7 @@ TEST(JSON_prettify, decimal_scientific_notation) {
   EXPECT_EQ(stream.str(), "1.23e+10");
 }
 
-TEST(JSON_prettify, decimal_in_array) {
+TEST(decimal_in_array) {
   const sourcemeta::core::Decimal value1{100};
   const sourcemeta::core::Decimal value2{"999.999"};
   const sourcemeta::core::Decimal value3{"-42"};
@@ -595,7 +595,7 @@ TEST(JSON_prettify, decimal_in_array) {
   EXPECT_EQ(stream.str(), "[ 1.00e+2, 9.99999e+2, -4.2e+1 ]");
 }
 
-TEST(JSON_prettify, decimal_large_numbers_in_array) {
+TEST(decimal_large_numbers_in_array) {
   const sourcemeta::core::Decimal value1{"123456789012345678901234567890"};
   const sourcemeta::core::Decimal value2{
       "98765432109876543210.98765432109876543210"};
@@ -609,7 +609,7 @@ TEST(JSON_prettify, decimal_large_numbers_in_array) {
                           "]");
 }
 
-TEST(JSON_prettify, decimal_nested_in_array) {
+TEST(decimal_nested_in_array) {
   const sourcemeta::core::Decimal value1{"111.111"};
   const sourcemeta::core::Decimal value2{"222.222"};
   sourcemeta::core::JSON inner_array{sourcemeta::core::JSON{value1},
@@ -621,7 +621,7 @@ TEST(JSON_prettify, decimal_nested_in_array) {
   EXPECT_EQ(stream.str(), "[\n  [ 1.11111e+2, 2.22222e+2 ]\n]");
 }
 
-TEST(JSON_prettify, decimal_in_object) {
+TEST(decimal_in_object) {
   const sourcemeta::core::Decimal value1{"12345"};
   const sourcemeta::core::Decimal value2{"-67.89"};
   sourcemeta::core::JSON document{
@@ -635,7 +635,7 @@ TEST(JSON_prettify, decimal_in_object) {
             "{\n  \"fractional\": -6.789e+1,\n  \"integer\": 1.2345e+4\n}");
 }
 
-TEST(JSON_prettify, decimal_large_numbers_in_object) {
+TEST(decimal_large_numbers_in_object) {
   const sourcemeta::core::Decimal big_int{"999999999999999999999999999999"};
   const sourcemeta::core::Decimal big_real{
       "123456789.123456789123456789123456789"};
@@ -651,7 +651,7 @@ TEST(JSON_prettify, decimal_large_numbers_in_object) {
             "\"bigReal\": 1.23456789123456789123456789123456789e+8\n}");
 }
 
-TEST(JSON_prettify, decimal_mixed_with_other_types_in_object) {
+TEST(decimal_mixed_with_other_types_in_object) {
   const sourcemeta::core::Decimal decimal_value{"3.14159"};
   sourcemeta::core::JSON document{
       {"string", sourcemeta::core::JSON{"hello"}},
@@ -667,7 +667,7 @@ TEST(JSON_prettify, decimal_mixed_with_other_types_in_object) {
             "\"integer\": 42,\n  \"string\": \"hello\"\n}");
 }
 
-TEST(JSON_prettify, decimal_nested_in_object_with_array) {
+TEST(decimal_nested_in_object_with_array) {
   const sourcemeta::core::Decimal value1{"111"};
   const sourcemeta::core::Decimal value2{"222.222"};
   sourcemeta::core::JSON array{sourcemeta::core::JSON::Array{}};
@@ -679,7 +679,7 @@ TEST(JSON_prettify, decimal_nested_in_object_with_array) {
   EXPECT_EQ(stream.str(), "{\n  \"decimals\": [ 1.11e+2, 2.22222e+2 ]\n}");
 }
 
-TEST(JSON_prettify, decimal_large_numbers_nested_with_indentation) {
+TEST(decimal_large_numbers_nested_with_indentation) {
   const sourcemeta::core::Decimal big1{"111111111111111111111111111111"};
   const sourcemeta::core::Decimal big2{"222222222222222222222222222222"};
   sourcemeta::core::JSON inner_object{{"first", sourcemeta::core::JSON{big1}},

--- a/test/json/json_real_test.cc
+++ b/test/json/json_real_test.cc
@@ -1,34 +1,34 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <cmath>
 #include <limits>
 
-TEST(JSON_real, positive) {
+TEST(positive) {
   const sourcemeta::core::JSON document{10.2};
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 10.2);
 }
 
-TEST(JSON_real, negative) {
+TEST(negative) {
   const sourcemeta::core::JSON document{-10.02};
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), -10.02);
 }
 
-TEST(JSON_real, zero) {
+TEST(zero) {
   const sourcemeta::core::JSON document{0.0};
   EXPECT_TRUE(document.is_real());
   EXPECT_EQ(document.to_real(), 0.0);
 }
 
-TEST(JSON_real, type) {
+TEST(type) {
   const sourcemeta::core::JSON document{1.23};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::Real);
 }
 
-TEST(JSON_real, long_double_nan) {
+TEST(long_double_nan) {
   const double value{static_cast<double>(NAN)};
   try {
     sourcemeta::core::JSON{value};
@@ -38,7 +38,7 @@ TEST(JSON_real, long_double_nan) {
   }
 }
 
-TEST(JSON_real, double_nan) {
+TEST(double_nan) {
   const double value{static_cast<double>(NAN)};
   try {
     sourcemeta::core::JSON{value};
@@ -48,7 +48,7 @@ TEST(JSON_real, double_nan) {
   }
 }
 
-TEST(JSON_real, float_nan) {
+TEST(float_nan) {
   const float value{NAN};
   try {
     sourcemeta::core::JSON{value};
@@ -58,7 +58,7 @@ TEST(JSON_real, float_nan) {
   }
 }
 
-TEST(JSON_real, long_double_infinity) {
+TEST(long_double_infinity) {
   const double value{std::numeric_limits<double>::infinity()};
   try {
     sourcemeta::core::JSON{value};
@@ -68,7 +68,7 @@ TEST(JSON_real, long_double_infinity) {
   }
 }
 
-TEST(JSON_real, double_infinity) {
+TEST(double_infinity) {
   const double value{std::numeric_limits<double>::infinity()};
   try {
     sourcemeta::core::JSON{value};
@@ -78,7 +78,7 @@ TEST(JSON_real, double_infinity) {
   }
 }
 
-TEST(JSON_real, float_infinity) {
+TEST(float_infinity) {
   const float value{std::numeric_limits<float>::infinity()};
   try {
     sourcemeta::core::JSON{value};
@@ -88,7 +88,7 @@ TEST(JSON_real, float_infinity) {
   }
 }
 
-TEST(JSON_real, copy_constructor_cannot_create_invalid_json) {
+TEST(copy_constructor_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON source{
         std::numeric_limits<double>::quiet_NaN()};
@@ -99,7 +99,7 @@ TEST(JSON_real, copy_constructor_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, move_constructor_cannot_create_invalid_json) {
+TEST(move_constructor_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON source{std::numeric_limits<double>::infinity()};
     const sourcemeta::core::JSON moved{std::move(source)};
@@ -109,7 +109,7 @@ TEST(JSON_real, move_constructor_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, copy_assignment_cannot_create_invalid_json) {
+TEST(copy_assignment_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON source{
         std::numeric_limits<double>::quiet_NaN()};
@@ -121,7 +121,7 @@ TEST(JSON_real, copy_assignment_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, move_assignment_cannot_create_invalid_json) {
+TEST(move_assignment_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON source{std::numeric_limits<double>::infinity()};
     sourcemeta::core::JSON target{1.0};
@@ -132,7 +132,7 @@ TEST(JSON_real, move_assignment_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, addition_operator_cannot_create_invalid_json) {
+TEST(addition_operator_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON left{std::numeric_limits<double>::infinity()};
     const sourcemeta::core::JSON right{1.0};
@@ -143,7 +143,7 @@ TEST(JSON_real, addition_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, subtraction_operator_cannot_create_invalid_json) {
+TEST(subtraction_operator_cannot_create_invalid_json) {
   try {
     const sourcemeta::core::JSON left{-std::numeric_limits<double>::infinity()};
     const sourcemeta::core::JSON right{1.0};
@@ -154,7 +154,7 @@ TEST(JSON_real, subtraction_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, addition_assignment_operator_cannot_create_invalid_json) {
+TEST(addition_assignment_operator_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON document{std::numeric_limits<double>::infinity()};
     const sourcemeta::core::JSON addend{1.0};
@@ -165,7 +165,7 @@ TEST(JSON_real, addition_assignment_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, subtraction_assignment_operator_cannot_create_invalid_json) {
+TEST(subtraction_assignment_operator_cannot_create_invalid_json) {
   try {
     sourcemeta::core::JSON document{-std::numeric_limits<double>::infinity()};
     const sourcemeta::core::JSON subtrahend{1.0};
@@ -176,54 +176,54 @@ TEST(JSON_real, subtraction_assignment_operator_cannot_create_invalid_json) {
   }
 }
 
-TEST(JSON_real, estimated_byte_size_3_14) {
+TEST(estimated_byte_size_3_14) {
   const sourcemeta::core::JSON document{3.14};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_real, estimated_byte_size_minus_3_14) {
+TEST(estimated_byte_size_minus_3_14) {
   const sourcemeta::core::JSON document{-3.14};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_real, estimated_byte_size_minus_5_0) {
+TEST(estimated_byte_size_minus_5_0) {
   const sourcemeta::core::JSON document{5.0};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_real, estimated_byte_size_minus_0_0) {
+TEST(estimated_byte_size_minus_0_0) {
   const sourcemeta::core::JSON document{0.0};
   EXPECT_EQ(document.estimated_byte_size(), 8);
 }
 
-TEST(JSON_real, fast_hash_3_14) {
+TEST(fast_hash_3_14) {
   const sourcemeta::core::JSON document{3.14};
   EXPECT_EQ(document.fast_hash(), 5);
 }
 
-TEST(JSON_real, fast_hash_minus_3_14) {
+TEST(fast_hash_minus_3_14) {
   const sourcemeta::core::JSON document{-3.14};
   EXPECT_EQ(document.fast_hash(), 5);
 }
 
-TEST(JSON_real, fast_hash_minus_5_0) {
+TEST(fast_hash_minus_5_0) {
   const sourcemeta::core::JSON document{5.0};
   EXPECT_EQ(document.fast_hash(), 5);
 }
 
-TEST(JSON_real, fast_hash_minus_0_0) {
+TEST(fast_hash_minus_0_0) {
   const sourcemeta::core::JSON document{0.0};
   EXPECT_EQ(document.fast_hash(), 5);
 }
 
-TEST(JSON_real, less_than_real_decimal) {
+TEST(less_than_real_decimal) {
   const sourcemeta::core::JSON real{3.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   EXPECT_TRUE(real < decimal);
   EXPECT_FALSE(decimal < real);
 }
 
-TEST(JSON_real, less_than_or_equal_real_decimal) {
+TEST(less_than_or_equal_real_decimal) {
   const sourcemeta::core::JSON real{3.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"3.5"}};
@@ -232,14 +232,14 @@ TEST(JSON_real, less_than_or_equal_real_decimal) {
   EXPECT_TRUE(real <= equal);
 }
 
-TEST(JSON_real, greater_than_real_decimal) {
+TEST(greater_than_real_decimal) {
   const sourcemeta::core::JSON real{5.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   EXPECT_TRUE(real > decimal);
   EXPECT_FALSE(decimal > real);
 }
 
-TEST(JSON_real, greater_than_or_equal_real_decimal) {
+TEST(greater_than_or_equal_real_decimal) {
   const sourcemeta::core::JSON real{5.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON equal{sourcemeta::core::Decimal{"5.5"}};
@@ -248,7 +248,7 @@ TEST(JSON_real, greater_than_or_equal_real_decimal) {
   EXPECT_TRUE(real >= equal);
 }
 
-TEST(JSON_real, addition_real_decimal) {
+TEST(addition_real_decimal) {
   const sourcemeta::core::JSON real{3.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   const sourcemeta::core::JSON result{real + decimal};
@@ -256,7 +256,7 @@ TEST(JSON_real, addition_real_decimal) {
   EXPECT_EQ(result.to_decimal().to_string(), "9.2");
 }
 
-TEST(JSON_real, subtraction_real_decimal) {
+TEST(subtraction_real_decimal) {
   const sourcemeta::core::JSON real{5.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   const sourcemeta::core::JSON result{real - decimal};
@@ -264,7 +264,7 @@ TEST(JSON_real, subtraction_real_decimal) {
   EXPECT_EQ(result.to_decimal().to_string(), "2.3");
 }
 
-TEST(JSON_real, addition_assignment_real_decimal) {
+TEST(addition_assignment_real_decimal) {
   sourcemeta::core::JSON real{3.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"5.7"}};
   real += decimal;
@@ -272,7 +272,7 @@ TEST(JSON_real, addition_assignment_real_decimal) {
   EXPECT_EQ(real.to_decimal().to_string(), "9.2");
 }
 
-TEST(JSON_real, subtraction_assignment_real_decimal) {
+TEST(subtraction_assignment_real_decimal) {
   sourcemeta::core::JSON real{5.5};
   const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3.2"}};
   real -= decimal;

--- a/test/json/json_string_test.cc
+++ b/test/json/json_string_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
@@ -7,40 +7,40 @@
 #include <unordered_set>
 #include <utility>
 
-TEST(JSON_string, foo_value_string) {
+TEST(foo_value_string) {
   const std::string value{"foo"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.to_string(), "foo");
 }
 
-TEST(JSON_string, foo_value_string_view) {
+TEST(foo_value_string_view) {
   const std::string_view value{"foo"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.to_string(), "foo");
 }
 
-TEST(JSON_string, foo_value_string_move) {
+TEST(foo_value_string_move) {
   std::string value{"foo"};
   const sourcemeta::core::JSON document{std::move(value)};
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.to_string(), "foo");
 }
 
-TEST(JSON_string, long_value_string_move) {
+TEST(long_value_string_move) {
   std::string value(64, 'x');
   const sourcemeta::core::JSON document{std::move(value)};
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.to_string(), std::string(64, 'x'));
 }
 
-TEST(JSON_string, type) {
+TEST(type) {
   const sourcemeta::core::JSON document{"foo"};
   EXPECT_EQ(document.type(), sourcemeta::core::JSON::Type::String);
 }
 
-TEST(JSON_string, to_stringstream) {
+TEST(to_stringstream) {
   const std::string value{"foo bar"};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_string());
@@ -56,37 +56,37 @@ TEST(JSON_string, to_stringstream) {
   EXPECT_TRUE(stream.eof());
 }
 
-TEST(JSON_string, estimated_byte_size_foo) {
+TEST(estimated_byte_size_foo) {
   const sourcemeta::core::JSON document{"foo"};
   EXPECT_EQ(document.estimated_byte_size(), 3);
 }
 
-TEST(JSON_string, estimated_byte_size_foo_bar_baz) {
+TEST(estimated_byte_size_foo_bar_baz) {
   const sourcemeta::core::JSON document{"foo bar baz"};
   EXPECT_EQ(document.estimated_byte_size(), 11);
 }
 
-TEST(JSON_string, estimated_byte_size_empty) {
+TEST(estimated_byte_size_empty) {
   const sourcemeta::core::JSON document{""};
   EXPECT_EQ(document.estimated_byte_size(), 0);
 }
 
-TEST(JSON_string, fast_hash_foo) {
+TEST(fast_hash_foo) {
   const sourcemeta::core::JSON document{"foo"};
   EXPECT_EQ(document.fast_hash(), 6);
 }
 
-TEST(JSON_string, fast_hash_foo_bar_baz) {
+TEST(fast_hash_foo_bar_baz) {
   const sourcemeta::core::JSON document{"foo bar baz"};
   EXPECT_EQ(document.fast_hash(), 14);
 }
 
-TEST(JSON_string, fast_hash_empty) {
+TEST(fast_hash_empty) {
   const sourcemeta::core::JSON document{""};
   EXPECT_EQ(document.fast_hash(), 3);
 }
 
-TEST(JSON_string, unicode_length_1) {
+TEST(unicode_length_1) {
   // This unicode string corresponds to 简律纯
   const auto document = sourcemeta::core::parse_json(R"JSON({
     "name": "\u7b80\u5f8b\u7eaf"
@@ -104,115 +104,115 @@ TEST(JSON_string, unicode_length_1) {
   EXPECT_EQ(document.at("name").byte_size(), 9);
 }
 
-TEST(JSON_string, includes_true) {
+TEST(includes_true) {
   const sourcemeta::core::JSON document{"foo bar baz"};
   EXPECT_TRUE(document.includes("foo"));
 }
 
-TEST(JSON_string, includes_false) {
+TEST(includes_false) {
   const sourcemeta::core::JSON document{"foo bar baz"};
   EXPECT_FALSE(document.includes("fooo"));
 }
 
-TEST(JSON_string, includes_character_true) {
+TEST(includes_character_true) {
   const sourcemeta::core::JSON document{"foo"};
   EXPECT_TRUE(document.includes('f'));
 }
 
-TEST(JSON_string, includes_character_false) {
+TEST(includes_character_false) {
   const sourcemeta::core::JSON document{"foo"};
   EXPECT_FALSE(document.includes('b'));
 }
 
-TEST(JSON_string, trim_const) {
+TEST(trim_const) {
   const sourcemeta::core::JSON document{" \r\t  foo   bar\n\v   \f"};
   EXPECT_EQ(document.trim(), "foo   bar");
   EXPECT_EQ(document.to_string(), " \r\t  foo   bar\n\v   \f");
 }
 
-TEST(JSON_string, trim_in_place) {
+TEST(trim_in_place) {
   sourcemeta::core::JSON document{" \r\t  foo   bar\n\v   \f"};
   const auto &result{document.trim()};
   EXPECT_EQ(result, "foo   bar");
   EXPECT_EQ(document.to_string(), "foo   bar");
 }
 
-TEST(JSON_string, is_trimmed_true) {
+TEST(is_trimmed_true) {
   const sourcemeta::core::JSON document{"Hello World"};
   EXPECT_TRUE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_empty) {
+TEST(is_trimmed_empty) {
   const sourcemeta::core::JSON document{""};
   EXPECT_TRUE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_leading_space) {
+TEST(is_trimmed_leading_space) {
   const sourcemeta::core::JSON document{" Hello World"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_trailing_space) {
+TEST(is_trimmed_trailing_space) {
   const sourcemeta::core::JSON document{"Hello World "};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_both_space) {
+TEST(is_trimmed_both_space) {
   const sourcemeta::core::JSON document{" Hello World "};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_leading_tab) {
+TEST(is_trimmed_leading_tab) {
   const sourcemeta::core::JSON document{"\tHello World"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_trailing_tab) {
+TEST(is_trimmed_trailing_tab) {
   const sourcemeta::core::JSON document{"Hello World\t"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_leading_newline) {
+TEST(is_trimmed_leading_newline) {
   const sourcemeta::core::JSON document{"\nHello World"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_trailing_newline) {
+TEST(is_trimmed_trailing_newline) {
   const sourcemeta::core::JSON document{"Hello World\n"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_leading_carriage_return) {
+TEST(is_trimmed_leading_carriage_return) {
   const sourcemeta::core::JSON document{"\rHello World"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_trailing_carriage_return) {
+TEST(is_trimmed_trailing_carriage_return) {
   const sourcemeta::core::JSON document{"Hello World\r"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_leading_vertical_tab) {
+TEST(is_trimmed_leading_vertical_tab) {
   const sourcemeta::core::JSON document{"\vHello World"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_trailing_vertical_tab) {
+TEST(is_trimmed_trailing_vertical_tab) {
   const sourcemeta::core::JSON document{"Hello World\v"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_leading_form_feed) {
+TEST(is_trimmed_leading_form_feed) {
   const sourcemeta::core::JSON document{"\fHello World"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_trailing_form_feed) {
+TEST(is_trimmed_trailing_form_feed) {
   const sourcemeta::core::JSON document{"Hello World\f"};
   EXPECT_FALSE(document.is_trimmed());
 }
 
-TEST(JSON_string, is_trimmed_inner_whitespace_ok) {
+TEST(is_trimmed_inner_whitespace_ok) {
   const sourcemeta::core::JSON document{"Hello \t\n\r World"};
   EXPECT_TRUE(document.is_trimmed());
 }

--- a/test/json/json_stringify_test.cc
+++ b/test/json/json_stringify_test.cc
@@ -1,122 +1,122 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <sstream>
 
-TEST(JSON_stringify, boolean_false) {
+TEST(boolean_false) {
   const sourcemeta::core::JSON document{false};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "false");
 }
 
-TEST(JSON_stringify, boolean_true) {
+TEST(boolean_true) {
   const sourcemeta::core::JSON document{true};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "true");
 }
 
-TEST(JSON_stringify, null) {
+TEST(null) {
   const sourcemeta::core::JSON document{nullptr};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "null");
 }
 
-TEST(JSON_stringify, integer_positive) {
+TEST(integer_positive) {
   const sourcemeta::core::JSON document{1234};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "1234");
 }
 
-TEST(JSON_stringify, integer_negative) {
+TEST(integer_negative) {
   const sourcemeta::core::JSON document{-1234};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "-1234");
 }
 
-TEST(JSON_stringify, integer_zero) {
+TEST(integer_zero) {
   const sourcemeta::core::JSON document{0};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "0");
 }
 
-TEST(JSON_stringify, integer_minus_zero) {
+TEST(integer_minus_zero) {
   const sourcemeta::core::JSON document{-0};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "0");
 }
 
-TEST(JSON_stringify, real_positive) {
+TEST(real_positive) {
   const sourcemeta::core::JSON document{12.34};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "12.34");
 }
 
-TEST(JSON_stringify, real_negative) {
+TEST(real_negative) {
   const sourcemeta::core::JSON document{-12.34};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "-12.34");
 }
 
-TEST(JSON_stringify, real_zero) {
+TEST(real_zero) {
   const sourcemeta::core::JSON document{0.0};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "0.0");
 }
 
-TEST(JSON_stringify, real_minus_zero) {
+TEST(real_minus_zero) {
   const sourcemeta::core::JSON document{-0.0};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "0.0");
 }
 
-TEST(JSON_stringify, integer_real_positive) {
+TEST(integer_real_positive) {
   const sourcemeta::core::JSON document{2.0};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "2.0");
 }
 
-TEST(JSON_stringify, integer_real_negative) {
+TEST(integer_real_negative) {
   const sourcemeta::core::JSON document{-2.0};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "-2.0");
 }
 
-TEST(JSON_stringify, very_large_real_number_with_decimal) {
+TEST(very_large_real_number_with_decimal) {
   const sourcemeta::core::JSON document{9.9999999999999997e+34};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "99999999999999996863366107917975552.0");
 }
 
-TEST(JSON_stringify, empty_string) {
+TEST(empty_string) {
   const sourcemeta::core::JSON document{""};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"\"");
 }
 
-TEST(JSON_stringify, small_string) {
+TEST(small_string) {
   const sourcemeta::core::JSON document{"foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\"");
 }
 
-TEST(JSON_stringify, array_integers) {
+TEST(array_integers) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
@@ -125,7 +125,7 @@ TEST(JSON_stringify, array_integers) {
   EXPECT_EQ(stream.str(), "[1,2,3,4]");
 }
 
-TEST(JSON_stringify, array_nested) {
+TEST(array_nested) {
   sourcemeta::core::JSON array{
       sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
@@ -136,14 +136,14 @@ TEST(JSON_stringify, array_nested) {
   EXPECT_EQ(stream.str(), "[[1,2,3,4]]");
 }
 
-TEST(JSON_stringify, array_empty) {
+TEST(array_empty) {
   const sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "[]");
 }
 
-TEST(JSON_stringify, object_integers) {
+TEST(object_integers) {
   const sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                         {"bar", sourcemeta::core::JSON{2}}};
   std::ostringstream stream;
@@ -154,7 +154,7 @@ TEST(JSON_stringify, object_integers) {
   EXPECT_TRUE(matches);
 }
 
-TEST(JSON_stringify, object_integers_order_1) {
+TEST(object_integers_order_1) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}},
                                   {"baz", sourcemeta::core::JSON{3}}};
@@ -165,7 +165,7 @@ TEST(JSON_stringify, object_integers_order_1) {
   EXPECT_EQ(stream.str(), "{\"bar\":2,\"baz\":3,\"foo\":1}");
 }
 
-TEST(JSON_stringify, object_integers_order_2) {
+TEST(object_integers_order_2) {
   sourcemeta::core::JSON document{{"foo", sourcemeta::core::JSON{1}},
                                   {"bar", sourcemeta::core::JSON{2}},
                                   {"baz", sourcemeta::core::JSON{3}}};
@@ -176,14 +176,14 @@ TEST(JSON_stringify, object_integers_order_2) {
   EXPECT_EQ(stream.str(), "{\"foo\":1,\"baz\":3,\"bar\":2}");
 }
 
-TEST(JSON_stringify, object_empty) {
+TEST(object_empty) {
   const sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "{}");
 }
 
-TEST(JSON_stringify, object_with_array) {
+TEST(object_with_array) {
   sourcemeta::core::JSON array{sourcemeta::core::JSON::Array{}};
   array.push_back(sourcemeta::core::JSON{1});
   array.push_back(sourcemeta::core::JSON{2});
@@ -193,70 +193,70 @@ TEST(JSON_stringify, object_with_array) {
   EXPECT_EQ(stream.str(), "{\"foo\":[1,2]}");
 }
 
-TEST(JSON_stringify, stringify_quote) {
+TEST(stringify_quote) {
   const sourcemeta::core::JSON document{"\""};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"\\\"\"");
 }
 
-TEST(JSON_stringify, stringify_escape) {
+TEST(stringify_escape) {
   const sourcemeta::core::JSON document{"\\"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"\\\\\"");
 }
 
-TEST(JSON_stringify, stringify_solidus) {
+TEST(stringify_solidus) {
   const sourcemeta::core::JSON document{"/"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"/\"");
 }
 
-TEST(JSON_stringify, stringify_backspace) {
+TEST(stringify_backspace) {
   const sourcemeta::core::JSON document{"foo\bbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\bbar\"");
 }
 
-TEST(JSON_stringify, stringify_formfeed) {
+TEST(stringify_formfeed) {
   const sourcemeta::core::JSON document{"foo\fbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\fbar\"");
 }
 
-TEST(JSON_stringify, stringify_newline) {
+TEST(stringify_newline) {
   const sourcemeta::core::JSON document{"foo\nbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\nbar\"");
 }
 
-TEST(JSON_stringify, stringify_carriage_return) {
+TEST(stringify_carriage_return) {
   const sourcemeta::core::JSON document{"foo\rbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\rbar\"");
 }
 
-TEST(JSON_stringify, stringify_tabulation) {
+TEST(stringify_tabulation) {
   const sourcemeta::core::JSON document{"foo\tbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\tbar\"");
 }
 
-TEST(JSON_stringify, stringify_scientific_real) {
+TEST(stringify_scientific_real) {
   const sourcemeta::core::JSON document{4.321768E3};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "4321.768");
 }
 
-TEST(JSON_stringify, escape_00) {
+TEST(escape_00) {
   using namespace std::string_literals;
   const sourcemeta::core::JSON document{"foo\0bar"s};
   std::ostringstream stream;
@@ -264,224 +264,224 @@ TEST(JSON_stringify, escape_00) {
   EXPECT_EQ(stream.str(), "\"foo\\u0000bar\"");
 }
 
-TEST(JSON_stringify, escape_01) {
+TEST(escape_01) {
   const sourcemeta::core::JSON document{"foo\u0001bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0001bar\"");
 }
 
-TEST(JSON_stringify, escape_02) {
+TEST(escape_02) {
   const sourcemeta::core::JSON document{"foo\u0002bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0002bar\"");
 }
 
-TEST(JSON_stringify, escape_03) {
+TEST(escape_03) {
   const sourcemeta::core::JSON document{"foo\u0003bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0003bar\"");
 }
 
-TEST(JSON_stringify, escape_04) {
+TEST(escape_04) {
   const sourcemeta::core::JSON document{"foo\u0004bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0004bar\"");
 }
 
-TEST(JSON_stringify, escape_05) {
+TEST(escape_05) {
   const sourcemeta::core::JSON document{"foo\u0005bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0005bar\"");
 }
 
-TEST(JSON_stringify, escape_06) {
+TEST(escape_06) {
   const sourcemeta::core::JSON document{"foo\u0006bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0006bar\"");
 }
 
-TEST(JSON_stringify, escape_07) {
+TEST(escape_07) {
   const sourcemeta::core::JSON document{"foo\u0007bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0007bar\"");
 }
 
-TEST(JSON_stringify, escape_08) {
+TEST(escape_08) {
   const sourcemeta::core::JSON document{"foo\u0008bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\bbar\"");
 }
 
-TEST(JSON_stringify, escape_09) {
+TEST(escape_09) {
   const sourcemeta::core::JSON document{"foo\u0009bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\tbar\"");
 }
 
-TEST(JSON_stringify, escape_0A) {
+TEST(escape_0A) {
   const sourcemeta::core::JSON document{"foo\u000abar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\nbar\"");
 }
 
-TEST(JSON_stringify, escape_0B) {
+TEST(escape_0B) {
   const sourcemeta::core::JSON document{"foo\u000bbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u000Bbar\"");
 }
 
-TEST(JSON_stringify, escape_0C) {
+TEST(escape_0C) {
   const sourcemeta::core::JSON document{"foo\u000cbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\fbar\"");
 }
 
-TEST(JSON_stringify, escape_0D) {
+TEST(escape_0D) {
   const sourcemeta::core::JSON document{"foo\u000dbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\rbar\"");
 }
 
-TEST(JSON_stringify, escape_0E) {
+TEST(escape_0E) {
   const sourcemeta::core::JSON document{"foo\u000ebar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u000Ebar\"");
 }
 
-TEST(JSON_stringify, escape_0F) {
+TEST(escape_0F) {
   const sourcemeta::core::JSON document{"foo\u000fbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u000Fbar\"");
 }
 
-TEST(JSON_stringify, escape_10) {
+TEST(escape_10) {
   const sourcemeta::core::JSON document{"foo\u0010bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0010bar\"");
 }
 
-TEST(JSON_stringify, escape_11) {
+TEST(escape_11) {
   const sourcemeta::core::JSON document{"foo\u0011bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0011bar\"");
 }
 
-TEST(JSON_stringify, escape_12) {
+TEST(escape_12) {
   const sourcemeta::core::JSON document{"foo\u0012bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0012bar\"");
 }
 
-TEST(JSON_stringify, escape_13) {
+TEST(escape_13) {
   const sourcemeta::core::JSON document{"foo\u0013bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0013bar\"");
 }
 
-TEST(JSON_stringify, escape_14) {
+TEST(escape_14) {
   const sourcemeta::core::JSON document{"foo\u0014bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0014bar\"");
 }
 
-TEST(JSON_stringify, escape_15) {
+TEST(escape_15) {
   const sourcemeta::core::JSON document{"foo\u0015bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0015bar\"");
 }
 
-TEST(JSON_stringify, escape_16) {
+TEST(escape_16) {
   const sourcemeta::core::JSON document{"foo\u0016bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0016bar\"");
 }
 
-TEST(JSON_stringify, escape_17) {
+TEST(escape_17) {
   const sourcemeta::core::JSON document{"foo\u0017bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0017bar\"");
 }
 
-TEST(JSON_stringify, escape_18) {
+TEST(escape_18) {
   const sourcemeta::core::JSON document{"foo\u0018bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0018bar\"");
 }
 
-TEST(JSON_stringify, escape_19) {
+TEST(escape_19) {
   const sourcemeta::core::JSON document{"foo\u0019bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u0019bar\"");
 }
 
-TEST(JSON_stringify, escape_1A) {
+TEST(escape_1A) {
   const sourcemeta::core::JSON document{"foo\u001abar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u001Abar\"");
 }
 
-TEST(JSON_stringify, escape_1B) {
+TEST(escape_1B) {
   const sourcemeta::core::JSON document{"foo\u001bbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u001Bbar\"");
 }
 
-TEST(JSON_stringify, escape_1C) {
+TEST(escape_1C) {
   const sourcemeta::core::JSON document{"foo\u001cbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u001Cbar\"");
 }
 
-TEST(JSON_stringify, escape_1D) {
+TEST(escape_1D) {
   const sourcemeta::core::JSON document{"foo\u001dbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u001Dbar\"");
 }
 
-TEST(JSON_stringify, escape_1E) {
+TEST(escape_1E) {
   const sourcemeta::core::JSON document{"foo\u001ebar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u001Ebar\"");
 }
 
-TEST(JSON_stringify, escape_1F) {
+TEST(escape_1F) {
   const sourcemeta::core::JSON document{"foo\u001fbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(document, stream);
   EXPECT_EQ(stream.str(), "\"foo\\u001Fbar\"");
 }
 
-TEST(JSON_stringify, decimal_positive_integer) {
+TEST(decimal_positive_integer) {
   const sourcemeta::core::Decimal value{12345};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -489,7 +489,7 @@ TEST(JSON_stringify, decimal_positive_integer) {
   EXPECT_EQ(stream.str(), "1.2345e+4");
 }
 
-TEST(JSON_stringify, decimal_negative_integer) {
+TEST(decimal_negative_integer) {
   const sourcemeta::core::Decimal value{-67890};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -497,7 +497,7 @@ TEST(JSON_stringify, decimal_negative_integer) {
   EXPECT_EQ(stream.str(), "-6.7890e+4");
 }
 
-TEST(JSON_stringify, decimal_zero) {
+TEST(decimal_zero) {
   const sourcemeta::core::Decimal value{0};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -505,7 +505,7 @@ TEST(JSON_stringify, decimal_zero) {
   EXPECT_EQ(stream.str(), "0e+0");
 }
 
-TEST(JSON_stringify, decimal_fractional) {
+TEST(decimal_fractional) {
   const sourcemeta::core::Decimal value{"3.14159"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -513,7 +513,7 @@ TEST(JSON_stringify, decimal_fractional) {
   EXPECT_EQ(stream.str(), "3.14159e+0");
 }
 
-TEST(JSON_stringify, decimal_negative_fractional) {
+TEST(decimal_negative_fractional) {
   const sourcemeta::core::Decimal value{"-2.71828"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -521,7 +521,7 @@ TEST(JSON_stringify, decimal_negative_fractional) {
   EXPECT_EQ(stream.str(), "-2.71828e+0");
 }
 
-TEST(JSON_stringify, decimal_large_integer) {
+TEST(decimal_large_integer) {
   const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -529,7 +529,7 @@ TEST(JSON_stringify, decimal_large_integer) {
   EXPECT_EQ(stream.str(), "1.23456789012345678901234567890e+29");
 }
 
-TEST(JSON_stringify, decimal_large_negative_integer) {
+TEST(decimal_large_negative_integer) {
   const sourcemeta::core::Decimal value{"-987654321098765432109876543210"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -537,7 +537,7 @@ TEST(JSON_stringify, decimal_large_negative_integer) {
   EXPECT_EQ(stream.str(), "-9.87654321098765432109876543210e+29");
 }
 
-TEST(JSON_stringify, decimal_high_precision_fractional) {
+TEST(decimal_high_precision_fractional) {
   const sourcemeta::core::Decimal value{
       "3.141592653589793238462643383279502884197"};
   const sourcemeta::core::JSON document{value};
@@ -546,7 +546,7 @@ TEST(JSON_stringify, decimal_high_precision_fractional) {
   EXPECT_EQ(stream.str(), "3.141592653589793238462643383279502884197e+0");
 }
 
-TEST(JSON_stringify, decimal_very_small_fractional) {
+TEST(decimal_very_small_fractional) {
   const sourcemeta::core::Decimal value{"0.000000000000000000000000000001"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -554,7 +554,7 @@ TEST(JSON_stringify, decimal_very_small_fractional) {
   EXPECT_EQ(stream.str(), "1e-30");
 }
 
-TEST(JSON_stringify, decimal_scientific_notation) {
+TEST(decimal_scientific_notation) {
   const sourcemeta::core::Decimal value{"1.23e10"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -562,7 +562,7 @@ TEST(JSON_stringify, decimal_scientific_notation) {
   EXPECT_EQ(stream.str(), "1.23e+10");
 }
 
-TEST(JSON_stringify, scientific_constant_planck) {
+TEST(scientific_constant_planck) {
   const sourcemeta::core::Decimal value{"6.62607E-34"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -570,7 +570,7 @@ TEST(JSON_stringify, scientific_constant_planck) {
   EXPECT_EQ(stream.str(), "6.62607e-34");
 }
 
-TEST(JSON_stringify, scientific_constant_elementary_charge) {
+TEST(scientific_constant_elementary_charge) {
   const sourcemeta::core::Decimal value{"1.60218E-19"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -578,7 +578,7 @@ TEST(JSON_stringify, scientific_constant_elementary_charge) {
   EXPECT_EQ(stream.str(), "1.60218e-19");
 }
 
-TEST(JSON_stringify, scientific_constant_boltzmann) {
+TEST(scientific_constant_boltzmann) {
   const sourcemeta::core::Decimal value{"1.38065E-23"};
   const sourcemeta::core::JSON document{value};
   std::ostringstream stream;
@@ -586,7 +586,7 @@ TEST(JSON_stringify, scientific_constant_boltzmann) {
   EXPECT_EQ(stream.str(), "1.38065e-23");
 }
 
-TEST(JSON_stringify, decimal_in_array) {
+TEST(decimal_in_array) {
   const sourcemeta::core::Decimal value1{100};
   const sourcemeta::core::Decimal value2{"999.999"};
   const sourcemeta::core::Decimal value3{"-42"};
@@ -598,7 +598,7 @@ TEST(JSON_stringify, decimal_in_array) {
   EXPECT_EQ(stream.str(), "[1.00e+2,9.99999e+2,-4.2e+1]");
 }
 
-TEST(JSON_stringify, decimal_large_numbers_in_array) {
+TEST(decimal_large_numbers_in_array) {
   const sourcemeta::core::Decimal value1{"123456789012345678901234567890"};
   const sourcemeta::core::Decimal value2{
       "98765432109876543210.98765432109876543210"};
@@ -610,7 +610,7 @@ TEST(JSON_stringify, decimal_large_numbers_in_array) {
                           "876543210987654321098765432109876543210e+19]");
 }
 
-TEST(JSON_stringify, decimal_nested_in_array) {
+TEST(decimal_nested_in_array) {
   const sourcemeta::core::Decimal value1{"111.111"};
   const sourcemeta::core::Decimal value2{"222.222"};
   sourcemeta::core::JSON inner_array{sourcemeta::core::JSON{value1},
@@ -622,7 +622,7 @@ TEST(JSON_stringify, decimal_nested_in_array) {
   EXPECT_EQ(stream.str(), "[[1.11111e+2,2.22222e+2]]");
 }
 
-TEST(JSON_stringify, decimal_in_object) {
+TEST(decimal_in_object) {
   const sourcemeta::core::Decimal value1{"12345"};
   const sourcemeta::core::Decimal value2{"-67.89"};
   const sourcemeta::core::JSON document{
@@ -636,7 +636,7 @@ TEST(JSON_stringify, decimal_in_object) {
   EXPECT_TRUE(matches);
 }
 
-TEST(JSON_stringify, decimal_large_numbers_in_object) {
+TEST(decimal_large_numbers_in_object) {
   const sourcemeta::core::Decimal big_int{"999999999999999999999999999999"};
   const sourcemeta::core::Decimal big_real{
       "123456789.123456789123456789123456789"};
@@ -652,7 +652,7 @@ TEST(JSON_stringify, decimal_large_numbers_in_object) {
             "23456789123456789123456789123456789e+8}");
 }
 
-TEST(JSON_stringify, decimal_mixed_with_other_types_in_object) {
+TEST(decimal_mixed_with_other_types_in_object) {
   const sourcemeta::core::Decimal decimal_value{"3.14159"};
   sourcemeta::core::JSON document{
       {"string", sourcemeta::core::JSON{"hello"}},
@@ -669,7 +669,7 @@ TEST(JSON_stringify, decimal_mixed_with_other_types_in_object) {
       "\"hello\"}");
 }
 
-TEST(JSON_stringify, decimal_nested_in_object_with_array) {
+TEST(decimal_nested_in_object_with_array) {
   const sourcemeta::core::Decimal value1{"111"};
   const sourcemeta::core::Decimal value2{"222.222"};
   sourcemeta::core::JSON array{sourcemeta::core::JSON::Array{}};

--- a/test/json/json_try_parse_test.cc
+++ b/test/json/json_try_parse_test.cc
@@ -1,64 +1,64 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
-TEST(JSON_try_parse, valid_object) {
+TEST(valid_object) {
   const auto document{sourcemeta::core::try_parse_json("{ \"foo\": 1 }")};
-  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.has_value());
   EXPECT_TRUE(document.value().is_object());
   EXPECT_EQ(document.value().size(), 1);
 }
 
-TEST(JSON_try_parse, valid_array) {
+TEST(valid_array) {
   const auto document{sourcemeta::core::try_parse_json("[ 1, 2, 3 ]")};
-  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.has_value());
   EXPECT_TRUE(document.value().is_array());
   EXPECT_EQ(document.value().size(), 3);
 }
 
-TEST(JSON_try_parse, valid_string) {
+TEST(valid_string) {
   const auto document{sourcemeta::core::try_parse_json("\"hello\"")};
-  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.has_value());
   EXPECT_TRUE(document.value().is_string());
   EXPECT_EQ(document.value().to_string(), "hello");
 }
 
-TEST(JSON_try_parse, valid_integer) {
+TEST(valid_integer) {
   const auto document{sourcemeta::core::try_parse_json("42")};
-  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.has_value());
   EXPECT_TRUE(document.value().is_integer());
   EXPECT_EQ(document.value().to_integer(), 42);
 }
 
-TEST(JSON_try_parse, valid_null) {
+TEST(valid_null) {
   const auto document{sourcemeta::core::try_parse_json("null")};
-  ASSERT_TRUE(document.has_value());
+  EXPECT_TRUE(document.has_value());
   EXPECT_TRUE(document.value().is_null());
 }
 
-TEST(JSON_try_parse, matches_throwing_parse) {
+TEST(matches_throwing_parse) {
   const auto via_try{sourcemeta::core::try_parse_json("[ 1, 2, 3 ]")};
   const auto via_throw{sourcemeta::core::parse_json("[ 1, 2, 3 ]")};
-  ASSERT_TRUE(via_try.has_value());
+  EXPECT_TRUE(via_try.has_value());
   EXPECT_EQ(via_try.value(), via_throw);
 }
 
-TEST(JSON_try_parse, rejects_empty) {
+TEST(rejects_empty) {
   EXPECT_FALSE(sourcemeta::core::try_parse_json("").has_value());
 }
 
-TEST(JSON_try_parse, rejects_garbage) {
+TEST(rejects_garbage) {
   EXPECT_FALSE(sourcemeta::core::try_parse_json("not json").has_value());
 }
 
-TEST(JSON_try_parse, rejects_truncated_array) {
+TEST(rejects_truncated_array) {
   EXPECT_FALSE(sourcemeta::core::try_parse_json("[ 1, 2,").has_value());
 }
 
-TEST(JSON_try_parse, rejects_unclosed_object) {
+TEST(rejects_unclosed_object) {
   EXPECT_FALSE(sourcemeta::core::try_parse_json("{ \"foo\":").has_value());
 }
 
-TEST(JSON_try_parse, rejects_invalid_number) {
+TEST(rejects_invalid_number) {
   EXPECT_FALSE(sourcemeta::core::try_parse_json("01").has_value());
 }

--- a/test/json/json_type_test.cc
+++ b/test/json/json_type_test.cc
@@ -1,57 +1,57 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
 #include <sstream>
 
-TEST(JSON_type, print_null) {
+TEST(print_null) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::Null;
   EXPECT_EQ(output.str(), "null");
 }
 
-TEST(JSON_type, print_boolean) {
+TEST(print_boolean) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::Boolean;
   EXPECT_EQ(output.str(), "boolean");
 }
 
-TEST(JSON_type, print_integer) {
+TEST(print_integer) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::Integer;
   EXPECT_EQ(output.str(), "integer");
 }
 
-TEST(JSON_type, print_real) {
+TEST(print_real) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::Real;
   EXPECT_EQ(output.str(), "real");
 }
 
-TEST(JSON_type, print_string) {
+TEST(print_string) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::String;
   EXPECT_EQ(output.str(), "string");
 }
 
-TEST(JSON_type, print_array) {
+TEST(print_array) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::Array;
   EXPECT_EQ(output.str(), "array");
 }
 
-TEST(JSON_type, print_object) {
+TEST(print_object) {
   std::ostringstream output;
   output << sourcemeta::core::JSON::Type::Object;
   EXPECT_EQ(output.str(), "object");
 }
 
-TEST(JSON_type, make_set_empty) {
+TEST(make_set_empty) {
   const auto types = sourcemeta::core::make_set({});
   EXPECT_TRUE(types.none());
 }
 
-TEST(JSON_type, make_set_single) {
+TEST(make_set_single) {
   const auto types =
       sourcemeta::core::make_set({sourcemeta::core::JSON::Type::String});
   EXPECT_FALSE(types.none());
@@ -63,7 +63,7 @@ TEST(JSON_type, make_set_single) {
       static_cast<std::size_t>(sourcemeta::core::JSON::Type::Object)));
 }
 
-TEST(JSON_type, make_set_multiple) {
+TEST(make_set_multiple) {
   const auto types =
       sourcemeta::core::make_set({sourcemeta::core::JSON::Type::Integer,
                                   sourcemeta::core::JSON::Type::Real});
@@ -78,7 +78,7 @@ TEST(JSON_type, make_set_multiple) {
       static_cast<std::size_t>(sourcemeta::core::JSON::Type::Object)));
 }
 
-TEST(JSON_type, make_set_intersection) {
+TEST(make_set_intersection) {
   const auto types_a =
       sourcemeta::core::make_set({sourcemeta::core::JSON::Type::Integer,
                                   sourcemeta::core::JSON::Type::Real,
@@ -98,7 +98,7 @@ TEST(JSON_type, make_set_intersection) {
       static_cast<std::size_t>(sourcemeta::core::JSON::Type::Object)));
 }
 
-TEST(JSON_type, make_set_no_intersection) {
+TEST(make_set_no_intersection) {
   const auto types_a =
       sourcemeta::core::make_set({sourcemeta::core::JSON::Type::Integer,
                                   sourcemeta::core::JSON::Type::Real});

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 
@@ -10,7 +10,7 @@
 #include <unordered_set> // std::unordered_set
 #include <utility>       // std::move
 
-TEST(JSON_value, general_traits) {
+TEST(general_traits) {
   EXPECT_FALSE(std::is_default_constructible<sourcemeta::core::JSON>::value);
   EXPECT_TRUE(std::is_destructible<sourcemeta::core::JSON>::value);
   EXPECT_TRUE(std::is_nothrow_destructible<sourcemeta::core::JSON>::value);
@@ -18,14 +18,14 @@ TEST(JSON_value, general_traits) {
 
 // BIG WARNING! Increase this number will make projects like Blaze slower,
 // as it will affect cache lines when dealing with JSON documents
-TEST(JSON_value, size) {
+TEST(size) {
   // The union's largest member is std::string, whose size varies across
   // standard library implementations (24 on libc++, 32 on libstdc++).
   // The Type enum (1 byte) is padded to 8 bytes for alignment.
   EXPECT_EQ(sizeof(sourcemeta::core::JSON), sizeof(std::string) + 8);
 }
 
-TEST(JSON_value, copy_traits) {
+TEST(copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::JSON>::value);
   EXPECT_TRUE(std::is_copy_constructible<sourcemeta::core::JSON>::value);
   EXPECT_FALSE(std::is_nothrow_copy_assignable<sourcemeta::core::JSON>::value);
@@ -33,12 +33,12 @@ TEST(JSON_value, copy_traits) {
       std::is_nothrow_copy_constructible<sourcemeta::core::JSON>::value);
 }
 
-TEST(JSON_value, move_traits) {
+TEST(move_traits) {
   EXPECT_TRUE(std::is_move_assignable<sourcemeta::core::JSON>::value);
   EXPECT_TRUE(std::is_move_constructible<sourcemeta::core::JSON>::value);
 }
 
-TEST(JSON_value, copy_equivalence_assignment) {
+TEST(copy_equivalence_assignment) {
   sourcemeta::core::JSON document{sourcemeta::core::JSON::Array{}};
   document.push_back(sourcemeta::core::JSON{1});
   sourcemeta::core::JSON object = sourcemeta::core::JSON::make_object();
@@ -49,161 +49,161 @@ TEST(JSON_value, copy_equivalence_assignment) {
   EXPECT_EQ(document, copy);
 }
 
-TEST(JSON_value, from_size_t) {
+TEST(from_size_t) {
   const std::size_t value{5};
   const sourcemeta::core::JSON document{value};
   EXPECT_TRUE(document.is_integer());
   EXPECT_EQ(document.to_integer(), 5);
 }
 
-TEST(JSON_value, compare_int_less_than_int) {
+TEST(compare_int_less_than_int) {
   const sourcemeta::core::JSON left{3};
   const sourcemeta::core::JSON right{4};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_int_greater_than_int) {
+TEST(compare_int_greater_than_int) {
   const sourcemeta::core::JSON left{4};
   const sourcemeta::core::JSON right{3};
   EXPECT_FALSE(left < right);
   EXPECT_TRUE(right < left);
 }
 
-TEST(JSON_value, compare_int_equal_int) {
+TEST(compare_int_equal_int) {
   const sourcemeta::core::JSON left{4};
   const sourcemeta::core::JSON right{4};
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_int_less_than_real) {
+TEST(compare_int_less_than_real) {
   const sourcemeta::core::JSON left{3};
   const sourcemeta::core::JSON right{4.3};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_int_greater_than_real) {
+TEST(compare_int_greater_than_real) {
   const sourcemeta::core::JSON left{4};
   const sourcemeta::core::JSON right{3.8};
   EXPECT_FALSE(left < right);
   EXPECT_TRUE(right < left);
 }
 
-TEST(JSON_value, compare_int_equal_real) {
+TEST(compare_int_equal_real) {
   const sourcemeta::core::JSON left{4};
   const sourcemeta::core::JSON right{4.0};
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_real_less_than_int) {
+TEST(compare_real_less_than_int) {
   const sourcemeta::core::JSON left{3.8};
   const sourcemeta::core::JSON right{4};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_real_greater_than_int) {
+TEST(compare_real_greater_than_int) {
   const sourcemeta::core::JSON left{4.2};
   const sourcemeta::core::JSON right{3};
   EXPECT_FALSE(left < right);
   EXPECT_TRUE(right < left);
 }
 
-TEST(JSON_value, compare_real_equal_int) {
+TEST(compare_real_equal_int) {
   const sourcemeta::core::JSON left{4.0};
   const sourcemeta::core::JSON right{4};
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_real_less_than_real) {
+TEST(compare_real_less_than_real) {
   const sourcemeta::core::JSON left{3.8};
   const sourcemeta::core::JSON right{4.1};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_real_greater_than_real) {
+TEST(compare_real_greater_than_real) {
   const sourcemeta::core::JSON left{4.2};
   const sourcemeta::core::JSON right{3.9};
   EXPECT_FALSE(left < right);
   EXPECT_TRUE(right < left);
 }
 
-TEST(JSON_value, compare_real_equal_real) {
+TEST(compare_real_equal_real) {
   const sourcemeta::core::JSON left{4.2};
   const sourcemeta::core::JSON right{4.2};
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_false_true) {
+TEST(compare_false_true) {
   const sourcemeta::core::JSON left{false};
   const sourcemeta::core::JSON right{true};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_false_false) {
+TEST(compare_false_false) {
   const sourcemeta::core::JSON left{false};
   const sourcemeta::core::JSON right{false};
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_true_true) {
+TEST(compare_true_true) {
   const sourcemeta::core::JSON left{true};
   const sourcemeta::core::JSON right{true};
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_bool_int) {
+TEST(compare_bool_int) {
   const sourcemeta::core::JSON left{true};
   const sourcemeta::core::JSON right{0};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_bool_real) {
+TEST(compare_bool_real) {
   const sourcemeta::core::JSON left{true};
   const sourcemeta::core::JSON right{4.5};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_int_array) {
+TEST(compare_int_array) {
   const sourcemeta::core::JSON left{4};
   const sourcemeta::core::JSON right = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_array_array_same) {
+TEST(compare_array_array_same) {
   const sourcemeta::core::JSON left = sourcemeta::core::parse_json("[1,2,3]");
   const sourcemeta::core::JSON right = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_FALSE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_array_array_different) {
+TEST(compare_array_array_different) {
   const sourcemeta::core::JSON left = sourcemeta::core::parse_json("[1,2]");
   const sourcemeta::core::JSON right = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_array_array_different_same_size) {
+TEST(compare_array_array_different_same_size) {
   const sourcemeta::core::JSON left = sourcemeta::core::parse_json("[1,3,4]");
   const sourcemeta::core::JSON right = sourcemeta::core::parse_json("[1,2,3]");
   EXPECT_FALSE(left < right);
   EXPECT_TRUE(right < left);
 }
 
-TEST(JSON_value, compare_object_object_same) {
+TEST(compare_object_object_same) {
   const sourcemeta::core::JSON left =
       sourcemeta::core::parse_json("{\"foo\":1}");
   const sourcemeta::core::JSON right =
@@ -212,7 +212,7 @@ TEST(JSON_value, compare_object_object_same) {
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_object_object_different_same_size) {
+TEST(compare_object_object_different_same_size) {
   const sourcemeta::core::JSON left =
       sourcemeta::core::parse_json("{\"foo\":1}");
   const sourcemeta::core::JSON right =
@@ -221,7 +221,7 @@ TEST(JSON_value, compare_object_object_different_same_size) {
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_object_object_different) {
+TEST(compare_object_object_different) {
   const sourcemeta::core::JSON left =
       sourcemeta::core::parse_json("{\"foo\":1}");
   const sourcemeta::core::JSON right =
@@ -230,40 +230,40 @@ TEST(JSON_value, compare_object_object_different) {
   EXPECT_FALSE(right < left);
 }
 
-TEST(JSON_value, compare_int_operator_less_than_or_equal_int) {
+TEST(compare_int_operator_less_than_or_equal_int) {
   const sourcemeta::core::JSON left{3};
   const sourcemeta::core::JSON right{4};
   EXPECT_TRUE(left <= right);
   EXPECT_FALSE(right <= left);
 }
 
-TEST(JSON_value, compare_int_operator_greater_than_int) {
+TEST(compare_int_operator_greater_than_int) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{4};
   EXPECT_TRUE(left > right);
   EXPECT_FALSE(right > left);
 }
 
-TEST(JSON_value, compare_int_operator_greater_than_int_equal) {
+TEST(compare_int_operator_greater_than_int_equal) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{5};
   EXPECT_FALSE(left > right);
 }
 
-TEST(JSON_value, compare_int_operator_greater_than_or_equal_int) {
+TEST(compare_int_operator_greater_than_or_equal_int) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{4};
   EXPECT_TRUE(left >= right);
   EXPECT_FALSE(right >= left);
 }
 
-TEST(JSON_value, compare_int_operator_not_equal_int) {
+TEST(compare_int_operator_not_equal_int) {
   const sourcemeta::core::JSON left{5};
   const sourcemeta::core::JSON right{4};
   EXPECT_TRUE(left != right);
 }
 
-TEST(JSON_value, set_null) {
+TEST(set_null) {
   sourcemeta::core::JSON document{true};
   EXPECT_FALSE(document.is_null());
   EXPECT_TRUE(document.is_boolean());
@@ -272,7 +272,7 @@ TEST(JSON_value, set_null) {
   EXPECT_FALSE(document.is_boolean());
 }
 
-TEST(JSON_value, set_const_null) {
+TEST(set_const_null) {
   sourcemeta::core::JSON document{true};
   EXPECT_FALSE(document.is_null());
   EXPECT_TRUE(document.is_boolean());
@@ -282,7 +282,7 @@ TEST(JSON_value, set_const_null) {
   EXPECT_FALSE(document.is_boolean());
 }
 
-TEST(JSON_value, set_negative_integer) {
+TEST(set_negative_integer) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into(sourcemeta::core::JSON{-4});
@@ -291,7 +291,7 @@ TEST(JSON_value, set_negative_integer) {
   EXPECT_EQ(document.to_integer(), -4);
 }
 
-TEST(JSON_value, set_negative_real) {
+TEST(set_negative_real) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into(sourcemeta::core::JSON{-4.3});
@@ -300,7 +300,7 @@ TEST(JSON_value, set_negative_real) {
   EXPECT_EQ(document.to_real(), -4.3);
 }
 
-TEST(JSON_value, set_negative_integral_real) {
+TEST(set_negative_integral_real) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into(sourcemeta::core::JSON{-4.0});
@@ -308,7 +308,7 @@ TEST(JSON_value, set_negative_integral_real) {
   EXPECT_TRUE(document.is_real());
 }
 
-TEST(JSON_value, set_positive_integer) {
+TEST(set_positive_integer) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into(sourcemeta::core::JSON{4});
@@ -316,7 +316,7 @@ TEST(JSON_value, set_positive_integer) {
   EXPECT_FALSE(document.is_real());
 }
 
-TEST(JSON_value, set_positive_real) {
+TEST(set_positive_real) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into(sourcemeta::core::JSON{4.3});
@@ -324,7 +324,7 @@ TEST(JSON_value, set_positive_real) {
   EXPECT_TRUE(document.is_real());
 }
 
-TEST(JSON_value, set_positive_integral_real) {
+TEST(set_positive_integral_real) {
   sourcemeta::core::JSON document{true};
   EXPECT_TRUE(document.is_boolean());
   document.into(sourcemeta::core::JSON{4.0});
@@ -332,7 +332,7 @@ TEST(JSON_value, set_positive_integral_real) {
   EXPECT_TRUE(document.is_real());
 }
 
-TEST(JSON_value, into_string_from_boolean) {
+TEST(into_string_from_boolean) {
   sourcemeta::core::JSON document{false};
   EXPECT_FALSE(document.is_string());
   document.into(sourcemeta::core::JSON{"foo"});
@@ -340,7 +340,7 @@ TEST(JSON_value, into_string_from_boolean) {
   EXPECT_EQ(document.to_string(), "foo");
 }
 
-TEST(JSON_value, into_string_from_string) {
+TEST(into_string_from_string) {
   sourcemeta::core::JSON document{"foo"};
   EXPECT_TRUE(document.is_string());
   EXPECT_EQ(document.to_string(), "foo");
@@ -349,7 +349,7 @@ TEST(JSON_value, into_string_from_string) {
   EXPECT_EQ(document.to_string(), "bar");
 }
 
-TEST(JSON_value, to_ostream) {
+TEST(to_ostream) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::JSON{1}, sourcemeta::core::JSON{2},
       sourcemeta::core::JSON{3}, sourcemeta::core::JSON{4}};
@@ -372,7 +372,7 @@ private:
   const sourcemeta::core::JSON data;
 };
 
-TEST(JSON_value, class_member_initializer_list) {
+TEST(class_member_initializer_list) {
   const sourcemeta::core::JSON document{5};
   EXPECT_TRUE(document.is_integer());
   const ClassMemberInitializerList container{document};
@@ -381,7 +381,7 @@ TEST(JSON_value, class_member_initializer_list) {
   EXPECT_EQ(container.get(), document);
 }
 
-TEST(JSON_value, try_at) {
+TEST(try_at) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":5}");
   EXPECT_TRUE(document.is_object());
@@ -390,7 +390,7 @@ TEST(JSON_value, try_at) {
   EXPECT_EQ(result->to_integer(), 5);
 }
 
-TEST(JSON_value, try_at_fail) {
+TEST(try_at_fail) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{\"foo\":5}");
   EXPECT_TRUE(document.is_object());
@@ -398,7 +398,7 @@ TEST(JSON_value, try_at_fail) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSON_value, unordered_set_with_custom_hash) {
+TEST(unordered_set_with_custom_hash) {
   std::unordered_set<sourcemeta::core::JSON,
                      sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
       value;
@@ -413,7 +413,7 @@ TEST(JSON_value, unordered_set_with_custom_hash) {
   EXPECT_TRUE(value.contains(sourcemeta::core::JSON{"baz"}));
 }
 
-TEST(JSON_value, unordered_set_with_reference_wrapper) {
+TEST(unordered_set_with_reference_wrapper) {
   const sourcemeta::core::JSON foo{"foo"};
   const sourcemeta::core::JSON bar{"bar"};
   const sourcemeta::core::JSON baz{"baz"};
@@ -437,7 +437,7 @@ TEST(JSON_value, unordered_set_with_reference_wrapper) {
   EXPECT_TRUE(value.contains(std::cref(bar_duplicate)));
 }
 
-TEST(JSON_value, unordered_map_with_reference_wrapper) {
+TEST(unordered_map_with_reference_wrapper) {
   const sourcemeta::core::JSON foo{"foo"};
   const sourcemeta::core::JSON bar{"bar"};
   const sourcemeta::core::JSON bar_duplicate{"bar"};
@@ -459,7 +459,7 @@ TEST(JSON_value, unordered_map_with_reference_wrapper) {
   EXPECT_EQ(value.at(std::cref(bar_duplicate)), 2);
 }
 
-TEST(JSON_value, destructs_deeply_nested_array_without_stack_overflow) {
+TEST(destructs_deeply_nested_array_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 2 + 1);
@@ -470,7 +470,7 @@ TEST(JSON_value, destructs_deeply_nested_array_without_stack_overflow) {
   EXPECT_TRUE(document.is_array());
 }
 
-TEST(JSON_value, destructs_deeply_nested_object_without_stack_overflow) {
+TEST(destructs_deeply_nested_object_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 6 + 1 + depth);
@@ -483,7 +483,7 @@ TEST(JSON_value, destructs_deeply_nested_object_without_stack_overflow) {
   EXPECT_TRUE(document.is_object());
 }
 
-TEST(JSON_value, copies_deeply_nested_array_without_stack_overflow) {
+TEST(copies_deeply_nested_array_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 2 + 1);
@@ -495,7 +495,7 @@ TEST(JSON_value, copies_deeply_nested_array_without_stack_overflow) {
   EXPECT_TRUE(copy.is_array());
 }
 
-TEST(JSON_value, copies_deeply_nested_object_without_stack_overflow) {
+TEST(copies_deeply_nested_object_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 6 + 1 + depth);
@@ -509,7 +509,7 @@ TEST(JSON_value, copies_deeply_nested_object_without_stack_overflow) {
   EXPECT_TRUE(copy.is_object());
 }
 
-TEST(JSON_value, copy_assigns_deeply_nested_array_without_stack_overflow) {
+TEST(copy_assigns_deeply_nested_array_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 2 + 1);
@@ -522,7 +522,7 @@ TEST(JSON_value, copy_assigns_deeply_nested_array_without_stack_overflow) {
   EXPECT_TRUE(target.is_array());
 }
 
-TEST(JSON_value, copy_assigns_deeply_nested_object_without_stack_overflow) {
+TEST(copy_assigns_deeply_nested_object_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 6 + 1 + depth);
@@ -537,7 +537,7 @@ TEST(JSON_value, copy_assigns_deeply_nested_object_without_stack_overflow) {
   EXPECT_TRUE(target.is_object());
 }
 
-TEST(JSON_value, move_assigns_deeply_nested_array_without_stack_overflow) {
+TEST(move_assigns_deeply_nested_array_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 2 + 1);
@@ -550,7 +550,7 @@ TEST(JSON_value, move_assigns_deeply_nested_array_without_stack_overflow) {
   EXPECT_TRUE(target.is_array());
 }
 
-TEST(JSON_value, move_assigns_deeply_nested_object_without_stack_overflow) {
+TEST(move_assigns_deeply_nested_object_without_stack_overflow) {
   constexpr std::size_t depth{100000};
   std::string deep;
   deep.reserve(depth * 6 + 1 + depth);
@@ -565,7 +565,7 @@ TEST(JSON_value, move_assigns_deeply_nested_object_without_stack_overflow) {
   EXPECT_TRUE(target.is_object());
 }
 
-TEST(JSON_value, direct_list_inits_deeply_nested_array_without_stack_overflow) {
+TEST(direct_list_inits_deeply_nested_array_without_stack_overflow) {
   // On GCC and MSVC, JSON x{other} selects JSON(initializer_list<JSON>) whose
   // single-element workaround invokes operator=(const JSON&)
   constexpr std::size_t depth{100000};

--- a/test/jsonl/CMakeLists.txt
+++ b/test/jsonl/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsonl
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonl
   SOURCES
     jsonl_parse_test.cc
     jsonl_parse_error_test.cc

--- a/test/jsonl/jsonl_gzip_parse_error_test.cc
+++ b/test/jsonl/jsonl_gzip_parse_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/gzip.h>
 #include <sourcemeta/core/jsonl.h>
@@ -8,7 +8,7 @@
 #include <sstream>   // std::istringstream
 #include <string>    // std::string
 
-TEST(JSONL_gzip_parse_error, invalid_compressed_data) {
+TEST(invalid_compressed_data) {
   const std::string garbage{"this is not gzip data"};
   std::istringstream stream{garbage};
   try {
@@ -25,7 +25,7 @@ TEST(JSONL_gzip_parse_error, invalid_compressed_data) {
   }
 }
 
-TEST(JSONL_gzip_parse_error, invalid_json_in_compressed_data) {
+TEST(invalid_json_in_compressed_data) {
   const std::string input{"trrue"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -45,7 +45,7 @@ TEST(JSONL_gzip_parse_error, invalid_json_in_compressed_data) {
   }
 }
 
-TEST(JSONL_gzip_parse_error, invalid_delimiter_in_compressed_data) {
+TEST(invalid_delimiter_in_compressed_data) {
   const std::string input{"false true"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};

--- a/test/jsonl/jsonl_gzip_parse_test.cc
+++ b/test/jsonl/jsonl_gzip_parse_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/gzip.h>
 #include <sourcemeta/core/jsonl.h>
@@ -8,7 +8,7 @@
 #include <string>  // std::string
 #include <vector>  // std::vector
 
-TEST(JSONL_gzip_parse, empty) {
+TEST(empty) {
   const std::string input;
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -22,7 +22,7 @@ TEST(JSONL_gzip_parse, empty) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONL_gzip_parse, integers_n) {
+TEST(integers_n) {
   const std::string input{"1\n2\n3\n4"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -44,7 +44,7 @@ TEST(JSONL_gzip_parse, integers_n) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_gzip_parse, integers_rn) {
+TEST(integers_rn) {
   const std::string input{"1\r\n2\r\n3\r\n4"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -66,7 +66,7 @@ TEST(JSONL_gzip_parse, integers_rn) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_gzip_parse, integers_trailing_n) {
+TEST(integers_trailing_n) {
   const std::string input{"1\n2\n3\n4\n"};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -88,7 +88,7 @@ TEST(JSONL_gzip_parse, integers_trailing_n) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_gzip_parse, whitespace_before_after) {
+TEST(whitespace_before_after) {
   const std::string input{" \t\r   1  \r\r\n2  \t\n3   \n4   \t\r   "};
   const auto compressed{sourcemeta::core::gzip(
       reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
@@ -110,7 +110,7 @@ TEST(JSONL_gzip_parse, whitespace_before_after) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_gzip_parse, objects) {
+TEST(objects) {
   const std::string input{
       R"EOF({"name": "Gilbert", "wins": [["straight", "7h"]]}
 {"name": "Alexa", "wins": [["two pair", "4s"]]}
@@ -158,7 +158,7 @@ TEST(JSONL_gzip_parse, objects) {
   EXPECT_EQ(result.at(3).at("wins").size(), 1);
 }
 
-TEST(JSONL_gzip_parse, large_dataset) {
+TEST(large_dataset) {
   std::string input;
   for (int index = 0; index < 1000; ++index) {
     input += "{\"index\":" + std::to_string(index) + "}\n";
@@ -182,7 +182,7 @@ TEST(JSONL_gzip_parse, large_dataset) {
   }
 }
 
-TEST(JSONL_gzip_parse, default_mode_is_raw) {
+TEST(default_mode_is_raw) {
   std::istringstream stream{"1\n2\n3"};
   std::vector<sourcemeta::core::JSON> result;
   for (const auto &document : sourcemeta::core::JSONL{stream}) {

--- a/test/jsonl/jsonl_parse_error_test.cc
+++ b/test/jsonl/jsonl_parse_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonl.h>
 
@@ -20,17 +20,17 @@
     FAIL();                                                                    \
   }
 
-TEST(JSONL_parse_error, invalid_first_row) {
+TEST(invalid_first_row) {
   std::istringstream input{"trrue"};
   EXPECT_PARSE_ERROR(input, 1, 3);
 }
 
-TEST(JSONL_parse_error, invalid_second_row) {
+TEST(invalid_second_row) {
   std::istringstream input{"true\ntrrue"};
   EXPECT_PARSE_ERROR(input, 2, 3);
 }
 
-TEST(JSONL_parse_error, blank_with_whitespace_characters) {
+TEST(blank_with_whitespace_characters) {
   std::istringstream input{"\r\r\n\n\t\t"};
   std::vector<sourcemeta::core::JSON> result;
   for (const auto &document : sourcemeta::core::JSONL{input}) {
@@ -40,27 +40,27 @@ TEST(JSONL_parse_error, blank_with_whitespace_characters) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONL_parse_error, invalid_delimiter_space) {
+TEST(invalid_delimiter_space) {
   std::istringstream input{"false true"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSONL_parse_error, invalid_delimiter_carriage_return) {
+TEST(invalid_delimiter_carriage_return) {
   std::istringstream input{"false\rtrue"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSONL_parse_error, invalid_delimiter_tab) {
+TEST(invalid_delimiter_tab) {
   std::istringstream input{"false\ttrue"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSONL_parse_error, invalid_delimiter_x) {
+TEST(invalid_delimiter_x) {
   std::istringstream input{"false x true"};
   EXPECT_PARSE_ERROR(input, 1, 7);
 }
 
-TEST(JSONL_parse_error, invalid_multi_line_row) {
+TEST(invalid_multi_line_row) {
   // Multi-line JSON values are not valid JSONL.
   // Each line must be a complete JSON value.
   // See https://jsonlines.org
@@ -69,7 +69,7 @@ TEST(JSONL_parse_error, invalid_multi_line_row) {
   EXPECT_PARSE_ERROR(input, 1, 2);
 }
 
-TEST(JSONL_parse_error, backspace_prefix) {
+TEST(backspace_prefix) {
   std::istringstream input{"false\n\btrue"};
   EXPECT_PARSE_ERROR(input, 2, 1);
 }

--- a/test/jsonl/jsonl_parse_test.cc
+++ b/test/jsonl/jsonl_parse_test.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonl.h>
 
 #include <sstream>
 #include <vector>
 
-TEST(JSONL_parse, empty) {
+TEST(empty) {
   std::istringstream stream{""};
   std::vector<sourcemeta::core::JSON> result;
   for (const auto &document : sourcemeta::core::JSONL{stream}) {
@@ -15,7 +15,7 @@ TEST(JSONL_parse, empty) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONL_parse, blank) {
+TEST(blank) {
   std::istringstream stream{"    "};
   std::vector<sourcemeta::core::JSON> result;
   for (const auto &document : sourcemeta::core::JSONL{stream}) {
@@ -25,7 +25,7 @@ TEST(JSONL_parse, blank) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONL_parse, integers_n) {
+TEST(integers_n) {
   std::string input{"1\n2\n3\n4"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -44,7 +44,7 @@ TEST(JSONL_parse, integers_n) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, whitespace_before_after_within) {
+TEST(whitespace_before_after_within) {
   std::string input{" \t\r   1  \r\r\n2  \t\n3   \n4   \t\r   "};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -63,7 +63,7 @@ TEST(JSONL_parse, whitespace_before_after_within) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, integers_n_trailing_n) {
+TEST(integers_n_trailing_n) {
   std::string input{"1\n2\n3\n4\n"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -82,7 +82,7 @@ TEST(JSONL_parse, integers_n_trailing_n) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, integers_n_trailing_rn) {
+TEST(integers_n_trailing_rn) {
   std::string input{"1\n2\n3\n4\r\n"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -101,7 +101,7 @@ TEST(JSONL_parse, integers_n_trailing_rn) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, integers_rn) {
+TEST(integers_rn) {
   std::string input{"1\r\n2\r\n3\r\n4"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -120,7 +120,7 @@ TEST(JSONL_parse, integers_rn) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, integers_rn_trailing_rn) {
+TEST(integers_rn_trailing_rn) {
   std::string input{"1\r\n2\r\n3\r\n4\r\n"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -139,7 +139,7 @@ TEST(JSONL_parse, integers_rn_trailing_rn) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, integers_rn_trailing_n) {
+TEST(integers_rn_trailing_n) {
   std::string input{"1\r\n2\r\n3\r\n4\n"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -158,7 +158,7 @@ TEST(JSONL_parse, integers_rn_trailing_n) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, integers_mixed) {
+TEST(integers_mixed) {
   std::string input{"1\r\n2\n3\r\n4\n"};
   std::istringstream stream{input};
   std::vector<sourcemeta::core::JSON> result;
@@ -177,7 +177,7 @@ TEST(JSONL_parse, integers_mixed) {
   EXPECT_EQ(result.at(3).to_integer(), 4);
 }
 
-TEST(JSONL_parse, example_1) {
+TEST(example_1) {
   std::string input{R"EOF(
     ["Name", "Session", "Score", "Completed"]
     ["Gilbert", "2013", 24, true]
@@ -252,7 +252,7 @@ TEST(JSONL_parse, example_1) {
   EXPECT_TRUE(result.at(4).at(3).to_boolean());
 }
 
-TEST(JSONL_parse, example_2) {
+TEST(example_2) {
   std::string input{R"EOF(
     {"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
     {"name": "Alexa", "wins": [["two pair", "4♠"], ["two pair", "9♠"]]}

--- a/test/jsonld/CMakeLists.txt
+++ b/test/jsonld/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsonld
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonld
   SOURCES jsonld_expand_test.cc jsonld_expand_error_test.cc
     jsonld_is_expanded_test.cc jsonld_compact_test.cc jsonld_flatten_test.cc
     jsonld_materialize_test.cc)

--- a/test/jsonld/jsonld_compact_test.cc
+++ b/test/jsonld/jsonld_compact_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
 
-TEST(JSONLD_compact, compact_to_relative_true_relativises_against_base) {
+TEST(compact_to_relative_true_relativises_against_base) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.org/a",
@@ -28,7 +28,7 @@ TEST(JSONLD_compact, compact_to_relative_true_relativises_against_base) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONLD_compact, compact_to_relative_false_keeps_absolute_against_base) {
+TEST(compact_to_relative_false_keeps_absolute_against_base) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.org/a",
@@ -53,7 +53,7 @@ TEST(JSONLD_compact, compact_to_relative_false_keeps_absolute_against_base) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONLD_compact, id_typed_value_with_index_keeps_index) {
+TEST(id_typed_value_with_index_keeps_index) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "http://example.com/id": [
@@ -76,7 +76,7 @@ TEST(JSONLD_compact, id_typed_value_with_index_keeps_index) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONLD_compact, nest_value_not_expanding_to_nest_is_rejected) {
+TEST(nest_value_not_expanding_to_nest_is_rejected) {
   const auto input = sourcemeta::core::parse_json(R"([
     { "http://example.com/p": [ { "@value": "v" } ] }
   ])");
@@ -95,7 +95,7 @@ TEST(JSONLD_compact, nest_value_not_expanding_to_nest_is_rejected) {
   }
 }
 
-TEST(JSONLD_compact, nest_value_aliasing_nest_nests_the_property) {
+TEST(nest_value_aliasing_nest_nests_the_property) {
   const auto input = sourcemeta::core::parse_json(R"([
     { "http://example.com/p": [ { "@value": "v" } ] }
   ])");
@@ -120,7 +120,7 @@ TEST(JSONLD_compact, nest_value_aliasing_nest_nests_the_property) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONLD_compact, type_map_remaining_stays_array_without_compact_arrays) {
+TEST(type_map_remaining_stays_array_without_compact_arrays) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "http://example.com/p": [
@@ -153,7 +153,7 @@ TEST(JSONLD_compact, type_map_remaining_stays_array_without_compact_arrays) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(JSONLD_compact, protected_redefinition_with_different_index_expansion) {
+TEST(protected_redefinition_with_different_index_expansion) {
   const auto input = sourcemeta::core::parse_json(R"([
     { "http://example.com/p": [ { "@value": "x" } ] }
   ])");
@@ -190,7 +190,7 @@ TEST(JSONLD_compact, protected_redefinition_with_different_index_expansion) {
   }
 }
 
-TEST(JSONLD_compact, list_object_stays_array_without_compact_arrays) {
+TEST(list_object_stays_array_without_compact_arrays) {
   const auto input = sourcemeta::core::parse_json(R"([
     { "http://example.com/p": [ { "@list": [ { "@value": "a" } ] } ] }
   ])");

--- a/test/jsonld/jsonld_expand_error_test.cc
+++ b/test/jsonld/jsonld_expand_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
@@ -38,7 +38,7 @@ auto remote_resolver() -> sourcemeta::core::JSONLDResolver {
 
 } // namespace
 
-TEST(JSONLD_expand_error, cyclic_iri_mapping) {
+TEST(cyclic_iri_mapping) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "term": { "@id": "term:term" } }
   })");
@@ -47,7 +47,7 @@ TEST(JSONLD_expand_error, cyclic_iri_mapping) {
                              "Cyclic IRI mapping", "/@context/term");
 }
 
-TEST(JSONLD_expand_error, invalid_term_definition_empty) {
+TEST(invalid_term_definition_empty) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "": "http://example.com/" }
   })");
@@ -56,7 +56,7 @@ TEST(JSONLD_expand_error, invalid_term_definition_empty) {
                              "Invalid term definition", "/@context");
 }
 
-TEST(JSONLD_expand_error, keyword_redefinition) {
+TEST(keyword_redefinition) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "@type": "http://example.com/" }
   })");
@@ -65,7 +65,7 @@ TEST(JSONLD_expand_error, keyword_redefinition) {
                              "Keyword redefinition", "/@context/@type");
 }
 
-TEST(JSONLD_expand_error, protected_term_redefinition) {
+TEST(protected_term_redefinition) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": [
       { "@protected": true, "a": "http://example.com/a" },
@@ -77,7 +77,7 @@ TEST(JSONLD_expand_error, protected_term_redefinition) {
                              "Protected term redefinition", "/@context/1/a");
 }
 
-TEST(JSONLD_expand_error, invalid_protected_value) {
+TEST(invalid_protected_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@protected": "yes" } }
   })");
@@ -87,7 +87,7 @@ TEST(JSONLD_expand_error, invalid_protected_value) {
                              "/@context/a/@protected");
 }
 
-TEST(JSONLD_expand_error, invalid_iri_mapping) {
+TEST(invalid_iri_mapping) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": true } }
   })");
@@ -96,7 +96,7 @@ TEST(JSONLD_expand_error, invalid_iri_mapping) {
                              "Invalid IRI mapping", "/@context/a/@id");
 }
 
-TEST(JSONLD_expand_error, invalid_keyword_alias) {
+TEST(invalid_keyword_alias) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "@context" } }
   })");
@@ -105,7 +105,7 @@ TEST(JSONLD_expand_error, invalid_keyword_alias) {
                              "Invalid keyword alias", "/@context/a/@id");
 }
 
-TEST(JSONLD_expand_error, invalid_reverse_property) {
+TEST(invalid_reverse_property) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "a": { "@reverse": "http://example.com/a", "@id": "http://example.com/b" }
@@ -117,7 +117,7 @@ TEST(JSONLD_expand_error, invalid_reverse_property) {
                              "/@context/a/@reverse");
 }
 
-TEST(JSONLD_expand_error, invalid_type_mapping) {
+TEST(invalid_type_mapping) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@type": true } }
   })");
@@ -126,7 +126,7 @@ TEST(JSONLD_expand_error, invalid_type_mapping) {
                              "Invalid type mapping", "/@context/a/@type");
 }
 
-TEST(JSONLD_expand_error, invalid_container_mapping) {
+TEST(invalid_container_mapping) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@container": "@unknown" } }
   })");
@@ -136,7 +136,7 @@ TEST(JSONLD_expand_error, invalid_container_mapping) {
                              "/@context/a/@container");
 }
 
-TEST(JSONLD_expand_error, invalid_language_mapping) {
+TEST(invalid_language_mapping) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@language": true } }
   })");
@@ -146,7 +146,7 @@ TEST(JSONLD_expand_error, invalid_language_mapping) {
                              "/@context/a/@language");
 }
 
-TEST(JSONLD_expand_error, invalid_prefix_value) {
+TEST(invalid_prefix_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@prefix": "yes" } }
   })");
@@ -155,7 +155,7 @@ TEST(JSONLD_expand_error, invalid_prefix_value) {
                              "Invalid @prefix value", "/@context/a/@prefix");
 }
 
-TEST(JSONLD_expand_error, invalid_nest_value_term) {
+TEST(invalid_nest_value_term) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@nest": "@id" } }
   })");
@@ -164,7 +164,7 @@ TEST(JSONLD_expand_error, invalid_nest_value_term) {
                              "Invalid @nest value", "/@context/a/@nest");
 }
 
-TEST(JSONLD_expand_error, invalid_scoped_context) {
+TEST(invalid_scoped_context) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "a": {
@@ -178,14 +178,14 @@ TEST(JSONLD_expand_error, invalid_scoped_context) {
                              "Invalid scoped context", "/@context/a/@context");
 }
 
-TEST(JSONLD_expand_error, invalid_local_context) {
+TEST(invalid_local_context) {
   const auto input = sourcemeta::core::parse_json(R"({ "@context": true })");
 
   EXPECT_JSONLD_EXPAND_ERROR(sourcemeta::core::jsonld_expand(input),
                              "Invalid local context", "/@context");
 }
 
-TEST(JSONLD_expand_error, invalid_version_value) {
+TEST(invalid_version_value) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@version": 2.0 } })");
 
@@ -193,7 +193,7 @@ TEST(JSONLD_expand_error, invalid_version_value) {
                              "Invalid @version value", "/@context/@version");
 }
 
-TEST(JSONLD_expand_error, invalid_propagate_value) {
+TEST(invalid_propagate_value) {
   const auto input = sourcemeta::core::parse_json(
       R"({ "@context": { "@propagate": "yes" } })");
 
@@ -202,7 +202,7 @@ TEST(JSONLD_expand_error, invalid_propagate_value) {
                              "/@context/@propagate");
 }
 
-TEST(JSONLD_expand_error, invalid_import_value) {
+TEST(invalid_import_value) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@import": true } })");
 
@@ -210,7 +210,7 @@ TEST(JSONLD_expand_error, invalid_import_value) {
                              "Invalid @import value", "/@context/@import");
 }
 
-TEST(JSONLD_expand_error, invalid_base_iri) {
+TEST(invalid_base_iri) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@base": true } })");
 
@@ -218,7 +218,7 @@ TEST(JSONLD_expand_error, invalid_base_iri) {
                              "Invalid base IRI", "/@context/@base");
 }
 
-TEST(JSONLD_expand_error, invalid_vocab_mapping) {
+TEST(invalid_vocab_mapping) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@vocab": true } })");
 
@@ -226,7 +226,7 @@ TEST(JSONLD_expand_error, invalid_vocab_mapping) {
                              "Invalid vocab mapping", "/@context/@vocab");
 }
 
-TEST(JSONLD_expand_error, invalid_default_language) {
+TEST(invalid_default_language) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@language": true } })");
 
@@ -234,7 +234,7 @@ TEST(JSONLD_expand_error, invalid_default_language) {
                              "Invalid default language", "/@context/@language");
 }
 
-TEST(JSONLD_expand_error, invalid_base_direction) {
+TEST(invalid_base_direction) {
   const auto input = sourcemeta::core::parse_json(
       R"({ "@context": { "@direction": "sideways" } })");
 
@@ -242,7 +242,7 @@ TEST(JSONLD_expand_error, invalid_base_direction) {
                              "Invalid base direction", "/@context/@direction");
 }
 
-TEST(JSONLD_expand_error, processing_mode_conflict) {
+TEST(processing_mode_conflict) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@version": 1.1 } })");
 
@@ -252,7 +252,7 @@ TEST(JSONLD_expand_error, processing_mode_conflict) {
       "Processing mode conflict", "/@context/@version");
 }
 
-TEST(JSONLD_expand_error, invalid_context_entry) {
+TEST(invalid_context_entry) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@context": { "@protected": true } })");
 
@@ -262,7 +262,7 @@ TEST(JSONLD_expand_error, invalid_context_entry) {
       "Invalid context entry", "/@context");
 }
 
-TEST(JSONLD_expand_error, loading_remote_context_failed) {
+TEST(loading_remote_context_failed) {
   const auto input = sourcemeta::core::parse_json(
       R"({ "@context": "https://example.com/missing" })");
 
@@ -271,7 +271,7 @@ TEST(JSONLD_expand_error, loading_remote_context_failed) {
       "Loading remote context failed", "/@context");
 }
 
-TEST(JSONLD_expand_error, invalid_remote_context) {
+TEST(invalid_remote_context) {
   const auto input = sourcemeta::core::parse_json(
       R"({ "@context": "https://example.com/no-context" })");
 
@@ -280,7 +280,7 @@ TEST(JSONLD_expand_error, invalid_remote_context) {
       "Invalid remote context", "/@context");
 }
 
-TEST(JSONLD_expand_error, recursive_context_inclusion) {
+TEST(recursive_context_inclusion) {
   const auto input = sourcemeta::core::parse_json(
       R"({ "@context": "https://example.com/recursive" })");
 
@@ -289,7 +289,7 @@ TEST(JSONLD_expand_error, recursive_context_inclusion) {
       "Recursive context inclusion", "/@context");
 }
 
-TEST(JSONLD_expand_error, colliding_keywords) {
+TEST(colliding_keywords) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "id": "@id" },
     "@id": "http://example.com/a",
@@ -300,21 +300,21 @@ TEST(JSONLD_expand_error, colliding_keywords) {
                              "Colliding keywords", "/id");
 }
 
-TEST(JSONLD_expand_error, invalid_id_value) {
+TEST(invalid_id_value) {
   const auto input = sourcemeta::core::parse_json(R"({ "@id": true })");
 
   EXPECT_JSONLD_EXPAND_ERROR(sourcemeta::core::jsonld_expand(input),
                              "Invalid @id value", "/@id");
 }
 
-TEST(JSONLD_expand_error, invalid_type_value) {
+TEST(invalid_type_value) {
   const auto input = sourcemeta::core::parse_json(R"({ "@type": true })");
 
   EXPECT_JSONLD_EXPAND_ERROR(sourcemeta::core::jsonld_expand(input),
                              "Invalid type value", "/@type");
 }
 
-TEST(JSONLD_expand_error, invalid_value_object) {
+TEST(invalid_value_object) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": {
       "@value": "x", "@type": "http://example.com/t", "@language": "en"
@@ -326,7 +326,7 @@ TEST(JSONLD_expand_error, invalid_value_object) {
                              "/http:~1~1example.com~1p");
 }
 
-TEST(JSONLD_expand_error, invalid_language_tagged_string) {
+TEST(invalid_language_tagged_string) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@value": "x", "@language": true }
   })");
@@ -336,7 +336,7 @@ TEST(JSONLD_expand_error, invalid_language_tagged_string) {
                              "/http:~1~1example.com~1p/@language");
 }
 
-TEST(JSONLD_expand_error, invalid_language_tagged_value) {
+TEST(invalid_language_tagged_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@value": 1, "@language": "en" }
   })");
@@ -346,7 +346,7 @@ TEST(JSONLD_expand_error, invalid_language_tagged_value) {
                              "/http:~1~1example.com~1p");
 }
 
-TEST(JSONLD_expand_error, invalid_typed_value) {
+TEST(invalid_typed_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@value": "x", "@type": "_:b" }
   })");
@@ -355,7 +355,7 @@ TEST(JSONLD_expand_error, invalid_typed_value) {
                              "Invalid typed value", "/http:~1~1example.com~1p");
 }
 
-TEST(JSONLD_expand_error, invalid_value_object_value) {
+TEST(invalid_value_object_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@value": { "a": 1 } }
   })");
@@ -365,7 +365,7 @@ TEST(JSONLD_expand_error, invalid_value_object_value) {
                              "/http:~1~1example.com~1p");
 }
 
-TEST(JSONLD_expand_error, invalid_set_or_list_object) {
+TEST(invalid_set_or_list_object) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@list": [ "a" ], "@id": "http://example.com/x" }
   })");
@@ -375,7 +375,7 @@ TEST(JSONLD_expand_error, invalid_set_or_list_object) {
                              "/http:~1~1example.com~1p");
 }
 
-TEST(JSONLD_expand_error, invalid_index_value) {
+TEST(invalid_index_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@index": true, "@value": "x" }
   })");
@@ -385,14 +385,14 @@ TEST(JSONLD_expand_error, invalid_index_value) {
                              "/http:~1~1example.com~1p/@index");
 }
 
-TEST(JSONLD_expand_error, invalid_reverse_value) {
+TEST(invalid_reverse_value) {
   const auto input = sourcemeta::core::parse_json(R"({ "@reverse": "foo" })");
 
   EXPECT_JSONLD_EXPAND_ERROR(sourcemeta::core::jsonld_expand(input),
                              "Invalid @reverse value", "/@reverse");
 }
 
-TEST(JSONLD_expand_error, invalid_reverse_property_value) {
+TEST(invalid_reverse_property_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@reverse": { "http://example.com/p": { "@value": "x" } }
   })");
@@ -401,7 +401,7 @@ TEST(JSONLD_expand_error, invalid_reverse_property_value) {
                              "Invalid reverse property value", "/@reverse");
 }
 
-TEST(JSONLD_expand_error, invalid_included_value) {
+TEST(invalid_included_value) {
   const auto input =
       sourcemeta::core::parse_json(R"({ "@included": { "@value": "x" } })");
 
@@ -409,7 +409,7 @@ TEST(JSONLD_expand_error, invalid_included_value) {
                              "Invalid @included value", "/@included");
 }
 
-TEST(JSONLD_expand_error, invalid_nest_value_expansion) {
+TEST(invalid_nest_value_expansion) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "nest": "@nest" },
     "nest": { "@value": "x" }
@@ -419,7 +419,7 @@ TEST(JSONLD_expand_error, invalid_nest_value_expansion) {
                              "Invalid @nest value", "/nest");
 }
 
-TEST(JSONLD_expand_error, list_of_lists) {
+TEST(list_of_lists) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/p": { "@list": [ { "@list": [ "a" ] } ] }
   })");
@@ -430,7 +430,7 @@ TEST(JSONLD_expand_error, list_of_lists) {
       "List of lists", "/http:~1~1example.com~1p/@list");
 }
 
-TEST(JSONLD_expand_error, invalid_base_direction_in_value_object) {
+TEST(invalid_base_direction_in_value_object) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "p": "http://example.com/p" },
     "p": { "@value": "v", "@direction": "up" }
@@ -440,7 +440,7 @@ TEST(JSONLD_expand_error, invalid_base_direction_in_value_object) {
                              "Invalid base direction", "/p/@direction");
 }
 
-TEST(JSONLD_expand_error, keyword_alias_dropped_inside_reverse_map) {
+TEST(keyword_alias_dropped_inside_reverse_map) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "none": "@none" },
     "@reverse": { "none": "x" }
@@ -450,7 +450,7 @@ TEST(JSONLD_expand_error, keyword_alias_dropped_inside_reverse_map) {
                              "Invalid reverse property map", "/@reverse/none");
 }
 
-TEST(JSONLD_expand_error, colliding_type_in_json_ld_1_0) {
+TEST(colliding_type_in_json_ld_1_0) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "type": "@type" },
     "@type": "http://example.com/A",
@@ -463,7 +463,7 @@ TEST(JSONLD_expand_error, colliding_type_in_json_ld_1_0) {
       "Colliding keywords", "/type");
 }
 
-TEST(JSONLD_expand_error, invalid_language_tagged_string_without_value) {
+TEST(invalid_language_tagged_string_without_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "p": "http://example.com/p" },
     "p": { "@language": 42 }
@@ -473,7 +473,7 @@ TEST(JSONLD_expand_error, invalid_language_tagged_string_without_value) {
                              "Invalid language-tagged string", "/p/@language");
 }
 
-TEST(JSONLD_expand_error, protected_in_term_definition_in_1_0) {
+TEST(protected_in_term_definition_in_1_0) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@protected": true } }
   })");
@@ -484,7 +484,7 @@ TEST(JSONLD_expand_error, protected_in_term_definition_in_1_0) {
       "Invalid term definition", "/@context/a/@protected");
 }
 
-TEST(JSONLD_expand_error, nest_in_term_definition_in_1_0) {
+TEST(nest_in_term_definition_in_1_0) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@nest": "@nest" } }
   })");
@@ -495,7 +495,7 @@ TEST(JSONLD_expand_error, nest_in_term_definition_in_1_0) {
       "Invalid term definition", "/@context/a/@nest");
 }
 
-TEST(JSONLD_expand_error, prefix_on_compact_iri_term) {
+TEST(prefix_on_compact_iri_term) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "ex": "http://example.com/",
@@ -508,7 +508,7 @@ TEST(JSONLD_expand_error, prefix_on_compact_iri_term) {
                              "/@context/ex:foo/@prefix");
 }
 
-TEST(JSONLD_expand_error, invalid_base_direction_in_term_definition) {
+TEST(invalid_base_direction_in_term_definition) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@direction": "up" } }
   })");
@@ -518,7 +518,7 @@ TEST(JSONLD_expand_error, invalid_base_direction_in_term_definition) {
                              "/@context/a/@direction");
 }
 
-TEST(JSONLD_expand_error, invalid_container_array_combination) {
+TEST(invalid_container_array_combination) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "a": { "@id": "http://example.com/a", "@container": [ "@id", "@language" ] }
@@ -530,7 +530,7 @@ TEST(JSONLD_expand_error, invalid_container_array_combination) {
                              "/@context/a/@container");
 }
 
-TEST(JSONLD_expand_error, unknown_entry_in_term_definition) {
+TEST(unknown_entry_in_term_definition) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "a": { "@id": "http://example.com/a", "@bogus": true } }
   })");
@@ -539,7 +539,7 @@ TEST(JSONLD_expand_error, unknown_entry_in_term_definition) {
                              "Invalid term definition", "/@context/a");
 }
 
-TEST(JSONLD_expand_error, type_keyword_container_id) {
+TEST(type_keyword_container_id) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "@type": { "@container": "@id" } }
   })");
@@ -548,7 +548,7 @@ TEST(JSONLD_expand_error, type_keyword_container_id) {
                              "Keyword redefinition", "/@context/@type");
 }
 
-TEST(JSONLD_expand_error, invalid_version_precedes_mode_conflict) {
+TEST(invalid_version_precedes_mode_conflict) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "@version": 1.5 }
   })");
@@ -559,7 +559,7 @@ TEST(JSONLD_expand_error, invalid_version_precedes_mode_conflict) {
       "Invalid @version value", "/@context/@version");
 }
 
-TEST(JSONLD_expand_error, relative_base_without_base) {
+TEST(relative_base_without_base) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": [ { "@base": null }, { "@base": "relative/path" } ]
   })");
@@ -568,7 +568,7 @@ TEST(JSONLD_expand_error, relative_base_without_base) {
                              "Invalid base IRI", "/@context/1/@base");
 }
 
-TEST(JSONLD_expand_error, protected_null_term_redefinition) {
+TEST(protected_null_term_redefinition) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": [
       { "term": { "@id": null, "@protected": true } },
@@ -580,7 +580,7 @@ TEST(JSONLD_expand_error, protected_null_term_redefinition) {
                              "Protected term redefinition", "/@context/1/term");
 }
 
-TEST(JSONLD_expand_error, free_floating_invalid_set_or_list_object) {
+TEST(free_floating_invalid_set_or_list_object) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@list": [ "foo" ], "@id": "http://example.com/bar"
   })");
@@ -589,7 +589,7 @@ TEST(JSONLD_expand_error, free_floating_invalid_set_or_list_object) {
                              "Invalid set or list object", "");
 }
 
-TEST(JSONLD_expand_error, import_loading_failed) {
+TEST(import_loading_failed) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "@import": "https://example.com/unknown" }
   })");
@@ -599,7 +599,7 @@ TEST(JSONLD_expand_error, import_loading_failed) {
       "Loading remote context failed", "/@context/@import");
 }
 
-TEST(JSONLD_expand_error, duplicate_container_keyword) {
+TEST(duplicate_container_keyword) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "a": { "@id": "http://example.com/a", "@container": [ "@set", "@set" ] }
@@ -611,7 +611,7 @@ TEST(JSONLD_expand_error, duplicate_container_keyword) {
                              "/@context/a/@container");
 }
 
-TEST(JSONLD_expand_error, error_code_value_is_owned) {
+TEST(error_code_value_is_owned) {
   std::string code{"A custom error code longer than small string optimization"};
   const sourcemeta::core::JSONLDError error{code.c_str(),
                                             sourcemeta::core::Pointer{}};

--- a/test/jsonld/jsonld_expand_test.cc
+++ b/test/jsonld/jsonld_expand_test.cc
@@ -1,17 +1,17 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
 
 #include <optional> // std::optional, std::nullopt
 
-TEST(JSONLD_expand, empty_object) {
+TEST(empty_object) {
   const auto input = sourcemeta::core::parse_json("{}");
   const auto expected = sourcemeta::core::parse_json("[]");
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, absolute_iri_property_with_string_value) {
+TEST(absolute_iri_property_with_string_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/foo": "bar"
   })");
@@ -25,7 +25,7 @@ TEST(JSONLD_expand, absolute_iri_property_with_string_value) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, node_with_id_and_property) {
+TEST(node_with_id_and_property) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@id": "http://example.com/a",
     "http://example.com/foo": "bar"
@@ -41,7 +41,7 @@ TEST(JSONLD_expand, node_with_id_and_property) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, type_is_made_an_array) {
+TEST(type_is_made_an_array) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@id": "http://example.com/a",
     "@type": "http://example.com/T",
@@ -59,7 +59,7 @@ TEST(JSONLD_expand, type_is_made_an_array) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, multiple_values_preserve_order) {
+TEST(multiple_values_preserve_order) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/foo": [ "a", "b" ]
   })");
@@ -73,7 +73,7 @@ TEST(JSONLD_expand, multiple_values_preserve_order) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, numeric_value) {
+TEST(numeric_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/foo": 1
   })");
@@ -87,7 +87,7 @@ TEST(JSONLD_expand, numeric_value) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, boolean_value) {
+TEST(boolean_value) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/foo": true
   })");
@@ -101,7 +101,7 @@ TEST(JSONLD_expand, boolean_value) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, undefined_term_without_context_is_dropped) {
+TEST(undefined_term_without_context_is_dropped) {
   const auto input = sourcemeta::core::parse_json(R"({
     "foo": "bar"
   })");
@@ -111,7 +111,7 @@ TEST(JSONLD_expand, undefined_term_without_context_is_dropped) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, term_maps_to_iri) {
+TEST(term_maps_to_iri) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "name": "http://example.com/name" },
     "name": "John"
@@ -126,7 +126,7 @@ TEST(JSONLD_expand, term_maps_to_iri) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, vocabulary_mapping) {
+TEST(vocabulary_mapping) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "@vocab": "http://example.com/" },
     "name": "John"
@@ -141,7 +141,7 @@ TEST(JSONLD_expand, vocabulary_mapping) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, compact_iri_via_prefix) {
+TEST(compact_iri_via_prefix) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "ex": "http://example.com/" },
     "ex:name": "John"
@@ -156,7 +156,7 @@ TEST(JSONLD_expand, compact_iri_via_prefix) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, type_coercion_to_id) {
+TEST(type_coercion_to_id) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "knows": { "@id": "http://example.com/knows", "@type": "@id" }
@@ -173,7 +173,7 @@ TEST(JSONLD_expand, type_coercion_to_id) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, type_coercion_to_datatype) {
+TEST(type_coercion_to_datatype) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "born": {
@@ -198,7 +198,7 @@ TEST(JSONLD_expand, type_coercion_to_datatype) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, default_language) {
+TEST(default_language) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "@language": "en", "name": "http://example.com/name" },
     "name": "John"
@@ -213,7 +213,7 @@ TEST(JSONLD_expand, default_language) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, list_keyword) {
+TEST(list_keyword) {
   const auto input = sourcemeta::core::parse_json(R"({
     "http://example.com/foo": { "@list": [ "a", "b" ] }
   })");
@@ -229,7 +229,7 @@ TEST(JSONLD_expand, list_keyword) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, direction_dropped_in_json_ld_1_0) {
+TEST(direction_dropped_in_json_ld_1_0) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "p": "http://example.com/p" },
     "p": { "@value": "v", "@direction": "rtl" }
@@ -244,7 +244,7 @@ TEST(JSONLD_expand, direction_dropped_in_json_ld_1_0) {
             expected);
 }
 
-TEST(JSONLD_expand, included_dropped_in_json_ld_1_0) {
+TEST(included_dropped_in_json_ld_1_0) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "p": "http://example.com/p" },
     "p": "v",
@@ -260,7 +260,7 @@ TEST(JSONLD_expand, included_dropped_in_json_ld_1_0) {
             expected);
 }
 
-TEST(JSONLD_expand, nest_term_whose_scoped_context_redefines_itself) {
+TEST(nest_term_whose_scoped_context_redefines_itself) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "nest": {
@@ -278,7 +278,7 @@ TEST(JSONLD_expand, nest_term_whose_scoped_context_redefines_itself) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, json_typed_value_in_list_container) {
+TEST(json_typed_value_in_list_container) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "e": {
@@ -301,7 +301,7 @@ TEST(JSONLD_expand, json_typed_value_in_list_container) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, id_typed_keyword_form_value_expands_to_null) {
+TEST(id_typed_keyword_form_value_expands_to_null) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": { "p": { "@id": "http://example.com/p", "@type": "@id" } },
     "p": "@foo"
@@ -314,7 +314,7 @@ TEST(JSONLD_expand, id_typed_keyword_form_value_expands_to_null) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, non_expandable_type_value_is_omitted) {
+TEST(non_expandable_type_value_is_omitted) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@id": "http://example.com/n",
     "@type": "@foo",
@@ -331,13 +331,13 @@ TEST(JSONLD_expand, non_expandable_type_value_is_omitted) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, graph_value_expanding_to_null_yields_no_element) {
+TEST(graph_value_expanding_to_null_yields_no_element) {
   const auto input = sourcemeta::core::parse_json(R"({ "@graph": "scalar" })");
   const auto expected = sourcemeta::core::parse_json("[]");
   EXPECT_EQ(sourcemeta::core::jsonld_expand(input), expected);
 }
 
-TEST(JSONLD_expand, base_in_remote_context_is_ignored) {
+TEST(base_in_remote_context_is_ignored) {
   const sourcemeta::core::JSONLDResolver resolver =
       [](const sourcemeta::core::JSON::StringView identifier)
       -> std::optional<sourcemeta::core::JSON> {
@@ -366,7 +366,7 @@ TEST(JSONLD_expand, base_in_remote_context_is_ignored) {
       expected);
 }
 
-TEST(JSONLD_expand, language_map_direction_uses_property_scoped_context) {
+TEST(language_map_direction_uses_property_scoped_context) {
   const auto input = sourcemeta::core::parse_json(R"({
     "@context": {
       "p": {

--- a/test/jsonld/jsonld_flatten_test.cc
+++ b/test/jsonld/jsonld_flatten_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
 
-TEST(JSONLD_flatten, nested_anonymous_node_gets_blank_node_identifier) {
+TEST(nested_anonymous_node_gets_blank_node_identifier) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/a",
@@ -27,7 +27,7 @@ TEST(JSONLD_flatten, nested_anonymous_node_gets_blank_node_identifier) {
   EXPECT_EQ(sourcemeta::core::jsonld_flatten(input), expected);
 }
 
-TEST(JSONLD_flatten, named_graph_is_folded_into_graph_entry) {
+TEST(named_graph_is_folded_into_graph_entry) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/g",
@@ -55,7 +55,7 @@ TEST(JSONLD_flatten, named_graph_is_folded_into_graph_entry) {
   EXPECT_EQ(sourcemeta::core::jsonld_flatten(input), expected);
 }
 
-TEST(JSONLD_flatten, reverse_property_becomes_forward_edge) {
+TEST(reverse_property_becomes_forward_edge) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/a",
@@ -75,7 +75,7 @@ TEST(JSONLD_flatten, reverse_property_becomes_forward_edge) {
   EXPECT_EQ(sourcemeta::core::jsonld_flatten(input), expected);
 }
 
-TEST(JSONLD_flatten, list_value_is_preserved) {
+TEST(list_value_is_preserved) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/a",
@@ -97,7 +97,7 @@ TEST(JSONLD_flatten, list_value_is_preserved) {
   EXPECT_EQ(sourcemeta::core::jsonld_flatten(input), expected);
 }
 
-TEST(JSONLD_flatten, set_object_items_are_unwrapped) {
+TEST(set_object_items_are_unwrapped) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/a",
@@ -117,7 +117,7 @@ TEST(JSONLD_flatten, set_object_items_are_unwrapped) {
   EXPECT_EQ(sourcemeta::core::jsonld_flatten(input), expected);
 }
 
-TEST(JSONLD_flatten, set_object_wrapping_anonymous_node) {
+TEST(set_object_wrapping_anonymous_node) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/a",
@@ -141,7 +141,7 @@ TEST(JSONLD_flatten, set_object_wrapping_anonymous_node) {
   EXPECT_EQ(sourcemeta::core::jsonld_flatten(input), expected);
 }
 
-TEST(JSONLD_flatten, conflicting_indexes_are_rejected) {
+TEST(conflicting_indexes_are_rejected) {
   const auto input = sourcemeta::core::parse_json(R"([
     { "@id": "http://example.com/a", "@index": "1" },
     { "@id": "http://example.com/a", "@index": "2" }
@@ -155,7 +155,7 @@ TEST(JSONLD_flatten, conflicting_indexes_are_rejected) {
   }
 }
 
-TEST(JSONLD_flatten, flatten_and_compact_against_context) {
+TEST(flatten_and_compact_against_context) {
   const auto input = sourcemeta::core::parse_json(R"([
     {
       "@id": "http://example.com/a",

--- a/test/jsonld/jsonld_is_expanded_test.cc
+++ b/test/jsonld/jsonld_is_expanded_test.cc
@@ -1,35 +1,35 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
 
-TEST(JSONLD_is_expanded, empty_array) {
+TEST(empty_array) {
   const auto document = sourcemeta::core::parse_json("[]");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, single_node_with_id) {
+TEST(single_node_with_id) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": "http://example.com/a" }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, node_with_iri_property) {
+TEST(node_with_iri_property) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": "bar" } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, node_with_type_array) {
+TEST(node_with_type_array) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": "http://example.com/a", "@type": [ "http://example.com/T" ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_with_datatype) {
+TEST(value_object_with_datatype) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@value": "v", "@type": "http://example.com/t" } ] }
@@ -37,14 +37,14 @@ TEST(JSONLD_is_expanded, value_object_with_datatype) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_with_language) {
+TEST(value_object_with_language) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": "v", "@language": "en" } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_with_language_and_direction) {
+TEST(value_object_with_language_and_direction) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@value": "v", "@language": "ar", "@direction": "rtl" } ] }
@@ -52,7 +52,7 @@ TEST(JSONLD_is_expanded, value_object_with_language_and_direction) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_json_literal) {
+TEST(value_object_json_literal) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@value": { "foo": "bar" }, "@type": "@json" } ] }
@@ -60,35 +60,35 @@ TEST(JSONLD_is_expanded, value_object_json_literal) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_native_number) {
+TEST(value_object_native_number) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": 4 } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_native_boolean) {
+TEST(value_object_native_boolean) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": true } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_with_index) {
+TEST(value_object_with_index) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": "v", "@index": "i" } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, list_object) {
+TEST(list_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@list": [ { "@value": "a" } ] } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, nested_list_object) {
+TEST(nested_list_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@list": [ { "@list": [ { "@value": "a" } ] } ] } ] }
@@ -96,21 +96,21 @@ TEST(JSONLD_is_expanded, nested_list_object) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, set_object) {
+TEST(set_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@set": [ { "@value": "a" } ] } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, graph_object) {
+TEST(graph_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@graph": [ { "@id": "http://example.com/a" } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, reverse_object) {
+TEST(reverse_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@reverse": {
       "http://example.com/p": [ { "@id": "http://example.com/a" } ] } }
@@ -118,7 +118,7 @@ TEST(JSONLD_is_expanded, reverse_object) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, included_block) {
+TEST(included_block) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": "http://example.com/a",
       "@included": [ { "@id": "http://example.com/b" } ] }
@@ -126,124 +126,124 @@ TEST(JSONLD_is_expanded, included_block) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, blank_node_identifier) {
+TEST(blank_node_identifier) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": "_:b0" }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, blank_node_property_key) {
+TEST(blank_node_property_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "_:b0": [ { "@value": "x" } ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, empty_blank_node_identifier) {
+TEST(empty_blank_node_identifier) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": "_:" }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, empty_blank_node_property_key) {
+TEST(empty_blank_node_property_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "_:": [ { "@value": "x" } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, top_level_object) {
+TEST(top_level_object) {
   const auto document = sourcemeta::core::parse_json(R"({
     "@id": "http://example.com/a"
   })");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, top_level_scalar) {
+TEST(top_level_scalar) {
   const auto document = sourcemeta::core::parse_json(R"("foo")");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, top_level_value_object) {
+TEST(top_level_value_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@value": "x" }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, top_level_list_object) {
+TEST(top_level_list_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@list": [ { "@value": "x" } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, top_level_set_object) {
+TEST(top_level_set_object) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@set": [ { "@value": "x" } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, context_present) {
+TEST(context_present) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@context": {}, "@id": "http://example.com/a" }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, relative_iri_property_key) {
+TEST(relative_iri_property_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "foo": [ { "@value": "x" } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, id_not_string) {
+TEST(id_not_string) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": [ "http://example.com/a" ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, id_null) {
+TEST(id_null) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": null }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, id_relative_reference) {
+TEST(id_relative_reference) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@id": "../document-relative" }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, type_relative_reference) {
+TEST(type_relative_reference) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@type": [ "#document-relative" ] }
   ])");
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, type_not_array) {
+TEST(type_not_array) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@type": "http://example.com/T" }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, type_entry_not_string) {
+TEST(type_entry_not_string) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@type": [ [ "http://example.com/T" ] ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, unnormalized_valid_property_key) {
+TEST(unnormalized_valid_property_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/vocabulary/./rel2#fragment": [
       { "@value": "x" } ] }
@@ -251,7 +251,7 @@ TEST(JSONLD_is_expanded, unnormalized_valid_property_key) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, invalid_iri_property_key) {
+TEST(invalid_iri_property_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/vocabulary/./rel2##fragment-works": [
       { "@value": "#fragment-works" } ] }
@@ -259,28 +259,28 @@ TEST(JSONLD_is_expanded, invalid_iri_property_key) {
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, relative_property_key) {
+TEST(relative_property_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "vocabulary/rel": [ { "@value": "x" } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, property_value_not_array) {
+TEST(property_value_not_array) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": { "@value": "x" } }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, property_value_bare_scalar) {
+TEST(property_value_bare_scalar) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ "x" ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_with_extra_property) {
+TEST(value_object_with_extra_property) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@value": "x", "http://example.com/bar": [] } ] }
@@ -288,7 +288,7 @@ TEST(JSONLD_is_expanded, value_object_with_extra_property) {
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_type_and_language) {
+TEST(value_object_type_and_language) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@value": "x", "@type": "http://example.com/t", "@language": "en" } ] }
@@ -296,21 +296,21 @@ TEST(JSONLD_is_expanded, value_object_type_and_language) {
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_object_without_json_type) {
+TEST(value_object_object_without_json_type) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": { "a": 1 } } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_invalid_language) {
+TEST(value_object_invalid_language) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": "x", "@language": "not a tag" } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_object_invalid_direction) {
+TEST(value_object_invalid_direction) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@value": "x", "@language": "en", "@direction": "up" } ] }
@@ -318,7 +318,7 @@ TEST(JSONLD_is_expanded, value_object_invalid_direction) {
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, list_object_with_extra_property) {
+TEST(list_object_with_extra_property) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [
       { "@list": [], "http://example.com/bar": [] } ] }
@@ -326,21 +326,21 @@ TEST(JSONLD_is_expanded, list_object_with_extra_property) {
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, value_and_list_together) {
+TEST(value_and_list_together) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "http://example.com/foo": [ { "@value": "x", "@list": [] } ] }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, unknown_keyword_form_key) {
+TEST(unknown_keyword_form_key) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@foo": "x" }
   ])");
   EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(document));
 }
 
-TEST(JSONLD_is_expanded, reverse_value_not_array) {
+TEST(reverse_value_not_array) {
   const auto document = sourcemeta::core::parse_json(R"([
     { "@reverse": { "http://example.com/p": { "@id": "http://example.com/a" } } }
   ])");

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
@@ -6,7 +6,7 @@
 
 #include <functional> // std::cref
 
-TEST(JSONLD_materialize, node_with_literal_property) {
+TEST(node_with_literal_property) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "name": "Sourcemeta" })");
 
@@ -33,7 +33,7 @@ TEST(JSONLD_materialize, node_with_literal_property) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, literal_with_datatype) {
+TEST(literal_with_datatype) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "isbn": "978-0131103627" })");
 
@@ -66,7 +66,7 @@ TEST(JSONLD_materialize, literal_with_datatype) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, literal_with_language_and_direction) {
+TEST(literal_with_language_and_direction) {
   const auto instance = sourcemeta::core::parse_json(R"({ "title": "مرحبا" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -96,7 +96,7 @@ TEST(JSONLD_materialize, literal_with_language_and_direction) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, reference_property) {
+TEST(reference_property) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "currency": "USD" })");
 
@@ -130,7 +130,7 @@ TEST(JSONLD_materialize, reference_property) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, ordered_collection_becomes_list) {
+TEST(ordered_collection_becomes_list) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "authors": [ "Ada", "Alan" ] })");
 
@@ -175,7 +175,7 @@ TEST(JSONLD_materialize, ordered_collection_becomes_list) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, unordered_collection_spreads_into_property) {
+TEST(unordered_collection_spreads_into_property) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "tags": [ "a", "b" ] })");
 
@@ -209,7 +209,7 @@ TEST(JSONLD_materialize, unordered_collection_spreads_into_property) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, field_with_multiple_predicates) {
+TEST(field_with_multiple_predicates) {
   const auto instance = sourcemeta::core::parse_json(R"({ "label": "Hi" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -238,7 +238,7 @@ TEST(JSONLD_materialize, field_with_multiple_predicates) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, reverse_edge) {
+TEST(reverse_edge) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "series": { "name": "Trilogy" } })");
 
@@ -273,7 +273,7 @@ TEST(JSONLD_materialize, reverse_edge) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, shared_blank_node_identifier_co_refers) {
+TEST(shared_blank_node_identifier_co_refers) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "billing": {}, "shipping": {} })");
 
@@ -305,7 +305,7 @@ TEST(JSONLD_materialize, shared_blank_node_identifier_co_refers) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, json_literal_preserved_verbatim) {
+TEST(json_literal_preserved_verbatim) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "payload": { "a": [ 1, 2 ] } })");
 
@@ -334,7 +334,7 @@ TEST(JSONLD_materialize, json_literal_preserved_verbatim) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, nested_ordered_collection_is_list_of_lists) {
+TEST(nested_ordered_collection_is_list_of_lists) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "matrix": [ [ 5 ] ] })");
 
@@ -385,7 +385,7 @@ TEST(JSONLD_materialize, nested_ordered_collection_is_list_of_lists) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, undescribed_object_with_described_child) {
+TEST(undescribed_object_with_described_child) {
   const auto instance = sourcemeta::core::parse_json(
       R"({ "name": "Doc", "meta": { "title": "T" } })");
 
@@ -417,7 +417,7 @@ TEST(JSONLD_materialize, undescribed_object_with_described_child) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, described_node_without_edge_is_standalone) {
+TEST(described_node_without_edge_is_standalone) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "extra": { "x": "v" } })");
 
@@ -450,7 +450,7 @@ TEST(JSONLD_materialize, described_node_without_edge_is_standalone) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, null_value_produces_no_triple) {
+TEST(null_value_produces_no_triple) {
   const auto instance = sourcemeta::core::parse_json(R"({ "maybe": null })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -473,7 +473,7 @@ TEST(JSONLD_materialize, null_value_produces_no_triple) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, named_graph) {
+TEST(named_graph) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "prov": { "who": "X" } })");
 
@@ -515,7 +515,7 @@ TEST(JSONLD_materialize, named_graph) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, scalar_root_reference) {
+TEST(scalar_root_reference) {
   const auto instance = sourcemeta::core::parse_json(R"("USD")");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -538,7 +538,7 @@ TEST(JSONLD_materialize, scalar_root_reference) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, empty_map_yields_empty_array) {
+TEST(empty_map_yields_empty_array) {
   const auto instance = sourcemeta::core::parse_json(R"({ "a": 1 })");
   const sourcemeta::core::JSONLDAnnotationMap map;
 
@@ -549,7 +549,7 @@ TEST(JSONLD_materialize, empty_map_yields_empty_array) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, node_with_type) {
+TEST(node_with_type) {
   const auto instance = sourcemeta::core::parse_json(R"({ "name": "Ada" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -577,7 +577,7 @@ TEST(JSONLD_materialize, node_with_type) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, node_with_multiple_types) {
+TEST(node_with_multiple_types) {
   const auto instance = sourcemeta::core::parse_json(R"({})");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -601,7 +601,7 @@ TEST(JSONLD_materialize, node_with_multiple_types) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, reference_without_types) {
+TEST(reference_without_types) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "currency": "USD" })");
 
@@ -631,7 +631,7 @@ TEST(JSONLD_materialize, reference_without_types) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, literal_with_language_only) {
+TEST(literal_with_language_only) {
   const auto instance = sourcemeta::core::parse_json(R"({ "title": "Hello" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -657,7 +657,7 @@ TEST(JSONLD_materialize, literal_with_language_only) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, literal_with_ltr_direction) {
+TEST(literal_with_ltr_direction) {
   const auto instance = sourcemeta::core::parse_json(R"({ "title": "Hello" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -687,7 +687,7 @@ TEST(JSONLD_materialize, literal_with_ltr_direction) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, boolean_literal) {
+TEST(boolean_literal) {
   const auto instance = sourcemeta::core::parse_json(R"({ "active": true })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -713,7 +713,7 @@ TEST(JSONLD_materialize, boolean_literal) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, integer_literal_without_datatype) {
+TEST(integer_literal_without_datatype) {
   const auto instance = sourcemeta::core::parse_json(R"({ "count": 42 })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -739,7 +739,7 @@ TEST(JSONLD_materialize, integer_literal_without_datatype) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, ordered_collection_of_nodes) {
+TEST(ordered_collection_of_nodes) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "authors": [ { "name": "Ada" } ] })");
 
@@ -780,7 +780,7 @@ TEST(JSONLD_materialize, ordered_collection_of_nodes) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, unordered_collection_of_nodes) {
+TEST(unordered_collection_of_nodes) {
   const auto instance = sourcemeta::core::parse_json(
       R"({ "items": [ { "sku": "1" }, { "sku": "2" } ] })");
 
@@ -825,7 +825,7 @@ TEST(JSONLD_materialize, unordered_collection_of_nodes) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, empty_ordered_collection_is_rdf_nil) {
+TEST(empty_ordered_collection_is_rdf_nil) {
   const auto instance = sourcemeta::core::parse_json(R"({ "authors": [] })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -852,7 +852,7 @@ TEST(JSONLD_materialize, empty_ordered_collection_is_rdf_nil) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, empty_unordered_collection_adds_no_property) {
+TEST(empty_unordered_collection_adds_no_property) {
   const auto instance = sourcemeta::core::parse_json(R"({ "tags": [] })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -876,7 +876,7 @@ TEST(JSONLD_materialize, empty_unordered_collection_adds_no_property) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, collection_with_undescribed_elements_skips_them) {
+TEST(collection_with_undescribed_elements_skips_them) {
   const auto instance = sourcemeta::core::parse_json(
       R"({ "authors": [ "Ada", "Unknown", "Alan" ] })");
 
@@ -912,7 +912,7 @@ TEST(JSONLD_materialize, collection_with_undescribed_elements_skips_them) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, nested_unordered_collection_flattens) {
+TEST(nested_unordered_collection_flattens) {
   const auto instance = sourcemeta::core::parse_json(
       R"({ "groups": [ [ "a", "b" ], [ "c" ] ] })");
 
@@ -961,7 +961,7 @@ TEST(JSONLD_materialize, nested_unordered_collection_flattens) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, array_root_spreads_into_default_graph) {
+TEST(array_root_spreads_into_default_graph) {
   const auto instance =
       sourcemeta::core::parse_json(R"([ { "name": "A" }, { "name": "B" } ])");
 
@@ -1006,7 +1006,7 @@ TEST(JSONLD_materialize, array_root_spreads_into_default_graph) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, root_collection_of_literals_is_dropped) {
+TEST(root_collection_of_literals_is_dropped) {
   const auto instance = sourcemeta::core::parse_json(R"([ "a", "b" ])");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -1029,7 +1029,7 @@ TEST(JSONLD_materialize, root_collection_of_literals_is_dropped) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, root_collection_keeps_only_node_elements) {
+TEST(root_collection_keeps_only_node_elements) {
   const auto instance =
       sourcemeta::core::parse_json(R"([ { "name": "A" }, "loose" ])");
 
@@ -1064,7 +1064,7 @@ TEST(JSONLD_materialize, root_collection_keeps_only_node_elements) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, scalar_root_literal_is_dropped) {
+TEST(scalar_root_literal_is_dropped) {
   const auto instance = sourcemeta::core::parse_json(R"("hello")");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -1079,7 +1079,7 @@ TEST(JSONLD_materialize, scalar_root_literal_is_dropped) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, collection_descriptor_on_non_array_is_dropped) {
+TEST(collection_descriptor_on_non_array_is_dropped) {
   const auto instance = sourcemeta::core::parse_json(R"({ "x": "scalar" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -1103,7 +1103,7 @@ TEST(JSONLD_materialize, collection_descriptor_on_non_array_is_dropped) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, output_is_a_fixed_point_of_expansion) {
+TEST(output_is_a_fixed_point_of_expansion) {
   const auto instance = sourcemeta::core::parse_json(R"({
     "name": "Ada",
     "homepage": "https://ada.example",
@@ -1145,7 +1145,7 @@ TEST(JSONLD_materialize, output_is_a_fixed_point_of_expansion) {
   EXPECT_EQ(sourcemeta::core::jsonld_expand(result), result);
 }
 
-TEST(JSONLD_materialize, node_descriptor_on_scalar_ignores_value) {
+TEST(node_descriptor_on_scalar_ignores_value) {
   const auto instance = sourcemeta::core::parse_json(R"({ "x": "scalar" })");
 
   sourcemeta::core::JSONLDAnnotationMap map;
@@ -1172,7 +1172,7 @@ TEST(JSONLD_materialize, node_descriptor_on_scalar_ignores_value) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, weak_node_with_literal_property) {
+TEST(weak_node_with_literal_property) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "name": "Sourcemeta" })");
 
@@ -1201,7 +1201,7 @@ TEST(JSONLD_materialize, weak_node_with_literal_property) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, weak_reference_property) {
+TEST(weak_reference_property) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "currency": "USD" })");
 
@@ -1237,7 +1237,7 @@ TEST(JSONLD_materialize, weak_reference_property) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, weak_ordered_collection_becomes_list) {
+TEST(weak_ordered_collection_becomes_list) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "authors": [ "Ada", "Alan" ] })");
 
@@ -1284,7 +1284,7 @@ TEST(JSONLD_materialize, weak_ordered_collection_becomes_list) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, weak_reverse_edge) {
+TEST(weak_reverse_edge) {
   const auto instance =
       sourcemeta::core::parse_json(R"({ "series": { "name": "Trilogy" } })");
 
@@ -1323,7 +1323,7 @@ TEST(JSONLD_materialize, weak_reverse_edge) {
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
 
-TEST(JSONLD_materialize, weak_array_root_spreads_into_default_graph) {
+TEST(weak_array_root_spreads_into_default_graph) {
   const auto instance =
       sourcemeta::core::parse_json(R"([ { "name": "A" }, { "name": "B" } ])");
 

--- a/test/jsonpointer/CMakeLists.txt
+++ b/test/jsonpointer/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsonpointer
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonpointer
   SOURCES
     jsonpointer_empty_pointer_test.cc
     jsonpointer_get_test.cc

--- a/test/jsonpointer/jsonpointer_concat_test.cc
+++ b/test/jsonpointer/jsonpointer_concat_test.cc
@@ -1,49 +1,49 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_concat, multi_multi) {
+TEST(multi_multi) {
   const sourcemeta::core::Pointer left{"foo", "bar"};
   const sourcemeta::core::Pointer right{"baz", "qux"};
   const sourcemeta::core::Pointer result{"foo", "bar", "baz", "qux"};
   EXPECT_EQ(left.concat(right), result);
 }
 
-TEST(JSONPointer_concat, single_single) {
+TEST(single_single) {
   const sourcemeta::core::Pointer left{"foo"};
   const sourcemeta::core::Pointer right{"bar"};
   const sourcemeta::core::Pointer result{"foo", "bar"};
   EXPECT_EQ(left.concat(right), result);
 }
 
-TEST(JSONPointer_concat, empty_multi) {
+TEST(empty_multi) {
   const sourcemeta::core::Pointer left;
   const sourcemeta::core::Pointer right{"foo", "bar"};
   const sourcemeta::core::Pointer result{"foo", "bar"};
   EXPECT_EQ(left.concat(right), result);
 }
 
-TEST(JSONPointer_concat, multi_empty) {
+TEST(multi_empty) {
   const sourcemeta::core::Pointer left{"foo", "bar"};
   const sourcemeta::core::Pointer right;
   const sourcemeta::core::Pointer result{"foo", "bar"};
   EXPECT_EQ(left.concat(right), result);
 }
 
-TEST(JSONPointer_concat, empty_empty) {
+TEST(empty_empty) {
   const sourcemeta::core::Pointer left;
   const sourcemeta::core::Pointer right;
   const sourcemeta::core::Pointer result;
   EXPECT_EQ(left.concat(right), result);
 }
 
-TEST(JSONPointer_concat, single_property_token) {
+TEST(single_property_token) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer result{"foo", "bar"};
   EXPECT_EQ(pointer.concat("bar"), result);
 }
 
-TEST(JSONPointer_concat, single_index_token) {
+TEST(single_index_token) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer result{"foo", 0};
   EXPECT_EQ(pointer.concat(0), result);

--- a/test/jsonpointer/jsonpointer_empty_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_empty_pointer_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_empty_pointer, is_empty) {
+TEST(is_empty) {
   EXPECT_TRUE(sourcemeta::core::empty_pointer.empty());
   EXPECT_EQ(sourcemeta::core::empty_pointer, sourcemeta::core::Pointer{});
 }

--- a/test/jsonpointer/jsonpointer_error_test.cc
+++ b/test/jsonpointer/jsonpointer_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
@@ -7,7 +7,7 @@
 #include <string>      // std::string
 #include <type_traits> // std::is_base_of_v
 
-TEST(JSONPointer_error, parse_error) {
+TEST(parse_error) {
   static_assert(
       std::is_base_of_v<std::exception, sourcemeta::core::PointerParseError>,
       "Must subclass std::exception");
@@ -23,7 +23,7 @@ TEST(JSONPointer_error, parse_error) {
   EXPECT_EQ(exception.column(), 5);
 }
 
-TEST(JSONPointer_error, line_is_always_one) {
+TEST(line_is_always_one) {
   auto exception_1{sourcemeta::core::PointerParseError(5)};
   auto exception_2{sourcemeta::core::PointerParseError(1)};
   auto exception_3{sourcemeta::core::PointerParseError(8)};

--- a/test/jsonpointer/jsonpointer_fragment_to_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_fragment_to_pointer_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/uri.h>
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_base_and_fragment) {
+TEST(uri_with_base_and_fragment) {
   const sourcemeta::core::URI uri{"https://example.com#/foo/bar"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -14,26 +14,26 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_base_and_fragment) {
   EXPECT_EQ(pointer.value().at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_without_fragment) {
+TEST(uri_without_fragment) {
   const sourcemeta::core::URI uri{"https://example.com"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_FALSE(pointer.has_value());
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_empty_fragment) {
+TEST(uri_with_empty_fragment) {
   const auto uri{sourcemeta::core::URI::from_fragment("")};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
   EXPECT_TRUE(pointer.value().empty());
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_plain_name_fragment) {
+TEST(uri_with_plain_name_fragment) {
   const sourcemeta::core::URI uri{"#foo"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_FALSE(pointer.has_value());
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_index_token) {
+TEST(uri_with_index_token) {
   const sourcemeta::core::URI uri{"#/foo/0"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -44,7 +44,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_index_token) {
   EXPECT_EQ(pointer.value().at(1).to_index(), 0);
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_empty_tokens) {
+TEST(uri_with_empty_tokens) {
   const sourcemeta::core::URI uri{"#//"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -55,7 +55,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_empty_tokens) {
   EXPECT_EQ(pointer.value().at(1).to_property(), "");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_colon) {
+TEST(uri_with_percent_encoded_colon) {
   const sourcemeta::core::URI uri{
       "#/$defs/https%3A~1~1example.com~1schema~1type"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
@@ -68,7 +68,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_colon) {
             "https://example.com/schema/type");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_percent) {
+TEST(uri_with_percent_encoded_percent) {
   const sourcemeta::core::URI uri{"#/c%25d"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -77,7 +77,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_percent) {
   EXPECT_EQ(pointer.value().at(0).to_property(), "c%d");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_caret) {
+TEST(uri_with_percent_encoded_caret) {
   const sourcemeta::core::URI uri{"#/e%5Ef"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -86,7 +86,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_caret) {
   EXPECT_EQ(pointer.value().at(0).to_property(), "e^f");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_slash) {
+TEST(uri_with_percent_encoded_slash) {
   const sourcemeta::core::URI uri{"#/foo%2Fbar"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -97,7 +97,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_slash) {
   EXPECT_EQ(pointer.value().at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_leading_slash) {
+TEST(uri_with_percent_encoded_leading_slash) {
   const sourcemeta::core::URI uri{"#%2Ffoo"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -106,7 +106,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_percent_encoded_leading_slash) {
   EXPECT_EQ(pointer.value().at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_lowercase_percent_encoding) {
+TEST(uri_with_lowercase_percent_encoding) {
   const sourcemeta::core::URI uri{"#/a%3ab"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -115,7 +115,7 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_lowercase_percent_encoding) {
   EXPECT_EQ(pointer.value().at(0).to_property(), "a:b");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_lone_percent) {
+TEST(uri_with_lone_percent) {
   const auto uri{sourcemeta::core::URI::from_fragment("/100%")};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_TRUE(pointer.has_value());
@@ -124,20 +124,19 @@ TEST(JSONPointer_fragment_to_pointer, uri_with_lone_percent) {
   EXPECT_EQ(pointer.value().at(0).to_property(), "100%");
 }
 
-TEST(JSONPointer_fragment_to_pointer, uri_with_invalid_tilde_escape) {
+TEST(uri_with_invalid_tilde_escape) {
   const sourcemeta::core::URI uri{"#/a~b"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_FALSE(pointer.has_value());
 }
 
-TEST(JSONPointer_fragment_to_pointer,
-     uri_with_percent_encoded_invalid_tilde_escape) {
+TEST(uri_with_percent_encoded_invalid_tilde_escape) {
   const sourcemeta::core::URI uri{"#/a%7Eb"};
   const auto pointer{sourcemeta::core::fragment_to_pointer(uri)};
   EXPECT_FALSE(pointer.has_value());
 }
 
-TEST(JSONPointer_fragment_to_pointer, round_trip_tricky_tokens) {
+TEST(round_trip_tricky_tokens) {
   const sourcemeta::core::Pointer pointer{"a b",  "qu\"ote", "til~de", "sla/sh",
                                           "100%", "co:lon",  "café"};
   const auto result{
@@ -146,7 +145,7 @@ TEST(JSONPointer_fragment_to_pointer, round_trip_tricky_tokens) {
   EXPECT_EQ(result.value(), pointer);
 }
 
-TEST(JSONPointer_fragment_to_pointer, round_trip_tricky_tokens_with_base) {
+TEST(round_trip_tricky_tokens_with_base) {
   const sourcemeta::core::Pointer pointer{"a b",  "qu\"ote", "til~de", "sla/sh",
                                           "100%", "co:lon",  "café"};
   const sourcemeta::core::URI base{"https://www.example.com"};
@@ -156,7 +155,7 @@ TEST(JSONPointer_fragment_to_pointer, round_trip_tricky_tokens_with_base) {
   EXPECT_EQ(result.value(), pointer);
 }
 
-TEST(JSONPointer_fragment_to_pointer, round_trip_percent_encoded_colon) {
+TEST(round_trip_percent_encoded_colon) {
   const sourcemeta::core::Pointer pointer{"$defs",
                                           "https://example.com/schema/type"};
   const auto result{

--- a/test/jsonpointer/jsonpointer_get_test.cc
+++ b/test/jsonpointer/jsonpointer_get_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_get, integer_property) {
+TEST(integer_property) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "0": 1
   })JSON");
@@ -15,7 +15,7 @@ TEST(JSONPointer_get, integer_property) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, integer_property_as_character) {
+TEST(integer_property_as_character) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "0": 1
   })JSON");
@@ -27,7 +27,7 @@ TEST(JSONPointer_get, integer_property_as_character) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, character_after_property) {
+TEST(character_after_property) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": { "x": 1 }
   })JSON");
@@ -39,7 +39,7 @@ TEST(JSONPointer_get, character_after_property) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, const_empty) {
+TEST(const_empty) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": 1
   })JSON");
@@ -51,7 +51,7 @@ TEST(JSONPointer_get, const_empty) {
   EXPECT_EQ(result, document);
 }
 
-TEST(JSONPointer_get, empty) {
+TEST(empty) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": 1
   })JSON");
@@ -62,7 +62,7 @@ TEST(JSONPointer_get, empty) {
   EXPECT_EQ(result, document);
 }
 
-TEST(JSONPointer_get, const_foo) {
+TEST(const_foo) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": 1,
     "bar": 2,
@@ -76,7 +76,7 @@ TEST(JSONPointer_get, const_foo) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, foo) {
+TEST(foo) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": 1,
     "bar": 2,
@@ -89,7 +89,7 @@ TEST(JSONPointer_get, foo) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, const_foo_0_bar_1) {
+TEST(const_foo_0_bar_1) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": [
       { "bar": [ 1, 2, 3 ] },
@@ -104,7 +104,7 @@ TEST(JSONPointer_get, const_foo_0_bar_1) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONPointer_get, foo_0_bar_1) {
+TEST(foo_0_bar_1) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": [
       { "bar": [ 1, 2, 3 ] },
@@ -118,7 +118,7 @@ TEST(JSONPointer_get, foo_0_bar_1) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONPointer_get, slash) {
+TEST(slash) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "/": 1
   })JSON");
@@ -130,7 +130,7 @@ TEST(JSONPointer_get, slash) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, tilde) {
+TEST(tilde) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "~": 1
   })JSON");
@@ -142,7 +142,7 @@ TEST(JSONPointer_get, tilde) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, hyphen) {
+TEST(hyphen) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "-": 1
   })JSON");
@@ -155,7 +155,7 @@ TEST(JSONPointer_get, hyphen) {
 }
 
 // Escaping should only happen while parsing
-TEST(JSONPointer_get, no_tilde_0_escape) {
+TEST(no_tilde_0_escape) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "~0": 1
   })JSON");
@@ -168,7 +168,7 @@ TEST(JSONPointer_get, no_tilde_0_escape) {
 }
 
 // Escaping should only happen while parsing
-TEST(JSONPointer_get, no_tilde_1_escape) {
+TEST(no_tilde_1_escape) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "~1": 1
   })JSON");
@@ -181,7 +181,7 @@ TEST(JSONPointer_get, no_tilde_1_escape) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_1) {
+TEST(rfc6901_1) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -204,7 +204,7 @@ TEST(JSONPointer_get, rfc6901_1) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_2) {
+TEST(rfc6901_2) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -231,7 +231,7 @@ TEST(JSONPointer_get, rfc6901_2) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_3) {
+TEST(rfc6901_3) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -254,7 +254,7 @@ TEST(JSONPointer_get, rfc6901_3) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_4) {
+TEST(rfc6901_4) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -277,7 +277,7 @@ TEST(JSONPointer_get, rfc6901_4) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_5) {
+TEST(rfc6901_5) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -300,7 +300,7 @@ TEST(JSONPointer_get, rfc6901_5) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_6) {
+TEST(rfc6901_6) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -323,7 +323,7 @@ TEST(JSONPointer_get, rfc6901_6) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_7) {
+TEST(rfc6901_7) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -346,7 +346,7 @@ TEST(JSONPointer_get, rfc6901_7) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_8) {
+TEST(rfc6901_8) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -369,7 +369,7 @@ TEST(JSONPointer_get, rfc6901_8) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_9) {
+TEST(rfc6901_9) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -392,7 +392,7 @@ TEST(JSONPointer_get, rfc6901_9) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_10) {
+TEST(rfc6901_10) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -415,7 +415,7 @@ TEST(JSONPointer_get, rfc6901_10) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_11) {
+TEST(rfc6901_11) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -438,7 +438,7 @@ TEST(JSONPointer_get, rfc6901_11) {
 }
 
 // See https://www.rfc-editor.org/rfc/rfc6901#section-5
-TEST(JSONPointer_get, rfc6901_12) {
+TEST(rfc6901_12) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": ["bar", "baz"],
     "": 0,
@@ -464,7 +464,7 @@ TEST(JSONPointer_get, rfc6901_12) {
 // character.  Care is needed not to misinterpret this character in
 // programming languages that use NUL to mark the end of a string.
 // See https://www.rfc-editor.org/rfc/rfc6901#section-8
-TEST(JSONPointer_get, null) {
+TEST(null) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo\u0000bar": 1
   })JSON");
@@ -478,7 +478,7 @@ TEST(JSONPointer_get, null) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, positive_integer_property) {
+TEST(positive_integer_property) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "0": 1
   })JSON");
@@ -490,7 +490,7 @@ TEST(JSONPointer_get, positive_integer_property) {
   EXPECT_EQ(result.to_integer(), 1);
 }
 
-TEST(JSONPointer_get, token_property) {
+TEST(token_property) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": 2
   })JSON");
@@ -501,7 +501,7 @@ TEST(JSONPointer_get, token_property) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONPointer_get, token_index) {
+TEST(token_index) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON");
 
@@ -511,7 +511,7 @@ TEST(JSONPointer_get, token_index) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONPointer_get, token_hyphen) {
+TEST(token_hyphen) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "-": 2
   })JSON");
@@ -522,7 +522,7 @@ TEST(JSONPointer_get, token_hyphen) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONWeakPointer_get, token_property) {
+TEST(weak_token_property) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "foo": 2
   })JSON");
@@ -534,7 +534,7 @@ TEST(JSONWeakPointer_get, token_property) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONWeakPointer_get, token_index) {
+TEST(weak_token_index) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON");
 
@@ -544,7 +544,7 @@ TEST(JSONWeakPointer_get, token_index) {
   EXPECT_EQ(result.to_integer(), 2);
 }
 
-TEST(JSONWeakPointer_get, token_hyphen) {
+TEST(weak_token_hyphen) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "-": 2
   })JSON");

--- a/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
@@ -1,220 +1,218 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_is_relative_pointer, valid_zero) {
-  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0"));
-}
+TEST(valid_zero) { EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0")); }
 
-TEST(JSONPointer_is_relative_pointer, valid_single_digit) {
+TEST(valid_single_digit) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("1"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_multi_digit) {
+TEST(valid_multi_digit) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("120"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_large_integer) {
+TEST(valid_large_integer) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("1234567890"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_zero_with_pointer) {
+TEST(valid_zero_with_pointer) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo/bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_zero_with_empty_pointer) {
+TEST(valid_zero_with_empty_pointer) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_valid_up_and_then_down) {
+TEST(suite_valid_up_and_then_down) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("2/0/baz/1/zip"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_valid_member_or_index_name) {
+TEST(suite_valid_member_or_index_name) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0#"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_multi_digit_hash) {
+TEST(valid_multi_digit_hash) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("42#"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_pointer_with_escape) {
+TEST(valid_pointer_with_escape) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~0/~1"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_empty) {
+TEST(suite_invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer(""));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_leading_zero_with_digit) {
+TEST(invalid_leading_zero_with_digit) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("01"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_leading_zero_with_pointer) {
+TEST(suite_invalid_leading_zero_with_pointer) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("01/a"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_leading_zero_with_hash) {
+TEST(suite_invalid_leading_zero_with_hash) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("01#"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_double_zero) {
+TEST(invalid_double_zero) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("00"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_negative_prefix) {
+TEST(suite_invalid_negative_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("-1/foo/bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_positive_prefix) {
+TEST(suite_invalid_positive_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("+1/foo/bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_valid_json_pointer) {
+TEST(suite_invalid_valid_json_pointer) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("/foo/bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_just_hash) {
+TEST(invalid_just_hash) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("#"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_invalid_double_hash) {
+TEST(suite_invalid_double_hash) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0##"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_hash_with_trailing) {
+TEST(invalid_hash_with_trailing) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0#a"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_integer_then_letter) {
+TEST(invalid_integer_then_letter) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0x"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_bad_pointer_escape) {
+TEST(invalid_bad_pointer_escape) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_bad_pointer_escape_digit) {
+TEST(invalid_bad_pointer_escape_digit) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~2"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_letter_prefix) {
+TEST(invalid_letter_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("a/foo"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer(" 0"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0 "));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_valid_upwards) {
+TEST(suite_valid_upwards) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("1"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_valid_downwards) {
+TEST(suite_valid_downwards) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo/bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, suite_valid_multi_digit_prefix) {
+TEST(suite_valid_multi_digit_prefix) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("120/foo/bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_max_digit_alone) {
+TEST(valid_max_digit_alone) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("9"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_single_nonzero_hash) {
+TEST(valid_single_nonzero_hash) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("1#"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_multiple_empty_tokens) {
+TEST(valid_multiple_empty_tokens) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0//"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_trailing_empty_token) {
+TEST(valid_trailing_empty_token) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo/"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_tilde_zero_escape) {
+TEST(valid_tilde_zero_escape) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~0"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_tilde_one_escape) {
+TEST(valid_tilde_one_escape) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~1"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_adjacent_escapes) {
+TEST(valid_adjacent_escapes) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~0~1"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_escape_then_literal_digit) {
+TEST(valid_escape_then_literal_digit) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~01"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_space_inside_token) {
+TEST(valid_space_inside_token) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo bar"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_hash_inside_token) {
+TEST(valid_hash_inside_token) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/#"));
 }
 
-TEST(JSONPointer_is_relative_pointer, valid_non_ascii_inside_token) {
+TEST(valid_non_ascii_inside_token) {
   EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/caf\xc3\xa9"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_lone_tilde) {
+TEST(invalid_lone_tilde) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_double_tilde) {
+TEST(invalid_double_tilde) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~~"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_hash_followed_by_digit) {
+TEST(invalid_hash_followed_by_digit) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0#0"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_hash_followed_by_space) {
+TEST(invalid_hash_followed_by_space) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0# "));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_hash_followed_by_slash) {
+TEST(invalid_hash_followed_by_slash) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0#/foo"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_only_space) {
+TEST(invalid_only_space) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer(" "));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_tab_prefix) {
+TEST(invalid_tab_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\t0"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_newline) {
+TEST(invalid_newline) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\n"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_trailing_newline) {
+TEST(invalid_trailing_newline) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\n"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_bengali_digit_prefix) {
+TEST(invalid_bengali_digit_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xe0\xa7\xa8"
                                                      "/foo"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_decimal_point) {
+TEST(invalid_decimal_point) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0.5"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_exponent_notation) {
+TEST(invalid_exponent_notation) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("1e5"));
 }
 
-TEST(JSONPointer_is_relative_pointer, invalid_hex_digits) {
+TEST(invalid_hex_digits) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0xa"));
 }

--- a/test/jsonpointer/jsonpointer_json_auto_test.cc
+++ b/test/jsonpointer/jsonpointer_json_auto_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_json_auto, foo_bar_baz) {
+TEST(foo_bar_baz) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const auto result{sourcemeta::core::to_json(pointer)};
   EXPECT_TRUE(result.is_array());
@@ -19,7 +19,7 @@ TEST(JSONPointer_json_auto, foo_bar_baz) {
   EXPECT_EQ(pointer, back.value());
 }
 
-TEST(JSONPointer_json_auto, with_index) {
+TEST(with_index) {
   const sourcemeta::core::Pointer pointer{"foo", 1, "bar"};
   const auto result{sourcemeta::core::to_json(pointer)};
   EXPECT_TRUE(result.is_array());
@@ -36,7 +36,7 @@ TEST(JSONPointer_json_auto, with_index) {
   EXPECT_EQ(pointer, back.value());
 }
 
-TEST(JSONPointer_json_auto, empty_pointer) {
+TEST(empty_pointer) {
   const sourcemeta::core::Pointer pointer;
   const auto result{sourcemeta::core::to_json(pointer)};
   EXPECT_TRUE(result.is_array());
@@ -47,21 +47,21 @@ TEST(JSONPointer_json_auto, empty_pointer) {
   EXPECT_EQ(pointer, back.value());
 }
 
-TEST(JSONPointer_json_auto, from_json_invalid_string) {
+TEST(from_json_invalid_string) {
   const sourcemeta::core::JSON input{"x"};
   const auto result{
       sourcemeta::core::from_json<sourcemeta::core::Pointer>(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSONPointer_json_auto, from_json_invalid_type) {
+TEST(from_json_invalid_type) {
   const sourcemeta::core::JSON input{1};
   const auto result{
       sourcemeta::core::from_json<sourcemeta::core::Pointer>(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSONPointer_json_auto, from_json_invalid_element_type) {
+TEST(from_json_invalid_element_type) {
   auto input{sourcemeta::core::JSON::make_array()};
   input.push_back(sourcemeta::core::JSON{true});
   const auto result{
@@ -69,7 +69,7 @@ TEST(JSONPointer_json_auto, from_json_invalid_element_type) {
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(JSONWeakPointer_json_auto, to_json_foo_bar_baz) {
+TEST(to_json_foo_bar_baz) {
   const std::string foo{"foo"};
   const std::string bar{"bar"};
   const std::string baz{"baz"};

--- a/test/jsonpointer/jsonpointer_parse_error_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
@@ -16,61 +16,61 @@
     FAIL();                                                                    \
   }
 
-TEST(JSONPointer_parse_error, missing_initial_slash) {
+TEST(missing_initial_slash) {
   const std::string input{"1"};
   EXPECT_POINTER_PARSE_ERROR(input, 1);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, tilde) {
+TEST(tilde) {
   const std::string input{"/~"};
   EXPECT_POINTER_PARSE_ERROR(input, 3);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, tilde_2) {
+TEST(tilde_2) {
   const std::string input{"/~2"};
   EXPECT_POINTER_PARSE_ERROR(input, 3);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, tilde_tilde) {
+TEST(tilde_tilde) {
   const std::string input{"/~~"};
   EXPECT_POINTER_PARSE_ERROR(input, 3);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, foo_tilde) {
+TEST(foo_tilde) {
   const std::string input{"/foo~"};
   EXPECT_POINTER_PARSE_ERROR(input, 6);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, index_foo_tilde) {
+TEST(index_foo_tilde) {
   const std::string input{"/123/foo~"};
   EXPECT_POINTER_PARSE_ERROR(input, 10);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, zero_index_foo_tilde) {
+TEST(zero_index_foo_tilde) {
   const std::string input{"/0/foo~"};
   EXPECT_POINTER_PARSE_ERROR(input, 8);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, slash_slash_foo_tilde) {
+TEST(slash_slash_foo_tilde) {
   const std::string input{"//foo~"};
   EXPECT_POINTER_PARSE_ERROR(input, 7);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, foo_tilde_2) {
+TEST(foo_tilde_2) {
   const std::string input{"/foo~2"};
   EXPECT_POINTER_PARSE_ERROR(input, 6);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));
 }
 
-TEST(JSONPointer_parse_error, foo_tilde_tilde) {
+TEST(foo_tilde_tilde) {
   const std::string input{"/foo~~"};
   EXPECT_POINTER_PARSE_ERROR(input, 6);
   EXPECT_FALSE(sourcemeta::core::is_pointer(input));

--- a/test/jsonpointer/jsonpointer_parse_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
@@ -6,13 +6,13 @@
 #include <string>
 #include <string_view>
 
-TEST(JSONPointer_parse, empty_string) {
+TEST(empty_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer(""));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("");
   EXPECT_EQ(pointer.size(), 0);
 }
 
-TEST(JSONPointer_parse, slash) {
+TEST(slash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/");
   EXPECT_EQ(pointer.size(), 1);
@@ -20,7 +20,7 @@ TEST(JSONPointer_parse, slash) {
   EXPECT_EQ(pointer.at(0).to_property(), "");
 }
 
-TEST(JSONPointer_parse, slash_f) {
+TEST(slash_f) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/f"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/f");
   EXPECT_EQ(pointer.size(), 1);
@@ -28,7 +28,7 @@ TEST(JSONPointer_parse, slash_f) {
   EXPECT_EQ(pointer.at(0).to_property(), "f");
 }
 
-TEST(JSONPointer_parse, slash_foo) {
+TEST(slash_foo) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo");
@@ -37,7 +37,7 @@ TEST(JSONPointer_parse, slash_foo) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_parse, slash_foo_bar_baz) {
+TEST(slash_foo_bar_baz) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo/bar/baz"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo/bar/baz");
@@ -50,7 +50,7 @@ TEST(JSONPointer_parse, slash_foo_bar_baz) {
   EXPECT_EQ(pointer.at(2).to_property(), "baz");
 }
 
-TEST(JSONPointer_parse, slash_0) {
+TEST(slash_0) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/0"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/0");
   EXPECT_EQ(pointer.size(), 1);
@@ -58,7 +58,7 @@ TEST(JSONPointer_parse, slash_0) {
   EXPECT_EQ(pointer.at(0).to_index(), 0);
 }
 
-TEST(JSONPointer_parse, slash_1) {
+TEST(slash_1) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/1"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/1");
   EXPECT_EQ(pointer.size(), 1);
@@ -66,7 +66,7 @@ TEST(JSONPointer_parse, slash_1) {
   EXPECT_EQ(pointer.at(0).to_index(), 1);
 }
 
-TEST(JSONPointer_parse, slash_1234) {
+TEST(slash_1234) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/1234"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/1234");
@@ -75,7 +75,7 @@ TEST(JSONPointer_parse, slash_1234) {
   EXPECT_EQ(pointer.at(0).to_index(), 1234);
 }
 
-TEST(JSONPointer_parse, slash_0_slash_1_slash_2) {
+TEST(slash_0_slash_1_slash_2) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/0/1/2"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/0/1/2");
@@ -88,7 +88,7 @@ TEST(JSONPointer_parse, slash_0_slash_1_slash_2) {
   EXPECT_EQ(pointer.at(2).to_index(), 2);
 }
 
-TEST(JSONPointer_parse, slash_0_slash_foo_slash_2) {
+TEST(slash_0_slash_foo_slash_2) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/0/foo/2"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/0/foo/2");
@@ -101,7 +101,7 @@ TEST(JSONPointer_parse, slash_0_slash_foo_slash_2) {
   EXPECT_EQ(pointer.at(2).to_index(), 2);
 }
 
-TEST(JSONPointer_parse, slash_0_slash_1234) {
+TEST(slash_0_slash_1234) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/0/1234"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/0/1234");
@@ -112,7 +112,7 @@ TEST(JSONPointer_parse, slash_0_slash_1234) {
   EXPECT_EQ(pointer.at(1).to_index(), 1234);
 }
 
-TEST(JSONPointer_parse, slash_1000) {
+TEST(slash_1000) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/1000"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/1000");
@@ -121,7 +121,7 @@ TEST(JSONPointer_parse, slash_1000) {
   EXPECT_EQ(pointer.at(0).to_index(), 1000);
 }
 
-TEST(JSONPointer_parse, negative_index_as_property) {
+TEST(negative_index_as_property) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/-1"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/-1");
   EXPECT_EQ(pointer.size(), 1);
@@ -129,7 +129,7 @@ TEST(JSONPointer_parse, negative_index_as_property) {
   EXPECT_EQ(pointer.at(0).to_property(), "-1");
 }
 
-TEST(JSONPointer_parse, slash_space_integer) {
+TEST(slash_space_integer) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/ 12"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/ 12");
@@ -138,7 +138,7 @@ TEST(JSONPointer_parse, slash_space_integer) {
   EXPECT_EQ(pointer.at(0).to_property(), " 12");
 }
 
-TEST(JSONPointer_parse, slash_foo_slash_space_integer) {
+TEST(slash_foo_slash_space_integer) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo/ 12"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo/ 12");
@@ -149,7 +149,7 @@ TEST(JSONPointer_parse, slash_foo_slash_space_integer) {
   EXPECT_EQ(pointer.at(1).to_property(), " 12");
 }
 
-TEST(JSONPointer_parse, slash_foo_slash_space_bar_space) {
+TEST(slash_foo_slash_space_bar_space) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo/ bar "));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo/ bar ");
@@ -160,7 +160,7 @@ TEST(JSONPointer_parse, slash_foo_slash_space_bar_space) {
   EXPECT_EQ(pointer.at(1).to_property(), " bar ");
 }
 
-TEST(JSONPointer_parse, slash_f_slash) {
+TEST(slash_f_slash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/f/"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/f/");
   EXPECT_EQ(pointer.size(), 2);
@@ -170,7 +170,7 @@ TEST(JSONPointer_parse, slash_f_slash) {
   EXPECT_EQ(pointer.at(1).to_property(), "");
 }
 
-TEST(JSONPointer_parse, slash_slash) {
+TEST(slash_slash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("//"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("//");
   EXPECT_EQ(pointer.size(), 2);
@@ -180,7 +180,7 @@ TEST(JSONPointer_parse, slash_slash) {
   EXPECT_EQ(pointer.at(1).to_property(), "");
 }
 
-TEST(JSONPointer_parse, slash_slash_slash) {
+TEST(slash_slash_slash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("///"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("///");
   EXPECT_EQ(pointer.size(), 3);
@@ -192,7 +192,7 @@ TEST(JSONPointer_parse, slash_slash_slash) {
   EXPECT_EQ(pointer.at(2).to_property(), "");
 }
 
-TEST(JSONPointer_parse, slash_slash_slash_foo) {
+TEST(slash_slash_slash_foo) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("///foo"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("///foo");
@@ -205,7 +205,7 @@ TEST(JSONPointer_parse, slash_slash_slash_foo) {
   EXPECT_EQ(pointer.at(2).to_property(), "foo");
 }
 
-TEST(JSONPointer_parse, positive_hex_index) {
+TEST(positive_hex_index) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/0x23"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/0x23");
@@ -214,7 +214,7 @@ TEST(JSONPointer_parse, positive_hex_index) {
   EXPECT_EQ(pointer.at(0).to_property(), "0x23");
 }
 
-TEST(JSONPointer_parse, slash_00) {
+TEST(slash_00) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/00"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/00");
   EXPECT_EQ(pointer.size(), 1);
@@ -222,7 +222,7 @@ TEST(JSONPointer_parse, slash_00) {
   EXPECT_EQ(pointer.at(0).to_property(), "00");
 }
 
-TEST(JSONPointer_parse, slash_01) {
+TEST(slash_01) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/01"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/01");
   EXPECT_EQ(pointer.size(), 1);
@@ -230,7 +230,7 @@ TEST(JSONPointer_parse, slash_01) {
   EXPECT_EQ(pointer.at(0).to_property(), "01");
 }
 
-TEST(JSONPointer_parse, slash_001) {
+TEST(slash_001) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/001"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/001");
@@ -239,7 +239,7 @@ TEST(JSONPointer_parse, slash_001) {
   EXPECT_EQ(pointer.at(0).to_property(), "001");
 }
 
-TEST(JSONPointer_parse, slash_0100) {
+TEST(slash_0100) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/0100"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/0100");
@@ -248,7 +248,7 @@ TEST(JSONPointer_parse, slash_0100) {
   EXPECT_EQ(pointer.at(0).to_property(), "0100");
 }
 
-TEST(JSONPointer_parse, positive_real_number_index) {
+TEST(positive_real_number_index) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/1.23"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/1.23");
@@ -257,7 +257,7 @@ TEST(JSONPointer_parse, positive_real_number_index) {
   EXPECT_EQ(pointer.at(0).to_property(), "1.23");
 }
 
-TEST(JSONPointer_parse, index_in_scientific_notation) {
+TEST(index_in_scientific_notation) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/1e1"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/1e1");
@@ -266,7 +266,7 @@ TEST(JSONPointer_parse, index_in_scientific_notation) {
   EXPECT_EQ(pointer.at(0).to_property(), "1e1");
 }
 
-TEST(JSONPointer_parse, integer_with_space) {
+TEST(integer_with_space) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/1 1"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/1 1");
@@ -275,7 +275,7 @@ TEST(JSONPointer_parse, integer_with_space) {
   EXPECT_EQ(pointer.at(0).to_property(), "1 1");
 }
 
-TEST(JSONPointer_parse, percentage) {
+TEST(percentage) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/c%d"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/c%d");
@@ -284,7 +284,7 @@ TEST(JSONPointer_parse, percentage) {
   EXPECT_EQ(pointer.at(0).to_property(), "c%d");
 }
 
-TEST(JSONPointer_parse, caret) {
+TEST(caret) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/e^f"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/e^f");
@@ -293,7 +293,7 @@ TEST(JSONPointer_parse, caret) {
   EXPECT_EQ(pointer.at(0).to_property(), "e^f");
 }
 
-TEST(JSONPointer_parse, pipe) {
+TEST(pipe) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/g|h"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/g|h");
@@ -302,7 +302,7 @@ TEST(JSONPointer_parse, pipe) {
   EXPECT_EQ(pointer.at(0).to_property(), "g|h");
 }
 
-TEST(JSONPointer_parse, backslash_after_letter) {
+TEST(backslash_after_letter) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/i\\j"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/i\\j");
@@ -311,7 +311,7 @@ TEST(JSONPointer_parse, backslash_after_letter) {
   EXPECT_EQ(pointer.at(0).to_property(), "i\\j");
 }
 
-TEST(JSONPointer_parse, backslash) {
+TEST(backslash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\\"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\\");
   EXPECT_EQ(pointer.size(), 1);
@@ -319,7 +319,7 @@ TEST(JSONPointer_parse, backslash) {
   EXPECT_EQ(pointer.at(0).to_property(), "\\");
 }
 
-TEST(JSONPointer_parse, double_quote_after_letter) {
+TEST(double_quote_after_letter) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/k\"l"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/k\"l");
@@ -328,7 +328,7 @@ TEST(JSONPointer_parse, double_quote_after_letter) {
   EXPECT_EQ(pointer.at(0).to_property(), "k\"l");
 }
 
-TEST(JSONPointer_parse, double_quote) {
+TEST(double_quote) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\""));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\"");
   EXPECT_EQ(pointer.size(), 1);
@@ -336,7 +336,7 @@ TEST(JSONPointer_parse, double_quote) {
   EXPECT_EQ(pointer.at(0).to_property(), "\"");
 }
 
-TEST(JSONPointer_parse, space) {
+TEST(space) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/ "));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/ ");
   EXPECT_EQ(pointer.size(), 1);
@@ -344,7 +344,7 @@ TEST(JSONPointer_parse, space) {
   EXPECT_EQ(pointer.at(0).to_property(), " ");
 }
 
-TEST(JSONPointer_parse, escaped_slash_after_letter) {
+TEST(escaped_slash_after_letter) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/a~1b"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/a~1b");
@@ -353,7 +353,7 @@ TEST(JSONPointer_parse, escaped_slash_after_letter) {
   EXPECT_EQ(pointer.at(0).to_property(), "a/b");
 }
 
-TEST(JSONPointer_parse, escaped_slash) {
+TEST(escaped_slash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/~1"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/~1");
   EXPECT_EQ(pointer.size(), 1);
@@ -361,7 +361,7 @@ TEST(JSONPointer_parse, escaped_slash) {
   EXPECT_EQ(pointer.at(0).to_property(), "/");
 }
 
-TEST(JSONPointer_parse, escaped_slash_with_backslash) {
+TEST(escaped_slash_with_backslash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\\/"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/\\/");
@@ -372,7 +372,7 @@ TEST(JSONPointer_parse, escaped_slash_with_backslash) {
   EXPECT_EQ(pointer.at(1).to_property(), "");
 }
 
-TEST(JSONPointer_parse, escaped_slash_with_backslash_after_letter) {
+TEST(escaped_slash_with_backslash_after_letter) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/x\\/"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/x\\/");
@@ -383,7 +383,7 @@ TEST(JSONPointer_parse, escaped_slash_with_backslash_after_letter) {
   EXPECT_EQ(pointer.at(1).to_property(), "");
 }
 
-TEST(JSONPointer_parse, escaped_tilde_after_letter) {
+TEST(escaped_tilde_after_letter) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/m~0n"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/m~0n");
@@ -392,7 +392,7 @@ TEST(JSONPointer_parse, escaped_tilde_after_letter) {
   EXPECT_EQ(pointer.at(0).to_property(), "m~n");
 }
 
-TEST(JSONPointer_parse, escaped_tilde) {
+TEST(escaped_tilde) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/~0"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/~0");
   EXPECT_EQ(pointer.size(), 1);
@@ -400,7 +400,7 @@ TEST(JSONPointer_parse, escaped_tilde) {
   EXPECT_EQ(pointer.at(0).to_property(), "~");
 }
 
-TEST(JSONPointer_parse, tilde_zero_one) {
+TEST(tilde_zero_one) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/~01"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/~01");
@@ -409,7 +409,7 @@ TEST(JSONPointer_parse, tilde_zero_one) {
   EXPECT_EQ(pointer.at(0).to_property(), "~1");
 }
 
-TEST(JSONPointer_parse, tilde_zero_one_after_letter) {
+TEST(tilde_zero_one_after_letter) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/x~01"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/x~01");
@@ -418,7 +418,7 @@ TEST(JSONPointer_parse, tilde_zero_one_after_letter) {
   EXPECT_EQ(pointer.at(0).to_property(), "x~1");
 }
 
-TEST(JSONPointer_parse, hyphen) {
+TEST(hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/-"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/-");
   EXPECT_EQ(pointer.size(), 1);
@@ -427,7 +427,7 @@ TEST(JSONPointer_parse, hyphen) {
   EXPECT_EQ(pointer.at(0).to_property(), "-");
 }
 
-TEST(JSONPointer_parse, hyphen_hyphen) {
+TEST(hyphen_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/--"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/--");
   EXPECT_EQ(pointer.size(), 1);
@@ -436,7 +436,7 @@ TEST(JSONPointer_parse, hyphen_hyphen) {
   EXPECT_EQ(pointer.at(0).to_property(), "--");
 }
 
-TEST(JSONPointer_parse, hyphen_slash_hyphen) {
+TEST(hyphen_slash_hyphen) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/-/-"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/-/-");
@@ -449,7 +449,7 @@ TEST(JSONPointer_parse, hyphen_slash_hyphen) {
   EXPECT_EQ(pointer.at(1).to_property(), "-");
 }
 
-TEST(JSONPointer_parse, quote_within_string) {
+TEST(quote_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\"bar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\"bar");
@@ -458,7 +458,7 @@ TEST(JSONPointer_parse, quote_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\"bar");
 }
 
-TEST(JSONPointer_parse, quote) {
+TEST(quote) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\""));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\"");
   EXPECT_EQ(pointer.size(), 1);
@@ -466,7 +466,7 @@ TEST(JSONPointer_parse, quote) {
   EXPECT_EQ(pointer.at(0).to_property(), "\"");
 }
 
-TEST(JSONPointer_parse, backslash_within_string) {
+TEST(backslash_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\\bar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\\bar");
@@ -475,7 +475,7 @@ TEST(JSONPointer_parse, backslash_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\\bar");
 }
 
-TEST(JSONPointer_parse, backslash_only) {
+TEST(backslash_only) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\\"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\\");
   EXPECT_EQ(pointer.size(), 1);
@@ -483,7 +483,7 @@ TEST(JSONPointer_parse, backslash_only) {
   EXPECT_EQ(pointer.at(0).to_property(), "\\");
 }
 
-TEST(JSONPointer_parse, control_backspace) {
+TEST(control_backspace) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\b"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\b");
   EXPECT_EQ(pointer.size(), 1);
@@ -491,7 +491,7 @@ TEST(JSONPointer_parse, control_backspace) {
   EXPECT_EQ(pointer.at(0).to_property(), "\b");
 }
 
-TEST(JSONPointer_parse, control_backspace_within_string) {
+TEST(control_backspace_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\bbar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\bbar");
@@ -500,7 +500,7 @@ TEST(JSONPointer_parse, control_backspace_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\bbar");
 }
 
-TEST(JSONPointer_parse, control_formfeed) {
+TEST(control_formfeed) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\f"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\f");
   EXPECT_EQ(pointer.size(), 1);
@@ -508,7 +508,7 @@ TEST(JSONPointer_parse, control_formfeed) {
   EXPECT_EQ(pointer.at(0).to_property(), "\f");
 }
 
-TEST(JSONPointer_parse, control_formfeed_within_string) {
+TEST(control_formfeed_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\fbar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\fbar");
@@ -517,7 +517,7 @@ TEST(JSONPointer_parse, control_formfeed_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\fbar");
 }
 
-TEST(JSONPointer_parse, control_newline) {
+TEST(control_newline) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\n"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\n");
   EXPECT_EQ(pointer.size(), 1);
@@ -525,7 +525,7 @@ TEST(JSONPointer_parse, control_newline) {
   EXPECT_EQ(pointer.at(0).to_property(), "\n");
 }
 
-TEST(JSONPointer_parse, control_newline_within_string) {
+TEST(control_newline_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\nbar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\nbar");
@@ -534,7 +534,7 @@ TEST(JSONPointer_parse, control_newline_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\nbar");
 }
 
-TEST(JSONPointer_parse, control_carriage) {
+TEST(control_carriage) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\r"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\r");
   EXPECT_EQ(pointer.size(), 1);
@@ -542,7 +542,7 @@ TEST(JSONPointer_parse, control_carriage) {
   EXPECT_EQ(pointer.at(0).to_property(), "\r");
 }
 
-TEST(JSONPointer_parse, control_carriage_within_string) {
+TEST(control_carriage_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\rbar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\rbar");
@@ -551,7 +551,7 @@ TEST(JSONPointer_parse, control_carriage_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\rbar");
 }
 
-TEST(JSONPointer_parse, control_tab) {
+TEST(control_tab) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\t"));
   const sourcemeta::core::Pointer pointer = sourcemeta::core::to_pointer("/\t");
   EXPECT_EQ(pointer.size(), 1);
@@ -559,7 +559,7 @@ TEST(JSONPointer_parse, control_tab) {
   EXPECT_EQ(pointer.at(0).to_property(), "\t");
 }
 
-TEST(JSONPointer_parse, control_tab_within_string) {
+TEST(control_tab_within_string) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\tbar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo\tbar");
@@ -568,7 +568,7 @@ TEST(JSONPointer_parse, control_tab_within_string) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\tbar");
 }
 
-TEST(JSONPointer_parse, property_with_asterisk) {
+TEST(property_with_asterisk) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo*bar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo*bar");
@@ -577,7 +577,7 @@ TEST(JSONPointer_parse, property_with_asterisk) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo*bar");
 }
 
-TEST(JSONPointer_parse, two_tokens) {
+TEST(two_tokens) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo/bar"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/foo/bar");
@@ -588,7 +588,7 @@ TEST(JSONPointer_parse, two_tokens) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_parse, regex_caret) {
+TEST(regex_caret) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/patternProperties/^v/foo"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/patternProperties/^v/foo");
@@ -601,7 +601,7 @@ TEST(JSONPointer_parse, regex_caret) {
   EXPECT_EQ(pointer.at(2).to_property(), "foo");
 }
 
-TEST(JSONPointer_parse, regex_backslash) {
+TEST(regex_backslash) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/[\\-]"));
   const sourcemeta::core::Pointer pointer =
       sourcemeta::core::to_pointer("/[\\-]");
@@ -610,7 +610,7 @@ TEST(JSONPointer_parse, regex_backslash) {
   EXPECT_EQ(pointer.at(0).to_property(), "[\\-]");
 }
 
-TEST(JSONPointer_parse, json_escape_backslash_n_treated_literally) {
+TEST(json_escape_backslash_n_treated_literally) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\\nbar"));
   const auto pointer = sourcemeta::core::to_pointer("/foo\\nbar");
   EXPECT_EQ(pointer.size(), 1);
@@ -618,7 +618,7 @@ TEST(JSONPointer_parse, json_escape_backslash_n_treated_literally) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\\nbar");
 }
 
-TEST(JSONPointer_parse, json_escape_unicode_treated_literally) {
+TEST(json_escape_unicode_treated_literally) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\\u002Abar"));
   const auto pointer = sourcemeta::core::to_pointer("/foo\\u002Abar");
   EXPECT_EQ(pointer.size(), 1);
@@ -626,7 +626,7 @@ TEST(JSONPointer_parse, json_escape_unicode_treated_literally) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\\u002Abar");
 }
 
-TEST(JSONPointer_parse, unicode_0001) {
+TEST(unicode_0001) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\u0001"));
   const auto pointer = sourcemeta::core::to_pointer("/\u0001");
   EXPECT_EQ(pointer.size(), 1);
@@ -634,7 +634,7 @@ TEST(JSONPointer_parse, unicode_0001) {
   EXPECT_EQ(pointer.at(0).to_property(), "\u0001");
 }
 
-TEST(JSONPointer_parse, unicode_0002) {
+TEST(unicode_0002) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\u0002"));
   const auto pointer = sourcemeta::core::to_pointer("/\u0002");
   EXPECT_EQ(pointer.size(), 1);
@@ -642,7 +642,7 @@ TEST(JSONPointer_parse, unicode_0002) {
   EXPECT_EQ(pointer.at(0).to_property(), "\u0002");
 }
 
-TEST(JSONPointer_parse, unicode_000B) {
+TEST(unicode_000B) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\u000B"));
   const auto pointer = sourcemeta::core::to_pointer("/\u000B");
   EXPECT_EQ(pointer.size(), 1);
@@ -650,7 +650,7 @@ TEST(JSONPointer_parse, unicode_000B) {
   EXPECT_EQ(pointer.at(0).to_property(), "\u000B");
 }
 
-TEST(JSONPointer_parse, unicode_000E) {
+TEST(unicode_000E) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\u000E"));
   const auto pointer = sourcemeta::core::to_pointer("/\u000E");
   EXPECT_EQ(pointer.size(), 1);
@@ -658,7 +658,7 @@ TEST(JSONPointer_parse, unicode_000E) {
   EXPECT_EQ(pointer.at(0).to_property(), "\u000E");
 }
 
-TEST(JSONPointer_parse, unicode_001F) {
+TEST(unicode_001F) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/\u001F"));
   const auto pointer = sourcemeta::core::to_pointer("/\u001F");
   EXPECT_EQ(pointer.size(), 1);
@@ -666,7 +666,7 @@ TEST(JSONPointer_parse, unicode_001F) {
   EXPECT_EQ(pointer.at(0).to_property(), "\u001F");
 }
 
-TEST(JSONPointer_parse, unicode_0001_within_word) {
+TEST(unicode_0001_within_word) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\u0001bar"));
   const auto pointer = sourcemeta::core::to_pointer("/foo\u0001bar");
   EXPECT_EQ(pointer.size(), 1);
@@ -674,7 +674,7 @@ TEST(JSONPointer_parse, unicode_0001_within_word) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\u0001bar");
 }
 
-TEST(JSONPointer_parse, unicode_000E_within_word) {
+TEST(unicode_000E_within_word) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\u000Ebar"));
   const auto pointer = sourcemeta::core::to_pointer("/foo\u000Ebar");
   EXPECT_EQ(pointer.size(), 1);
@@ -682,7 +682,7 @@ TEST(JSONPointer_parse, unicode_000E_within_word) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\u000Ebar");
 }
 
-TEST(JSONPointer_parse, unicode_001F_within_word) {
+TEST(unicode_001F_within_word) {
   EXPECT_TRUE(sourcemeta::core::is_pointer("/foo\u001Fbar"));
   const auto pointer = sourcemeta::core::to_pointer("/foo\u001Fbar");
   EXPECT_EQ(pointer.size(), 1);
@@ -690,7 +690,7 @@ TEST(JSONPointer_parse, unicode_001F_within_word) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo\u001Fbar");
 }
 
-TEST(JSONPointer_parse, to_pointer_with_string_view) {
+TEST(to_pointer_with_string_view) {
   const std::string_view input{"/foo/bar"};
   const auto pointer = sourcemeta::core::to_pointer(input);
   EXPECT_EQ(pointer.size(), 2);
@@ -698,7 +698,7 @@ TEST(JSONPointer_parse, to_pointer_with_string_view) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_parse, to_pointer_with_string_view_subview) {
+TEST(to_pointer_with_string_view_subview) {
   const std::string buffer{"prefix/foo/bar/0suffix"};
   const std::string_view view{buffer.data() + 6, 10};
   const auto pointer = sourcemeta::core::to_pointer(view);
@@ -709,7 +709,7 @@ TEST(JSONPointer_parse, to_pointer_with_string_view_subview) {
   EXPECT_EQ(pointer.at(2).to_index(), 0);
 }
 
-TEST(JSONPointer_parse, to_pointer_default_string_view) {
+TEST(to_pointer_default_string_view) {
   const std::string_view input{};
   EXPECT_EQ(input.data(), nullptr);
   const auto pointer = sourcemeta::core::to_pointer(input);

--- a/test/jsonpointer/jsonpointer_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_pointer_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-TEST(JSONPointer_pointer, general_traits) {
+TEST(general_traits) {
   EXPECT_TRUE(std::is_default_constructible<sourcemeta::core::Pointer>::value);
   EXPECT_TRUE(
       std::is_nothrow_default_constructible<sourcemeta::core::Pointer>::value);
@@ -14,7 +14,7 @@ TEST(JSONPointer_pointer, general_traits) {
   EXPECT_TRUE(std::is_nothrow_destructible<sourcemeta::core::Pointer>::value);
 }
 
-TEST(JSONPointer_pointer, copy_traits) {
+TEST(copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::Pointer>::value);
   EXPECT_TRUE(std::is_copy_constructible<sourcemeta::core::Pointer>::value);
   EXPECT_FALSE(
@@ -23,7 +23,7 @@ TEST(JSONPointer_pointer, copy_traits) {
       std::is_nothrow_copy_constructible<sourcemeta::core::Pointer>::value);
 }
 
-TEST(JSONPointer_pointer, move_traits) {
+TEST(move_traits) {
   EXPECT_TRUE(std::is_move_assignable<sourcemeta::core::Pointer>::value);
   EXPECT_TRUE(std::is_move_constructible<sourcemeta::core::Pointer>::value);
   EXPECT_TRUE(
@@ -32,13 +32,13 @@ TEST(JSONPointer_pointer, move_traits) {
       std::is_nothrow_move_constructible<sourcemeta::core::Pointer>::value);
 }
 
-TEST(JSONPointer_pointer, empty) {
+TEST(empty) {
   const sourcemeta::core::Pointer pointer;
   EXPECT_EQ(pointer.size(), 0);
   EXPECT_TRUE(pointer.empty());
 }
 
-TEST(JSONPointer_pointer, one_fragment_property) {
+TEST(one_fragment_property) {
   const sourcemeta::core::Pointer pointer{"foo"};
   EXPECT_EQ(pointer.size(), 1);
   EXPECT_FALSE(pointer.empty());
@@ -46,14 +46,14 @@ TEST(JSONPointer_pointer, one_fragment_property) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_pointer, one_fragment_back) {
+TEST(one_fragment_back) {
   const sourcemeta::core::Pointer pointer{"foo"};
   EXPECT_EQ(pointer.size(), 1);
   EXPECT_TRUE(pointer.back().is_property());
   EXPECT_EQ(pointer.back().to_property(), "foo");
 }
 
-TEST(JSONPointer_pointer, one_fragment_index) {
+TEST(one_fragment_index) {
   const sourcemeta::core::Pointer pointer{0};
   EXPECT_EQ(pointer.size(), 1);
   EXPECT_FALSE(pointer.empty());
@@ -61,7 +61,7 @@ TEST(JSONPointer_pointer, one_fragment_index) {
   EXPECT_EQ(pointer.at(0).to_index(), 0);
 }
 
-TEST(JSONPointer_pointer, multiple_fragments_mixed) {
+TEST(multiple_fragments_mixed) {
   const sourcemeta::core::Pointer pointer{"foo", 1, "bar"};
   EXPECT_EQ(pointer.size(), 3);
   EXPECT_FALSE(pointer.empty());
@@ -73,14 +73,14 @@ TEST(JSONPointer_pointer, multiple_fragments_mixed) {
   EXPECT_EQ(pointer.at(2).to_property(), "bar");
 }
 
-TEST(JSONPointer_pointer, multiple_fragments_back) {
+TEST(multiple_fragments_back) {
   const sourcemeta::core::Pointer pointer{"foo", 1, "bar"};
   EXPECT_EQ(pointer.size(), 3);
   EXPECT_TRUE(pointer.back().is_property());
   EXPECT_EQ(pointer.back().to_property(), "bar");
 }
 
-TEST(JSONPointer_pointer, build_with_emplace_back) {
+TEST(build_with_emplace_back) {
   sourcemeta::core::Pointer pointer;
   EXPECT_EQ(pointer.size(), 0);
 
@@ -99,25 +99,25 @@ TEST(JSONPointer_pointer, build_with_emplace_back) {
   EXPECT_EQ(pointer.at(1).to_index(), 1);
 }
 
-TEST(JSONPointer_pointer, equality_empty) {
+TEST(equality_empty) {
   const sourcemeta::core::Pointer pointer_1;
   const sourcemeta::core::Pointer pointer_2;
   EXPECT_EQ(pointer_1, pointer_2);
 }
 
-TEST(JSONPointer_pointer, equality_true) {
+TEST(equality_true) {
   const sourcemeta::core::Pointer pointer_1{"foo", 1, "bar"};
   const sourcemeta::core::Pointer pointer_2{"foo", 1, "bar"};
   EXPECT_EQ(pointer_1, pointer_2);
 }
 
-TEST(JSONPointer_pointer, equality_false) {
+TEST(equality_false) {
   const sourcemeta::core::Pointer pointer_1{"foo", 1, "bar"};
   const sourcemeta::core::Pointer pointer_2{"foo", 2, "bar"};
   EXPECT_FALSE(pointer_1 == pointer_2);
 }
 
-TEST(JSONPointer_pointer, pop_back_non_empty) {
+TEST(pop_back_non_empty) {
   sourcemeta::core::Pointer pointer{"foo", "bar"};
   pointer.pop_back();
   EXPECT_EQ(pointer.size(), 1);
@@ -125,7 +125,7 @@ TEST(JSONPointer_pointer, pop_back_non_empty) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_pointer, ordering_less_than) {
+TEST(ordering_less_than) {
   const sourcemeta::core::Pointer pointer_1{"foo", "bar"};
   const sourcemeta::core::Pointer pointer_2{"foo"};
   const sourcemeta::core::Pointer pointer_3{"baz"};
@@ -134,13 +134,13 @@ TEST(JSONPointer_pointer, ordering_less_than) {
   EXPECT_TRUE(pointer_3 < pointer_2);
 }
 
-TEST(JSONPointer_pointer, pop_back_zero_empty) {
+TEST(pop_back_zero_empty) {
   sourcemeta::core::Pointer pointer{};
   pointer.pop_back(0);
   EXPECT_EQ(pointer.size(), 0);
 }
 
-TEST(JSONPointer_pointer, pop_back_many_subset) {
+TEST(pop_back_many_subset) {
   sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   pointer.pop_back(2);
   EXPECT_EQ(pointer.size(), 1);
@@ -148,13 +148,13 @@ TEST(JSONPointer_pointer, pop_back_many_subset) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_pointer, pop_back_many_all) {
+TEST(pop_back_many_all) {
   sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   pointer.pop_back(3);
   EXPECT_EQ(pointer.size(), 0);
 }
 
-TEST(JSONPointer_pointer, push_back_pointer_copy) {
+TEST(push_back_pointer_copy) {
   sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer other{"baz", "qux"};
   pointer.push_back(other);
@@ -169,7 +169,7 @@ TEST(JSONPointer_pointer, push_back_pointer_copy) {
   EXPECT_EQ(pointer.at(3).to_property(), "qux");
 }
 
-TEST(JSONPointer_pointer, push_back_pointer_move) {
+TEST(push_back_pointer_move) {
   sourcemeta::core::Pointer pointer{"foo", "bar"};
   sourcemeta::core::Pointer other{"baz", "qux"};
   pointer.push_back(std::move(other));
@@ -184,13 +184,13 @@ TEST(JSONPointer_pointer, push_back_pointer_move) {
   EXPECT_EQ(pointer.at(3).to_property(), "qux");
 }
 
-TEST(JSONPointer_pointer, initial_with_one_token) {
+TEST(initial_with_one_token) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 0);
 }
 
-TEST(JSONPointer_pointer, initial_with_two_tokens) {
+TEST(initial_with_two_tokens) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 1);
@@ -198,7 +198,7 @@ TEST(JSONPointer_pointer, initial_with_two_tokens) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_pointer, initial_with_three_tokens) {
+TEST(initial_with_three_tokens) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 2);
@@ -208,7 +208,7 @@ TEST(JSONPointer_pointer, initial_with_three_tokens) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_pointer, push_back_property_copy) {
+TEST(push_back_property_copy) {
   sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer other{"bar"};
   pointer.push_back(other.back().to_property());
@@ -219,7 +219,7 @@ TEST(JSONPointer_pointer, push_back_property_copy) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_pointer, push_back_property_move) {
+TEST(push_back_property_move) {
   sourcemeta::core::Pointer pointer{"foo"};
   pointer.push_back("bar");
   EXPECT_EQ(pointer.size(), 2);
@@ -229,7 +229,7 @@ TEST(JSONPointer_pointer, push_back_property_move) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_pointer, push_back_index_copy) {
+TEST(push_back_index_copy) {
   sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer other{0};
   pointer.push_back(other.back().to_index());
@@ -240,7 +240,7 @@ TEST(JSONPointer_pointer, push_back_index_copy) {
   EXPECT_EQ(pointer.at(1).to_index(), 0);
 }
 
-TEST(JSONPointer_pointer, push_back_index_move) {
+TEST(push_back_index_move) {
   sourcemeta::core::Pointer pointer{"foo"};
   pointer.push_back(0);
   EXPECT_EQ(pointer.size(), 2);
@@ -250,7 +250,7 @@ TEST(JSONPointer_pointer, push_back_index_move) {
   EXPECT_EQ(pointer.at(1).to_index(), 0);
 }
 
-TEST(JSONPointer_pointer, hash_unordered_set) {
+TEST(hash_unordered_set) {
   std::unordered_set<sourcemeta::core::Pointer,
                      sourcemeta::core::Pointer::Hasher>
       set;
@@ -283,7 +283,7 @@ TEST(JSONPointer_pointer, hash_unordered_set) {
   EXPECT_TRUE(set.contains(two_dup));
 }
 
-TEST(JSONPointer_pointer, hash_unordered_map) {
+TEST(hash_unordered_map) {
   std::unordered_map<sourcemeta::core::Pointer, int,
                      sourcemeta::core::Pointer::Hasher>
       map;
@@ -309,14 +309,14 @@ TEST(JSONPointer_pointer, hash_unordered_map) {
   EXPECT_EQ(map.at(four), 4);
 }
 
-TEST(JSONPointer_pointer, hash_empty_consistency) {
+TEST(hash_empty_consistency) {
   const sourcemeta::core::Pointer::Hasher hasher;
   const sourcemeta::core::Pointer empty_1{};
   const sourcemeta::core::Pointer empty_2{};
   EXPECT_EQ(hasher(empty_1), hasher(empty_2));
 }
 
-TEST(JSONPointer_pointer, hash_single_token_consistency) {
+TEST(hash_single_token_consistency) {
   const sourcemeta::core::Pointer::Hasher hasher;
   const sourcemeta::core::Pointer single_1{"foo"};
   const sourcemeta::core::Pointer single_2{"foo"};
@@ -325,7 +325,7 @@ TEST(JSONPointer_pointer, hash_single_token_consistency) {
   EXPECT_NE(hasher(single_1), hasher(single_3));
 }
 
-TEST(JSONPointer_pointer, hash_two_token_consistency) {
+TEST(hash_two_token_consistency) {
   const sourcemeta::core::Pointer::Hasher hasher;
   const sourcemeta::core::Pointer two_1{"foo", "bar"};
   const sourcemeta::core::Pointer two_2{"foo", "bar"};
@@ -334,7 +334,7 @@ TEST(JSONPointer_pointer, hash_two_token_consistency) {
   EXPECT_NE(hasher(two_1), hasher(two_3));
 }
 
-TEST(JSONPointer_pointer, hash_three_token_consistency) {
+TEST(hash_three_token_consistency) {
   const sourcemeta::core::Pointer::Hasher hasher;
   const sourcemeta::core::Pointer multi_1{"foo", "bar", 1};
   const sourcemeta::core::Pointer multi_2{"foo", "bar", 1};

--- a/test/jsonpointer/jsonpointer_position_test.cc
+++ b/test/jsonpointer/jsonpointer_position_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_position, track_1) {
+TEST(track_1) {
   const auto input{R"JSON([
   {
     "foo": {
@@ -39,7 +39,7 @@ TEST(JSONPointer_position, track_1) {
             sourcemeta::core::PointerPositionTracker::Position({4, 7, 4, 14}));
 }
 
-TEST(JSONPointer_position, to_json_1) {
+TEST(to_json_1) {
   const auto input{R"JSON([
   {
     "foo": {

--- a/test/jsonpointer/jsonpointer_rebase_test.cc
+++ b/test/jsonpointer/jsonpointer_rebase_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_rebase, first_property_for_one) {
+TEST(first_property_for_one) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   const sourcemeta::core::Pointer replacement{"baz"};
@@ -10,7 +10,7 @@ TEST(JSONPointer_rebase, first_property_for_one) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, first_property_for_two) {
+TEST(first_property_for_two) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   const sourcemeta::core::Pointer replacement{"baz", "qux"};
@@ -18,7 +18,7 @@ TEST(JSONPointer_rebase, first_property_for_two) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, first_property_for_empty) {
+TEST(first_property_for_empty) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   const sourcemeta::core::Pointer replacement;
@@ -26,7 +26,7 @@ TEST(JSONPointer_rebase, first_property_for_empty) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, empty_for_single_property) {
+TEST(empty_for_single_property) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix;
   const sourcemeta::core::Pointer replacement{"baz"};
@@ -34,7 +34,7 @@ TEST(JSONPointer_rebase, empty_for_single_property) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, empty_for_multi_property) {
+TEST(empty_for_multi_property) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix;
   const sourcemeta::core::Pointer replacement{"baz", "qux"};
@@ -42,7 +42,7 @@ TEST(JSONPointer_rebase, empty_for_multi_property) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, prefix_equal_pointer) {
+TEST(prefix_equal_pointer) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   const sourcemeta::core::Pointer replacement{"baz", "qux"};
@@ -50,7 +50,7 @@ TEST(JSONPointer_rebase, prefix_equal_pointer) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, empty_replacement) {
+TEST(empty_replacement) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer prefix{"foo"};
   const sourcemeta::core::Pointer replacement;
@@ -58,7 +58,7 @@ TEST(JSONPointer_rebase, empty_replacement) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, empty_empty_empty) {
+TEST(empty_empty_empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer prefix;
   const sourcemeta::core::Pointer replacement;
@@ -66,7 +66,7 @@ TEST(JSONPointer_rebase, empty_empty_empty) {
   EXPECT_EQ(pointer.rebase(prefix, replacement), expected);
 }
 
-TEST(JSONPointer_rebase, no_prefix_match_1) {
+TEST(no_prefix_match_1) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"bar"};
   const sourcemeta::core::Pointer replacement{"baz"};

--- a/test/jsonpointer/jsonpointer_remove_test.cc
+++ b/test/jsonpointer/jsonpointer_remove_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_remove, array_element) {
+TEST(array_element) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON");
 
@@ -11,7 +11,7 @@ TEST(JSONPointer_remove, array_element) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON([ 1, 3 ])JSON"));
 }
 
-TEST(JSONPointer_remove, nonexistent_array_element) {
+TEST(nonexistent_array_element) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON");
 
@@ -20,7 +20,7 @@ TEST(JSONPointer_remove, nonexistent_array_element) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON"));
 }
 
-TEST(JSONPointer_remove, empty_property) {
+TEST(empty_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "": 2 })JSON");
 
@@ -29,7 +29,7 @@ TEST(JSONPointer_remove, empty_property) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON"));
 }
 
-TEST(JSONPointer_remove, nonexistent_property) {
+TEST(nonexistent_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON");
 
@@ -38,7 +38,7 @@ TEST(JSONPointer_remove, nonexistent_property) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON"));
 }
 
-TEST(JSONPointer_remove, cannot_remove_root_object) {
+TEST(cannot_remove_root_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "": 2 })JSON");
 
@@ -47,7 +47,7 @@ TEST(JSONPointer_remove, cannot_remove_root_object) {
             sourcemeta::core::parse_json(R"JSON({ "foo": 1, "": 2 })JSON"));
 }
 
-TEST(JSONPointer_remove, positive_integer_property) {
+TEST(positive_integer_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON");
 
@@ -55,7 +55,7 @@ TEST(JSONPointer_remove, positive_integer_property) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 2 })JSON"));
 }
 
-TEST(JSONPointer_remove, positive_nonexistent_integer_property) {
+TEST(positive_nonexistent_integer_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON");
 
@@ -65,7 +65,7 @@ TEST(JSONPointer_remove, positive_nonexistent_integer_property) {
             sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON"));
 }
 
-TEST(JSONPointer_remove, positive_integer_property_string_pointer) {
+TEST(positive_integer_property_string_pointer) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON");
 
@@ -74,7 +74,7 @@ TEST(JSONPointer_remove, positive_integer_property_string_pointer) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 2 })JSON"));
 }
 
-TEST(JSONWeakPointer_remove, array_element) {
+TEST(weak_array_element) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON");
 
@@ -83,7 +83,7 @@ TEST(JSONWeakPointer_remove, array_element) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON([ 1, 3 ])JSON"));
 }
 
-TEST(JSONWeakPointer_remove, nonexistent_array_element) {
+TEST(weak_nonexistent_array_element) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON");
 
@@ -92,7 +92,7 @@ TEST(JSONWeakPointer_remove, nonexistent_array_element) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON"));
 }
 
-TEST(JSONWeakPointer_remove, empty_property) {
+TEST(weak_empty_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "": 2 })JSON");
 
@@ -102,7 +102,7 @@ TEST(JSONWeakPointer_remove, empty_property) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON"));
 }
 
-TEST(JSONWeakPointer_remove, nonexistent_property) {
+TEST(weak_nonexistent_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON");
 
@@ -112,7 +112,7 @@ TEST(JSONWeakPointer_remove, nonexistent_property) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON"));
 }
 
-TEST(JSONWeakPointer_remove, cannot_remove_root_object) {
+TEST(weak_cannot_remove_root_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "foo": 1, "": 2 })JSON");
 
@@ -122,7 +122,7 @@ TEST(JSONWeakPointer_remove, cannot_remove_root_object) {
             sourcemeta::core::parse_json(R"JSON({ "foo": 1, "": 2 })JSON"));
 }
 
-TEST(JSONWeakPointer_remove, positive_integer_property) {
+TEST(weak_positive_integer_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON");
 
@@ -131,7 +131,7 @@ TEST(JSONWeakPointer_remove, positive_integer_property) {
   EXPECT_EQ(document, sourcemeta::core::parse_json(R"JSON({ "foo": 2 })JSON"));
 }
 
-TEST(JSONWeakPointer_remove, positive_nonexistent_integer_property) {
+TEST(weak_positive_nonexistent_integer_property) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON");
 
@@ -141,7 +141,7 @@ TEST(JSONWeakPointer_remove, positive_nonexistent_integer_property) {
             sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON"));
 }
 
-TEST(JSONWeakPointer_remove, positive_integer_property_string_pointer) {
+TEST(weak_positive_integer_property_string_pointer) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json(R"JSON({ "1": 1, "foo": 2 })JSON");
 

--- a/test/jsonpointer/jsonpointer_resolve_from_test.cc
+++ b/test/jsonpointer/jsonpointer_resolve_from_test.cc
@@ -1,45 +1,45 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_resolve_from, mismatch_base_shorter) {
+TEST(mismatch_base_shorter) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer base{"foo", "bar", "baz"};
   EXPECT_EQ(pointer.resolve_from(base), pointer);
 }
 
-TEST(JSONPointer_resolve_from, mismatch_pointer_empty) {
+TEST(mismatch_pointer_empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer base{"foo", "bar", "baz"};
   EXPECT_EQ(pointer.resolve_from(base), pointer);
 }
 
-TEST(JSONPointer_resolve_from, mismatch_base_empty) {
+TEST(mismatch_base_empty) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer base;
   EXPECT_EQ(pointer.resolve_from(base), pointer);
 }
 
-TEST(JSONPointer_resolve_from, equal_empty) {
+TEST(equal_empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer base;
   EXPECT_EQ(pointer.resolve_from(base), pointer);
 }
 
-TEST(JSONPointer_resolve_from, equal_non_empty) {
+TEST(equal_non_empty) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer base{"foo", "bar"};
   EXPECT_EQ(pointer.resolve_from(base), sourcemeta::core::Pointer{});
 }
 
-TEST(JSONPointer_resolve_from, match_1) {
+TEST(match_1) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz", "qux"};
   const sourcemeta::core::Pointer base{"foo", "bar"};
   EXPECT_EQ(pointer.resolve_from(base),
             sourcemeta::core::Pointer({"baz", "qux"}));
 }
 
-TEST(JSONPointer_resolve_from, match_2) {
+TEST(match_2) {
   const sourcemeta::core::Pointer pointer{0, 1, 2};
   const sourcemeta::core::Pointer base{0, 1};
   EXPECT_EQ(pointer.resolve_from(base), sourcemeta::core::Pointer({2}));

--- a/test/jsonpointer/jsonpointer_set_test.cc
+++ b/test/jsonpointer/jsonpointer_set_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_set, property_to_integer) {
+TEST(property_to_integer) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1 }");
   const sourcemeta::core::Pointer pointer{"foo"};
@@ -15,7 +15,7 @@ TEST(JSONPointer_set, property_to_integer) {
   EXPECT_EQ(document.at("foo").to_integer(), 2);
 }
 
-TEST(JSONPointer_set, property_to_integer_copy) {
+TEST(property_to_integer_copy) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1 }");
   const sourcemeta::core::Pointer pointer{"foo"};
@@ -28,7 +28,7 @@ TEST(JSONPointer_set, property_to_integer_copy) {
   EXPECT_EQ(document.at("foo").to_integer(), 2);
 }
 
-TEST(JSONPointer_set, top_level_to_integer) {
+TEST(top_level_to_integer) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1 }");
   const sourcemeta::core::Pointer pointer;
@@ -37,7 +37,7 @@ TEST(JSONPointer_set, top_level_to_integer) {
   EXPECT_EQ(document.to_integer(), 2);
 }
 
-TEST(JSONPointer_set, top_level_to_integer_copy) {
+TEST(top_level_to_integer_copy) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1 }");
   const sourcemeta::core::Pointer pointer;
@@ -47,7 +47,7 @@ TEST(JSONPointer_set, top_level_to_integer_copy) {
   EXPECT_EQ(document.to_integer(), 2);
 }
 
-TEST(JSONPointer_set, array_element_to_integer) {
+TEST(array_element_to_integer) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": [ 1, 2, 3 ] }");
   const sourcemeta::core::Pointer pointer{"foo", 1};
@@ -65,7 +65,7 @@ TEST(JSONPointer_set, array_element_to_integer) {
   EXPECT_EQ(document.at("foo").at(2).to_integer(), 3);
 }
 
-TEST(JSONPointer_set, array_element_to_integer_copy) {
+TEST(array_element_to_integer_copy) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": [ 1, 2, 3 ] }");
   const sourcemeta::core::Pointer pointer{"foo", 1};
@@ -84,7 +84,7 @@ TEST(JSONPointer_set, array_element_to_integer_copy) {
   EXPECT_EQ(document.at("foo").at(2).to_integer(), 3);
 }
 
-TEST(JSONPointer_set, hyphen_property_in_object) {
+TEST(hyphen_property_in_object) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": { \"-\": 1 } }");
   const sourcemeta::core::Pointer pointer{"foo", "-"};
@@ -98,7 +98,7 @@ TEST(JSONPointer_set, hyphen_property_in_object) {
   EXPECT_EQ(document.at("foo").at("-").to_integer(), 2);
 }
 
-TEST(JSONPointer_set, hyphen_in_array_single_token) {
+TEST(hyphen_in_array_single_token) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   const sourcemeta::core::Pointer pointer{"-"};
   sourcemeta::core::set(document, pointer, sourcemeta::core::JSON{4});
@@ -114,7 +114,7 @@ TEST(JSONPointer_set, hyphen_in_array_single_token) {
   EXPECT_EQ(document.at(3).to_integer(), 4);
 }
 
-TEST(JSONPointer_set, hyphen_in_array_single_token_copy) {
+TEST(hyphen_in_array_single_token_copy) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json("[ 1, 2, 3 ]");
   const sourcemeta::core::Pointer pointer{"-"};
   const sourcemeta::core::JSON value{4};
@@ -131,7 +131,7 @@ TEST(JSONPointer_set, hyphen_in_array_single_token_copy) {
   EXPECT_EQ(document.at(3).to_integer(), 4);
 }
 
-TEST(JSONPointer_set, hyphen_in_array_multiple_tokens) {
+TEST(hyphen_in_array_multiple_tokens) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": [ 1, 2, 3 ] }");
   const sourcemeta::core::Pointer pointer{"foo", "-"};
@@ -150,7 +150,7 @@ TEST(JSONPointer_set, hyphen_in_array_multiple_tokens) {
   EXPECT_EQ(document.at("foo").at(3).to_integer(), 4);
 }
 
-TEST(JSONPointer_set, hyphen_in_array_multiple_tokens_copy) {
+TEST(hyphen_in_array_multiple_tokens_copy) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": [ 1, 2, 3 ] }");
   const sourcemeta::core::Pointer pointer{"foo", "-"};
@@ -170,7 +170,7 @@ TEST(JSONPointer_set, hyphen_in_array_multiple_tokens_copy) {
   EXPECT_EQ(document.at("foo").at(3).to_integer(), 4);
 }
 
-TEST(JSONPointer_set, hyphen_in_array_multiple_tokens_with_inner_hyphen) {
+TEST(hyphen_in_array_multiple_tokens_with_inner_hyphen) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"-\": [ 1, 2, 3 ] }");
   const sourcemeta::core::Pointer pointer{"-", "-"};
@@ -189,7 +189,7 @@ TEST(JSONPointer_set, hyphen_in_array_multiple_tokens_with_inner_hyphen) {
   EXPECT_EQ(document.at("-").at(3).to_integer(), 4);
 }
 
-TEST(JSONPointer_set, hyphen_in_array_multiple_tokens_with_inner_hyphen_copy) {
+TEST(hyphen_in_array_multiple_tokens_with_inner_hyphen_copy) {
   sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"-\": [ 1, 2, 3 ] }");
   const sourcemeta::core::Pointer pointer{"-", "-"};
@@ -209,7 +209,7 @@ TEST(JSONPointer_set, hyphen_in_array_multiple_tokens_with_inner_hyphen_copy) {
   EXPECT_EQ(document.at("-").at(3).to_integer(), 4);
 }
 
-TEST(JSONPointer_set, positive_integer_property) {
+TEST(positive_integer_property) {
   sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({
     "0": 1
   })JSON");

--- a/test/jsonpointer/jsonpointer_slice_test.cc
+++ b/test/jsonpointer/jsonpointer_slice_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_slice, from_zero) {
+TEST(from_zero) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(0)};
   EXPECT_EQ(result.size(), 3);
@@ -14,7 +14,7 @@ TEST(JSONPointer_slice, from_zero) {
   EXPECT_EQ(result.at(2).to_property(), "baz");
 }
 
-TEST(JSONPointer_slice, from_one) {
+TEST(from_one) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(1)};
   EXPECT_EQ(result.size(), 2);
@@ -24,7 +24,7 @@ TEST(JSONPointer_slice, from_one) {
   EXPECT_EQ(result.at(1).to_property(), "baz");
 }
 
-TEST(JSONPointer_slice, from_two) {
+TEST(from_two) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(2)};
   EXPECT_EQ(result.size(), 1);
@@ -32,21 +32,21 @@ TEST(JSONPointer_slice, from_two) {
   EXPECT_EQ(result.at(0).to_property(), "baz");
 }
 
-TEST(JSONPointer_slice, from_end) {
+TEST(from_end) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(3)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONPointer_slice, empty_from_zero) {
+TEST(empty_from_zero) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer result{pointer.slice(0)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONPointer_slice, with_indices) {
+TEST(with_indices) {
   const sourcemeta::core::Pointer pointer{"foo", 1, "bar", 2};
   const sourcemeta::core::Pointer result{pointer.slice(1)};
   EXPECT_EQ(result.size(), 3);
@@ -58,7 +58,7 @@ TEST(JSONPointer_slice, with_indices) {
   EXPECT_EQ(result.at(2).to_index(), 2);
 }
 
-TEST(JSONPointer_slice, single_element_from_zero) {
+TEST(single_element_from_zero) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer result{pointer.slice(0)};
   EXPECT_EQ(result.size(), 1);
@@ -66,14 +66,14 @@ TEST(JSONPointer_slice, single_element_from_zero) {
   EXPECT_EQ(result.at(0).to_property(), "foo");
 }
 
-TEST(JSONPointer_slice, single_element_from_one) {
+TEST(single_element_from_one) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer result{pointer.slice(1)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONPointer_slice, range_middle) {
+TEST(range_middle) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz", "qux"};
   const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
   EXPECT_EQ(result.size(), 2);
@@ -83,7 +83,7 @@ TEST(JSONPointer_slice, range_middle) {
   EXPECT_EQ(result.at(1).to_property(), "baz");
 }
 
-TEST(JSONPointer_slice, range_from_start) {
+TEST(range_from_start) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(0, 2)};
   EXPECT_EQ(result.size(), 2);
@@ -93,7 +93,7 @@ TEST(JSONPointer_slice, range_from_start) {
   EXPECT_EQ(result.at(1).to_property(), "bar");
 }
 
-TEST(JSONPointer_slice, range_to_end) {
+TEST(range_to_end) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
   EXPECT_EQ(result.size(), 2);
@@ -103,7 +103,7 @@ TEST(JSONPointer_slice, range_to_end) {
   EXPECT_EQ(result.at(1).to_property(), "baz");
 }
 
-TEST(JSONPointer_slice, range_full) {
+TEST(range_full) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(0, 3)};
   EXPECT_EQ(result.size(), 3);
@@ -115,14 +115,14 @@ TEST(JSONPointer_slice, range_full) {
   EXPECT_EQ(result.at(2).to_property(), "baz");
 }
 
-TEST(JSONPointer_slice, range_empty_same_indices) {
+TEST(range_empty_same_indices) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(1, 1)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONPointer_slice, range_single_element) {
+TEST(range_single_element) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer result{pointer.slice(1, 2)};
   EXPECT_EQ(result.size(), 1);
@@ -130,14 +130,14 @@ TEST(JSONPointer_slice, range_single_element) {
   EXPECT_EQ(result.at(0).to_property(), "bar");
 }
 
-TEST(JSONPointer_slice, range_empty_pointer) {
+TEST(range_empty_pointer) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer result{pointer.slice(0, 0)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONPointer_slice, range_with_indices) {
+TEST(range_with_indices) {
   const sourcemeta::core::Pointer pointer{"foo", 1, "bar", 2};
   const sourcemeta::core::Pointer result{pointer.slice(1, 3)};
   EXPECT_EQ(result.size(), 2);

--- a/test/jsonpointer/jsonpointer_starts_with_initial_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_initial_test.cc
@@ -1,86 +1,86 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_starts_with_initial, property_prefix_true) {
+TEST(property_prefix_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, property_prefix_false) {
+TEST(property_prefix_false) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"bar"};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, index_prefix_false) {
+TEST(index_prefix_false) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{1};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, property_same) {
+TEST(property_same) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, index_same) {
+TEST(index_same) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{0, 1};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, property_different) {
+TEST(property_different) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"bar", "baz"};
   EXPECT_FALSE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, index_different) {
+TEST(index_different) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{2, 3};
   EXPECT_FALSE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, non_empty_empty) {
+TEST(non_empty_empty) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, empty_non_empty_1) {
+TEST(empty_non_empty_1) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, empty_non_empty_3) {
+TEST(empty_non_empty_3) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer prefix{"foo", 1, "bar"};
   EXPECT_FALSE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, empty_empty) {
+TEST(empty_empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, initial_equal_true) {
+TEST(initial_equal_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo", "bar", "baz"};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, initial_equal_false) {
+TEST(initial_equal_false) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo", "qux", "baz"};
   EXPECT_FALSE(pointer.starts_with_initial(prefix));
 }
 
-TEST(JSONPointer_starts_with_initial, initial_subset) {
+TEST(initial_subset) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "qux"};
   const sourcemeta::core::Pointer prefix{"foo", "bar", "baz"};
   EXPECT_TRUE(pointer.starts_with_initial(prefix));

--- a/test/jsonpointer/jsonpointer_starts_with_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_test.cc
@@ -1,203 +1,203 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_starts_with, property_prefix_true) {
+TEST(property_prefix_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, property_prefix_false) {
+TEST(property_prefix_false) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"bar"};
   EXPECT_FALSE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, index_prefix_true) {
+TEST(index_prefix_true) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{0};
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, index_prefix_false) {
+TEST(index_prefix_false) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{1};
   EXPECT_FALSE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, property_same) {
+TEST(property_same) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, index_same) {
+TEST(index_same) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{0, 1};
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, property_different) {
+TEST(property_different) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::Pointer prefix{"bar", "baz"};
   EXPECT_FALSE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, index_different) {
+TEST(index_different) {
   const sourcemeta::core::Pointer pointer{0, 1};
   const sourcemeta::core::Pointer prefix{2, 3};
   EXPECT_FALSE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, non_empty_empty) {
+TEST(non_empty_empty) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, empty_non_empty) {
+TEST(empty_non_empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, empty_empty) {
+TEST(empty_empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix));
 }
 
-TEST(JSONPointer_starts_with, tail_equal_initial) {
+TEST(tail_equal_initial) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"foo", "bar", "baz"};
   EXPECT_TRUE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_subset_initial_true) {
+TEST(tail_subset_initial_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"foo", "bar"};
   EXPECT_TRUE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_subset_initial_false) {
+TEST(tail_subset_initial_false) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"foo", "qux"};
   EXPECT_FALSE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_equal_initial_plus_tail_true) {
+TEST(tail_equal_initial_plus_tail_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"foo", "bar", "baz", "qux"};
   EXPECT_TRUE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_equal_initial_plus_tail_false) {
+TEST(tail_equal_initial_plus_tail_false) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"foo", "bar", "baz", "xxx"};
   EXPECT_FALSE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_equal_tail) {
+TEST(tail_equal_tail) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"qux"};
   EXPECT_FALSE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_empty_initial_true) {
+TEST(tail_empty_initial_true) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"qux"};
   EXPECT_TRUE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_empty_initial_false) {
+TEST(tail_empty_initial_false) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix{"bar"};
   EXPECT_FALSE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, tail_empty_prefix) {
+TEST(tail_empty_prefix) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::Pointer::Token tail{"qux"};
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix, tail));
 }
 
-TEST(JSONPointer_starts_with, property_tail_true) {
+TEST(property_tail_true) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_TRUE(pointer.starts_with(prefix, "$defs"));
 }
 
-TEST(JSONPointer_starts_with, property_tail_false_wrong_tail) {
+TEST(property_tail_false_wrong_tail) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "other"));
 }
 
-TEST(JSONPointer_starts_with, property_tail_false_wrong_prefix) {
+TEST(property_tail_false_wrong_prefix) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar"};
   const sourcemeta::core::Pointer prefix{"baz"};
   EXPECT_FALSE(pointer.starts_with(prefix, "$defs"));
 }
 
-TEST(JSONPointer_starts_with, property_tail_pointer_too_short) {
+TEST(property_tail_pointer_too_short) {
   const sourcemeta::core::Pointer pointer{"foo"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "$defs"));
 }
 
-TEST(JSONPointer_starts_with, property_tail_empty_prefix) {
+TEST(property_tail_empty_prefix) {
   const sourcemeta::core::Pointer pointer{"$defs", "bar"};
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix, "$defs"));
 }
 
-TEST(JSONPointer_starts_with, property_tail_index_token) {
+TEST(property_tail_index_token) {
   const sourcemeta::core::Pointer pointer{"foo", 0, "bar"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "0"));
 }
 
-TEST(JSONPointer_starts_with, property_two_tails_true) {
+TEST(property_two_tails_true) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar", "baz"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_TRUE(pointer.starts_with(prefix, "$defs", "bar"));
 }
 
-TEST(JSONPointer_starts_with, property_two_tails_false_wrong_left) {
+TEST(property_two_tails_false_wrong_left) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar", "baz"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "other", "bar"));
 }
 
-TEST(JSONPointer_starts_with, property_two_tails_false_wrong_right) {
+TEST(property_two_tails_false_wrong_right) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", "bar", "baz"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "$defs", "other"));
 }
 
-TEST(JSONPointer_starts_with, property_two_tails_pointer_too_short) {
+TEST(property_two_tails_pointer_too_short) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "$defs", "bar"));
 }
 
-TEST(JSONPointer_starts_with, property_two_tails_empty_prefix) {
+TEST(property_two_tails_empty_prefix) {
   const sourcemeta::core::Pointer pointer{"$defs", "bar", "baz"};
   const sourcemeta::core::Pointer prefix;
   EXPECT_TRUE(pointer.starts_with(prefix, "$defs", "bar"));
 }
 
-TEST(JSONPointer_starts_with, property_two_tails_index_in_right) {
+TEST(property_two_tails_index_in_right) {
   const sourcemeta::core::Pointer pointer{"foo", "$defs", 0, "baz"};
   const sourcemeta::core::Pointer prefix{"foo"};
   EXPECT_FALSE(pointer.starts_with(prefix, "$defs", "0"));

--- a/test/jsonpointer/jsonpointer_stringify_test.cc
+++ b/test/jsonpointer/jsonpointer_stringify_test.cc
@@ -1,150 +1,150 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
 #include <sstream>
 
-TEST(JSONPointer_stringify, empty_pointer) {
+TEST(empty_pointer) {
   const sourcemeta::core::Pointer pointer;
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "");
 }
 
-TEST(JSONPointer_stringify, empty_string) {
+TEST(empty_string) {
   const sourcemeta::core::Pointer pointer{""};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/");
 }
 
-TEST(JSONPointer_stringify, string_space) {
+TEST(string_space) {
   const sourcemeta::core::Pointer pointer{" "};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/ ");
 }
 
-TEST(JSONPointer_stringify, foo) {
+TEST(foo) {
   const sourcemeta::core::Pointer pointer{"foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo");
 }
 
-TEST(JSONPointer_stringify, hyphen_single) {
+TEST(hyphen_single) {
   const sourcemeta::core::Pointer pointer{"-"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/-");
 }
 
-TEST(JSONPointer_stringify, hyphen_last) {
+TEST(hyphen_last) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "-"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo/bar/-");
 }
 
-TEST(JSONPointer_stringify, hyphen_multi) {
+TEST(hyphen_multi) {
   const sourcemeta::core::Pointer pointer{"-", "-", "-"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/-/-/-");
 }
 
-TEST(JSONPointer_stringify, foo_bar_baz) {
+TEST(foo_bar_baz) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo/bar/baz");
 }
 
-TEST(JSONPointer_stringify, foo_empty_bar) {
+TEST(foo_empty_bar) {
   const sourcemeta::core::Pointer pointer{"foo", "", "baz"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo//baz");
 }
 
-TEST(JSONPointer_stringify, 0) {
+TEST(0) {
   const sourcemeta::core::Pointer pointer{0};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/0");
 }
 
-TEST(JSONPointer_stringify, 0_1_2) {
+TEST(0_1_2) {
   const sourcemeta::core::Pointer pointer{0, 1, 2};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/0/1/2");
 }
 
-TEST(JSONPointer_stringify, multi_digit) {
+TEST(multi_digit) {
   const sourcemeta::core::Pointer pointer{1234};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/1234");
 }
 
-TEST(JSONPointer_stringify, escape_slash) {
+TEST(escape_slash) {
   const sourcemeta::core::Pointer pointer{"foo/bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo~1bar");
 }
 
-TEST(JSONPointer_stringify, escape_tilde) {
+TEST(escape_tilde) {
   const sourcemeta::core::Pointer pointer{"foo~bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo~0bar");
 }
 
-TEST(JSONPointer_stringify, escape_multiple) {
+TEST(escape_multiple) {
   const sourcemeta::core::Pointer pointer{"a/b", "m~n"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/a~1b/m~0n");
 }
 
-TEST(JSONPointer_stringify, tilde_0) {
+TEST(tilde_0) {
   const sourcemeta::core::Pointer pointer{"foo~0bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo~00bar");
 }
 
-TEST(JSONPointer_stringify, tilde_1) {
+TEST(tilde_1) {
   const sourcemeta::core::Pointer pointer{"foo~1bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo~01bar");
 }
 
-TEST(JSONPointer_stringify, backslash) {
+TEST(backslash) {
   const sourcemeta::core::Pointer pointer{"foo\\bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\\bar");
 }
 
-TEST(JSONPointer_stringify, double_quote) {
+TEST(double_quote) {
   const sourcemeta::core::Pointer pointer{"foo\"bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\"bar");
 }
 
-TEST(JSONPointer_stringify, single_quote) {
+TEST(single_quote) {
   const sourcemeta::core::Pointer pointer{"foo'bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo'bar");
 }
 
-TEST(JSONPointer_stringify, escape_00) {
+TEST(escape_00) {
   using namespace std::string_literals;
   const sourcemeta::core::Pointer pointer{"foo\0bar"s};
   std::ostringstream stream;
@@ -152,231 +152,231 @@ TEST(JSONPointer_stringify, escape_00) {
   EXPECT_EQ(stream.str(), "/foo\0bar"s);
 }
 
-TEST(JSONPointer_stringify, escape_01) {
+TEST(escape_01) {
   const sourcemeta::core::Pointer pointer{"foo\u0001bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0001bar");
 }
 
-TEST(JSONPointer_stringify, escape_02) {
+TEST(escape_02) {
   const sourcemeta::core::Pointer pointer{"foo\u0002bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0002bar");
 }
 
-TEST(JSONPointer_stringify, escape_03) {
+TEST(escape_03) {
   const sourcemeta::core::Pointer pointer{"foo\u0003bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0003bar");
 }
 
-TEST(JSONPointer_stringify, escape_04) {
+TEST(escape_04) {
   const sourcemeta::core::Pointer pointer{"foo\u0004bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0004bar");
 }
 
-TEST(JSONPointer_stringify, escape_05) {
+TEST(escape_05) {
   const sourcemeta::core::Pointer pointer{"foo\u0005bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0005bar");
 }
 
-TEST(JSONPointer_stringify, escape_06) {
+TEST(escape_06) {
   const sourcemeta::core::Pointer pointer{"foo\u0006bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0006bar");
 }
 
-TEST(JSONPointer_stringify, escape_07) {
+TEST(escape_07) {
   const sourcemeta::core::Pointer pointer{"foo\u0007bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0007bar");
 }
 
-TEST(JSONPointer_stringify, escape_08) {
+TEST(escape_08) {
   const sourcemeta::core::Pointer pointer{"foo\u0008bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0008bar");
 }
 
-TEST(JSONPointer_stringify, escape_09) {
+TEST(escape_09) {
   const sourcemeta::core::Pointer pointer{"foo\u0009bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0009bar");
 }
 
-TEST(JSONPointer_stringify, escape_0A) {
+TEST(escape_0A) {
   const sourcemeta::core::Pointer pointer{"foo\u000abar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u000Abar");
 }
 
-TEST(JSONPointer_stringify, escape_0B) {
+TEST(escape_0B) {
   const sourcemeta::core::Pointer pointer{"foo\u000bbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u000Bbar");
 }
 
-TEST(JSONPointer_stringify, escape_0C) {
+TEST(escape_0C) {
   const sourcemeta::core::Pointer pointer{"foo\u000cbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u000Cbar");
 }
 
-TEST(JSONPointer_stringify, escape_0D) {
+TEST(escape_0D) {
   const sourcemeta::core::Pointer pointer{"foo\u000dbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u000Dbar");
 }
 
-TEST(JSONPointer_stringify, escape_0E) {
+TEST(escape_0E) {
   const sourcemeta::core::Pointer pointer{"foo\u000ebar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u000Ebar");
 }
 
-TEST(JSONPointer_stringify, escape_0F) {
+TEST(escape_0F) {
   const sourcemeta::core::Pointer pointer{"foo\u000fbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u000Fbar");
 }
 
-TEST(JSONPointer_stringify, escape_10) {
+TEST(escape_10) {
   const sourcemeta::core::Pointer pointer{"foo\u0010bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0010bar");
 }
 
-TEST(JSONPointer_stringify, escape_11) {
+TEST(escape_11) {
   const sourcemeta::core::Pointer pointer{"foo\u0011bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0011bar");
 }
 
-TEST(JSONPointer_stringify, escape_12) {
+TEST(escape_12) {
   const sourcemeta::core::Pointer pointer{"foo\u0012bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0012bar");
 }
 
-TEST(JSONPointer_stringify, escape_13) {
+TEST(escape_13) {
   const sourcemeta::core::Pointer pointer{"foo\u0013bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0013bar");
 }
 
-TEST(JSONPointer_stringify, escape_14) {
+TEST(escape_14) {
   const sourcemeta::core::Pointer pointer{"foo\u0014bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0014bar");
 }
 
-TEST(JSONPointer_stringify, escape_15) {
+TEST(escape_15) {
   const sourcemeta::core::Pointer pointer{"foo\u0015bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0015bar");
 }
 
-TEST(JSONPointer_stringify, escape_16) {
+TEST(escape_16) {
   const sourcemeta::core::Pointer pointer{"foo\u0016bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0016bar");
 }
 
-TEST(JSONPointer_stringify, escape_17) {
+TEST(escape_17) {
   const sourcemeta::core::Pointer pointer{"foo\u0017bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0017bar");
 }
 
-TEST(JSONPointer_stringify, escape_18) {
+TEST(escape_18) {
   const sourcemeta::core::Pointer pointer{"foo\u0018bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0018bar");
 }
 
-TEST(JSONPointer_stringify, escape_19) {
+TEST(escape_19) {
   const sourcemeta::core::Pointer pointer{"foo\u0019bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u0019bar");
 }
 
-TEST(JSONPointer_stringify, escape_1A) {
+TEST(escape_1A) {
   const sourcemeta::core::Pointer pointer{"foo\u001abar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u001Abar");
 }
 
-TEST(JSONPointer_stringify, escape_1B) {
+TEST(escape_1B) {
   const sourcemeta::core::Pointer pointer{"foo\u001bbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u001Bbar");
 }
 
-TEST(JSONPointer_stringify, escape_1C) {
+TEST(escape_1C) {
   const sourcemeta::core::Pointer pointer{"foo\u001cbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u001Cbar");
 }
 
-TEST(JSONPointer_stringify, escape_1D) {
+TEST(escape_1D) {
   const sourcemeta::core::Pointer pointer{"foo\u001dbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u001Dbar");
 }
 
-TEST(JSONPointer_stringify, escape_1E) {
+TEST(escape_1E) {
   const sourcemeta::core::Pointer pointer{"foo\u001ebar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u001Ebar");
 }
 
-TEST(JSONPointer_stringify, escape_1F) {
+TEST(escape_1F) {
   const sourcemeta::core::Pointer pointer{"foo\u001fbar"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo\u001Fbar");
 }
 
-TEST(JSONPointer_stringify, no_uri_escape) {
+TEST(no_uri_escape) {
   const sourcemeta::core::Pointer pointer{"foo", "percent%field"};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/foo/percent%field");
 }
 
-TEST(JSONWeakPointer, empty_string) {
+TEST(weak_empty_string) {
   const std::string empty_string = "";
   const sourcemeta::core::WeakPointer pointer{std::cref(empty_string)};
   std::ostringstream stream;
@@ -384,7 +384,7 @@ TEST(JSONWeakPointer, empty_string) {
   EXPECT_EQ(stream.str(), "/");
 }
 
-TEST(JSONWeakPointer, string) {
+TEST(string) {
   const std::string foo = "foo";
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   std::ostringstream stream;
@@ -392,14 +392,14 @@ TEST(JSONWeakPointer, string) {
   EXPECT_EQ(stream.str(), "/foo");
 }
 
-TEST(JSONWeakPointer, index) {
+TEST(index) {
   const sourcemeta::core::WeakPointer pointer{2};
   std::ostringstream stream;
   sourcemeta::core::stringify(pointer, stream);
   EXPECT_EQ(stream.str(), "/2");
 }
 
-TEST(JSONWeakPointer, foo_bar_baz) {
+TEST(weak_foo_bar_baz) {
   const std::string foo = "foo";
   const std::string bar = "bar";
   const std::string baz = "baz";

--- a/test/jsonpointer/jsonpointer_to_string_test.cc
+++ b/test/jsonpointer/jsonpointer_to_string_test.cc
@@ -1,39 +1,39 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_to_string, empty) {
+TEST(empty) {
   const sourcemeta::core::Pointer pointer;
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "");
 }
 
-TEST(JSONPointer_to_string, empty_property) {
+TEST(empty_property) {
   const sourcemeta::core::Pointer pointer{""};
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "/");
 }
 
-TEST(JSONPointer_to_string, foo_bar_baz) {
+TEST(foo_bar_baz) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "/foo/bar/baz");
 }
 
-TEST(JSONPointer_to_string, foo_1_2) {
+TEST(foo_1_2) {
   const sourcemeta::core::Pointer pointer{"foo", 1, 2};
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "/foo/1/2");
 }
 
-TEST(JSONWeakPointer_to_string, empty) {
+TEST(weak_empty) {
   const sourcemeta::core::WeakPointer pointer;
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "");
 }
 
-TEST(JSONWeakPointer_to_string, empty_property) {
+TEST(weak_empty_property) {
   const std::string empty = "";
   const sourcemeta::core::WeakPointer pointer{std::cref(empty)};
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "/");
 }
 
-TEST(JSONWeakPointer_to_string, foo_bar_baz) {
+TEST(weak_foo_bar_baz) {
   const std::string foo = "foo";
   const std::string bar = "bar";
   const std::string baz = "baz";
@@ -42,7 +42,7 @@ TEST(JSONWeakPointer_to_string, foo_bar_baz) {
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "/foo/bar/baz");
 }
 
-TEST(JSONWeakPointer_to_string, foo_1_2) {
+TEST(weak_foo_1_2) {
   const std::string foo = "foo";
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), 1, 2};
   EXPECT_EQ(sourcemeta::core::to_string(pointer), "/foo/1/2");

--- a/test/jsonpointer/jsonpointer_to_uri_test.cc
+++ b/test/jsonpointer/jsonpointer_to_uri_test.cc
@@ -1,300 +1,300 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/uri.h>
 
-TEST(JSONPointer_to_uri, empty) {
+TEST(empty) {
   const sourcemeta::core::Pointer pointer;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#");
 }
 
-TEST(JSONPointer_to_uri, empty_fragment) {
+TEST(empty_fragment) {
   const sourcemeta::core::Pointer pointer{""};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/");
 }
 
-TEST(JSONPointer_to_uri, with_property_tokens) {
+TEST(with_property_tokens) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar/baz");
 }
 
-TEST(JSONPointer_to_uri, with_index_tokens) {
+TEST(with_index_tokens) {
   const sourcemeta::core::Pointer pointer{0, 1, 2};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/0/1/2");
 }
 
-TEST(JSONPointer_to_uri, escape_slash) {
+TEST(escape_slash) {
   const sourcemeta::core::Pointer pointer{"foo", "bar/baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar~1baz");
 }
 
-TEST(JSONPointer_to_uri, escape_tilde) {
+TEST(escape_tilde) {
   const sourcemeta::core::Pointer pointer{"foo", "bar~baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar~0baz");
 }
 
-TEST(JSONPointer_to_uri, escape_uri_percentage) {
+TEST(escape_uri_percentage) {
   const sourcemeta::core::Pointer pointer{"foo", "percent%field"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/percent%25field");
 }
 
-TEST(JSONPointer_to_uri, escape_uri_quote) {
+TEST(escape_uri_quote) {
   const sourcemeta::core::Pointer pointer{"foo", "quote\"field"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/quote%22field");
 }
 
-TEST(JSONPointer_to_uri, escape_uri_backslash) {
+TEST(escape_uri_backslash) {
   const sourcemeta::core::Pointer pointer{"foo", "bar\\baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar%5Cbaz");
 }
 
-TEST(JSONPointer_to_uri, escape_uri_dollar_sign) {
+TEST(escape_uri_dollar_sign) {
   const sourcemeta::core::Pointer pointer{"foo", "$id"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/$id");
 }
 
-TEST(JSONPointer_to_uri, escape_00) {
+TEST(escape_00) {
   using namespace std::string_literals;
   const sourcemeta::core::Pointer pointer{"foo\0bar"s};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%00bar");
 }
 
-TEST(JSONPointer_to_uri, escape_01) {
+TEST(escape_01) {
   const sourcemeta::core::Pointer pointer{"foo\u0001bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%01bar");
 }
 
-TEST(JSONPointer_to_uri, escape_02) {
+TEST(escape_02) {
   const sourcemeta::core::Pointer pointer{"foo\u0002bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%02bar");
 }
 
-TEST(JSONPointer_to_uri, escape_03) {
+TEST(escape_03) {
   const sourcemeta::core::Pointer pointer{"foo\u0003bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%03bar");
 }
 
-TEST(JSONPointer_to_uri, escape_04) {
+TEST(escape_04) {
   const sourcemeta::core::Pointer pointer{"foo\u0004bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%04bar");
 }
 
-TEST(JSONPointer_to_uri, escape_05) {
+TEST(escape_05) {
   const sourcemeta::core::Pointer pointer{"foo\u0005bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%05bar");
 }
 
-TEST(JSONPointer_to_uri, escape_06) {
+TEST(escape_06) {
   const sourcemeta::core::Pointer pointer{"foo\u0006bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%06bar");
 }
 
-TEST(JSONPointer_to_uri, escape_07) {
+TEST(escape_07) {
   const sourcemeta::core::Pointer pointer{"foo\u0007bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%07bar");
 }
 
-TEST(JSONPointer_to_uri, escape_08) {
+TEST(escape_08) {
   const sourcemeta::core::Pointer pointer{"foo\u0008bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%08bar");
 }
 
-TEST(JSONPointer_to_uri, escape_09) {
+TEST(escape_09) {
   const sourcemeta::core::Pointer pointer{"foo\u0009bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%09bar");
 }
 
-TEST(JSONPointer_to_uri, escape_0A) {
+TEST(escape_0A) {
   const sourcemeta::core::Pointer pointer{"foo\u000abar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%0Abar");
 }
 
-TEST(JSONPointer_to_uri, escape_0B) {
+TEST(escape_0B) {
   const sourcemeta::core::Pointer pointer{"foo\u000bbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%0Bbar");
 }
 
-TEST(JSONPointer_to_uri, escape_0C) {
+TEST(escape_0C) {
   const sourcemeta::core::Pointer pointer{"foo\u000cbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%0Cbar");
 }
 
-TEST(JSONPointer_to_uri, escape_0D) {
+TEST(escape_0D) {
   const sourcemeta::core::Pointer pointer{"foo\u000dbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%0Dbar");
 }
 
-TEST(JSONPointer_to_uri, escape_0E) {
+TEST(escape_0E) {
   const sourcemeta::core::Pointer pointer{"foo\u000ebar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%0Ebar");
 }
 
-TEST(JSONPointer_to_uri, escape_0F) {
+TEST(escape_0F) {
   const sourcemeta::core::Pointer pointer{"foo\u000fbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%0Fbar");
 }
 
-TEST(JSONPointer_to_uri, escape_10) {
+TEST(escape_10) {
   const sourcemeta::core::Pointer pointer{"foo\u0010bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%10bar");
 }
 
-TEST(JSONPointer_to_uri, escape_11) {
+TEST(escape_11) {
   const sourcemeta::core::Pointer pointer{"foo\u0011bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%11bar");
 }
 
-TEST(JSONPointer_to_uri, escape_12) {
+TEST(escape_12) {
   const sourcemeta::core::Pointer pointer{"foo\u0012bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%12bar");
 }
 
-TEST(JSONPointer_to_uri, escape_13) {
+TEST(escape_13) {
   const sourcemeta::core::Pointer pointer{"foo\u0013bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%13bar");
 }
 
-TEST(JSONPointer_to_uri, escape_14) {
+TEST(escape_14) {
   const sourcemeta::core::Pointer pointer{"foo\u0014bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%14bar");
 }
 
-TEST(JSONPointer_to_uri, escape_15) {
+TEST(escape_15) {
   const sourcemeta::core::Pointer pointer{"foo\u0015bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%15bar");
 }
 
-TEST(JSONPointer_to_uri, escape_16) {
+TEST(escape_16) {
   const sourcemeta::core::Pointer pointer{"foo\u0016bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%16bar");
 }
 
-TEST(JSONPointer_to_uri, escape_17) {
+TEST(escape_17) {
   const sourcemeta::core::Pointer pointer{"foo\u0017bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%17bar");
 }
 
-TEST(JSONPointer_to_uri, escape_18) {
+TEST(escape_18) {
   const sourcemeta::core::Pointer pointer{"foo\u0018bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%18bar");
 }
 
-TEST(JSONPointer_to_uri, escape_19) {
+TEST(escape_19) {
   const sourcemeta::core::Pointer pointer{"foo\u0019bar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%19bar");
 }
 
-TEST(JSONPointer_to_uri, escape_1A) {
+TEST(escape_1A) {
   const sourcemeta::core::Pointer pointer{"foo\u001abar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%1Abar");
 }
 
-TEST(JSONPointer_to_uri, escape_1B) {
+TEST(escape_1B) {
   const sourcemeta::core::Pointer pointer{"foo\u001bbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%1Bbar");
 }
 
-TEST(JSONPointer_to_uri, escape_1C) {
+TEST(escape_1C) {
   const sourcemeta::core::Pointer pointer{"foo\u001cbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%1Cbar");
 }
 
-TEST(JSONPointer_to_uri, escape_1D) {
+TEST(escape_1D) {
   const sourcemeta::core::Pointer pointer{"foo\u001dbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%1Dbar");
 }
 
-TEST(JSONPointer_to_uri, escape_1E) {
+TEST(escape_1E) {
   const sourcemeta::core::Pointer pointer{"foo\u001ebar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%1Ebar");
 }
 
-TEST(JSONPointer_to_uri, escape_1F) {
+TEST(escape_1F) {
   const sourcemeta::core::Pointer pointer{"foo\u001fbar"};
   std::ostringstream stream;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo%1Fbar");
 }
 
-TEST(JSONPointer_to_uri, with_absolute_base) {
+TEST(with_absolute_base) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::URI base{"https://www.example.com"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "https://www.example.com#/foo/bar");
 }
 
-TEST(JSONPointer_to_uri, with_absolute_base_percentage) {
+TEST(with_absolute_base_percentage) {
   const sourcemeta::core::Pointer pointer{"foo%bar"};
   const sourcemeta::core::URI base{"https://www.example.com"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
@@ -303,14 +303,14 @@ TEST(JSONPointer_to_uri, with_absolute_base_percentage) {
   EXPECT_EQ(fragment.recompose(), "https://www.example.com#/foo%BAr");
 }
 
-TEST(JSONPointer_to_uri, with_relative_base) {
+TEST(with_relative_base) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};
   const sourcemeta::core::URI base{"../baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "../baz#/foo/bar");
 }
 
-TEST(JSONPointer_to_uri, with_at_sign) {
+TEST(with_at_sign) {
   const sourcemeta::core::Pointer pointer{"@foo", "bar"};
   const auto fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/@foo/bar");

--- a/test/jsonpointer/jsonpointer_token_test.cc
+++ b/test/jsonpointer/jsonpointer_token_test.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
 #include <type_traits>
 
-TEST(JSONPointer_token, general_traits) {
+TEST(general_traits) {
   EXPECT_FALSE(
       std::is_default_constructible<sourcemeta::core::Pointer::Token>::value);
   EXPECT_FALSE(std::is_nothrow_default_constructible<
@@ -15,7 +15,7 @@ TEST(JSONPointer_token, general_traits) {
       std::is_nothrow_destructible<sourcemeta::core::Pointer::Token>::value);
 }
 
-TEST(JSONPointer_token, copy_traits) {
+TEST(copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::Pointer::Token>::value);
   EXPECT_TRUE(
       std::is_copy_constructible<sourcemeta::core::Pointer::Token>::value);
@@ -25,7 +25,7 @@ TEST(JSONPointer_token, copy_traits) {
                sourcemeta::core::Pointer::Token>::value);
 }
 
-TEST(JSONPointer_token, move_traits) {
+TEST(move_traits) {
   EXPECT_TRUE(std::is_move_assignable<sourcemeta::core::Pointer::Token>::value);
   EXPECT_TRUE(
       std::is_move_constructible<sourcemeta::core::Pointer::Token>::value);
@@ -35,7 +35,7 @@ TEST(JSONPointer_token, move_traits) {
               sourcemeta::core::Pointer::Token>::value);
 }
 
-TEST(JSONPointer_token, character_token) {
+TEST(character_token) {
   const sourcemeta::core::Pointer::Token token{'f'};
   EXPECT_TRUE(token.is_property());
   EXPECT_FALSE(token.is_index());
@@ -43,7 +43,7 @@ TEST(JSONPointer_token, character_token) {
   EXPECT_EQ(token.to_property(), "f");
 }
 
-TEST(JSONPointer_token, string_token) {
+TEST(string_token) {
   const sourcemeta::core::Pointer::Token token{"foo"};
   EXPECT_TRUE(token.is_property());
   EXPECT_FALSE(token.is_index());
@@ -51,7 +51,7 @@ TEST(JSONPointer_token, string_token) {
   EXPECT_EQ(token.to_property(), "foo");
 }
 
-TEST(JSONPointer_token, integer_token) {
+TEST(integer_token) {
   const sourcemeta::core::Pointer::Token token{5};
   EXPECT_TRUE(token.is_index());
   EXPECT_FALSE(token.is_property());
@@ -59,19 +59,19 @@ TEST(JSONPointer_token, integer_token) {
   EXPECT_EQ(token.to_index(), 5);
 }
 
-TEST(JSONPointer_token, hyphen_string_token) {
+TEST(hyphen_string_token) {
   const sourcemeta::core::Pointer::Token token{"-"};
   EXPECT_FALSE(token.is_index());
   EXPECT_TRUE(token.is_hyphen());
 }
 
-TEST(JSONPointer_token, hyphen_char_token) {
+TEST(hyphen_char_token) {
   const sourcemeta::core::Pointer::Token token{'-'};
   EXPECT_FALSE(token.is_index());
   EXPECT_TRUE(token.is_hyphen());
 }
 
-TEST(JSONPointer_token, ordering_less_than) {
+TEST(ordering_less_than) {
   const sourcemeta::core::Pointer::Token token_1{"foo"};
   const sourcemeta::core::Pointer::Token token_2{"bar"};
   const sourcemeta::core::Pointer::Token token_3{"baz"};
@@ -80,21 +80,21 @@ TEST(JSONPointer_token, ordering_less_than) {
   EXPECT_TRUE(token_2 < token_3);
 }
 
-TEST(JSONPointer_token, to_json_index) {
+TEST(to_json_index) {
   const sourcemeta::core::Pointer::Token token{5};
   const sourcemeta::core::JSON result{token.to_json()};
   EXPECT_TRUE(result.is_integer());
   EXPECT_EQ(result.to_integer(), 5);
 }
 
-TEST(JSONPointer_token, to_json_property) {
+TEST(to_json_property) {
   const sourcemeta::core::Pointer::Token token{"foo"};
   const sourcemeta::core::JSON result{token.to_json()};
   EXPECT_TRUE(result.is_string());
   EXPECT_EQ(result.to_string(), "foo");
 }
 
-TEST(JSONPointer_token, property_hash) {
+TEST(property_hash) {
   const sourcemeta::core::Pointer::Token first{"foo"};
   const sourcemeta::core::Pointer::Token second{"bar"};
   const sourcemeta::core::Pointer::Token third{"foo"};
@@ -103,7 +103,7 @@ TEST(JSONPointer_token, property_hash) {
   EXPECT_EQ(first.property_hash(), third.property_hash());
 }
 
-TEST(JSONPointer_get, at_property_with_hash) {
+TEST(at_property_with_hash) {
   const auto document = sourcemeta::core::parse_json(R"JSON({
     "foo": 1,
     "bar": 2,

--- a/test/jsonpointer/jsonpointer_try_get_test.cc
+++ b/test/jsonpointer/jsonpointer_try_get_test.cc
@@ -1,9 +1,9 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-TEST(JSONPointer_try_get, empty_on_integer) {
+TEST(empty_on_integer) {
   const sourcemeta::core::JSON document{5};
   const sourcemeta::core::Pointer pointer;
   const auto result{sourcemeta::core::try_get(document, pointer)};
@@ -11,7 +11,7 @@ TEST(JSONPointer_try_get, empty_on_integer) {
   EXPECT_EQ(*result, document);
 }
 
-TEST(JSONPointer_try_get, empty_on_object) {
+TEST(empty_on_object) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": 1
   })JSON")};
@@ -22,7 +22,7 @@ TEST(JSONPointer_try_get, empty_on_object) {
   EXPECT_EQ(*result, document);
 }
 
-TEST(JSONPointer_try_get, empty_on_array) {
+TEST(empty_on_array) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
   const sourcemeta::core::Pointer pointer;
   const auto result{sourcemeta::core::try_get(document, pointer)};
@@ -30,7 +30,7 @@ TEST(JSONPointer_try_get, empty_on_array) {
   EXPECT_EQ(*result, document);
 }
 
-TEST(JSONPointer_try_get, top_level_property_true) {
+TEST(top_level_property_true) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": 1
   })JSON")};
@@ -41,7 +41,7 @@ TEST(JSONPointer_try_get, top_level_property_true) {
   EXPECT_EQ(*result, document.at("foo"));
 }
 
-TEST(JSONPointer_try_get, top_level_property_false) {
+TEST(top_level_property_false) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": 1
   })JSON")};
@@ -51,7 +51,7 @@ TEST(JSONPointer_try_get, top_level_property_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONPointer_try_get, top_level_index_true) {
+TEST(top_level_index_true) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
 
   const sourcemeta::core::Pointer pointer{2};
@@ -60,7 +60,7 @@ TEST(JSONPointer_try_get, top_level_index_true) {
   EXPECT_EQ(*result, document.at(2));
 }
 
-TEST(JSONPointer_try_get, top_level_index_false) {
+TEST(top_level_index_false) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
 
   const sourcemeta::core::Pointer pointer{3};
@@ -68,7 +68,7 @@ TEST(JSONPointer_try_get, top_level_index_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONPointer_try_get, top_level_numeric_property_true) {
+TEST(top_level_numeric_property_true) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "0": 1
   })JSON")};
@@ -79,7 +79,7 @@ TEST(JSONPointer_try_get, top_level_numeric_property_true) {
   EXPECT_EQ(*result, document.at("0"));
 }
 
-TEST(JSONPointer_try_get, top_level_numeric_property_as_index_true) {
+TEST(top_level_numeric_property_as_index_true) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "0": 1
   })JSON")};
@@ -90,7 +90,7 @@ TEST(JSONPointer_try_get, top_level_numeric_property_as_index_true) {
   EXPECT_EQ(*result, document.at("0"));
 }
 
-TEST(JSONPointer_try_get, complex_true) {
+TEST(complex_true) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -103,7 +103,7 @@ TEST(JSONPointer_try_get, complex_true) {
   EXPECT_EQ(*result, document.at("foo").at("bar").at(2).at("baz"));
 }
 
-TEST(JSONPointer_try_get, complex_false) {
+TEST(complex_false) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -115,7 +115,7 @@ TEST(JSONPointer_try_get, complex_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONPointer_try_get, complex_non_existent_property) {
+TEST(complex_non_existent_property) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -127,7 +127,7 @@ TEST(JSONPointer_try_get, complex_non_existent_property) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONPointer_try_get, complex_non_existent_index) {
+TEST(complex_non_existent_index) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -139,14 +139,14 @@ TEST(JSONPointer_try_get, complex_non_existent_index) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONPointer_try_get, non_object) {
+TEST(non_object) {
   const sourcemeta::core::JSON document{"foo"};
   const sourcemeta::core::Pointer pointer{"bar"};
   const auto result{sourcemeta::core::try_get(document, pointer)};
   EXPECT_FALSE(result);
 }
 
-TEST(JSONPointer_try_get, non_array) {
+TEST(non_array) {
   const sourcemeta::core::JSON document{"foo"};
   const sourcemeta::core::Pointer pointer{2};
   const auto result{sourcemeta::core::try_get(document, pointer)};

--- a/test/jsonpointer/jsonpointer_walker_test.cc
+++ b/test/jsonpointer/jsonpointer_walker_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-TEST(JSONPointer_walker, null) {
+TEST(null) {
   const sourcemeta::core::JSON document{nullptr};
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -18,7 +18,7 @@ TEST(JSONPointer_walker, null) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, boolean_false) {
+TEST(boolean_false) {
   const sourcemeta::core::JSON document{false};
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -29,7 +29,7 @@ TEST(JSONPointer_walker, boolean_false) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, boolean_true) {
+TEST(boolean_true) {
   const sourcemeta::core::JSON document{true};
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -40,7 +40,7 @@ TEST(JSONPointer_walker, boolean_true) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, integer) {
+TEST(integer) {
   const sourcemeta::core::JSON document{5};
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -51,7 +51,7 @@ TEST(JSONPointer_walker, integer) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, real) {
+TEST(real) {
   const sourcemeta::core::JSON document{3.14};
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -62,7 +62,7 @@ TEST(JSONPointer_walker, real) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, string) {
+TEST(string) {
   const sourcemeta::core::JSON document{"foo bar"};
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -73,7 +73,7 @@ TEST(JSONPointer_walker, string) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, array_empty) {
+TEST(array_empty) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("[]");
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -84,7 +84,7 @@ TEST(JSONPointer_walker, array_empty) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, array_scalars) {
+TEST(array_scalars) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("[ 1, 2, 3, 4 ]");
   std::vector<std::string> subpointers;
@@ -100,7 +100,7 @@ TEST(JSONPointer_walker, array_scalars) {
   EXPECT_EQ(subpointers.at(4), "/3");
 }
 
-TEST(JSONPointer_walker, array_deep) {
+TEST(array_deep) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"EOF([
     [],
     [ 1, 2 ],
@@ -121,7 +121,7 @@ TEST(JSONPointer_walker, array_deep) {
   EXPECT_EQ(subpointers.at(6), "/2/0");
 }
 
-TEST(JSONPointer_walker, object_empty) {
+TEST(object_empty) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json("{}");
   std::vector<std::string> subpointers;
   for (const auto &subpointer : sourcemeta::core::PointerWalker{document}) {
@@ -132,7 +132,7 @@ TEST(JSONPointer_walker, object_empty) {
   EXPECT_EQ(subpointers.at(0), "");
 }
 
-TEST(JSONPointer_walker, object_scalars) {
+TEST(object_scalars) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": 1, \"bar\": 2, \"baz\": 3 }");
   // Do a set to not depend on object property ordering
@@ -148,7 +148,7 @@ TEST(JSONPointer_walker, object_scalars) {
   EXPECT_TRUE(subpointers.contains("/baz"));
 }
 
-TEST(JSONPointer_walker, object_nested) {
+TEST(object_nested) {
   const sourcemeta::core::JSON document =
       sourcemeta::core::parse_json("{ \"foo\": { \"bar\": 1 } }");
   std::vector<std::string> subpointers;

--- a/test/jsonpointer/jsonpointer_weakpointer_test.cc
+++ b/test/jsonpointer/jsonpointer_weakpointer_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
@@ -16,7 +16,7 @@ static const std::string bar = "bar";
 static const std::string baz = "baz";
 static const std::string qux = "qux";
 
-TEST(JSONWeakPointer_pointer, general_traits) {
+TEST(general_traits) {
   EXPECT_TRUE(
       std::is_default_constructible<sourcemeta::core::WeakPointer>::value);
   EXPECT_TRUE(std::is_nothrow_default_constructible<
@@ -26,7 +26,7 @@ TEST(JSONWeakPointer_pointer, general_traits) {
       std::is_nothrow_destructible<sourcemeta::core::WeakPointer>::value);
 }
 
-TEST(JSONWeakPointer_pointer, copy_traits) {
+TEST(copy_traits) {
   EXPECT_TRUE(std::is_copy_assignable<sourcemeta::core::WeakPointer>::value);
   EXPECT_TRUE(std::is_copy_constructible<sourcemeta::core::WeakPointer>::value);
   EXPECT_FALSE(
@@ -35,7 +35,7 @@ TEST(JSONWeakPointer_pointer, copy_traits) {
       std::is_nothrow_copy_constructible<sourcemeta::core::WeakPointer>::value);
 }
 
-TEST(JSONWeakPointer_pointer, move_traits) {
+TEST(move_traits) {
   EXPECT_TRUE(std::is_move_assignable<sourcemeta::core::WeakPointer>::value);
   EXPECT_TRUE(std::is_move_constructible<sourcemeta::core::WeakPointer>::value);
   EXPECT_TRUE(
@@ -44,13 +44,13 @@ TEST(JSONWeakPointer_pointer, move_traits) {
       std::is_nothrow_move_constructible<sourcemeta::core::WeakPointer>::value);
 }
 
-TEST(JSONWeakPointer_pointer, empty) {
+TEST(empty) {
   const sourcemeta::core::WeakPointer pointer;
   EXPECT_EQ(pointer.size(), 0);
   EXPECT_TRUE(pointer.empty());
 }
 
-TEST(JSONWeakPointer_pointer, store_a_const_ref) {
+TEST(store_a_const_ref) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
 
   EXPECT_EQ(pointer.size(), 1);
@@ -59,7 +59,7 @@ TEST(JSONWeakPointer_pointer, store_a_const_ref) {
   EXPECT_EQ(pointer.at(0).to_property(), foo);
 }
 
-TEST(JSONWeakPointer_pointer, one_fragment_back) {
+TEST(one_fragment_back) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
 
   EXPECT_EQ(pointer.size(), 1);
@@ -67,7 +67,7 @@ TEST(JSONWeakPointer_pointer, one_fragment_back) {
   EXPECT_EQ(pointer.back().to_property(), foo);
 }
 
-TEST(JSONWeakPointer_pointer, multiple_fragments_mixed) {
+TEST(multiple_fragments_mixed) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), 2,
                                               std::cref(bar)};
   EXPECT_EQ(pointer.size(), 3);
@@ -80,14 +80,14 @@ TEST(JSONWeakPointer_pointer, multiple_fragments_mixed) {
   EXPECT_EQ(pointer.at(2).to_property(), bar);
 }
 
-TEST(JSONWeakPointer_pointer, multiple_fragments_back) {
+TEST(multiple_fragments_back) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), 2,
                                               std::cref(bar)};
   EXPECT_TRUE(pointer.back().is_property());
   EXPECT_EQ(pointer.back().to_property(), bar);
 }
 
-TEST(JSONWeakPointer_pointer, build_with_emplace_back) {
+TEST(build_with_emplace_back) {
   sourcemeta::core::WeakPointer pointer;
   EXPECT_EQ(pointer.size(), 0);
   auto &result_1{pointer.emplace_back(std::cref(foo))};
@@ -105,13 +105,13 @@ TEST(JSONWeakPointer_pointer, build_with_emplace_back) {
   EXPECT_EQ(pointer.at(1).to_index(), 1);
 }
 
-TEST(JSONWeakPointer_pointer, equality_empty) {
+TEST(equality_empty) {
   const sourcemeta::core::WeakPointer pointer_1;
   const sourcemeta::core::WeakPointer pointer_2;
   EXPECT_EQ(pointer_1, pointer_2);
 }
 
-TEST(JSONWeakPointer_pointer, equality_true) {
+TEST(equality_true) {
   const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), 1,
                                                 std::cref(bar)};
   const sourcemeta::core::WeakPointer pointer_2{std::cref(foo), 1,
@@ -119,7 +119,7 @@ TEST(JSONWeakPointer_pointer, equality_true) {
   EXPECT_EQ(pointer_1, pointer_2);
 }
 
-TEST(JSONWeakPointer_pointer, equality_false) {
+TEST(equality_false) {
   const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), 1,
                                                 std::cref(bar)};
   const sourcemeta::core::WeakPointer pointer_2{std::cref(foo), 3,
@@ -127,7 +127,7 @@ TEST(JSONWeakPointer_pointer, equality_false) {
   EXPECT_FALSE(pointer_1 == pointer_2);
 }
 
-TEST(JSONWeakPointer_pointer, pop_back_non_empty) {
+TEST(pop_back_non_empty) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
 
   pointer.pop_back();
@@ -136,7 +136,7 @@ TEST(JSONWeakPointer_pointer, pop_back_non_empty) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONWeakPointer_pointer, ordering_less_than) {
+TEST(ordering_less_than) {
   const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::WeakPointer pointer_2{std::cref(foo)};
   const sourcemeta::core::WeakPointer pointer_3{std::cref(baz)};
@@ -145,13 +145,13 @@ TEST(JSONWeakPointer_pointer, ordering_less_than) {
   EXPECT_TRUE(pointer_3 < pointer_2);
 }
 
-TEST(JSONWeakPointer_pointer, pop_back_zero_empty) {
+TEST(pop_back_zero_empty) {
   sourcemeta::core::WeakPointer pointer{};
   pointer.pop_back(0);
   EXPECT_EQ(pointer.size(), 0);
 }
 
-TEST(JSONWeakPointer_pointer, pop_back_many_subset) {
+TEST(pop_back_many_subset) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                         std::cref(baz)};
   pointer.pop_back(2);
@@ -160,14 +160,14 @@ TEST(JSONWeakPointer_pointer, pop_back_many_subset) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONWeakPointer_pointer, pop_back_many_all) {
+TEST(pop_back_many_all) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                         std::cref(baz)};
   pointer.pop_back(3);
   EXPECT_EQ(pointer.size(), 0);
 }
 
-TEST(JSONWeakPointer_pointer, push_back_pointer_copy) {
+TEST(push_back_pointer_copy) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::WeakPointer other{std::cref(baz), std::cref(qux)};
   pointer.push_back(other);
@@ -182,7 +182,7 @@ TEST(JSONWeakPointer_pointer, push_back_pointer_copy) {
   EXPECT_EQ(pointer.at(3).to_property(), "qux");
 }
 
-TEST(JSONWeakPointer_pointer, push_back_pointer_move) {
+TEST(push_back_pointer_move) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   sourcemeta::core::WeakPointer other{std::cref(baz), std::cref(qux)};
 
@@ -200,13 +200,13 @@ TEST(JSONWeakPointer_pointer, push_back_pointer_move) {
   // TODO: we should assert that other has been moved
 }
 
-TEST(JSONWeakPointer_pointer, initial_with_one_token) {
+TEST(initial_with_one_token) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   const sourcemeta::core::WeakPointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 0);
 }
 
-TEST(JSONWeakPointer_pointer, initial_with_two_tokens) {
+TEST(initial_with_two_tokens) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::WeakPointer result{pointer.initial()};
   EXPECT_EQ(result.size(), 1);
@@ -214,7 +214,7 @@ TEST(JSONWeakPointer_pointer, initial_with_two_tokens) {
   EXPECT_EQ(pointer.at(0).to_property(), "foo");
 }
 
-TEST(JSONWeakPointer_pointer, initial_with_three_tokens) {
+TEST(initial_with_three_tokens) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                         std::cref(baz)};
   const sourcemeta::core::WeakPointer result{pointer.initial()};
@@ -225,7 +225,7 @@ TEST(JSONWeakPointer_pointer, initial_with_three_tokens) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONWeakPointer_pointer, push_back_property_copy) {
+TEST(push_back_property_copy) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   const sourcemeta::core::WeakPointer other{std::cref(bar)};
   pointer.push_back(other.back().to_property());
@@ -236,7 +236,7 @@ TEST(JSONWeakPointer_pointer, push_back_property_copy) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONWeakPointer_pointer, push_back_property_move) {
+TEST(push_back_property_move) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   pointer.push_back(std::cref(bar));
   EXPECT_EQ(pointer.size(), 2);
@@ -246,7 +246,7 @@ TEST(JSONWeakPointer_pointer, push_back_property_move) {
   EXPECT_EQ(pointer.at(1).to_property(), "bar");
 }
 
-TEST(JSONWeakPointer_pointer, push_back_index_copy) {
+TEST(push_back_index_copy) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   const sourcemeta::core::WeakPointer other{0};
   pointer.push_back(other.back().to_index());
@@ -257,7 +257,7 @@ TEST(JSONWeakPointer_pointer, push_back_index_copy) {
   EXPECT_EQ(pointer.at(1).to_index(), 0);
 }
 
-TEST(JSONWeakPointer_pointer, push_back_index_move) {
+TEST(push_back_index_move) {
   sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   pointer.push_back(0);
   EXPECT_EQ(pointer.size(), 2);
@@ -267,7 +267,7 @@ TEST(JSONWeakPointer_pointer, push_back_index_move) {
   EXPECT_EQ(pointer.at(1).to_index(), 0);
 }
 
-TEST(JSONWeakPointer_pointer, push_back_pointer) {
+TEST(push_back_pointer) {
   const sourcemeta::core::Pointer pointer{bar, baz};
   sourcemeta::core::WeakPointer destination{std::cref(foo)};
   destination.push_back(pointer);
@@ -280,7 +280,7 @@ TEST(JSONWeakPointer_pointer, push_back_pointer) {
   EXPECT_EQ(destination.at(2).to_property(), "baz");
 }
 
-TEST(JSONWeakPointer_pointer, try_get_complex_true) {
+TEST(try_get_complex_true) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -295,7 +295,7 @@ TEST(JSONWeakPointer_pointer, try_get_complex_true) {
   EXPECT_EQ(*result, document.at("foo").at("bar").at(2).at("baz"));
 }
 
-TEST(JSONWeakPointer_pointer, try_get_complex_false) {
+TEST(try_get_complex_false) {
   const auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -309,7 +309,7 @@ TEST(JSONWeakPointer_pointer, try_get_complex_false) {
   EXPECT_FALSE(result);
 }
 
-TEST(JSONWeakPointer_pointer, get_mutable_empty_pointer) {
+TEST(get_mutable_empty_pointer) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": { "bar": 1 }
   })JSON")};
@@ -320,7 +320,7 @@ TEST(JSONWeakPointer_pointer, get_mutable_empty_pointer) {
   EXPECT_TRUE(result.defines("foo"));
 }
 
-TEST(JSONWeakPointer_pointer, get_mutable_nested) {
+TEST(get_mutable_nested) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": {
       "bar": [ 1, 2, { "baz": "qux" } ]
@@ -339,7 +339,7 @@ TEST(JSONWeakPointer_pointer, get_mutable_nested) {
             "modified");
 }
 
-TEST(JSONWeakPointer_pointer, get_mutable_from_pointer_conversion) {
+TEST(get_mutable_from_pointer_conversion) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "foo": { "bar": 1 }
   })JSON")};
@@ -355,7 +355,7 @@ TEST(JSONWeakPointer_pointer, get_mutable_from_pointer_conversion) {
   EXPECT_EQ(document.at("foo").at("bar").to_integer(), 42);
 }
 
-TEST(JSONWeakPointer_pointer, to_pointer) {
+TEST(to_pointer) {
   const sourcemeta::core::WeakPointer weak{std::cref(foo), 0};
   const sourcemeta::core::Pointer pointer{sourcemeta::core::to_pointer(weak)};
 
@@ -372,7 +372,7 @@ TEST(JSONWeakPointer_pointer, to_pointer) {
   EXPECT_EQ(pointer.at(1).to_index(), 0);
 }
 
-TEST(JSONWeakPointer_pointer, to_weak_pointer) {
+TEST(to_weak_pointer) {
   const sourcemeta::core::Pointer pointer{"foo", 1, "baz"};
   const auto result{sourcemeta::core::to_weak_pointer(pointer)};
   EXPECT_EQ(result.size(), 3);
@@ -387,7 +387,7 @@ TEST(JSONWeakPointer_pointer, to_weak_pointer) {
   EXPECT_EQ(result.at(2).to_property(), "baz");
 }
 
-TEST(JSONWeakPointer_pointer, hash_unordered_set) {
+TEST(hash_unordered_set) {
   std::unordered_set<sourcemeta::core::WeakPointer,
                      sourcemeta::core::WeakPointer::Hasher>
       set;
@@ -422,7 +422,7 @@ TEST(JSONWeakPointer_pointer, hash_unordered_set) {
   EXPECT_TRUE(set.contains(two_dup));
 }
 
-TEST(JSONWeakPointer_pointer, hash_unordered_map) {
+TEST(hash_unordered_map) {
   std::unordered_map<sourcemeta::core::WeakPointer, int,
                      sourcemeta::core::WeakPointer::Hasher>
       map;
@@ -449,14 +449,14 @@ TEST(JSONWeakPointer_pointer, hash_unordered_map) {
   EXPECT_EQ(map.at(four), 4);
 }
 
-TEST(JSONWeakPointer_pointer, hash_empty_consistency) {
+TEST(hash_empty_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
   const sourcemeta::core::WeakPointer empty_1{};
   const sourcemeta::core::WeakPointer empty_2{};
   EXPECT_EQ(hasher(empty_1), hasher(empty_2));
 }
 
-TEST(JSONWeakPointer_pointer, hash_single_token_consistency) {
+TEST(hash_single_token_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
   const sourcemeta::core::WeakPointer single_1{std::cref(foo)};
   const sourcemeta::core::WeakPointer single_2{std::cref(foo)};
@@ -465,7 +465,7 @@ TEST(JSONWeakPointer_pointer, hash_single_token_consistency) {
   EXPECT_NE(hasher(single_1), hasher(single_3));
 }
 
-TEST(JSONWeakPointer_pointer, hash_two_token_consistency) {
+TEST(hash_two_token_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
   const sourcemeta::core::WeakPointer two_1{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::WeakPointer two_2{std::cref(foo), std::cref(bar)};
@@ -474,7 +474,7 @@ TEST(JSONWeakPointer_pointer, hash_two_token_consistency) {
   EXPECT_NE(hasher(two_1), hasher(two_3));
 }
 
-TEST(JSONWeakPointer_pointer, hash_three_token_consistency) {
+TEST(hash_three_token_consistency) {
   const sourcemeta::core::WeakPointer::Hasher hasher;
   const sourcemeta::core::WeakPointer multi_1{std::cref(foo), std::cref(bar),
                                               1};
@@ -486,7 +486,7 @@ TEST(JSONWeakPointer_pointer, hash_three_token_consistency) {
   EXPECT_NE(hasher(multi_1), hasher(multi_3));
 }
 
-TEST(JSONWeakPointer_pointer, hash_reference_wrapper_unordered_map) {
+TEST(hash_reference_wrapper_unordered_map) {
   const sourcemeta::core::WeakPointer pointer_1{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::WeakPointer pointer_2{std::cref(baz)};
   const sourcemeta::core::WeakPointer pointer_3{std::cref(foo), std::cref(bar),
@@ -518,7 +518,7 @@ TEST(JSONWeakPointer_pointer, hash_reference_wrapper_unordered_map) {
   EXPECT_FALSE(map.contains(missing));
 }
 
-TEST(JSONWeakPointer_pointer, slice_from_zero) {
+TEST(slice_from_zero) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                               std::cref(baz)};
   const sourcemeta::core::WeakPointer result{pointer.slice(0)};
@@ -531,7 +531,7 @@ TEST(JSONWeakPointer_pointer, slice_from_zero) {
   EXPECT_EQ(result.at(2).to_property(), "baz");
 }
 
-TEST(JSONWeakPointer_pointer, slice_from_one) {
+TEST(slice_from_one) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                               std::cref(baz)};
   const sourcemeta::core::WeakPointer result{pointer.slice(1)};
@@ -542,7 +542,7 @@ TEST(JSONWeakPointer_pointer, slice_from_one) {
   EXPECT_EQ(result.at(1).to_property(), "baz");
 }
 
-TEST(JSONWeakPointer_pointer, slice_from_two) {
+TEST(slice_from_two) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                               std::cref(baz)};
   const sourcemeta::core::WeakPointer result{pointer.slice(2)};
@@ -551,7 +551,7 @@ TEST(JSONWeakPointer_pointer, slice_from_two) {
   EXPECT_EQ(result.at(0).to_property(), "baz");
 }
 
-TEST(JSONWeakPointer_pointer, slice_from_end) {
+TEST(slice_from_end) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                               std::cref(baz)};
   const sourcemeta::core::WeakPointer result{pointer.slice(3)};
@@ -559,14 +559,14 @@ TEST(JSONWeakPointer_pointer, slice_from_end) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONWeakPointer_pointer, slice_empty_from_zero) {
+TEST(slice_empty_from_zero) {
   const sourcemeta::core::WeakPointer pointer;
   const sourcemeta::core::WeakPointer result{pointer.slice(0)};
   EXPECT_EQ(result.size(), 0);
   EXPECT_TRUE(result.empty());
 }
 
-TEST(JSONWeakPointer_pointer, slice_with_indices) {
+TEST(slice_with_indices) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), 1, std::cref(bar),
                                               2};
   const sourcemeta::core::WeakPointer result{pointer.slice(1)};
@@ -579,74 +579,74 @@ TEST(JSONWeakPointer_pointer, slice_with_indices) {
   EXPECT_EQ(result.at(2).to_index(), 2);
 }
 
-TEST(JSONWeakPointer_to_uri, empty) {
+TEST(to_uri_empty) {
   const sourcemeta::core::WeakPointer pointer;
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#");
 }
 
-TEST(JSONWeakPointer_to_uri, with_property_tokens) {
+TEST(with_property_tokens) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar),
                                               std::cref(baz)};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar/baz");
 }
 
-TEST(JSONWeakPointer_to_uri, with_index_tokens) {
+TEST(with_index_tokens) {
   const sourcemeta::core::WeakPointer pointer{0, 1, 2};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/0/1/2");
 }
 
-TEST(JSONWeakPointer_to_uri, with_mixed_tokens) {
+TEST(with_mixed_tokens) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), 1,
                                               std::cref(bar)};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer)};
   EXPECT_EQ(fragment.recompose(), "#/foo/1/bar");
 }
 
-TEST(JSONWeakPointer_to_uri, with_absolute_base_uri) {
+TEST(with_absolute_base_uri) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::URI base{"https://www.example.com"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "https://www.example.com#/foo/bar");
 }
 
-TEST(JSONWeakPointer_to_uri, with_relative_base_uri) {
+TEST(with_relative_base_uri) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const sourcemeta::core::URI base{"../baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "../baz#/foo/bar");
 }
 
-TEST(JSONWeakPointer_to_uri, with_absolute_base_string_view) {
+TEST(with_absolute_base_string_view) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const std::string_view base{"https://www.example.com"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "https://www.example.com#/foo/bar");
 }
 
-TEST(JSONWeakPointer_to_uri, with_empty_base_string_view) {
+TEST(with_empty_base_string_view) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const std::string_view base{""};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "#/foo/bar");
 }
 
-TEST(JSONWeakPointer_to_uri, with_relative_base_string_view) {
+TEST(with_relative_base_string_view) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo), std::cref(bar)};
   const std::string_view base{"../baz"};
   const sourcemeta::core::URI fragment{sourcemeta::core::to_uri(pointer, base)};
   EXPECT_EQ(fragment.recompose(), "../baz#/foo/bar");
 }
 
-TEST(JSONWeakPointer_concat, single_property_token) {
+TEST(single_property_token) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   const sourcemeta::core::WeakPointer result{std::cref(foo), std::cref(bar)};
   EXPECT_EQ(pointer.concat(std::cref(bar)), result);
 }
 
-TEST(JSONWeakPointer_concat, single_index_token) {
+TEST(single_index_token) {
   const sourcemeta::core::WeakPointer pointer{std::cref(foo)};
   const sourcemeta::core::WeakPointer result{std::cref(foo), 1};
   EXPECT_EQ(pointer.concat(1), result);

--- a/test/jsonrpc/CMakeLists.txt
+++ b/test/jsonrpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsonrpc
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonrpc
   SOURCES jsonrpc_test.cc)
 
 target_link_libraries(sourcemeta_core_jsonrpc_unit

--- a/test/jsonrpc/jsonrpc_test.cc
+++ b/test/jsonrpc/jsonrpc_test.cc
@@ -2,11 +2,11 @@
 
 #include <sourcemeta/core/json.h>
 
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint> // std::int64_t
 
-TEST(JSONRPC, code_constants) {
+TEST(code_constants) {
   EXPECT_EQ(sourcemeta::core::JSONRPC_CODE_PARSE,
             static_cast<std::int64_t>(-32700));
   EXPECT_EQ(sourcemeta::core::JSONRPC_CODE_INVALID_REQUEST,
@@ -23,342 +23,342 @@ TEST(JSONRPC, code_constants) {
             static_cast<std::int64_t>(-32000));
 }
 
-TEST(JSONRPC, is_server_error_lower_bound) {
+TEST(is_server_error_lower_bound) {
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_server_error(-32099));
 }
 
-TEST(JSONRPC, is_server_error_upper_bound) {
+TEST(is_server_error_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_server_error(-32000));
 }
 
-TEST(JSONRPC, is_server_error_inside_range) {
+TEST(is_server_error_inside_range) {
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_server_error(-32050));
 }
 
-TEST(JSONRPC, is_server_error_below_range) {
+TEST(is_server_error_below_range) {
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_server_error(-32100));
 }
 
-TEST(JSONRPC, is_server_error_above_range) {
+TEST(is_server_error_above_range) {
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_server_error(-31999));
 }
 
-TEST(JSONRPC, is_server_error_predefined_internal) {
+TEST(is_server_error_predefined_internal) {
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_server_error(-32603));
 }
 
-TEST(JSONRPC, is_server_error_positive_application_code) {
+TEST(is_server_error_positive_application_code) {
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_server_error(1));
 }
 
-TEST(JSONRPC, is_batch_empty_array) {
+TEST(is_batch_empty_array) {
   const auto payload{sourcemeta::core::parse_json(R"([])")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_batch(payload));
 }
 
-TEST(JSONRPC, is_batch_non_empty_array) {
+TEST(is_batch_non_empty_array) {
   const auto payload{sourcemeta::core::parse_json(
       R"([ { "jsonrpc": "2.0", "method": "ping" } ])")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_batch(payload));
 }
 
-TEST(JSONRPC, is_batch_object) {
+TEST(is_batch_object) {
   const auto payload{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_batch(payload));
 }
 
-TEST(JSONRPC, is_batch_string) {
+TEST(is_batch_string) {
   const auto payload{sourcemeta::core::parse_json(R"("hello")")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_batch(payload));
 }
 
-TEST(JSONRPC, is_batch_null) {
+TEST(is_batch_null) {
   const auto payload{sourcemeta::core::parse_json(R"(null)")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_batch(payload));
 }
 
-TEST(JSONRPC, is_batch_integer) {
+TEST(is_batch_integer) {
   const auto payload{sourcemeta::core::parse_json(R"(42)")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_batch(payload));
 }
 
-TEST(JSONRPC, is_valid_batch_non_empty_array) {
+TEST(is_valid_batch_non_empty_array) {
   const auto payload{sourcemeta::core::parse_json(
       R"([ { "jsonrpc": "2.0", "method": "ping" } ])")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_valid_batch(payload));
 }
 
-TEST(JSONRPC, is_valid_batch_empty_array) {
+TEST(is_valid_batch_empty_array) {
   const auto payload{sourcemeta::core::parse_json(R"([])")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_valid_batch(payload));
 }
 
-TEST(JSONRPC, is_valid_batch_object) {
+TEST(is_valid_batch_object) {
   const auto payload{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_valid_batch(payload));
 }
 
-TEST(JSONRPC, is_valid_batch_string) {
+TEST(is_valid_batch_string) {
   const auto payload{sourcemeta::core::parse_json(R"("hello")")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_valid_batch(payload));
 }
 
-TEST(JSONRPC, is_valid_batch_null) {
+TEST(is_valid_batch_null) {
   const auto payload{sourcemeta::core::parse_json(R"(null)")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_valid_batch(payload));
 }
 
-TEST(JSONRPC, is_valid_batch_integer) {
+TEST(is_valid_batch_integer) {
   const auto payload{sourcemeta::core::parse_json(R"(42)")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_valid_batch(payload));
 }
 
-TEST(JSONRPC, request_id_integer) {
+TEST(request_id_integer) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 7, "method": "ping" })")};
   const auto *identifier{sourcemeta::core::jsonrpc_request_id(request)};
-  ASSERT_NE(identifier, nullptr);
+  EXPECT_NE(identifier, nullptr);
   EXPECT_TRUE(identifier->is_integer());
   EXPECT_EQ(identifier->to_integer(), 7);
 }
 
-TEST(JSONRPC, request_id_string) {
+TEST(request_id_string) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": "abc", "method": "ping" })")};
   const auto *identifier{sourcemeta::core::jsonrpc_request_id(request)};
-  ASSERT_NE(identifier, nullptr);
+  EXPECT_NE(identifier, nullptr);
   EXPECT_TRUE(identifier->is_string());
   EXPECT_EQ(identifier->to_string(), "abc");
 }
 
-TEST(JSONRPC, request_id_missing) {
+TEST(request_id_missing) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "ping" })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_request_id(request), nullptr);
 }
 
-TEST(JSONRPC, request_id_null) {
+TEST(request_id_null) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": null, "method": "ping" })")};
   const auto *identifier{sourcemeta::core::jsonrpc_request_id(request)};
-  ASSERT_NE(identifier, nullptr);
+  EXPECT_NE(identifier, nullptr);
   EXPECT_TRUE(identifier->is_null());
 }
 
-TEST(JSONRPC, request_id_floating_point) {
+TEST(request_id_floating_point) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1.5, "method": "ping" })")};
   const auto *identifier{sourcemeta::core::jsonrpc_request_id(request)};
-  ASSERT_NE(identifier, nullptr);
+  EXPECT_NE(identifier, nullptr);
   EXPECT_TRUE(identifier->is_real());
   EXPECT_EQ(identifier->to_real(), 1.5);
 }
 
-TEST(JSONRPC, request_id_boolean) {
+TEST(request_id_boolean) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": true, "method": "ping" })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_request_id(request), nullptr);
 }
 
-TEST(JSONRPC, request_id_object) {
+TEST(request_id_object) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": {}, "method": "ping" })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_request_id(request), nullptr);
 }
 
-TEST(JSONRPC, request_id_array) {
+TEST(request_id_array) {
   const auto request{sourcemeta::core::parse_json(R"([ 1, 2, 3 ])")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_request_id(request), nullptr);
 }
 
-TEST(JSONRPC, request_id_primitive) {
+TEST(request_id_primitive) {
   const auto request{sourcemeta::core::parse_json(R"(42)")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_request_id(request), nullptr);
 }
 
-TEST(JSONRPC, is_request_valid_integer_id) {
+TEST(is_request_valid_integer_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_valid_string_id) {
+TEST(is_request_valid_string_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": "x", "method": "ping" })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_missing_id) {
+TEST(is_request_missing_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_null_id) {
+TEST(is_request_null_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": null, "method": "ping" })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_floating_point_id) {
+TEST(is_request_floating_point_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1.5, "method": "ping" })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_missing_method) {
+TEST(is_request_missing_method) {
   const auto request{
       sourcemeta::core::parse_json(R"({ "jsonrpc": "2.0", "id": 1 })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_non_string_method) {
+TEST(is_request_non_string_method) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": 5 })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_missing_jsonrpc) {
+TEST(is_request_missing_jsonrpc) {
   const auto request{
       sourcemeta::core::parse_json(R"({ "id": 1, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_wrong_jsonrpc_version) {
+TEST(is_request_wrong_jsonrpc_version) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "1.0", "id": 1, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_jsonrpc_not_string) {
+TEST(is_request_jsonrpc_not_string) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": 2, "id": 1, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_array) {
+TEST(is_request_array) {
   const auto request{sourcemeta::core::parse_json(R"([ 1, 2 ])")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_primitive) {
+TEST(is_request_primitive) {
   const auto request{sourcemeta::core::parse_json(R"("hello")")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_primitive_params) {
+TEST(is_request_primitive_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping", "params": "x" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_null_params) {
+TEST(is_request_null_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping", "params": null })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_request_omitted_params) {
+TEST(is_request_omitted_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_request(request));
 }
 
-TEST(JSONRPC, is_notification_valid) {
+TEST(is_notification_valid) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "notifications/initialized" })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_with_id) {
+TEST(is_notification_with_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_with_null_id) {
+TEST(is_notification_with_null_id) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": null, "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_missing_method) {
+TEST(is_notification_missing_method) {
   const auto request{sourcemeta::core::parse_json(R"({ "jsonrpc": "2.0" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_non_string_method) {
+TEST(is_notification_non_string_method) {
   const auto request{
       sourcemeta::core::parse_json(R"({ "jsonrpc": "2.0", "method": 5 })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_missing_jsonrpc) {
+TEST(is_notification_missing_jsonrpc) {
   const auto request{sourcemeta::core::parse_json(R"({ "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_wrong_jsonrpc_version) {
+TEST(is_notification_wrong_jsonrpc_version) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "1.0", "method": "ping" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_array) {
+TEST(is_notification_array) {
   const auto request{sourcemeta::core::parse_json(R"([ 1, 2 ])")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_primitive_params) {
+TEST(is_notification_primitive_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "ping", "params": "x" })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_null_params) {
+TEST(is_notification_null_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "ping", "params": null })")};
   EXPECT_FALSE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_array_params) {
+TEST(is_notification_array_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "ping", "params": [ 1, 2 ] })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, is_notification_object_params) {
+TEST(is_notification_object_params) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "method": "ping", "params": { "x": 1 } })")};
   EXPECT_TRUE(sourcemeta::core::jsonrpc_is_notification(request));
 }
 
-TEST(JSONRPC, method_present) {
+TEST(method_present) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_method(request), "ping");
 }
 
-TEST(JSONRPC, method_missing) {
+TEST(method_missing) {
   const auto request{
       sourcemeta::core::parse_json(R"({ "jsonrpc": "2.0", "id": 1 })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_method(request), "");
 }
 
-TEST(JSONRPC, method_non_string) {
+TEST(method_non_string) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": 5 })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_method(request), "");
 }
 
-TEST(JSONRPC, method_on_non_object) {
+TEST(method_on_non_object) {
   const auto request{sourcemeta::core::parse_json(R"([ 1, 2 ])")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_method(request), "");
 }
 
-TEST(JSONRPC, params_object) {
+TEST(params_object) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -366,12 +366,12 @@ TEST(JSONRPC, params_object) {
     "params": { "uri": "http://example.com" }
   })JSON")};
   const auto *params{sourcemeta::core::jsonrpc_params(request)};
-  ASSERT_NE(params, nullptr);
+  EXPECT_NE(params, nullptr);
   EXPECT_TRUE(params->is_object());
   EXPECT_EQ(params->at("uri").to_string(), "http://example.com");
 }
 
-TEST(JSONRPC, params_array) {
+TEST(params_array) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -379,35 +379,35 @@ TEST(JSONRPC, params_array) {
     "params": [ 42, 23 ]
   })JSON")};
   const auto *params{sourcemeta::core::jsonrpc_params(request)};
-  ASSERT_NE(params, nullptr);
+  EXPECT_NE(params, nullptr);
   EXPECT_TRUE(params->is_array());
   EXPECT_EQ(params->size(), 2);
 }
 
-TEST(JSONRPC, params_missing) {
+TEST(params_missing) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping" })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_params(request), nullptr);
 }
 
-TEST(JSONRPC, params_primitive) {
+TEST(params_primitive) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping", "params": "x" })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_params(request), nullptr);
 }
 
-TEST(JSONRPC, params_null) {
+TEST(params_null) {
   const auto request{sourcemeta::core::parse_json(
       R"({ "jsonrpc": "2.0", "id": 1, "method": "ping", "params": null })")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_params(request), nullptr);
 }
 
-TEST(JSONRPC, params_on_non_object) {
+TEST(params_on_non_object) {
   const auto request{sourcemeta::core::parse_json(R"([ 1, 2 ])")};
   EXPECT_EQ(sourcemeta::core::jsonrpc_params(request), nullptr);
 }
 
-TEST(JSONRPC, make_success_empty) {
+TEST(make_success_empty) {
   const auto identifier{sourcemeta::core::JSON{1}};
   const auto envelope{sourcemeta::core::jsonrpc_make_success_empty(identifier)};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -418,7 +418,7 @@ TEST(JSONRPC, make_success_empty) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_success_empty_object_result) {
+TEST(make_success_empty_object_result) {
   const auto identifier{sourcemeta::core::JSON{1}};
   const auto envelope{sourcemeta::core::jsonrpc_make_success(
       identifier, sourcemeta::core::JSON::make_object())};
@@ -430,7 +430,7 @@ TEST(JSONRPC, make_success_empty_object_result) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_success_populated_object_result) {
+TEST(make_success_populated_object_result) {
   const auto identifier{sourcemeta::core::JSON{"abc"}};
   auto result{sourcemeta::core::JSON::make_object()};
   result.assign("foo", sourcemeta::core::JSON{42});
@@ -444,7 +444,7 @@ TEST(JSONRPC, make_success_populated_object_result) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_success_array_result) {
+TEST(make_success_array_result) {
   const auto identifier{sourcemeta::core::JSON{2}};
   const auto envelope{sourcemeta::core::jsonrpc_make_success(
       identifier, sourcemeta::core::parse_json(R"([ 1, 2, 3 ])"))};
@@ -456,7 +456,7 @@ TEST(JSONRPC, make_success_array_result) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_with_id_no_data) {
+TEST(make_error_with_id_no_data) {
   const auto identifier{sourcemeta::core::JSON{1}};
   const auto envelope{sourcemeta::core::jsonrpc_make_error(&identifier, -32000,
                                                            "Server error")};
@@ -471,7 +471,7 @@ TEST(JSONRPC, make_error_with_id_no_data) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_with_id_and_data) {
+TEST(make_error_with_id_and_data) {
   const auto identifier{sourcemeta::core::JSON{"req-1"}};
   const auto envelope{sourcemeta::core::jsonrpc_make_error(
       &identifier, -32000, "Server error",
@@ -488,7 +488,7 @@ TEST(JSONRPC, make_error_with_id_and_data) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_without_id) {
+TEST(make_error_without_id) {
   const auto envelope{
       sourcemeta::core::jsonrpc_make_error(nullptr, -32000, "Server error")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -502,7 +502,7 @@ TEST(JSONRPC, make_error_without_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_without_id_with_object_data) {
+TEST(make_error_without_id_with_object_data) {
   auto data{sourcemeta::core::JSON::make_object()};
   data.assign("hint", sourcemeta::core::JSON{"check input"});
   const auto envelope{sourcemeta::core::jsonrpc_make_error(
@@ -519,7 +519,7 @@ TEST(JSONRPC, make_error_without_id_with_object_data) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_parse) {
+TEST(make_error_parse) {
   const auto &envelope{sourcemeta::core::jsonrpc_make_error_parse()};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
@@ -532,13 +532,13 @@ TEST(JSONRPC, make_error_parse) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_parse_returns_same_reference) {
+TEST(make_error_parse_returns_same_reference) {
   const auto *first{&sourcemeta::core::jsonrpc_make_error_parse()};
   const auto *second{&sourcemeta::core::jsonrpc_make_error_parse()};
   EXPECT_EQ(first, second);
 }
 
-TEST(JSONRPC, make_error_invalid_request_with_id) {
+TEST(make_error_invalid_request_with_id) {
   const auto identifier{sourcemeta::core::JSON{1}};
   const auto envelope{
       sourcemeta::core::jsonrpc_make_error_invalid_request(&identifier)};
@@ -553,7 +553,7 @@ TEST(JSONRPC, make_error_invalid_request_with_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_invalid_request_without_id) {
+TEST(make_error_invalid_request_without_id) {
   const auto envelope{sourcemeta::core::jsonrpc_make_error_invalid_request()};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
@@ -566,7 +566,7 @@ TEST(JSONRPC, make_error_invalid_request_without_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_method_not_found) {
+TEST(make_error_method_not_found) {
   const auto identifier{sourcemeta::core::JSON{2}};
   const auto envelope{
       sourcemeta::core::jsonrpc_make_error_method_not_found(identifier)};
@@ -581,7 +581,7 @@ TEST(JSONRPC, make_error_method_not_found) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_invalid_params) {
+TEST(make_error_invalid_params) {
   const auto identifier{sourcemeta::core::JSON{"req-7"}};
   const auto envelope{
       sourcemeta::core::jsonrpc_make_error_invalid_params(identifier)};
@@ -596,7 +596,7 @@ TEST(JSONRPC, make_error_invalid_params) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_invalid_params_with_data) {
+TEST(make_error_invalid_params_with_data) {
   const auto identifier{sourcemeta::core::JSON{"req-8"}};
   const auto envelope{sourcemeta::core::jsonrpc_make_error_invalid_params(
       identifier, sourcemeta::core::JSON{"abc"})};
@@ -612,7 +612,7 @@ TEST(JSONRPC, make_error_invalid_params_with_data) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_internal_with_id) {
+TEST(make_error_internal_with_id) {
   const auto identifier{sourcemeta::core::JSON{3}};
   const auto envelope{
       sourcemeta::core::jsonrpc_make_error_internal(&identifier)};
@@ -627,7 +627,7 @@ TEST(JSONRPC, make_error_internal_with_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(JSONRPC, make_error_internal_without_id) {
+TEST(make_error_internal_without_id) {
   const auto envelope{sourcemeta::core::jsonrpc_make_error_internal()};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",

--- a/test/langtag/CMakeLists.txt
+++ b/test/langtag/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME langtag
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME langtag
   SOURCES langtag_test.cc)
 
 target_link_libraries(sourcemeta_core_langtag_unit

--- a/test/langtag/langtag_test.cc
+++ b/test/langtag/langtag_test.cc
@@ -1,16 +1,16 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/langtag.h>
 
 // RFC 5646 Appendix A: simple language subtag
-TEST(LangTag, rfc_simple_language_subtag) {
+TEST(rfc_simple_language_subtag) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("fr"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("ja"));
 }
 
 // RFC 5646 Appendix A: language subtag plus script subtag
-TEST(LangTag, rfc_language_plus_script) {
+TEST(rfc_language_plus_script) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-Hant"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-Hans"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("sr-Cyrl"));
@@ -18,7 +18,7 @@ TEST(LangTag, rfc_language_plus_script) {
 }
 
 // RFC 5646 Appendix A: extended language subtags
-TEST(LangTag, rfc_extended_language_subtags) {
+TEST(rfc_extended_language_subtags) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-cmn-Hans-CN"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("cmn-Hans-CN"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-yue-HK"));
@@ -26,44 +26,44 @@ TEST(LangTag, rfc_extended_language_subtags) {
 }
 
 // RFC 5646 Appendix A: language-script-region
-TEST(LangTag, rfc_language_script_region) {
+TEST(rfc_language_script_region) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-Hans-CN"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("sr-Latn-RS"));
 }
 
 // RFC 5646 Appendix A: language-variant
-TEST(LangTag, rfc_language_variant) {
+TEST(rfc_language_variant) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("sl-rozaj"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("sl-rozaj-biske"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("sl-nedis"));
 }
 
 // RFC 5646 Appendix A: language-region-variant
-TEST(LangTag, rfc_language_region_variant) {
+TEST(rfc_language_region_variant) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-CH-1901"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("sl-IT-nedis"));
 }
 
 // RFC 5646 Appendix A: language-script-region-variant
-TEST(LangTag, rfc_language_script_region_variant) {
+TEST(rfc_language_script_region_variant) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("hy-Latn-IT-arevela"));
 }
 
 // RFC 5646 Appendix A: language-region
-TEST(LangTag, rfc_language_region) {
+TEST(rfc_language_region) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-DE"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-US"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("es-419"));
 }
 
 // RFC 5646 Appendix A: private use subtags
-TEST(LangTag, rfc_private_use_subtags) {
+TEST(rfc_private_use_subtags) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-CH-x-phonebk"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("az-Arab-x-AYB"));
 }
 
 // RFC 5646 Appendix A: tags using the private use registry values
-TEST(LangTag, rfc_private_use_registry_values) {
+TEST(rfc_private_use_registry_values) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("qaa-Qaaa-QM-x-southern"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-Qaaa"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("sr-Latn-QM"));
@@ -71,308 +71,300 @@ TEST(LangTag, rfc_private_use_registry_values) {
 }
 
 // RFC 5646 Appendix A: tags using extensions
-TEST(LangTag, rfc_extensions) {
+TEST(rfc_extensions) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-US-u-islamcal"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-CN-a-myext-x-private"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-a-myext-b-another"));
 }
 
 // RFC 5646 Appendix A: private use only
-TEST(LangTag, rfc_private_use_only) {
+TEST(rfc_private_use_only) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("x-whatever"));
 }
 
 // RFC 5646 Appendix A: invalid, two region subtags
-TEST(LangTag, rfc_invalid_two_region_subtags) {
+TEST(rfc_invalid_two_region_subtags) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("de-419-DE"));
 }
 
 // RFC 5646 Appendix A: invalid, single-character primary language
-TEST(LangTag, rfc_invalid_single_character_primary) {
+TEST(rfc_invalid_single_character_primary) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("a-DE"));
 }
 
 // RFC 5646 Appendix A: invalid, two extensions with the same singleton
-TEST(LangTag, rfc_invalid_duplicate_singleton) {
+TEST(rfc_invalid_duplicate_singleton) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("ar-a-aaa-b-bbb-a-ccc"));
 }
 
 // RFC 5646 Appendix A: invalid, singleton with no following subtag
-TEST(LangTag, rfc_invalid_extension_without_subtag) {
+TEST(rfc_invalid_extension_without_subtag) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("tlh-a-b-foo"));
 }
 
 // RFC 5646 Section 2.2.1: primary language of two letters
-TEST(LangTag, language_two_letters) {
-  EXPECT_TRUE(sourcemeta::core::is_langtag("en"));
-}
+TEST(language_two_letters) { EXPECT_TRUE(sourcemeta::core::is_langtag("en")); }
 
 // RFC 5646 Section 2.2.1: primary language of three letters
-TEST(LangTag, language_three_letters) {
+TEST(language_three_letters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("mas"));
 }
 
 // RFC 5646 Section 2.2.1: four-letter reserved primary language
-TEST(LangTag, language_four_letters_reserved) {
+TEST(language_four_letters_reserved) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("aaaa"));
 }
 
 // RFC 5646 Section 2.2.1: a four-letter primary language takes no extended
 // language but still admits a script and region
-TEST(LangTag, language_four_letters_with_script_region) {
+TEST(language_four_letters_with_script_region) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("aaaa-Latn-US"));
 }
 
 // RFC 5646 Section 2.2.1: registered primary language of five to eight letters
-TEST(LangTag, language_five_to_eight_letters) {
+TEST(language_five_to_eight_letters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("abcde"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("abcdefgh"));
 }
 
 // RFC 5646 Section 2.2.1: a long primary language still admits a region
-TEST(LangTag, language_five_to_eight_letters_with_region) {
+TEST(language_five_to_eight_letters_with_region) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("abcde-US"));
 }
 
 // RFC 5646 Section 2.2.1: a single-letter primary language is not allowed
-TEST(LangTag, language_one_letter_rejected) {
+TEST(language_one_letter_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("a"));
 }
 
 // RFC 5646 Section 2.2.1: a primary language longer than eight letters is not
 // allowed
-TEST(LangTag, language_nine_letters_rejected) {
+TEST(language_nine_letters_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("abcdefghi"));
 }
 
 // RFC 5646 Section 2.2.1: the primary language is letters only
-TEST(LangTag, language_with_digit_rejected) {
+TEST(language_with_digit_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("e2"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("12"));
 }
 
 // RFC 5646 Section 2.2.2: a single extended language subtag
-TEST(LangTag, single_extlang) {
-  EXPECT_TRUE(sourcemeta::core::is_langtag("zh-yue"));
-}
+TEST(single_extlang) { EXPECT_TRUE(sourcemeta::core::is_langtag("zh-yue")); }
 
 // RFC 5646 Section 2.2.2: up to three extended language subtags
-TEST(LangTag, three_extlangs) {
+TEST(three_extlangs) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-aaa-bbb-ccc"));
 }
 
 // RFC 5646 Section 2.2.2: more than three extended language subtags is not
 // allowed
-TEST(LangTag, four_extlangs_rejected) {
+TEST(four_extlangs_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("zh-aaa-bbb-ccc-ddd"));
 }
 
 // RFC 5646 Section 2.2.2: extended language subtags only follow a two or three
 // letter primary language
-TEST(LangTag, extlang_only_after_short_primary) {
+TEST(extlang_only_after_short_primary) {
   // A four-letter or longer primary language cannot take an extended language
   EXPECT_FALSE(sourcemeta::core::is_langtag("aaaa-bbb"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("abcde-fgh"));
 }
 
 // RFC 5646 Section 2.2.3: a script subtag after an extended language
-TEST(LangTag, script_after_extlang) {
+TEST(script_after_extlang) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-yue-Hant-CN"));
 }
 
 // RFC 5646 Section 2.1: extlang, script, region, variant, extension and
 // private use all present in a single tag
-TEST(LangTag, full_langtag) {
+TEST(full_langtag) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-yue-Hant-CN-1994-a-bbb-x-foo"));
 }
 
 // RFC 5646 Section 2.2.3: at most one script subtag
-TEST(LangTag, two_scripts_rejected) {
+TEST(two_scripts_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("zh-Hant-Latn"));
 }
 
 // RFC 5646 Section 2.2.4: an alphabetic region subtag
-TEST(LangTag, region_alpha) {
-  EXPECT_TRUE(sourcemeta::core::is_langtag("en-GB"));
-}
+TEST(region_alpha) { EXPECT_TRUE(sourcemeta::core::is_langtag("en-GB")); }
 
 // RFC 5646 Section 2.2.4: a numeric region subtag
-TEST(LangTag, region_numeric) {
-  EXPECT_TRUE(sourcemeta::core::is_langtag("es-005"));
-}
+TEST(region_numeric) { EXPECT_TRUE(sourcemeta::core::is_langtag("es-005")); }
 
 // RFC 5646 Section 2.2.4: a numeric region subtag has exactly three digits
-TEST(LangTag, two_digit_region_rejected) {
+TEST(two_digit_region_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-12"));
 }
 
 // RFC 5646 Section 2.2.4: at most one region subtag
-TEST(LangTag, two_regions_rejected) {
+TEST(two_regions_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-US-GB"));
 }
 
 // RFC 5646 Section 2.2.5: a variant of five to eight characters
-TEST(LangTag, variant_five_letters) {
+TEST(variant_five_letters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-nedis"));
 }
 
 // RFC 5646 Section 2.2.5: a variant of eight characters
-TEST(LangTag, variant_eight_characters) {
+TEST(variant_eight_characters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-abcdefgh"));
 }
 
 // RFC 5646 Section 2.2.5: a four-character variant beginning with a digit
-TEST(LangTag, digit_led_four_character_variant) {
+TEST(digit_led_four_character_variant) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-1994"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-1234"));
 }
 
 // RFC 5646 Section 2.2.5: a digit-led four-character variant may mix letters
-TEST(LangTag, digit_led_four_character_variant_with_letters) {
+TEST(digit_led_four_character_variant_with_letters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-1abc"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("de-1a2b"));
 }
 
 // RFC 5646 Section 2.2.5: a four-character subtag must begin with a digit
-TEST(LangTag, four_character_non_digit_led_rejected) {
+TEST(four_character_non_digit_led_rejected) {
   // A four-character subtag is only a variant when it begins with a digit
   EXPECT_FALSE(sourcemeta::core::is_langtag("de-ab12"));
 }
 
 // RFC 5646 Section 2.2.5: several variant subtags in a row
-TEST(LangTag, multiple_variants) {
+TEST(multiple_variants) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("sl-rozaj-biske-1994"));
 }
 
 // RFC 5646 Section 2.2.5: the same variant must not appear twice
-TEST(LangTag, duplicate_variant_rejected) {
+TEST(duplicate_variant_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("de-1994-1994"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("sl-rozaj-rozaj"));
 }
 
 // RFC 5646 Section 2.2.5: variant duplication is detected case insensitively
-TEST(LangTag, duplicate_variant_case_insensitive_rejected) {
+TEST(duplicate_variant_case_insensitive_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("sl-rozaj-ROZAJ"));
 }
 
 // RFC 5646 Section 2.2.6: a digit singleton introduces an extension
-TEST(LangTag, digit_singleton_extension) {
+TEST(digit_singleton_extension) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-0-bbb"));
 }
 
 // RFC 5646 Section 2.2.6: an extension may carry several subtags
-TEST(LangTag, extension_multiple_subtags) {
+TEST(extension_multiple_subtags) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-a-bbb-ccc-ddd"));
 }
 
 // RFC 5646 Section 2.2.6: several extensions with different singletons
-TEST(LangTag, multiple_extensions) {
+TEST(multiple_extensions) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-a-bbb-c-ddd"));
 }
 
 // RFC 5646 Section 2.2.6: every letter except "x" is a valid singleton,
 // including the letters bordering the reserved "x"
-TEST(LangTag, extension_singleton_letter_boundaries) {
+TEST(extension_singleton_letter_boundaries) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-w-aa"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-y-aa"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-z-aa"));
 }
 
 // RFC 5646 Section 2.2.6: a singleton must be followed by a subtag
-TEST(LangTag, bare_extension_singleton_rejected) {
+TEST(bare_extension_singleton_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-a"));
 }
 
 // RFC 5646 Section 2.2.6: a singleton cannot be followed by another singleton
-TEST(LangTag, adjacent_singletons_rejected) {
+TEST(adjacent_singletons_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-a-b"));
 }
 
 // RFC 5646 Section 2.2.6: an extension subtag is at most eight characters
-TEST(LangTag, extension_subtag_too_long_rejected) {
+TEST(extension_subtag_too_long_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-a-123456789"));
 }
 
 // RFC 5646 Section 2.2.6: an eight-character extension subtag is allowed
-TEST(LangTag, extension_subtag_eight_characters) {
+TEST(extension_subtag_eight_characters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-a-abcd1234"));
 }
 
 // RFC 5646 Section 2.2.6: an extension subtag is at least two characters
-TEST(LangTag, extension_subtag_single_character_rejected) {
+TEST(extension_subtag_single_character_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-a-b-ccc"));
 }
 
 // RFC 5646 Section 2.2.6: a singleton must not appear more than once
-TEST(LangTag, duplicate_singleton_rejected) {
+TEST(duplicate_singleton_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-a-bbb-a-ccc"));
 }
 
 // RFC 5646 Section 2.2.6: singleton duplication is detected case insensitively
-TEST(LangTag, duplicate_singleton_case_insensitive_rejected) {
+TEST(duplicate_singleton_case_insensitive_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-a-bbb-A-ccc"));
 }
 
 // RFC 5646 Section 2.2.6: a digit singleton must not appear more than once
-TEST(LangTag, duplicate_digit_singleton_rejected) {
+TEST(duplicate_digit_singleton_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-0-aaa-0-bbb"));
 }
 
 // RFC 5646 Section 2.2.7: a private use tag with a single subtag
-TEST(LangTag, private_use_only_single_subtag) {
+TEST(private_use_only_single_subtag) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("x-foo"));
 }
 
 // RFC 5646 Section 2.2.7: a private use tag with several subtags
-TEST(LangTag, private_use_only_multiple_subtags) {
+TEST(private_use_only_multiple_subtags) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("x-a-b-c"));
 }
 
 // RFC 5646 Section 2.2.7: a private use subtag of a single character
-TEST(LangTag, private_use_single_character_subtag) {
+TEST(private_use_single_character_subtag) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("x-a"));
 }
 
 // RFC 5646 Section 2.2.7: a single-character private use subtag is allowed
 // after a language, where an extension subtag could never be that short
-TEST(LangTag, private_use_single_character_subtag_after_language) {
+TEST(private_use_single_character_subtag_after_language) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-x-c"));
 }
 
 // RFC 5646 Section 2.2.7: the private use singleton is case insensitive
-TEST(LangTag, private_use_uppercase_singleton) {
+TEST(private_use_uppercase_singleton) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("X-foo"));
 }
 
 // RFC 5646 Section 2.2.7: an uppercase "X" introduces private use after a
 // language and is never treated as an extension singleton
-TEST(LangTag, private_use_uppercase_singleton_after_language) {
+TEST(private_use_uppercase_singleton_after_language) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-X-foo"));
 }
 
 // RFC 5646 Section 2.2.7: a private use sequence after an extension
-TEST(LangTag, private_use_after_extension) {
+TEST(private_use_after_extension) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-a-bb-x-cc"));
 }
 
 // RFC 5646 Section 2.2.7: a private use singleton must be followed by a subtag
-TEST(LangTag, bare_private_use_singleton_rejected) {
+TEST(bare_private_use_singleton_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("x"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-x"));
 }
 
 // RFC 5646 Section 2.2.7: a private use subtag is at most eight characters
-TEST(LangTag, private_use_subtag_too_long_rejected) {
+TEST(private_use_subtag_too_long_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("x-123456789"));
 }
 
 // RFC 5646 Section 2.2.7: an eight-character private use subtag is allowed
-TEST(LangTag, private_use_subtag_eight_characters) {
+TEST(private_use_subtag_eight_characters) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("x-abcd1234"));
 }
 
 // RFC 5646 Section 2.2.8: the irregular grandfathered tags
-TEST(LangTag, grandfathered_irregular) {
+TEST(grandfathered_irregular) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("en-GB-oed"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("i-ami"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("i-bnn"));
@@ -393,14 +385,14 @@ TEST(LangTag, grandfathered_irregular) {
 }
 
 // RFC 5646 Section 2.2.8: irregular grandfathered tags are case insensitive
-TEST(LangTag, grandfathered_irregular_case_insensitive) {
+TEST(grandfathered_irregular_case_insensitive) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("I-AMI"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("EN-gb-OED"));
 }
 
 // RFC 5646 Section 2.2.8: the regular grandfathered tags match the langtag
 // grammar
-TEST(LangTag, grandfathered_regular_via_grammar) {
+TEST(grandfathered_regular_via_grammar) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("art-lojban"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("cel-gaulish"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("no-bok"));
@@ -413,55 +405,49 @@ TEST(LangTag, grandfathered_regular_via_grammar) {
 }
 
 // RFC 5646 Section 2.1.1: language tags are not case sensitive
-TEST(LangTag, case_insensitive) {
+TEST(case_insensitive) {
   EXPECT_TRUE(sourcemeta::core::is_langtag("EN-us"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("zh-hant-hk"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("DE-ch-1901"));
 }
 
 // RFC 5646 Section 2.2.9: well-formedness does not require registered subtags
-TEST(LangTag, well_formed_but_not_valid) {
+TEST(well_formed_but_not_valid) {
   // Unregistered subtags are still well-formed
   EXPECT_TRUE(sourcemeta::core::is_langtag("zz-Zzzz"));
   EXPECT_TRUE(sourcemeta::core::is_langtag("qaa"));
 }
 
 // RFC 5646 Section 2.1: the empty string is not a language tag
-TEST(LangTag, empty) { EXPECT_FALSE(sourcemeta::core::is_langtag("")); }
+TEST(empty) { EXPECT_FALSE(sourcemeta::core::is_langtag("")); }
 
 // RFC 5646 Section 2.1: a lone separator is not a language tag
-TEST(LangTag, only_hyphen) { EXPECT_FALSE(sourcemeta::core::is_langtag("-")); }
+TEST(only_hyphen) { EXPECT_FALSE(sourcemeta::core::is_langtag("-")); }
 
 // RFC 5646 Section 2.1: a tag must not begin with a separator
-TEST(LangTag, leading_hyphen) {
-  EXPECT_FALSE(sourcemeta::core::is_langtag("-en"));
-}
+TEST(leading_hyphen) { EXPECT_FALSE(sourcemeta::core::is_langtag("-en")); }
 
 // RFC 5646 Section 2.1: a tag must not end with a separator
-TEST(LangTag, trailing_hyphen) {
-  EXPECT_FALSE(sourcemeta::core::is_langtag("en-"));
-}
+TEST(trailing_hyphen) { EXPECT_FALSE(sourcemeta::core::is_langtag("en-")); }
 
 // RFC 5646 Section 2.1: subtags must not be empty
-TEST(LangTag, double_hyphen) {
-  EXPECT_FALSE(sourcemeta::core::is_langtag("en--US"));
-}
+TEST(double_hyphen) { EXPECT_FALSE(sourcemeta::core::is_langtag("en--US")); }
 
 // RFC 5646 Section 2.1: subtags are alphanumeric only
-TEST(LangTag, non_alphanumeric_character) {
+TEST(non_alphanumeric_character) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en_US"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-US!"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en.US"));
 }
 
 // RFC 5646 Section 2.1: subtags are limited to ASCII letters and digits
-TEST(LangTag, non_ascii_character) {
+TEST(non_ascii_character) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("én"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en-café"));
 }
 
 // RFC 5646 Section 2.1: whitespace is not part of the grammar
-TEST(LangTag, whitespace) {
+TEST(whitespace) {
   EXPECT_FALSE(sourcemeta::core::is_langtag(" en"));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en "));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en US"));

--- a/test/markdown/CMakeLists.txt
+++ b/test/markdown/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME markdown
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME markdown
   SOURCES markdown_test.cc)
 
 target_link_libraries(sourcemeta_core_markdown_unit

--- a/test/markdown/markdown_test.cc
+++ b/test/markdown/markdown_test.cc
@@ -1,13 +1,13 @@
 #include <sourcemeta/core/markdown.h>
 
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstddef> // std::size_t
 #include <string>  // std::string
 #include <thread>  // std::thread
 #include <vector>  // std::vector
 
-TEST(Markdown_to_html, concurrent_calls) {
+TEST(concurrent_calls) {
   static constexpr std::size_t THREAD_COUNT{16};
   std::vector<std::thread> threads;
   threads.reserve(THREAD_COUNT);
@@ -41,196 +41,196 @@ TEST(Markdown_to_html, concurrent_calls) {
   EXPECT_EQ(results[15], "<p><strong>hello</strong> world</p>\n");
 }
 
-TEST(Markdown_to_html, simple_paragraph) {
+TEST(simple_paragraph) {
   const auto result{sourcemeta::core::markdown_to_html("Hello world")};
   EXPECT_EQ(result, "<p>Hello world</p>\n");
 }
 
-TEST(Markdown_to_html, safe_mode_renders_plain_content) {
+TEST(safe_mode_renders_plain_content) {
   const auto result{
       sourcemeta::core::markdown_to_html("Hello **world**", true)};
   EXPECT_EQ(result, "<p>Hello <strong>world</strong></p>\n");
 }
 
-TEST(Markdown_to_html, safe_mode_omits_raw_html) {
+TEST(safe_mode_omits_raw_html) {
   const auto result{
       sourcemeta::core::markdown_to_html("<div onclick=\"x\">hi</div>", true)};
   EXPECT_EQ(result, "<!-- raw HTML omitted -->\n");
 }
 
-TEST(Markdown_to_html, multiple_paragraphs) {
+TEST(multiple_paragraphs) {
   const auto result{sourcemeta::core::markdown_to_html(
       "First paragraph\n\nSecond paragraph")};
   EXPECT_EQ(result, "<p>First paragraph</p>\n<p>Second paragraph</p>\n");
 }
 
-TEST(Markdown_to_html, three_paragraphs) {
+TEST(three_paragraphs) {
   const auto result{sourcemeta::core::markdown_to_html("One\n\nTwo\n\nThree")};
   EXPECT_EQ(result, "<p>One</p>\n<p>Two</p>\n<p>Three</p>\n");
 }
 
-TEST(Markdown_to_html, empty_input) {
+TEST(empty_input) {
   const auto result{sourcemeta::core::markdown_to_html("")};
   EXPECT_TRUE(result.empty());
 }
 
-TEST(Markdown_to_html, whitespace_only) {
+TEST(whitespace_only) {
   const auto result{sourcemeta::core::markdown_to_html("   \n\n   ")};
   EXPECT_TRUE(result.empty());
 }
 
-TEST(Markdown_to_html, soft_line_break) {
+TEST(soft_line_break) {
   const auto result{sourcemeta::core::markdown_to_html("line one\nline two")};
   EXPECT_EQ(result, "<p>line one\nline two</p>\n");
 }
 
-TEST(Markdown_to_html, hard_line_break_with_two_spaces) {
+TEST(hard_line_break_with_two_spaces) {
   const auto result{sourcemeta::core::markdown_to_html("line one  \nline two")};
   EXPECT_EQ(result, "<p>line one<br />\nline two</p>\n");
 }
 
-TEST(Markdown_to_html, hard_line_break_with_backslash) {
+TEST(hard_line_break_with_backslash) {
   const auto result{sourcemeta::core::markdown_to_html("line one\\\nline two")};
   EXPECT_EQ(result, "<p>line one<br />\nline two</p>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_level_1) {
+TEST(atx_heading_level_1) {
   const auto result{sourcemeta::core::markdown_to_html("# Heading 1")};
   EXPECT_EQ(result, "<h1>Heading 1</h1>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_level_2) {
+TEST(atx_heading_level_2) {
   const auto result{sourcemeta::core::markdown_to_html("## Heading 2")};
   EXPECT_EQ(result, "<h2>Heading 2</h2>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_level_3) {
+TEST(atx_heading_level_3) {
   const auto result{sourcemeta::core::markdown_to_html("### Heading 3")};
   EXPECT_EQ(result, "<h3>Heading 3</h3>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_level_4) {
+TEST(atx_heading_level_4) {
   const auto result{sourcemeta::core::markdown_to_html("#### Heading 4")};
   EXPECT_EQ(result, "<h4>Heading 4</h4>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_level_5) {
+TEST(atx_heading_level_5) {
   const auto result{sourcemeta::core::markdown_to_html("##### Heading 5")};
   EXPECT_EQ(result, "<h5>Heading 5</h5>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_level_6) {
+TEST(atx_heading_level_6) {
   const auto result{sourcemeta::core::markdown_to_html("###### Heading 6")};
   EXPECT_EQ(result, "<h6>Heading 6</h6>\n");
 }
 
-TEST(Markdown_to_html, atx_heading_with_closing_hashes) {
+TEST(atx_heading_with_closing_hashes) {
   const auto result{sourcemeta::core::markdown_to_html("## Heading ##")};
   EXPECT_EQ(result, "<h2>Heading</h2>\n");
 }
 
-TEST(Markdown_to_html, setext_heading_level_1) {
+TEST(setext_heading_level_1) {
   const auto result{sourcemeta::core::markdown_to_html("Heading 1\n=========")};
   EXPECT_EQ(result, "<h1>Heading 1</h1>\n");
 }
 
-TEST(Markdown_to_html, setext_heading_level_2) {
+TEST(setext_heading_level_2) {
   const auto result{sourcemeta::core::markdown_to_html("Heading 2\n---------")};
   EXPECT_EQ(result, "<h2>Heading 2</h2>\n");
 }
 
-TEST(Markdown_to_html, italic_with_asterisks) {
+TEST(italic_with_asterisks) {
   const auto result{sourcemeta::core::markdown_to_html("*italic*")};
   EXPECT_EQ(result, "<p><em>italic</em></p>\n");
 }
 
-TEST(Markdown_to_html, italic_with_underscores) {
+TEST(italic_with_underscores) {
   const auto result{sourcemeta::core::markdown_to_html("_italic_")};
   EXPECT_EQ(result, "<p><em>italic</em></p>\n");
 }
 
-TEST(Markdown_to_html, bold_with_asterisks) {
+TEST(bold_with_asterisks) {
   const auto result{sourcemeta::core::markdown_to_html("**bold**")};
   EXPECT_EQ(result, "<p><strong>bold</strong></p>\n");
 }
 
-TEST(Markdown_to_html, bold_with_underscores) {
+TEST(bold_with_underscores) {
   const auto result{sourcemeta::core::markdown_to_html("__bold__")};
   EXPECT_EQ(result, "<p><strong>bold</strong></p>\n");
 }
 
-TEST(Markdown_to_html, bold_and_italic) {
+TEST(bold_and_italic) {
   const auto result{sourcemeta::core::markdown_to_html("***bold italic***")};
   EXPECT_EQ(result, "<p><em><strong>bold italic</strong></em></p>\n");
 }
 
-TEST(Markdown_to_html, bold_inside_italic) {
+TEST(bold_inside_italic) {
   const auto result{
       sourcemeta::core::markdown_to_html("*this is **bold** inside italic*")};
   EXPECT_EQ(result,
             "<p><em>this is <strong>bold</strong> inside italic</em></p>\n");
 }
 
-TEST(Markdown_to_html, italic_inside_bold) {
+TEST(italic_inside_bold) {
   const auto result{
       sourcemeta::core::markdown_to_html("**this is *italic* inside bold**")};
   EXPECT_EQ(result,
             "<p><strong>this is <em>italic</em> inside bold</strong></p>\n");
 }
 
-TEST(Markdown_to_html, inline_code) {
+TEST(inline_code) {
   const auto result{sourcemeta::core::markdown_to_html("Use `printf()`")};
   EXPECT_EQ(result, "<p>Use <code>printf()</code></p>\n");
 }
 
-TEST(Markdown_to_html, inline_code_with_backticks_inside) {
+TEST(inline_code_with_backticks_inside) {
   const auto result{
       sourcemeta::core::markdown_to_html("`` there is a ` here ``")};
   EXPECT_EQ(result, "<p><code>there is a ` here</code></p>\n");
 }
 
-TEST(Markdown_to_html, inline_code_preserves_html) {
+TEST(inline_code_preserves_html) {
   const auto result{
       sourcemeta::core::markdown_to_html("`<div class=\"foo\">`")};
   EXPECT_EQ(result, "<p><code>&lt;div class=&quot;foo&quot;&gt;</code></p>\n");
 }
 
-TEST(Markdown_to_html, fenced_code_block_backticks) {
+TEST(fenced_code_block_backticks) {
   const auto result{sourcemeta::core::markdown_to_html("```\ncode here\n```")};
   EXPECT_EQ(result, "<pre><code>code here\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, fenced_code_block_tildes) {
+TEST(fenced_code_block_tildes) {
   const auto result{sourcemeta::core::markdown_to_html("~~~\ncode here\n~~~")};
   EXPECT_EQ(result, "<pre><code>code here\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, fenced_code_block_with_language) {
+TEST(fenced_code_block_with_language) {
   const auto result{
       sourcemeta::core::markdown_to_html("```cpp\nint x = 0;\n```")};
   EXPECT_EQ(result, "<pre lang=\"cpp\"><code>int x = 0;\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, fenced_code_block_html_escaped) {
+TEST(fenced_code_block_html_escaped) {
   const auto result{
       sourcemeta::core::markdown_to_html("```\n<div>&amp;</div>\n```")};
   EXPECT_EQ(result,
             "<pre><code>&lt;div&gt;&amp;amp;&lt;/div&gt;\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, indented_code_block) {
+TEST(indented_code_block) {
   const auto result{
       sourcemeta::core::markdown_to_html("    int x = 0;\n    return x;")};
   EXPECT_EQ(result, "<pre><code>int x = 0;\nreturn x;\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, inline_link) {
+TEST(inline_link) {
   const auto result{
       sourcemeta::core::markdown_to_html("[click here](https://example.com)")};
   EXPECT_EQ(result, "<p><a href=\"https://example.com\">click here</a></p>\n");
 }
 
-TEST(Markdown_to_html, inline_link_with_title) {
+TEST(inline_link_with_title) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[click](https://example.com \"My Title\")")};
   EXPECT_EQ(
@@ -238,13 +238,13 @@ TEST(Markdown_to_html, inline_link_with_title) {
       "<p><a href=\"https://example.com\" title=\"My Title\">click</a></p>\n");
 }
 
-TEST(Markdown_to_html, reference_link) {
+TEST(reference_link) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[click][ref]\n\n[ref]: https://example.com")};
   EXPECT_EQ(result, "<p><a href=\"https://example.com\">click</a></p>\n");
 }
 
-TEST(Markdown_to_html, reference_link_with_title) {
+TEST(reference_link_with_title) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[click][ref]\n\n[ref]: https://example.com \"Title\"")};
   EXPECT_EQ(
@@ -252,32 +252,32 @@ TEST(Markdown_to_html, reference_link_with_title) {
       "<p><a href=\"https://example.com\" title=\"Title\">click</a></p>\n");
 }
 
-TEST(Markdown_to_html, collapsed_reference_link) {
+TEST(collapsed_reference_link) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[example][]\n\n[example]: https://example.com")};
   EXPECT_EQ(result, "<p><a href=\"https://example.com\">example</a></p>\n");
 }
 
-TEST(Markdown_to_html, shortcut_reference_link) {
+TEST(shortcut_reference_link) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[example]\n\n[example]: https://example.com")};
   EXPECT_EQ(result, "<p><a href=\"https://example.com\">example</a></p>\n");
 }
 
-TEST(Markdown_to_html, link_with_emphasis_inside) {
+TEST(link_with_emphasis_inside) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[**bold link**](https://example.com)")};
   EXPECT_EQ(result, "<p><a href=\"https://example.com\"><strong>bold "
                     "link</strong></a></p>\n");
 }
 
-TEST(Markdown_to_html, image) {
+TEST(image) {
   const auto result{
       sourcemeta::core::markdown_to_html("![alt text](image.png)")};
   EXPECT_EQ(result, "<p><img src=\"image.png\" alt=\"alt text\" /></p>\n");
 }
 
-TEST(Markdown_to_html, image_with_title) {
+TEST(image_with_title) {
   const auto result{
       sourcemeta::core::markdown_to_html("![alt](image.png \"My Image\")")};
   EXPECT_EQ(
@@ -285,24 +285,24 @@ TEST(Markdown_to_html, image_with_title) {
       "<p><img src=\"image.png\" alt=\"alt\" title=\"My Image\" /></p>\n");
 }
 
-TEST(Markdown_to_html, simple_blockquote) {
+TEST(simple_blockquote) {
   const auto result{sourcemeta::core::markdown_to_html("> quoted text")};
   EXPECT_EQ(result, "<blockquote>\n<p>quoted text</p>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, multiline_blockquote) {
+TEST(multiline_blockquote) {
   const auto result{
       sourcemeta::core::markdown_to_html("> line one\n> line two")};
   EXPECT_EQ(result, "<blockquote>\n<p>line one\nline two</p>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, nested_blockquote) {
+TEST(nested_blockquote) {
   const auto result{sourcemeta::core::markdown_to_html("> outer\n>> inner")};
   EXPECT_EQ(result, "<blockquote>\n<p>outer</p>\n<blockquote>\n<p>inner</p>\n"
                     "</blockquote>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, blockquote_with_formatting) {
+TEST(blockquote_with_formatting) {
   const auto result{
       sourcemeta::core::markdown_to_html("> **bold** and *italic*")};
   EXPECT_EQ(result,
@@ -310,42 +310,42 @@ TEST(Markdown_to_html, blockquote_with_formatting) {
             "</blockquote>\n");
 }
 
-TEST(Markdown_to_html, unordered_list_with_dashes) {
+TEST(unordered_list_with_dashes) {
   const auto result{
       sourcemeta::core::markdown_to_html("- one\n- two\n- three")};
   EXPECT_EQ(result,
             "<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, unordered_list_with_asterisks) {
+TEST(unordered_list_with_asterisks) {
   const auto result{
       sourcemeta::core::markdown_to_html("* one\n* two\n* three")};
   EXPECT_EQ(result,
             "<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, unordered_list_with_plus) {
+TEST(unordered_list_with_plus) {
   const auto result{
       sourcemeta::core::markdown_to_html("+ one\n+ two\n+ three")};
   EXPECT_EQ(result,
             "<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, nested_unordered_list) {
+TEST(nested_unordered_list) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- outer\n  - inner\n  - inner2\n- outer2")};
   EXPECT_EQ(result, "<ul>\n<li>outer\n<ul>\n<li>inner</li>\n<li>inner2</li>\n"
                     "</ul>\n</li>\n<li>outer2</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, ordered_list) {
+TEST(ordered_list) {
   const auto result{
       sourcemeta::core::markdown_to_html("1. one\n2. two\n3. three")};
   EXPECT_EQ(result,
             "<ol>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ol>\n");
 }
 
-TEST(Markdown_to_html, ordered_list_starting_at_nonone) {
+TEST(ordered_list_starting_at_nonone) {
   const auto result{
       sourcemeta::core::markdown_to_html("3. three\n4. four\n5. five")};
   EXPECT_EQ(result,
@@ -353,130 +353,130 @@ TEST(Markdown_to_html, ordered_list_starting_at_nonone) {
             "</ol>\n");
 }
 
-TEST(Markdown_to_html, nested_ordered_in_unordered) {
+TEST(nested_ordered_in_unordered) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- item\n  1. sub one\n  2. sub two\n- item2")};
   EXPECT_EQ(result, "<ul>\n<li>item\n<ol>\n<li>sub one</li>\n<li>sub two</li>\n"
                     "</ol>\n</li>\n<li>item2</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, loose_list) {
+TEST(loose_list) {
   const auto result{
       sourcemeta::core::markdown_to_html("- one\n\n- two\n\n- three")};
   EXPECT_EQ(result, "<ul>\n<li>\n<p>one</p>\n</li>\n<li>\n<p>two</p>\n</li>\n"
                     "<li>\n<p>three</p>\n</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, thematic_break_with_dashes) {
+TEST(thematic_break_with_dashes) {
   const auto result{sourcemeta::core::markdown_to_html("---")};
   EXPECT_EQ(result, "<hr />\n");
 }
 
-TEST(Markdown_to_html, thematic_break_with_asterisks) {
+TEST(thematic_break_with_asterisks) {
   const auto result{sourcemeta::core::markdown_to_html("***")};
   EXPECT_EQ(result, "<hr />\n");
 }
 
-TEST(Markdown_to_html, thematic_break_with_underscores) {
+TEST(thematic_break_with_underscores) {
   const auto result{sourcemeta::core::markdown_to_html("___")};
   EXPECT_EQ(result, "<hr />\n");
 }
 
-TEST(Markdown_to_html, thematic_break_with_spaces) {
+TEST(thematic_break_with_spaces) {
   const auto result{sourcemeta::core::markdown_to_html("- - -")};
   EXPECT_EQ(result, "<hr />\n");
 }
 
-TEST(Markdown_to_html, escape_asterisk) {
+TEST(escape_asterisk) {
   const auto result{sourcemeta::core::markdown_to_html("\\*not italic\\*")};
   EXPECT_EQ(result, "<p>*not italic*</p>\n");
 }
 
-TEST(Markdown_to_html, escape_hash) {
+TEST(escape_hash) {
   const auto result{sourcemeta::core::markdown_to_html("\\# not a heading")};
   EXPECT_EQ(result, "<p># not a heading</p>\n");
 }
 
-TEST(Markdown_to_html, escape_brackets) {
+TEST(escape_brackets) {
   const auto result{
       sourcemeta::core::markdown_to_html("\\[not a link\\](url)")};
   EXPECT_EQ(result, "<p>[not a link](url)</p>\n");
 }
 
-TEST(Markdown_to_html, escape_backtick) {
+TEST(escape_backtick) {
   const auto result{sourcemeta::core::markdown_to_html("\\`not code\\`")};
   EXPECT_EQ(result, "<p>`not code`</p>\n");
 }
 
-TEST(Markdown_to_html, html_entity_named) {
+TEST(html_entity_named) {
   const auto result{sourcemeta::core::markdown_to_html("&copy; 2025")};
   EXPECT_EQ(result, "<p>\xC2\xA9 2025</p>\n");
 }
 
-TEST(Markdown_to_html, html_entity_numeric) {
+TEST(html_entity_numeric) {
   const auto result{sourcemeta::core::markdown_to_html("&#169; 2025")};
   EXPECT_EQ(result, "<p>\xC2\xA9 2025</p>\n");
 }
 
-TEST(Markdown_to_html, ampersand_in_text) {
+TEST(ampersand_in_text) {
   const auto result{sourcemeta::core::markdown_to_html("AT&T")};
   EXPECT_EQ(result, "<p>AT&amp;T</p>\n");
 }
 
-TEST(Markdown_to_html, angle_brackets_in_text) {
+TEST(angle_brackets_in_text) {
   const auto result{sourcemeta::core::markdown_to_html("1 < 2 and 3 > 2")};
   EXPECT_EQ(result, "<p>1 &lt; 2 and 3 &gt; 2</p>\n");
 }
 
-TEST(Markdown_to_html, unicode_content) {
+TEST(unicode_content) {
   const auto result{
       sourcemeta::core::markdown_to_html("Hello \xC3\xA9\xC3\xA0\xC3\xBC")};
   EXPECT_EQ(result, "<p>Hello \xC3\xA9\xC3\xA0\xC3\xBC</p>\n");
 }
 
-TEST(Markdown_to_html, cjk_characters) {
+TEST(cjk_characters) {
   const auto result{
       sourcemeta::core::markdown_to_html("\xE4\xBD\xA0\xE5\xA5\xBD")};
   EXPECT_EQ(result, "<p>\xE4\xBD\xA0\xE5\xA5\xBD</p>\n");
 }
 
-TEST(Markdown_to_html, emoji) {
+TEST(emoji) {
   const auto result{sourcemeta::core::markdown_to_html("\xF0\x9F\x98\x80")};
   EXPECT_EQ(result, "<p>\xF0\x9F\x98\x80</p>\n");
 }
 
-TEST(Markdown_to_html, inline_html_is_sanitized) {
+TEST(inline_html_is_sanitized) {
   const auto result{sourcemeta::core::markdown_to_html("Hello <em>world</em>")};
   EXPECT_EQ(
       result,
       "<p>Hello <!-- raw HTML omitted -->world<!-- raw HTML omitted --></p>\n");
 }
 
-TEST(Markdown_to_html, raw_html_block_is_sanitized) {
+TEST(raw_html_block_is_sanitized) {
   const auto result{
       sourcemeta::core::markdown_to_html("<div class=\"foo\">bar</div>")};
   EXPECT_EQ(result, "<!-- raw HTML omitted -->\n");
 }
 
-TEST(Markdown_to_html, script_tag_is_sanitized) {
+TEST(script_tag_is_sanitized) {
   const auto result{
       sourcemeta::core::markdown_to_html("<script>alert('xss')</script>")};
   EXPECT_EQ(result, "<!-- raw HTML omitted -->\n");
 }
 
-TEST(Markdown_to_html, iframe_is_sanitized) {
+TEST(iframe_is_sanitized) {
   const auto result{sourcemeta::core::markdown_to_html(
       "<iframe src=\"https://evil.com\"></iframe>")};
   EXPECT_EQ(result, "<!-- raw HTML omitted -->\n");
 }
 
-TEST(Markdown_to_html, javascript_link_is_sanitized) {
+TEST(javascript_link_is_sanitized) {
   const auto result{
       sourcemeta::core::markdown_to_html("[click](javascript:alert('xss'))")};
   EXPECT_EQ(result, "<p><a href=\"\">click</a></p>\n");
 }
 
-TEST(Markdown_to_html, simple_table) {
+TEST(simple_table) {
   const auto result{
       sourcemeta::core::markdown_to_html("| a | b |\n| - | - |\n| 1 | 2 |")};
   EXPECT_EQ(
@@ -485,7 +485,7 @@ TEST(Markdown_to_html, simple_table) {
       "<tbody>\n<tr>\n<td>1</td>\n<td>2</td>\n</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, table_with_alignment) {
+TEST(table_with_alignment) {
   const auto result{sourcemeta::core::markdown_to_html(
       "| left | center | right |\n| :--- | :---: | ---: |\n| a | b | c |")};
   EXPECT_EQ(result, "<table>\n<thead>\n<tr>\n"
@@ -499,7 +499,7 @@ TEST(Markdown_to_html, table_with_alignment) {
                     "</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, table_with_formatting_in_cells) {
+TEST(table_with_formatting_in_cells) {
   const auto result{
       sourcemeta::core::markdown_to_html("| h |\n| - |\n| **bold** |")};
   EXPECT_EQ(result, "<table>\n<thead>\n<tr>\n<th>h</th>\n</tr>\n</thead>\n"
@@ -507,7 +507,7 @@ TEST(Markdown_to_html, table_with_formatting_in_cells) {
                     "</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, table_with_multiple_rows) {
+TEST(table_with_multiple_rows) {
   const auto result{sourcemeta::core::markdown_to_html(
       "| x | y |\n| - | - |\n| 1 | 2 |\n| 3 | 4 |\n| 5 | 6 |")};
   EXPECT_EQ(result,
@@ -517,7 +517,7 @@ TEST(Markdown_to_html, table_with_multiple_rows) {
             "<tr>\n<td>5</td>\n<td>6</td>\n</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, table_with_pipe_in_cell) {
+TEST(table_with_pipe_in_cell) {
   const auto result{
       sourcemeta::core::markdown_to_html("| h |\n| - |\n| a \\| b |")};
   EXPECT_EQ(result,
@@ -525,7 +525,7 @@ TEST(Markdown_to_html, table_with_pipe_in_cell) {
             "<tbody>\n<tr>\n<td>a | b</td>\n</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, autolink_url) {
+TEST(autolink_url) {
   const auto result{
       sourcemeta::core::markdown_to_html("Visit https://example.com today")};
   EXPECT_EQ(result,
@@ -533,64 +533,64 @@ TEST(Markdown_to_html, autolink_url) {
             " today</p>\n");
 }
 
-TEST(Markdown_to_html, autolink_http) {
+TEST(autolink_http) {
   const auto result{sourcemeta::core::markdown_to_html("http://example.com")};
   EXPECT_EQ(result,
             "<p><a href=\"http://example.com\">http://example.com</a></p>\n");
 }
 
-TEST(Markdown_to_html, autolink_www) {
+TEST(autolink_www) {
   const auto result{sourcemeta::core::markdown_to_html("www.example.com")};
   EXPECT_EQ(result,
             "<p><a href=\"http://www.example.com\">www.example.com</a></p>\n");
 }
 
-TEST(Markdown_to_html, autolink_email) {
+TEST(autolink_email) {
   const auto result{
       sourcemeta::core::markdown_to_html("Contact user@example.com")};
   EXPECT_EQ(result, "<p>Contact <a href=\"mailto:user@example.com\">"
                     "user@example.com</a></p>\n");
 }
 
-TEST(Markdown_to_html, angle_bracket_autolink) {
+TEST(angle_bracket_autolink) {
   const auto result{
       sourcemeta::core::markdown_to_html("<https://example.com>")};
   EXPECT_EQ(result,
             "<p><a href=\"https://example.com\">https://example.com</a></p>\n");
 }
 
-TEST(Markdown_to_html, strikethrough) {
+TEST(strikethrough) {
   const auto result{sourcemeta::core::markdown_to_html("~~deleted~~")};
   EXPECT_EQ(result, "<p><del>deleted</del></p>\n");
 }
 
-TEST(Markdown_to_html, strikethrough_with_other_formatting) {
+TEST(strikethrough_with_other_formatting) {
   const auto result{
       sourcemeta::core::markdown_to_html("~~deleted **bold** text~~")};
   EXPECT_EQ(result, "<p><del>deleted <strong>bold</strong> text</del></p>\n");
 }
 
-TEST(Markdown_to_html, strikethrough_in_sentence) {
+TEST(strikethrough_in_sentence) {
   const auto result{
       sourcemeta::core::markdown_to_html("This is ~~wrong~~ correct")};
   EXPECT_EQ(result, "<p>This is <del>wrong</del> correct</p>\n");
 }
 
-TEST(Markdown_to_html, task_list_unchecked) {
+TEST(task_list_unchecked) {
   const auto result{sourcemeta::core::markdown_to_html("- [ ] todo")};
   EXPECT_EQ(result,
             "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> todo</li>\n"
             "</ul>\n");
 }
 
-TEST(Markdown_to_html, task_list_checked) {
+TEST(task_list_checked) {
   const auto result{sourcemeta::core::markdown_to_html("- [x] done")};
   EXPECT_EQ(result,
             "<ul>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" />"
             " done</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, task_list_mixed) {
+TEST(task_list_mixed) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- [x] done\n- [ ] todo\n- [x] also done")};
   EXPECT_EQ(
@@ -603,13 +603,13 @@ TEST(Markdown_to_html, task_list_mixed) {
       "</ul>\n");
 }
 
-TEST(Markdown_to_html, heading_followed_by_paragraph) {
+TEST(heading_followed_by_paragraph) {
   const auto result{
       sourcemeta::core::markdown_to_html("# Title\n\nSome text here.")};
   EXPECT_EQ(result, "<h1>Title</h1>\n<p>Some text here.</p>\n");
 }
 
-TEST(Markdown_to_html, blockquote_with_list) {
+TEST(blockquote_with_list) {
   const auto result{
       sourcemeta::core::markdown_to_html("> items:\n> - one\n> - two")};
   EXPECT_EQ(result,
@@ -617,33 +617,33 @@ TEST(Markdown_to_html, blockquote_with_list) {
             "</ul>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, list_with_code_block) {
+TEST(list_with_code_block) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- item:\n\n  ```\n  code\n  ```\n\n- next")};
   EXPECT_EQ(result, "<ul>\n<li>\n<p>item:</p>\n<pre><code>code\n</code></pre>\n"
                     "</li>\n<li>\n<p>next</p>\n</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, link_inside_heading) {
+TEST(link_inside_heading) {
   const auto result{
       sourcemeta::core::markdown_to_html("## [Link](https://example.com)")};
   EXPECT_EQ(result, "<h2><a href=\"https://example.com\">Link</a></h2>\n");
 }
 
-TEST(Markdown_to_html, emphasis_across_words) {
+TEST(emphasis_across_words) {
   const auto result{
       sourcemeta::core::markdown_to_html("this is **all bold** here")};
   EXPECT_EQ(result, "<p>this is <strong>all bold</strong> here</p>\n");
 }
 
-TEST(Markdown_to_html, paragraph_with_inline_code_and_link) {
+TEST(paragraph_with_inline_code_and_link) {
   const auto result{sourcemeta::core::markdown_to_html(
       "Use `foo()` from [the docs](https://docs.com).")};
   EXPECT_EQ(result, "<p>Use <code>foo()</code> from "
                     "<a href=\"https://docs.com\">the docs</a>.</p>\n");
 }
 
-TEST(Markdown_to_html, strikethrough_inside_table_cell) {
+TEST(strikethrough_inside_table_cell) {
   const auto result{
       sourcemeta::core::markdown_to_html("| h |\n| - |\n| ~~old~~ |")};
   EXPECT_EQ(result, "<table>\n<thead>\n<tr>\n<th>h</th>\n</tr>\n</thead>\n"
@@ -651,7 +651,7 @@ TEST(Markdown_to_html, strikethrough_inside_table_cell) {
                     "</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, link_inside_table_cell) {
+TEST(link_inside_table_cell) {
   const auto result{sourcemeta::core::markdown_to_html(
       "| h |\n| - |\n| [click](https://example.com) |")};
   EXPECT_EQ(result,
@@ -660,7 +660,7 @@ TEST(Markdown_to_html, link_inside_table_cell) {
             "</td>\n</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, code_inside_table_cell) {
+TEST(code_inside_table_cell) {
   const auto result{
       sourcemeta::core::markdown_to_html("| h |\n| - |\n| `code` |")};
   EXPECT_EQ(result, "<table>\n<thead>\n<tr>\n<th>h</th>\n</tr>\n</thead>\n"
@@ -668,7 +668,7 @@ TEST(Markdown_to_html, code_inside_table_cell) {
                     "</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, empty_table_cells) {
+TEST(empty_table_cells) {
   const auto result{
       sourcemeta::core::markdown_to_html("| a | b |\n| - | - |\n|   |   |")};
   EXPECT_EQ(result,
@@ -676,20 +676,20 @@ TEST(Markdown_to_html, empty_table_cells) {
             "<tbody>\n<tr>\n<td></td>\n<td></td>\n</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, table_header_only) {
+TEST(table_header_only) {
   const auto result{sourcemeta::core::markdown_to_html("| a | b |\n| - | - |")};
   EXPECT_EQ(result, "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</"
                     "thead>\n</table>\n");
 }
 
-TEST(Markdown_to_html, task_list_with_bold) {
+TEST(task_list_with_bold) {
   const auto result{
       sourcemeta::core::markdown_to_html("- [ ] **important** task")};
   EXPECT_EQ(result, "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> "
                     "<strong>important</strong> task</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, task_list_with_link) {
+TEST(task_list_with_link) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- [x] see [docs](https://example.com)")};
   EXPECT_EQ(result,
@@ -697,89 +697,89 @@ TEST(Markdown_to_html, task_list_with_link) {
             "see <a href=\"https://example.com\">docs</a></li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, task_list_with_code) {
+TEST(task_list_with_code) {
   const auto result{sourcemeta::core::markdown_to_html("- [ ] fix `bug`")};
   EXPECT_EQ(result, "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> "
                     "fix <code>bug</code></li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, code_inside_link) {
+TEST(code_inside_link) {
   const auto result{
       sourcemeta::core::markdown_to_html("[`code`](https://example.com)")};
   EXPECT_EQ(result,
             "<p><a href=\"https://example.com\"><code>code</code></a></p>\n");
 }
 
-TEST(Markdown_to_html, inline_code_inside_heading) {
+TEST(inline_code_inside_heading) {
   const auto result{
       sourcemeta::core::markdown_to_html("## The `main` function")};
   EXPECT_EQ(result, "<h2>The <code>main</code> function</h2>\n");
 }
 
-TEST(Markdown_to_html, image_as_link) {
+TEST(image_as_link) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[![logo](logo.png)](https://example.com)")};
   EXPECT_EQ(result, "<p><a href=\"https://example.com\">"
                     "<img src=\"logo.png\" alt=\"logo\" /></a></p>\n");
 }
 
-TEST(Markdown_to_html, strikethrough_with_code) {
+TEST(strikethrough_with_code) {
   const auto result{sourcemeta::core::markdown_to_html("~~use `old_func()`~~")};
   EXPECT_EQ(result, "<p><del>use <code>old_func()</code></del></p>\n");
 }
 
-TEST(Markdown_to_html, strikethrough_with_link) {
+TEST(strikethrough_with_link) {
   const auto result{
       sourcemeta::core::markdown_to_html("~~[removed](https://example.com)~~")};
   EXPECT_EQ(result,
             "<p><del><a href=\"https://example.com\">removed</a></del></p>\n");
 }
 
-TEST(Markdown_to_html, autolink_inside_list) {
+TEST(autolink_inside_list) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- visit https://example.com\n- done")};
   EXPECT_EQ(result, "<ul>\n<li>visit <a href=\"https://example.com\">"
                     "https://example.com</a></li>\n<li>done</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, blockquote_with_code_block) {
+TEST(blockquote_with_code_block) {
   const auto result{
       sourcemeta::core::markdown_to_html("> example:\n>\n>     code here")};
   EXPECT_EQ(result, "<blockquote>\n<p>example:</p>\n"
                     "<pre><code>code here\n</code></pre>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, blockquote_with_heading) {
+TEST(blockquote_with_heading) {
   const auto result{sourcemeta::core::markdown_to_html("> ## Quoted heading")};
   EXPECT_EQ(result, "<blockquote>\n<h2>Quoted heading</h2>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, deeply_nested_list) {
+TEST(deeply_nested_list) {
   const auto result{
       sourcemeta::core::markdown_to_html("- a\n  - b\n    - c\n      - d")};
   EXPECT_EQ(result, "<ul>\n<li>a\n<ul>\n<li>b\n<ul>\n<li>c\n<ul>\n<li>d</li>\n"
                     "</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, deeply_nested_blockquote) {
+TEST(deeply_nested_blockquote) {
   const auto result{sourcemeta::core::markdown_to_html("> a\n>> b\n>>> c")};
   EXPECT_EQ(result, "<blockquote>\n<p>a</p>\n<blockquote>\n<p>b</p>\n"
                     "<blockquote>\n<p>c</p>\n</blockquote>\n</blockquote>\n"
                     "</blockquote>\n");
 }
 
-TEST(Markdown_to_html, consecutive_headings) {
+TEST(consecutive_headings) {
   const auto result{
       sourcemeta::core::markdown_to_html("# One\n\n## Two\n\n### Three")};
   EXPECT_EQ(result, "<h1>One</h1>\n<h2>Two</h2>\n<h3>Three</h3>\n");
 }
 
-TEST(Markdown_to_html, consecutive_thematic_breaks) {
+TEST(consecutive_thematic_breaks) {
   const auto result{sourcemeta::core::markdown_to_html("---\n\n---")};
   EXPECT_EQ(result, "<hr />\n<hr />\n");
 }
 
-TEST(Markdown_to_html, link_with_special_chars_in_url) {
+TEST(link_with_special_chars_in_url) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[search](https://example.com/q?a=1&b=2)")};
   EXPECT_EQ(
@@ -787,12 +787,12 @@ TEST(Markdown_to_html, link_with_special_chars_in_url) {
       "<p><a href=\"https://example.com/q?a=1&amp;b=2\">search</a></p>\n");
 }
 
-TEST(Markdown_to_html, image_with_empty_alt) {
+TEST(image_with_empty_alt) {
   const auto result{sourcemeta::core::markdown_to_html("![](image.png)")};
   EXPECT_EQ(result, "<p><img src=\"image.png\" alt=\"\" /></p>\n");
 }
 
-TEST(Markdown_to_html, bold_and_italic_in_list_item) {
+TEST(bold_and_italic_in_list_item) {
   const auto result{
       sourcemeta::core::markdown_to_html("- ***bold italic item***\n- normal")};
   EXPECT_EQ(result,
@@ -800,26 +800,26 @@ TEST(Markdown_to_html, bold_and_italic_in_list_item) {
             "<li>normal</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, fenced_code_block_with_empty_lines) {
+TEST(fenced_code_block_with_empty_lines) {
   const auto result{
       sourcemeta::core::markdown_to_html("```\nline one\n\nline three\n```")};
   EXPECT_EQ(result, "<pre><code>line one\n\nline three\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, ordered_list_with_paragraphs) {
+TEST(ordered_list_with_paragraphs) {
   const auto result{sourcemeta::core::markdown_to_html(
       "1. first\n\n   more text\n\n2. second")};
   EXPECT_EQ(result, "<ol>\n<li>\n<p>first</p>\n<p>more text</p>\n</li>\n"
                     "<li>\n<p>second</p>\n</li>\n</ol>\n");
 }
 
-TEST(Markdown_to_html, heading_with_thematic_break) {
+TEST(heading_with_thematic_break) {
   const auto result{
       sourcemeta::core::markdown_to_html("# Title\n\n---\n\nContent")};
   EXPECT_EQ(result, "<h1>Title</h1>\n<hr />\n<p>Content</p>\n");
 }
 
-TEST(Markdown_to_html, table_after_paragraph) {
+TEST(table_after_paragraph) {
   const auto result{sourcemeta::core::markdown_to_html(
       "Here is a table:\n\n| a |\n| - |\n| 1 |")};
   EXPECT_EQ(result, "<p>Here is a table:</p>\n"
@@ -827,14 +827,14 @@ TEST(Markdown_to_html, table_after_paragraph) {
                     "<tbody>\n<tr>\n<td>1</td>\n</tr>\n</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, blockquote_followed_by_list) {
+TEST(blockquote_followed_by_list) {
   const auto result{
       sourcemeta::core::markdown_to_html("> quote\n\n- item one\n- item two")};
   EXPECT_EQ(result, "<blockquote>\n<p>quote</p>\n</blockquote>\n"
                     "<ul>\n<li>item one</li>\n<li>item two</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, multiple_autolinks_in_paragraph) {
+TEST(multiple_autolinks_in_paragraph) {
   const auto result{sourcemeta::core::markdown_to_html(
       "See https://one.com and https://two.com")};
   EXPECT_EQ(result,
@@ -842,36 +842,36 @@ TEST(Markdown_to_html, multiple_autolinks_in_paragraph) {
             "<a href=\"https://two.com\">https://two.com</a></p>\n");
 }
 
-TEST(Markdown_to_html, emphasis_does_not_cross_code_span) {
+TEST(emphasis_does_not_cross_code_span) {
   const auto result{sourcemeta::core::markdown_to_html("*start `code* end`")};
   EXPECT_EQ(result, "<p>*start <code>code* end</code></p>\n");
 }
 
-TEST(Markdown_to_html, vbscript_link_is_sanitized) {
+TEST(vbscript_link_is_sanitized) {
   const auto result{
       sourcemeta::core::markdown_to_html("[click](vbscript:MsgBox)")};
   EXPECT_EQ(result, "<p><a href=\"\">click</a></p>\n");
 }
 
-TEST(Markdown_to_html, data_uri_link_is_sanitized) {
+TEST(data_uri_link_is_sanitized) {
   const auto result{sourcemeta::core::markdown_to_html(
       "[click](data:text/html,<h1>hi</h1>)")};
   EXPECT_EQ(result, "<p><a href=\"\">click</a></p>\n");
 }
 
-TEST(Markdown_to_html, single_character_emphasis) {
+TEST(single_character_emphasis) {
   const auto result{sourcemeta::core::markdown_to_html("*a*")};
   EXPECT_EQ(result, "<p><em>a</em></p>\n");
 }
 
-TEST(Markdown_to_html, list_item_with_multiple_paragraphs) {
+TEST(list_item_with_multiple_paragraphs) {
   const auto result{sourcemeta::core::markdown_to_html(
       "- paragraph one\n\n  paragraph two\n\n  paragraph three")};
   EXPECT_EQ(result, "<ul>\n<li>\n<p>paragraph one</p>\n<p>paragraph two</p>\n"
                     "<p>paragraph three</p>\n</li>\n</ul>\n");
 }
 
-TEST(Markdown_to_html, table_with_inline_code_in_header) {
+TEST(table_with_inline_code_in_header) {
   const auto result{sourcemeta::core::markdown_to_html(
       "| `key` | `value` |\n| - | - |\n| a | b |")};
   EXPECT_EQ(result, "<table>\n<thead>\n<tr>\n<th><code>key</code></th>\n"
@@ -880,12 +880,12 @@ TEST(Markdown_to_html, table_with_inline_code_in_header) {
                     "</tbody>\n</table>\n");
 }
 
-TEST(Markdown_to_html, strikethrough_bold_italic_combined) {
+TEST(strikethrough_bold_italic_combined) {
   const auto result{sourcemeta::core::markdown_to_html("~~***all three***~~")};
   EXPECT_EQ(result, "<p><del><em><strong>all three</strong></em></del></p>\n");
 }
 
-TEST(Markdown_to_html, autolink_with_trailing_punctuation) {
+TEST(autolink_with_trailing_punctuation) {
   const auto result{
       sourcemeta::core::markdown_to_html("See https://example.com.")};
   EXPECT_EQ(
@@ -893,7 +893,7 @@ TEST(Markdown_to_html, autolink_with_trailing_punctuation) {
       "<p>See <a href=\"https://example.com\">https://example.com</a>.</p>\n");
 }
 
-TEST(Markdown_to_html, autolink_in_parentheses) {
+TEST(autolink_in_parentheses) {
   const auto result{
       sourcemeta::core::markdown_to_html("(see https://example.com)")};
   EXPECT_EQ(
@@ -901,18 +901,18 @@ TEST(Markdown_to_html, autolink_in_parentheses) {
       "<p>(see <a href=\"https://example.com\">https://example.com</a>)</p>\n");
 }
 
-TEST(Markdown_to_html, blockquote_with_strikethrough) {
+TEST(blockquote_with_strikethrough) {
   const auto result{sourcemeta::core::markdown_to_html("> ~~deleted~~")};
   EXPECT_EQ(result, "<blockquote>\n<p><del>deleted</del></p>\n</blockquote>\n");
 }
 
-TEST(Markdown_to_html, heading_with_bold_and_code) {
+TEST(heading_with_bold_and_code) {
   const auto result{
       sourcemeta::core::markdown_to_html("## **Bold** and `code`")};
   EXPECT_EQ(result, "<h2><strong>Bold</strong> and <code>code</code></h2>\n");
 }
 
-TEST(Markdown_to_html, footnote_basic) {
+TEST(footnote_basic) {
   const auto result{
       sourcemeta::core::markdown_to_html("Text[^1]\n\n[^1]: Footnote content")};
   EXPECT_EQ(
@@ -927,7 +927,7 @@ TEST(Markdown_to_html, footnote_basic) {
       "</li>\n</ol>\n</section>\n");
 }
 
-TEST(Markdown_to_html, footnote_multiple) {
+TEST(footnote_multiple) {
   const auto result{sourcemeta::core::markdown_to_html(
       "A[^1] and B[^2]\n\n[^1]: First\n\n[^2]: Second")};
   EXPECT_EQ(result,
@@ -948,18 +948,18 @@ TEST(Markdown_to_html, footnote_multiple) {
             "</li>\n</ol>\n</section>\n");
 }
 
-TEST(Markdown_to_html, single_tilde_is_not_strikethrough) {
+TEST(single_tilde_is_not_strikethrough) {
   const auto result{sourcemeta::core::markdown_to_html("~not deleted~")};
   EXPECT_EQ(result, "<p>~not deleted~</p>\n");
 }
 
-TEST(Markdown_to_html, github_pre_lang_format) {
+TEST(github_pre_lang_format) {
   const auto result{
       sourcemeta::core::markdown_to_html("```python\nprint()\n```")};
   EXPECT_EQ(result, "<pre lang=\"python\"><code>print()\n</code></pre>\n");
 }
 
-TEST(Markdown_to_html, invalid_utf8_is_replaced) {
+TEST(invalid_utf8_is_replaced) {
   const auto result{sourcemeta::core::markdown_to_html("hello \xFF world")};
   EXPECT_EQ(result, "<p>hello \xEF\xBF\xBD world</p>\n");
 }

--- a/test/mcp/CMakeLists.txt
+++ b/test/mcp/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME mcp
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME mcp
   SOURCES mcp_test.cc)
 
 target_link_libraries(sourcemeta_core_mcp_unit

--- a/test/mcp/mcp_test.cc
+++ b/test/mcp/mcp_test.cc
@@ -3,7 +3,7 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonrpc.h>
 
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstddef>  // std::size_t
 #include <cstdint>  // std::int64_t
@@ -11,251 +11,251 @@
 #include <optional> // std::optional, std::nullopt
 #include <utility>  // std::move
 
-TEST(MCP, protocol_version_string_2025_03_26) {
+TEST(protocol_version_string_2025_03_26) {
   EXPECT_EQ(sourcemeta::core::mcp_protocol_version_string(
                 sourcemeta::core::MCPProtocolVersion::V_2025_03_26),
             "2025-03-26");
 }
 
-TEST(MCP, protocol_version_string_2025_06_18) {
+TEST(protocol_version_string_2025_06_18) {
   EXPECT_EQ(sourcemeta::core::mcp_protocol_version_string(
                 sourcemeta::core::MCPProtocolVersion::V_2025_06_18),
             "2025-06-18");
 }
 
-TEST(MCP, protocol_version_string_2025_11_25) {
+TEST(protocol_version_string_2025_11_25) {
   EXPECT_EQ(sourcemeta::core::mcp_protocol_version_string(
                 sourcemeta::core::MCPProtocolVersion::V_2025_11_25),
             "2025-11-25");
 }
 
-TEST(MCP, method_initialize) {
+TEST(method_initialize) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_INITIALIZE, "initialize");
 }
 
-TEST(MCP, method_ping) { EXPECT_EQ(sourcemeta::core::MCP_METHOD_PING, "ping"); }
+TEST(method_ping) { EXPECT_EQ(sourcemeta::core::MCP_METHOD_PING, "ping"); }
 
-TEST(MCP, method_tools_list) {
+TEST(method_tools_list) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_TOOLS_LIST, "tools/list");
 }
 
-TEST(MCP, method_tools_call) {
+TEST(method_tools_call) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_TOOLS_CALL, "tools/call");
 }
 
-TEST(MCP, method_resources_list) {
+TEST(method_resources_list) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_RESOURCES_LIST, "resources/list");
 }
 
-TEST(MCP, method_resources_read) {
+TEST(method_resources_read) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_RESOURCES_READ, "resources/read");
 }
 
-TEST(MCP, method_resources_templates_list) {
+TEST(method_resources_templates_list) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_RESOURCES_TEMPLATES_LIST,
             "resources/templates/list");
 }
 
-TEST(MCP, method_notifications_initialized) {
+TEST(method_notifications_initialized) {
   EXPECT_EQ(sourcemeta::core::MCP_METHOD_NOTIFICATIONS_INITIALIZED,
             "notifications/initialized");
 }
 
-TEST(MCP, code_resource_not_found) {
+TEST(code_resource_not_found) {
   EXPECT_EQ(sourcemeta::core::MCP_CODE_RESOURCE_NOT_FOUND,
             static_cast<std::int64_t>(-32002));
 }
 
-TEST(MCP, code_url_elicitation_required) {
+TEST(code_url_elicitation_required) {
   EXPECT_EQ(sourcemeta::core::MCP_CODE_URL_ELICITATION_REQUIRED,
             static_cast<std::int64_t>(-32042));
 }
 
-TEST(MCP, is_request_method_initialize) {
+TEST(is_request_method_initialize) {
   EXPECT_TRUE(sourcemeta::core::mcp_is_request_method("initialize"));
 }
 
-TEST(MCP, is_request_method_ping) {
+TEST(is_request_method_ping) {
   EXPECT_TRUE(sourcemeta::core::mcp_is_request_method("ping"));
 }
 
-TEST(MCP, is_request_method_tools_list) {
+TEST(is_request_method_tools_list) {
   EXPECT_TRUE(sourcemeta::core::mcp_is_request_method("tools/list"));
 }
 
-TEST(MCP, is_request_method_tools_call) {
+TEST(is_request_method_tools_call) {
   EXPECT_TRUE(sourcemeta::core::mcp_is_request_method("tools/call"));
 }
 
-TEST(MCP, is_request_method_resources_list) {
+TEST(is_request_method_resources_list) {
   EXPECT_TRUE(sourcemeta::core::mcp_is_request_method("resources/list"));
 }
 
-TEST(MCP, is_request_method_resources_read) {
+TEST(is_request_method_resources_read) {
   EXPECT_TRUE(sourcemeta::core::mcp_is_request_method("resources/read"));
 }
 
-TEST(MCP, is_request_method_resources_templates_list) {
+TEST(is_request_method_resources_templates_list) {
   EXPECT_TRUE(
       sourcemeta::core::mcp_is_request_method("resources/templates/list"));
 }
 
-TEST(MCP, is_request_method_notifications_initialized_is_not_request) {
+TEST(is_request_method_notifications_initialized_is_not_request) {
   EXPECT_FALSE(
       sourcemeta::core::mcp_is_request_method("notifications/initialized"));
 }
 
-TEST(MCP, is_request_method_unknown) {
+TEST(is_request_method_unknown) {
   EXPECT_FALSE(sourcemeta::core::mcp_is_request_method("foo/bar"));
 }
 
-TEST(MCP, is_request_method_empty) {
+TEST(is_request_method_empty) {
   EXPECT_FALSE(sourcemeta::core::mcp_is_request_method(""));
 }
 
-TEST(MCP, resolve_protocol_version_empty_defaults_to_2025_03_26) {
+TEST(resolve_protocol_version_empty_defaults_to_2025_03_26) {
   const auto result{sourcemeta::core::mcp_resolve_protocol_version("")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::MCPProtocolVersion::V_2025_03_26);
 }
 
-TEST(MCP, resolve_protocol_version_2025_03_26) {
+TEST(resolve_protocol_version_2025_03_26) {
   const auto result{
       sourcemeta::core::mcp_resolve_protocol_version("2025-03-26")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::MCPProtocolVersion::V_2025_03_26);
 }
 
-TEST(MCP, resolve_protocol_version_2025_06_18) {
+TEST(resolve_protocol_version_2025_06_18) {
   const auto result{
       sourcemeta::core::mcp_resolve_protocol_version("2025-06-18")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::MCPProtocolVersion::V_2025_06_18);
 }
 
-TEST(MCP, resolve_protocol_version_2025_11_25) {
+TEST(resolve_protocol_version_2025_11_25) {
   const auto result{
       sourcemeta::core::mcp_resolve_protocol_version("2025-11-25")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::MCPProtocolVersion::V_2025_11_25);
 }
 
-TEST(MCP, resolve_protocol_version_unknown) {
+TEST(resolve_protocol_version_unknown) {
   EXPECT_FALSE(
       sourcemeta::core::mcp_resolve_protocol_version("9999-01-01").has_value());
 }
 
-TEST(MCP, resolve_protocol_version_malformed) {
+TEST(resolve_protocol_version_malformed) {
   EXPECT_FALSE(
       sourcemeta::core::mcp_resolve_protocol_version("not-a-date").has_value());
 }
 
-TEST(MCP, supports_output_schema_2025_03_26) {
+TEST(supports_output_schema_2025_03_26) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_output_schema(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_output_schema_2025_06_18) {
+TEST(supports_output_schema_2025_06_18) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_output_schema(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_output_schema_2025_11_25) {
+TEST(supports_output_schema_2025_11_25) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_output_schema(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, supports_structured_content_2025_03_26) {
+TEST(supports_structured_content_2025_03_26) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_structured_content(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_structured_content_2025_06_18) {
+TEST(supports_structured_content_2025_06_18) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_structured_content(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_structured_content_2025_11_25) {
+TEST(supports_structured_content_2025_11_25) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_structured_content(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, supports_resource_link_content_2025_03_26) {
+TEST(supports_resource_link_content_2025_03_26) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_resource_link_content(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_resource_link_content_2025_06_18) {
+TEST(supports_resource_link_content_2025_06_18) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_resource_link_content(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_resource_link_content_2025_11_25) {
+TEST(supports_resource_link_content_2025_11_25) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_resource_link_content(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, supports_implementation_title_2025_03_26) {
+TEST(supports_implementation_title_2025_03_26) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_implementation_title(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_implementation_title_2025_06_18) {
+TEST(supports_implementation_title_2025_06_18) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_implementation_title(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_implementation_title_2025_11_25) {
+TEST(supports_implementation_title_2025_11_25) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_implementation_title(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, supports_implementation_description_2025_03_26) {
+TEST(supports_implementation_description_2025_03_26) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_implementation_description(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_implementation_description_2025_06_18) {
+TEST(supports_implementation_description_2025_06_18) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_implementation_description(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_implementation_description_2025_11_25) {
+TEST(supports_implementation_description_2025_11_25) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_implementation_description(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, supports_implementation_website_url_2025_03_26) {
+TEST(supports_implementation_website_url_2025_03_26) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_implementation_website_url(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_implementation_website_url_2025_06_18) {
+TEST(supports_implementation_website_url_2025_06_18) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_implementation_website_url(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_implementation_website_url_2025_11_25) {
+TEST(supports_implementation_website_url_2025_11_25) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_implementation_website_url(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, supports_jsonrpc_batching_2025_03_26) {
+TEST(supports_jsonrpc_batching_2025_03_26) {
   EXPECT_TRUE(sourcemeta::core::mcp_supports_jsonrpc_batching(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26));
 }
 
-TEST(MCP, supports_jsonrpc_batching_2025_06_18) {
+TEST(supports_jsonrpc_batching_2025_06_18) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_jsonrpc_batching(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18));
 }
 
-TEST(MCP, supports_jsonrpc_batching_2025_11_25) {
+TEST(supports_jsonrpc_batching_2025_11_25) {
   EXPECT_FALSE(sourcemeta::core::mcp_supports_jsonrpc_batching(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25));
 }
 
-TEST(MCP, make_text_block) {
+TEST(make_text_block) {
   const auto block{sourcemeta::core::mcp_make_text_block("hello")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "type": "text",
@@ -264,7 +264,7 @@ TEST(MCP, make_text_block) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_text_block_empty_string) {
+TEST(make_text_block_empty_string) {
   const auto block{sourcemeta::core::mcp_make_text_block("")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "type": "text",
@@ -273,7 +273,7 @@ TEST(MCP, make_text_block_empty_string) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_text_block_with_newlines) {
+TEST(make_text_block_with_newlines) {
   const auto block{sourcemeta::core::mcp_make_text_block("line1\nline2")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
     "type": "text",
@@ -282,7 +282,7 @@ TEST(MCP, make_text_block_with_newlines) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_11_25_full) {
+TEST(make_resource_link_2025_11_25_full) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25, "file:///foo",
       "text/plain", "My File", "A description")};
@@ -296,7 +296,7 @@ TEST(MCP, make_resource_link_2025_11_25_full) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_11_25_without_name_and_description) {
+TEST(make_resource_link_2025_11_25_without_name_and_description) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25, "file:///foo",
       "text/plain")};
@@ -308,7 +308,7 @@ TEST(MCP, make_resource_link_2025_11_25_without_name_and_description) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_06_18_supports_structured) {
+TEST(make_resource_link_2025_06_18_supports_structured) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_06_18, "file:///foo",
       "text/plain", "My File")};
@@ -321,7 +321,7 @@ TEST(MCP, make_resource_link_2025_06_18_supports_structured) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_with_name) {
+TEST(make_resource_link_2025_03_26_falls_back_to_text_with_name) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "file:///foo",
       "text/plain", "My File", "A description")};
@@ -332,7 +332,7 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_with_name) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_without_name) {
+TEST(make_resource_link_2025_03_26_falls_back_to_text_without_name) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "file:///foo",
       "text/plain", {}, "A description")};
@@ -343,8 +343,7 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_without_name) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP,
-     make_resource_link_2025_03_26_falls_back_to_text_without_description) {
+TEST(make_resource_link_2025_03_26_falls_back_to_text_without_description) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "file:///foo",
       "text/plain", "My File")};
@@ -355,7 +354,7 @@ TEST(MCP,
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_uri_only) {
+TEST(make_resource_link_2025_03_26_falls_back_to_text_uri_only) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "file:///foo",
       "text/plain")};
@@ -366,8 +365,7 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_to_text_uri_only) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP,
-     make_resource_link_2025_03_26_falls_back_handles_parentheses_in_name) {
+TEST(make_resource_link_2025_03_26_falls_back_handles_parentheses_in_name) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26,
       "https://example.com/schema", "application/schema+json",
@@ -379,8 +377,7 @@ TEST(MCP,
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP,
-     make_resource_link_2025_03_26_falls_back_preserves_empty_uri_position) {
+TEST(make_resource_link_2025_03_26_falls_back_preserves_empty_uri_position) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "", "text/plain",
       "My File", "A description")};
@@ -391,8 +388,7 @@ TEST(MCP,
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP,
-     make_resource_link_2025_03_26_falls_back_empty_uri_with_description_only) {
+TEST(make_resource_link_2025_03_26_falls_back_empty_uri_with_description_only) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "", "text/plain", {},
       "A description")};
@@ -403,7 +399,7 @@ TEST(MCP,
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, make_resource_link_2025_03_26_falls_back_empty_uri_with_name_only) {
+TEST(make_resource_link_2025_03_26_falls_back_empty_uri_with_name_only) {
   const auto block{sourcemeta::core::mcp_make_resource_link(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "", "text/plain",
       "My File")};
@@ -414,7 +410,7 @@ TEST(MCP, make_resource_link_2025_03_26_falls_back_empty_uri_with_name_only) {
   EXPECT_EQ(block, expected);
 }
 
-TEST(MCP, tool_success_with_object_result) {
+TEST(tool_success_with_object_result) {
   const auto identifier{sourcemeta::core::JSON{1}};
   auto result{sourcemeta::core::JSON::make_object()};
   result.assign("foo", sourcemeta::core::JSON{42});
@@ -435,7 +431,7 @@ TEST(MCP, tool_success_with_object_result) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_success_with_array_result) {
+TEST(tool_success_with_array_result) {
   const auto identifier{sourcemeta::core::JSON{"abc"}};
   const auto envelope{sourcemeta::core::mcp_make_tool_success(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25, identifier,
@@ -454,7 +450,7 @@ TEST(MCP, tool_success_with_array_result) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_success_with_null_id) {
+TEST(tool_success_with_null_id) {
   const auto envelope{sourcemeta::core::mcp_make_tool_success(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25,
       sourcemeta::core::JSON{nullptr}, sourcemeta::core::JSON::make_object())};
@@ -472,7 +468,7 @@ TEST(MCP, tool_success_with_null_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_success_2025_03_26_omits_structured_content) {
+TEST(tool_success_2025_03_26_omits_structured_content) {
   const auto identifier{sourcemeta::core::JSON{1}};
   auto result{sourcemeta::core::JSON::make_object()};
   result.assign("foo", sourcemeta::core::JSON{42});
@@ -492,7 +488,7 @@ TEST(MCP, tool_success_2025_03_26_omits_structured_content) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_success_with_explicit_content_blocks) {
+TEST(tool_success_with_explicit_content_blocks) {
   const auto identifier{sourcemeta::core::JSON{1}};
   auto structured{sourcemeta::core::JSON::make_object()};
   structured.assign("ok", sourcemeta::core::JSON{true});
@@ -513,7 +509,7 @@ TEST(MCP, tool_success_with_explicit_content_blocks) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_success_with_explicit_blocks_omits_structured_on_2025_03_26) {
+TEST(tool_success_with_explicit_blocks_omits_structured_on_2025_03_26) {
   const auto identifier{sourcemeta::core::JSON{1}};
   auto structured{sourcemeta::core::JSON::make_object()};
   structured.assign("ok", sourcemeta::core::JSON{true});
@@ -533,7 +529,7 @@ TEST(MCP, tool_success_with_explicit_blocks_omits_structured_on_2025_03_26) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_error_with_message) {
+TEST(tool_error_with_message) {
   const auto identifier{sourcemeta::core::JSON{7}};
   const auto envelope{
       sourcemeta::core::mcp_make_tool_error(identifier, "Schema not found")};
@@ -548,7 +544,7 @@ TEST(MCP, tool_error_with_message) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_error_with_string_id) {
+TEST(tool_error_with_string_id) {
   const auto identifier{sourcemeta::core::JSON{"req-1"}};
   const auto envelope{
       sourcemeta::core::mcp_make_tool_error(identifier, "Invalid input")};
@@ -563,7 +559,7 @@ TEST(MCP, tool_error_with_string_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, tool_error_with_null_id) {
+TEST(tool_error_with_null_id) {
   const auto envelope{sourcemeta::core::mcp_make_tool_error(
       sourcemeta::core::JSON{nullptr}, "Boom")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -577,7 +573,7 @@ TEST(MCP, tool_error_with_null_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, error_resource_not_found_with_integer_id) {
+TEST(error_resource_not_found_with_integer_id) {
   const auto identifier{sourcemeta::core::JSON{3}};
   const auto envelope{
       sourcemeta::core::mcp_make_error_resource_not_found(identifier)};
@@ -592,7 +588,7 @@ TEST(MCP, error_resource_not_found_with_integer_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, error_resource_not_found_with_string_id) {
+TEST(error_resource_not_found_with_string_id) {
   const auto identifier{sourcemeta::core::JSON{"req-7"}};
   const auto envelope{
       sourcemeta::core::mcp_make_error_resource_not_found(identifier)};
@@ -607,7 +603,7 @@ TEST(MCP, error_resource_not_found_with_string_id) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, make_resource_full) {
+TEST(make_resource_full) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", "First file",
       std::optional<std::size_t>{1024})};
@@ -621,7 +617,7 @@ TEST(MCP, make_resource_full) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_without_description) {
+TEST(make_resource_without_description) {
   const auto resource{
       sourcemeta::core::mcp_make_resource("file:///a", "Alpha", "text/plain")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -632,7 +628,7 @@ TEST(MCP, make_resource_without_description) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_without_size) {
+TEST(make_resource_without_size) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", "First file")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -644,7 +640,7 @@ TEST(MCP, make_resource_without_size) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority) {
+TEST(make_resource_with_priority) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", "First file",
       std::optional<std::size_t>{1024}, std::optional<double>{0.75})};
@@ -659,7 +655,7 @@ TEST(MCP, make_resource_with_priority) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority_without_size) {
+TEST(make_resource_with_priority_without_size) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", {}, std::nullopt,
       std::optional<double>{0.25})};
@@ -672,7 +668,7 @@ TEST(MCP, make_resource_with_priority_without_size) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority_clamped_high) {
+TEST(make_resource_with_priority_clamped_high) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", {}, std::nullopt,
       std::optional<double>{2.5})};
@@ -685,7 +681,7 @@ TEST(MCP, make_resource_with_priority_clamped_high) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority_clamped_low) {
+TEST(make_resource_with_priority_clamped_low) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", {}, std::nullopt,
       std::optional<double>{-5.0})};
@@ -698,7 +694,7 @@ TEST(MCP, make_resource_with_priority_clamped_low) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority_positive_infinity) {
+TEST(make_resource_with_priority_positive_infinity) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", {}, std::nullopt,
       std::optional<double>{std::numeric_limits<double>::infinity()})};
@@ -711,7 +707,7 @@ TEST(MCP, make_resource_with_priority_positive_infinity) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority_negative_infinity) {
+TEST(make_resource_with_priority_negative_infinity) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", {}, std::nullopt,
       std::optional<double>{-std::numeric_limits<double>::infinity()})};
@@ -724,7 +720,7 @@ TEST(MCP, make_resource_with_priority_negative_infinity) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_with_priority_nan) {
+TEST(make_resource_with_priority_nan) {
   const auto resource{sourcemeta::core::mcp_make_resource(
       "file:///a", "Alpha", "text/plain", {}, std::nullopt,
       std::optional<double>{std::numeric_limits<double>::quiet_NaN()})};
@@ -737,7 +733,7 @@ TEST(MCP, make_resource_with_priority_nan) {
   EXPECT_EQ(resource, expected);
 }
 
-TEST(MCP, make_resource_text_content) {
+TEST(make_resource_text_content) {
   const auto content{sourcemeta::core::mcp_make_resource_text_content(
       "file:///a", "text/plain", "Hello")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -748,7 +744,7 @@ TEST(MCP, make_resource_text_content) {
   EXPECT_EQ(content, expected);
 }
 
-TEST(MCP, make_resources_read_result_single) {
+TEST(make_resources_read_result_single) {
   auto contents{sourcemeta::core::JSON::make_array()};
   contents.push_back(sourcemeta::core::mcp_make_resource_text_content(
       "file:///a", "text/plain", "Hello"));
@@ -762,7 +758,7 @@ TEST(MCP, make_resources_read_result_single) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(MCP, make_resources_read_result_empty) {
+TEST(make_resources_read_result_empty) {
   const auto result{sourcemeta::core::mcp_make_resources_read_result(
       sourcemeta::core::JSON::make_array())};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -771,7 +767,7 @@ TEST(MCP, make_resources_read_result_empty) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(MCP, make_resource_template) {
+TEST(make_resource_template) {
   const auto entry{sourcemeta::core::mcp_make_resource_template(
       "file:///{path}", "Files", "Resolves a file path", "text/plain")};
   const auto expected{sourcemeta::core::parse_json(R"JSON({
@@ -783,7 +779,7 @@ TEST(MCP, make_resource_template) {
   EXPECT_EQ(entry, expected);
 }
 
-TEST(MCP, make_tool_descriptor_default_annotations_2025_11_25) {
+TEST(make_tool_descriptor_default_annotations_2025_11_25) {
   const auto entry{sourcemeta::core::mcp_make_tool_descriptor(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25, "say", "Says hello",
       sourcemeta::core::parse_json(R"({ "type": "object" })"))};
@@ -801,7 +797,7 @@ TEST(MCP, make_tool_descriptor_default_annotations_2025_11_25) {
   EXPECT_EQ(entry, expected);
 }
 
-TEST(MCP, make_tool_descriptor_with_output_schema_2025_11_25) {
+TEST(make_tool_descriptor_with_output_schema_2025_11_25) {
   const auto entry{sourcemeta::core::mcp_make_tool_descriptor(
       sourcemeta::core::MCPProtocolVersion::V_2025_11_25, "say", "Says hello",
       sourcemeta::core::parse_json(R"({ "type": "object" })"),
@@ -821,7 +817,7 @@ TEST(MCP, make_tool_descriptor_with_output_schema_2025_11_25) {
   EXPECT_EQ(entry, expected);
 }
 
-TEST(MCP, make_tool_descriptor_with_output_schema_dropped_on_2025_03_26) {
+TEST(make_tool_descriptor_with_output_schema_dropped_on_2025_03_26) {
   const auto entry{sourcemeta::core::mcp_make_tool_descriptor(
       sourcemeta::core::MCPProtocolVersion::V_2025_03_26, "say", "Says hello",
       sourcemeta::core::parse_json(R"({ "type": "object" })"),
@@ -840,7 +836,7 @@ TEST(MCP, make_tool_descriptor_with_output_schema_dropped_on_2025_03_26) {
   EXPECT_EQ(entry, expected);
 }
 
-TEST(MCP, make_tool_descriptor_with_title_and_read_only_hints) {
+TEST(make_tool_descriptor_with_title_and_read_only_hints) {
   sourcemeta::core::MCPToolAnnotations annotations;
   annotations.title = "Say Hello";
   annotations.read_only = true;
@@ -866,7 +862,7 @@ TEST(MCP, make_tool_descriptor_with_title_and_read_only_hints) {
   EXPECT_EQ(entry, expected);
 }
 
-TEST(MCP, make_initialize_result_minimal_2025_11_25) {
+TEST(make_initialize_result_minimal_2025_11_25) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -889,7 +885,7 @@ TEST(MCP, make_initialize_result_minimal_2025_11_25) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, make_initialize_result_with_all_capabilities) {
+TEST(make_initialize_result_with_all_capabilities) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -923,7 +919,7 @@ TEST(MCP, make_initialize_result_with_all_capabilities) {
   EXPECT_EQ(envelope, expected);
 }
 
-TEST(MCP, make_initialize_result_includes_instructions_when_provided) {
+TEST(make_initialize_result_includes_instructions_when_provided) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -938,7 +934,7 @@ TEST(MCP, make_initialize_result_includes_instructions_when_provided) {
             "Be careful.");
 }
 
-TEST(MCP, make_initialize_result_includes_title_on_2025_06_18) {
+TEST(make_initialize_result_includes_title_on_2025_06_18) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -956,7 +952,7 @@ TEST(MCP, make_initialize_result_includes_title_on_2025_06_18) {
   EXPECT_FALSE(envelope.at("result").at("serverInfo").defines("websiteUrl"));
 }
 
-TEST(MCP, make_initialize_result_includes_full_implementation_on_2025_11_25) {
+TEST(make_initialize_result_includes_full_implementation_on_2025_11_25) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -978,7 +974,6 @@ TEST(MCP, make_initialize_result_includes_full_implementation_on_2025_11_25) {
 }
 
 TEST(
-    MCP,
     make_initialize_result_strips_unsupported_implementation_fields_on_2025_03_26) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
@@ -996,7 +991,7 @@ TEST(
   EXPECT_FALSE(envelope.at("result").at("serverInfo").defines("websiteUrl"));
 }
 
-TEST(MCP, make_initialize_result_falls_back_to_2025_11_25_on_unknown_version) {
+TEST(make_initialize_result_falls_back_to_2025_11_25_on_unknown_version) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1011,7 +1006,7 @@ TEST(MCP, make_initialize_result_falls_back_to_2025_11_25_on_unknown_version) {
             "2025-11-25");
 }
 
-TEST(MCP, make_initialize_result_returns_invalid_request_when_missing_params) {
+TEST(make_initialize_result_returns_invalid_request_when_missing_params) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0", "id": 1, "method": "initialize"
   })JSON")};
@@ -1023,7 +1018,7 @@ TEST(MCP, make_initialize_result_returns_invalid_request_when_missing_params) {
             sourcemeta::core::JSONRPC_CODE_INVALID_REQUEST);
 }
 
-TEST(MCP, make_initialize_result_returns_invalid_request_when_id_missing) {
+TEST(make_initialize_result_returns_invalid_request_when_id_missing) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0", "method": "initialize", "params": {}
   })JSON")};
@@ -1035,7 +1030,7 @@ TEST(MCP, make_initialize_result_returns_invalid_request_when_id_missing) {
             sourcemeta::core::JSONRPC_CODE_INVALID_REQUEST);
 }
 
-TEST(MCP, tool_call_arguments_present) {
+TEST(tool_call_arguments_present) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1043,12 +1038,12 @@ TEST(MCP, tool_call_arguments_present) {
     "params": { "name": "foo", "arguments": { "x": 1 } }
   })JSON")};
   const auto *arguments{sourcemeta::core::mcp_tool_call_arguments(envelope)};
-  ASSERT_NE(arguments, nullptr);
+  EXPECT_NE(arguments, nullptr);
   EXPECT_TRUE(arguments->is_object());
   EXPECT_EQ(arguments->at("x").to_integer(), 1);
 }
 
-TEST(MCP, tool_call_arguments_missing) {
+TEST(tool_call_arguments_missing) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1058,7 +1053,7 @@ TEST(MCP, tool_call_arguments_missing) {
   EXPECT_EQ(sourcemeta::core::mcp_tool_call_arguments(envelope), nullptr);
 }
 
-TEST(MCP, tool_call_arguments_params_not_object) {
+TEST(tool_call_arguments_params_not_object) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1068,7 +1063,7 @@ TEST(MCP, tool_call_arguments_params_not_object) {
   EXPECT_EQ(sourcemeta::core::mcp_tool_call_arguments(envelope), nullptr);
 }
 
-TEST(MCP, tool_call_arguments_no_params) {
+TEST(tool_call_arguments_no_params) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1077,7 +1072,7 @@ TEST(MCP, tool_call_arguments_no_params) {
   EXPECT_EQ(sourcemeta::core::mcp_tool_call_arguments(envelope), nullptr);
 }
 
-TEST(MCP, tool_call_arguments_string_value) {
+TEST(tool_call_arguments_string_value) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1087,7 +1082,7 @@ TEST(MCP, tool_call_arguments_string_value) {
   EXPECT_EQ(sourcemeta::core::mcp_tool_call_arguments(envelope), nullptr);
 }
 
-TEST(MCP, tool_call_arguments_array_value) {
+TEST(tool_call_arguments_array_value) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,
@@ -1097,7 +1092,7 @@ TEST(MCP, tool_call_arguments_array_value) {
   EXPECT_EQ(sourcemeta::core::mcp_tool_call_arguments(envelope), nullptr);
 }
 
-TEST(MCP, tool_call_arguments_null_value) {
+TEST(tool_call_arguments_null_value) {
   const auto envelope{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",
     "id": 1,

--- a/test/numeric/CMakeLists.txt
+++ b/test/numeric/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME numeric
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME numeric
   SOURCES numeric_decimal_test.cc numeric_parse_test.cc numeric_uint128_test.cc
           numeric_util_test.cc numeric_zigzag_test.cc)
 

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/numeric.h>
 
@@ -9,323 +9,323 @@
 #include <thread>  // std::thread
 #include <vector>  // std::vector
 
-TEST(Numeric_decimal, add_small_integers) {
+TEST(add_small_integers) {
   const sourcemeta::core::Decimal left{2};
   const sourcemeta::core::Decimal right{3};
   const sourcemeta::core::Decimal result{5};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, add_large_integers) {
+TEST(add_large_integers) {
   const sourcemeta::core::Decimal left{1000000000};
   const sourcemeta::core::Decimal right{2000000000};
   const sourcemeta::core::Decimal result{3000000000};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, add_negative_integers) {
+TEST(add_negative_integers) {
   const sourcemeta::core::Decimal left{-5};
   const sourcemeta::core::Decimal right{-10};
   const sourcemeta::core::Decimal result{-15};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, add_mixed_sign_integers) {
+TEST(add_mixed_sign_integers) {
   const sourcemeta::core::Decimal left{100};
   const sourcemeta::core::Decimal right{-50};
   const sourcemeta::core::Decimal result{50};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, add_decimals) {
+TEST(add_decimals) {
   const sourcemeta::core::Decimal left{"1.5"};
   const sourcemeta::core::Decimal right{"2.3"};
   const sourcemeta::core::Decimal result{"3.8"};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, add_very_large_numbers) {
+TEST(add_very_large_numbers) {
   const sourcemeta::core::Decimal left{"999999999999999999999999999999"};
   const sourcemeta::core::Decimal right{"1"};
   const sourcemeta::core::Decimal result{"1000000000000000000000000000000"};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, add_high_precision_decimals) {
+TEST(add_high_precision_decimals) {
   const sourcemeta::core::Decimal left{"0.123456789012345"};
   const sourcemeta::core::Decimal right{"0.987654321098765"};
   const sourcemeta::core::Decimal result{"1.111111110111110"};
   EXPECT_EQ(left + right, result);
 }
 
-TEST(Numeric_decimal, subtract_small_integers) {
+TEST(subtract_small_integers) {
   const sourcemeta::core::Decimal left{10};
   const sourcemeta::core::Decimal right{3};
   const sourcemeta::core::Decimal result{7};
   EXPECT_EQ(left - right, result);
 }
 
-TEST(Numeric_decimal, subtract_to_negative) {
+TEST(subtract_to_negative) {
   const sourcemeta::core::Decimal left{5};
   const sourcemeta::core::Decimal right{15};
   const sourcemeta::core::Decimal result{-10};
   EXPECT_EQ(left - right, result);
 }
 
-TEST(Numeric_decimal, subtract_decimals) {
+TEST(subtract_decimals) {
   const sourcemeta::core::Decimal left{"10.5"};
   const sourcemeta::core::Decimal right{"3.2"};
   const sourcemeta::core::Decimal result{"7.3"};
   EXPECT_EQ(left - right, result);
 }
 
-TEST(Numeric_decimal, subtract_negative_numbers) {
+TEST(subtract_negative_numbers) {
   const sourcemeta::core::Decimal left{-5};
   const sourcemeta::core::Decimal right{-3};
   const sourcemeta::core::Decimal result{-2};
   EXPECT_EQ(left - right, result);
 }
 
-TEST(Numeric_decimal, multiply_small_integers) {
+TEST(multiply_small_integers) {
   const sourcemeta::core::Decimal left{7};
   const sourcemeta::core::Decimal right{8};
   const sourcemeta::core::Decimal result{56};
   EXPECT_EQ(left * right, result);
 }
 
-TEST(Numeric_decimal, multiply_by_zero) {
+TEST(multiply_by_zero) {
   const sourcemeta::core::Decimal left{12345};
   const sourcemeta::core::Decimal right{0};
   const sourcemeta::core::Decimal result{0};
   EXPECT_EQ(left * right, result);
 }
 
-TEST(Numeric_decimal, multiply_negative_numbers) {
+TEST(multiply_negative_numbers) {
   const sourcemeta::core::Decimal left{-5};
   const sourcemeta::core::Decimal right{-4};
   const sourcemeta::core::Decimal result{20};
   EXPECT_EQ(left * right, result);
 }
 
-TEST(Numeric_decimal, multiply_mixed_sign) {
+TEST(multiply_mixed_sign) {
   const sourcemeta::core::Decimal left{6};
   const sourcemeta::core::Decimal right{-7};
   const sourcemeta::core::Decimal result{-42};
   EXPECT_EQ(left * right, result);
 }
 
-TEST(Numeric_decimal, multiply_decimals) {
+TEST(multiply_decimals) {
   const sourcemeta::core::Decimal left{"2.5"};
   const sourcemeta::core::Decimal right{"4.0"};
   const sourcemeta::core::Decimal result{"10.0"};
   EXPECT_EQ(left * right, result);
 }
 
-TEST(Numeric_decimal, multiply_large_numbers) {
+TEST(multiply_large_numbers) {
   const sourcemeta::core::Decimal left{"123456789"};
   const sourcemeta::core::Decimal right{"987654321"};
   const sourcemeta::core::Decimal result{"1.219326311126353E+17"};
   EXPECT_EQ(left * right, result);
 }
 
-TEST(Numeric_decimal, divide_exact) {
+TEST(divide_exact) {
   const sourcemeta::core::Decimal left{15};
   const sourcemeta::core::Decimal right{3};
   const sourcemeta::core::Decimal result{5};
   EXPECT_EQ(left / right, result);
 }
 
-TEST(Numeric_decimal, divide_decimals) {
+TEST(divide_decimals) {
   const sourcemeta::core::Decimal left{"10.0"};
   const sourcemeta::core::Decimal right{"4.0"};
   const sourcemeta::core::Decimal result{"2.5"};
   EXPECT_EQ(left / right, result);
 }
 
-TEST(Numeric_decimal, divide_negative_numbers) {
+TEST(divide_negative_numbers) {
   const sourcemeta::core::Decimal left{-20};
   const sourcemeta::core::Decimal right{4};
   const sourcemeta::core::Decimal result{-5};
   EXPECT_EQ(left / right, result);
 }
 
-TEST(Numeric_decimal, divide_both_negative) {
+TEST(divide_both_negative) {
   const sourcemeta::core::Decimal left{-30};
   const sourcemeta::core::Decimal right{-6};
   const sourcemeta::core::Decimal result{5};
   EXPECT_EQ(left / right, result);
 }
 
-TEST(Numeric_decimal, divide_one) {
+TEST(divide_one) {
   const sourcemeta::core::Decimal left{"7.5"};
   const sourcemeta::core::Decimal right{1};
   const sourcemeta::core::Decimal result{"7.5"};
   EXPECT_EQ(left / right, result);
 }
 
-TEST(Numeric_decimal, modulo_basic) {
+TEST(modulo_basic) {
   const sourcemeta::core::Decimal left{17};
   const sourcemeta::core::Decimal right{5};
   const sourcemeta::core::Decimal result{2};
   EXPECT_EQ(left % right, result);
 }
 
-TEST(Numeric_decimal, modulo_exact) {
+TEST(modulo_exact) {
   const sourcemeta::core::Decimal left{20};
   const sourcemeta::core::Decimal right{4};
   const sourcemeta::core::Decimal result{0};
   EXPECT_EQ(left % right, result);
 }
 
-TEST(Numeric_decimal, modulo_negative_dividend) {
+TEST(modulo_negative_dividend) {
   const sourcemeta::core::Decimal left{-17};
   const sourcemeta::core::Decimal right{5};
   const sourcemeta::core::Decimal result{-2};
   EXPECT_EQ(left % right, result);
 }
 
-TEST(Numeric_decimal, equal_integers) {
+TEST(equal_integers) {
   const sourcemeta::core::Decimal left{42};
   const sourcemeta::core::Decimal right{42};
   EXPECT_TRUE(left == right);
   EXPECT_FALSE(left != right);
 }
 
-TEST(Numeric_decimal, not_equal_integers) {
+TEST(not_equal_integers) {
   const sourcemeta::core::Decimal left{42};
   const sourcemeta::core::Decimal right{43};
   EXPECT_TRUE(left != right);
   EXPECT_FALSE(left == right);
 }
 
-TEST(Numeric_decimal, less_than) {
+TEST(less_than) {
   const sourcemeta::core::Decimal left{10};
   const sourcemeta::core::Decimal right{20};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(Numeric_decimal, less_than_or_equal) {
+TEST(less_than_or_equal) {
   const sourcemeta::core::Decimal left{10};
   const sourcemeta::core::Decimal right{10};
   EXPECT_TRUE(left <= right);
   EXPECT_TRUE(left <= sourcemeta::core::Decimal{11});
 }
 
-TEST(Numeric_decimal, greater_than) {
+TEST(greater_than) {
   const sourcemeta::core::Decimal left{50};
   const sourcemeta::core::Decimal right{25};
   EXPECT_TRUE(left > right);
   EXPECT_FALSE(right > left);
 }
 
-TEST(Numeric_decimal, greater_than_or_equal) {
+TEST(greater_than_or_equal) {
   const sourcemeta::core::Decimal left{100};
   const sourcemeta::core::Decimal right{100};
   EXPECT_TRUE(left >= right);
   EXPECT_TRUE(left >= sourcemeta::core::Decimal{99});
 }
 
-TEST(Numeric_decimal, compare_decimals) {
+TEST(compare_decimals) {
   const sourcemeta::core::Decimal left{"1.5"};
   const sourcemeta::core::Decimal right{"1.6"};
   EXPECT_TRUE(left < right);
   EXPECT_TRUE(right > left);
 }
 
-TEST(Numeric_decimal, compare_negative_numbers) {
+TEST(compare_negative_numbers) {
   const sourcemeta::core::Decimal left{-10};
   const sourcemeta::core::Decimal right{-5};
   EXPECT_TRUE(left < right);
   EXPECT_TRUE(right > left);
 }
 
-TEST(Numeric_decimal, unary_minus) {
+TEST(unary_minus) {
   const sourcemeta::core::Decimal value{42};
   const sourcemeta::core::Decimal result{-42};
   EXPECT_EQ(-value, result);
 }
 
-TEST(Numeric_decimal, unary_minus_negative) {
+TEST(unary_minus_negative) {
   const sourcemeta::core::Decimal value{-42};
   const sourcemeta::core::Decimal result{42};
   EXPECT_EQ(-value, result);
 }
 
-TEST(Numeric_decimal, unary_plus) {
+TEST(unary_plus) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_EQ(+value, value);
 }
 
-TEST(Numeric_decimal, parse_integer_string) {
+TEST(parse_integer_string) {
   const sourcemeta::core::Decimal value{"12345"};
   const sourcemeta::core::Decimal expected{12345};
   EXPECT_EQ(value, expected);
 }
 
-TEST(Numeric_decimal, parse_decimal_string) {
+TEST(parse_decimal_string) {
   const sourcemeta::core::Decimal value{"123.456"};
   const std::string str{value.to_scientific_string()};
   EXPECT_EQ(str, "1.23456e+2");
 }
 
-TEST(Numeric_decimal, parse_negative_string) {
+TEST(parse_negative_string) {
   const sourcemeta::core::Decimal value{"-987.654"};
   const std::string str{value.to_scientific_string()};
   EXPECT_EQ(str, "-9.87654e+2");
 }
 
-TEST(Numeric_decimal, parse_scientific_notation) {
+TEST(parse_scientific_notation) {
   const sourcemeta::core::Decimal value{"1.23E+10"};
   const sourcemeta::core::Decimal expected{"12300000000"};
   EXPECT_EQ(value, expected);
 }
 
-TEST(Numeric_decimal, parse_negative_exponent) {
+TEST(parse_negative_exponent) {
   const sourcemeta::core::Decimal value{"1.23E-3"};
   const sourcemeta::core::Decimal expected{"0.00123"};
   EXPECT_EQ(value, expected);
 }
 
-TEST(Numeric_decimal, parse_zero) {
+TEST(parse_zero) {
   const sourcemeta::core::Decimal value{"0"};
   const sourcemeta::core::Decimal expected{0};
   EXPECT_EQ(value, expected);
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_very_small_number) {
+TEST(parse_very_small_number) {
   const sourcemeta::core::Decimal value{"0.000000001"};
   const std::string str{value.to_scientific_string()};
   EXPECT_EQ(str, "1e-9");
 }
 
-TEST(Numeric_decimal, convert_to_int64) {
+TEST(convert_to_int64) {
   const sourcemeta::core::Decimal value{123456789};
   EXPECT_EQ(value.to_int64(), 123456789);
 }
 
-TEST(Numeric_decimal, convert_to_int32) {
+TEST(convert_to_int32) {
   const sourcemeta::core::Decimal value{12345};
   EXPECT_EQ(value.to_int32(), 12345);
 }
 
-TEST(Numeric_decimal, convert_to_uint64) {
+TEST(convert_to_uint64) {
   const sourcemeta::core::Decimal value{987654321};
   EXPECT_EQ(value.to_uint64(), 987654321ULL);
 }
 
-TEST(Numeric_decimal, convert_to_uint32) {
+TEST(convert_to_uint32) {
   const sourcemeta::core::Decimal value{54321};
   EXPECT_EQ(value.to_uint32(), 54321U);
 }
 
-TEST(Numeric_decimal, convert_negative_to_int64) {
+TEST(convert_negative_to_int64) {
   const sourcemeta::core::Decimal value{-999999};
   EXPECT_EQ(value.to_int64(), -999999);
 }
 
-TEST(Numeric_decimal, very_large_integer) {
+TEST(very_large_integer) {
   const sourcemeta::core::Decimal value{
       "99999999999999999999999999999999999999"};
   const sourcemeta::core::Decimal increment{1};
@@ -334,129 +334,129 @@ TEST(Numeric_decimal, very_large_integer) {
   EXPECT_EQ(value + increment, expected);
 }
 
-TEST(Numeric_decimal, large_multiplication) {
+TEST(large_multiplication) {
   const sourcemeta::core::Decimal left{"999999999999999999"};
   const sourcemeta::core::Decimal right{"999999999999999999"};
   const sourcemeta::core::Decimal expected{"1.000000000000000E+36"};
   EXPECT_EQ(left * right, expected);
 }
 
-TEST(Numeric_decimal, high_precision_addition) {
+TEST(high_precision_addition) {
   const sourcemeta::core::Decimal left{"0.1111111111111111111111111111"};
   const sourcemeta::core::Decimal right{"0.2222222222222222222222222222"};
   const sourcemeta::core::Decimal expected{"0.3333333333333333"};
   EXPECT_EQ(left + right, expected);
 }
 
-TEST(Numeric_decimal, preserve_trailing_zeros) {
+TEST(preserve_trailing_zeros) {
   const sourcemeta::core::Decimal value{"1.000"};
   const std::string str{value.to_scientific_string()};
   EXPECT_EQ(str, "1.000e+0");
 }
 
-TEST(Numeric_decimal, add_zero) {
+TEST(add_zero) {
   const sourcemeta::core::Decimal value{42};
   const sourcemeta::core::Decimal zero{0};
   EXPECT_EQ(value + zero, value);
 }
 
-TEST(Numeric_decimal, multiply_by_one) {
+TEST(multiply_by_one) {
   const sourcemeta::core::Decimal value{"12.34"};
   const sourcemeta::core::Decimal one{1};
   EXPECT_EQ(value * one, value);
 }
 
-TEST(Numeric_decimal, subtract_self) {
+TEST(subtract_self) {
   const sourcemeta::core::Decimal value{123};
   const sourcemeta::core::Decimal zero{0};
   EXPECT_EQ(value - value, zero);
 }
 
-TEST(Numeric_decimal, is_zero_predicate) {
+TEST(is_zero_predicate) {
   const sourcemeta::core::Decimal zero{0};
   const sourcemeta::core::Decimal nonzero{1};
   EXPECT_TRUE(zero.is_zero());
   EXPECT_FALSE(nonzero.is_zero());
 }
 
-TEST(Numeric_decimal, is_integer_predicate) {
+TEST(is_integer_predicate) {
   const sourcemeta::core::Decimal integer{42};
   const sourcemeta::core::Decimal decimal{"42.5"};
   EXPECT_TRUE(integer.is_integer());
   EXPECT_FALSE(decimal.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_real_with_zero_positive) {
+TEST(is_integer_real_with_zero_positive) {
   const sourcemeta::core::Decimal value{"42.0"};
   EXPECT_FALSE(value.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_real_with_zero_negative) {
+TEST(is_integer_real_with_zero_negative) {
   const sourcemeta::core::Decimal value{"-42.0"};
   EXPECT_FALSE(value.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_real_with_zero_zero) {
+TEST(is_integer_real_with_zero_zero) {
   const sourcemeta::core::Decimal value{"0.0"};
   EXPECT_FALSE(value.is_integer());
 }
 
-TEST(Numeric_decimal, is_integral_integer) {
+TEST(is_integral_integer) {
   const sourcemeta::core::Decimal value{3};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_integer_negative) {
+TEST(is_integral_integer_negative) {
   const sourcemeta::core::Decimal value{-42};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_real_with_zero_positive) {
+TEST(is_integral_real_with_zero_positive) {
   const sourcemeta::core::Decimal value{"3.0"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_real_with_zero_negative) {
+TEST(is_integral_real_with_zero_negative) {
   const sourcemeta::core::Decimal value{"-42.0"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_real_with_zero_zero) {
+TEST(is_integral_real_with_zero_zero) {
   const sourcemeta::core::Decimal value{"0.0"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_non_integral_positive) {
+TEST(is_integral_non_integral_positive) {
   const sourcemeta::core::Decimal value{"3.1"};
   EXPECT_FALSE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_non_integral_negative) {
+TEST(is_integral_non_integral_negative) {
   const sourcemeta::core::Decimal value{"-42.5"};
   EXPECT_FALSE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_large_integer) {
+TEST(is_integral_large_integer) {
   const sourcemeta::core::Decimal value{"999999999999999999999"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_large_real_with_zero) {
+TEST(is_integral_large_real_with_zero) {
   const sourcemeta::core::Decimal value{"999999999999999999999.0"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_large_non_integral) {
+TEST(is_integral_large_non_integral) {
   const sourcemeta::core::Decimal value{"999999999999999999999.1"};
   EXPECT_FALSE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_finite_predicate) {
+TEST(is_finite_predicate) {
   const sourcemeta::core::Decimal value{123};
   EXPECT_TRUE(value.is_finite());
 }
 
-TEST(Numeric_decimal, is_real_not_integer) {
+TEST(is_real_not_integer) {
   const sourcemeta::core::Decimal positive{3};
   const sourcemeta::core::Decimal negative{-5};
   const sourcemeta::core::Decimal zero{0};
@@ -465,19 +465,19 @@ TEST(Numeric_decimal, is_real_not_integer) {
   EXPECT_FALSE(zero.is_real());
 }
 
-TEST(Numeric_decimal, is_real_decimal) {
+TEST(is_real_decimal) {
   const sourcemeta::core::Decimal value1{"3.1"};
   const sourcemeta::core::Decimal value2{"-2.5"};
   EXPECT_TRUE(value1.is_real());
   EXPECT_TRUE(value2.is_real());
 }
 
-TEST(Numeric_decimal, is_real_decimal_with_zero_fraction) {
+TEST(is_real_decimal_with_zero_fraction) {
   const sourcemeta::core::Decimal value{"3.0"};
   EXPECT_FALSE(value.is_real());
 }
 
-TEST(Numeric_decimal, is_real_special_values) {
+TEST(is_real_special_values) {
   const sourcemeta::core::Decimal nan_value{"NaN"};
   const sourcemeta::core::Decimal inf_value{"Infinity"};
   const sourcemeta::core::Decimal neg_inf_value{"-Infinity"};
@@ -486,21 +486,21 @@ TEST(Numeric_decimal, is_real_special_values) {
   EXPECT_FALSE(neg_inf_value.is_real());
 }
 
-TEST(Numeric_decimal, is_nan_predicate) {
+TEST(is_nan_predicate) {
   const sourcemeta::core::Decimal nan_value{"NaN"};
   const sourcemeta::core::Decimal normal_value{42};
   EXPECT_TRUE(nan_value.is_nan());
   EXPECT_FALSE(normal_value.is_nan());
 }
 
-TEST(Numeric_decimal, is_infinite_predicate) {
+TEST(is_infinite_predicate) {
   const sourcemeta::core::Decimal inf_value{"Infinity"};
   const sourcemeta::core::Decimal normal_value{42};
   EXPECT_TRUE(inf_value.is_infinite());
   EXPECT_FALSE(normal_value.is_infinite());
 }
 
-TEST(Numeric_decimal, is_signed_predicate) {
+TEST(is_signed_predicate) {
   const sourcemeta::core::Decimal positive{42};
   const sourcemeta::core::Decimal negative{-42};
   const sourcemeta::core::Decimal zero{0};
@@ -511,19 +511,19 @@ TEST(Numeric_decimal, is_signed_predicate) {
   EXPECT_TRUE(negative_zero.is_signed());
 }
 
-TEST(Numeric_decimal, to_integral_rounds_down) {
+TEST(to_integral_rounds_down) {
   const sourcemeta::core::Decimal value{"42.3"};
   const sourcemeta::core::Decimal expected{42};
   EXPECT_EQ(value.to_integral(), expected);
 }
 
-TEST(Numeric_decimal, to_integral_rounds_up) {
+TEST(to_integral_rounds_up) {
   const sourcemeta::core::Decimal value{"42.7"};
   const sourcemeta::core::Decimal expected{43};
   EXPECT_EQ(value.to_integral(), expected);
 }
 
-TEST(Numeric_decimal, to_integral_half_even) {
+TEST(to_integral_half_even) {
   const sourcemeta::core::Decimal value1{"42.5"};
   const sourcemeta::core::Decimal expected1{42};
   const sourcemeta::core::Decimal value2{"43.5"};
@@ -532,20 +532,20 @@ TEST(Numeric_decimal, to_integral_half_even) {
   EXPECT_EQ(value2.to_integral(), expected2);
 }
 
-TEST(Numeric_decimal, to_integral_already_integer) {
+TEST(to_integral_already_integer) {
   const sourcemeta::core::Decimal value{100};
   const sourcemeta::core::Decimal expected{100};
   EXPECT_EQ(value.to_integral(), expected);
 }
 
-TEST(Numeric_decimal, factory_nan) {
+TEST(factory_nan) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_TRUE(nan_value.is_nan());
   EXPECT_FALSE(nan_value.is_finite());
   EXPECT_FALSE(nan_value.is_infinite());
 }
 
-TEST(Numeric_decimal, factory_infinity) {
+TEST(factory_infinity) {
   const auto inf_value{sourcemeta::core::Decimal::infinity()};
   EXPECT_TRUE(inf_value.is_infinite());
   EXPECT_FALSE(inf_value.is_nan());
@@ -553,7 +553,7 @@ TEST(Numeric_decimal, factory_infinity) {
   EXPECT_FALSE(inf_value.is_signed());
 }
 
-TEST(Numeric_decimal, factory_negative_infinity) {
+TEST(factory_negative_infinity) {
   const auto neg_inf{sourcemeta::core::Decimal::negative_infinity()};
   EXPECT_TRUE(neg_inf.is_infinite());
   EXPECT_FALSE(neg_inf.is_nan());
@@ -561,7 +561,7 @@ TEST(Numeric_decimal, factory_negative_infinity) {
   EXPECT_TRUE(neg_inf.is_signed());
 }
 
-TEST(Numeric_decimal, is_float_simple_values) {
+TEST(is_float_simple_values) {
   const sourcemeta::core::Decimal value1{3};
   const sourcemeta::core::Decimal value2{"3.14"};
   const sourcemeta::core::Decimal value3{"-2.5"};
@@ -570,7 +570,7 @@ TEST(Numeric_decimal, is_float_simple_values) {
   EXPECT_TRUE(value3.is_float());
 }
 
-TEST(Numeric_decimal, is_float_special_values) {
+TEST(is_float_special_values) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   const auto inf_value{sourcemeta::core::Decimal::infinity()};
   const auto neg_inf{sourcemeta::core::Decimal::negative_infinity()};
@@ -579,92 +579,92 @@ TEST(Numeric_decimal, is_float_special_values) {
   EXPECT_TRUE(neg_inf.is_float());
 }
 
-TEST(Numeric_decimal, is_float_high_precision_loss) {
+TEST(is_float_high_precision_loss) {
   const sourcemeta::core::Decimal value{"3.141592653589793238462643383279"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_large_exponent_in_range) {
+TEST(is_float_large_exponent_in_range) {
   const sourcemeta::core::Decimal value{"1.5e30"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_large_negative_exponent_in_range) {
+TEST(is_float_large_negative_exponent_in_range) {
   const sourcemeta::core::Decimal value{"1.5e-30"};
   EXPECT_TRUE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_too_large) {
+TEST(is_float_too_large) {
   const sourcemeta::core::Decimal value{"1e100"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_too_small) {
+TEST(is_float_too_small) {
   const sourcemeta::core::Decimal value{"1e-100"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_near_max_float) {
+TEST(is_float_near_max_float) {
   const sourcemeta::core::Decimal value{"3.4e38"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_exceeds_max_float) {
+TEST(is_float_exceeds_max_float) {
   const sourcemeta::core::Decimal value{"4e38"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_near_min_float) {
+TEST(is_float_near_min_float) {
   const sourcemeta::core::Decimal value{"1.2e-38"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_below_min_float) {
+TEST(is_float_below_min_float) {
   const sourcemeta::core::Decimal value{"1e-50"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_6_significant_digits) {
+TEST(is_float_6_significant_digits) {
   const sourcemeta::core::Decimal value{"1.234375"};
   EXPECT_TRUE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_7_significant_digits_no_loss) {
+TEST(is_float_7_significant_digits_no_loss) {
   const sourcemeta::core::Decimal value{"1.2343750"};
   EXPECT_TRUE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_many_digits_with_loss) {
+TEST(is_float_many_digits_with_loss) {
   const sourcemeta::core::Decimal value{"1.23456789"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_big_integer_in_float_range) {
+TEST(is_float_big_integer_in_float_range) {
   const sourcemeta::core::Decimal value{"16777216"};
   EXPECT_TRUE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_big_integer_exceeds_precision) {
+TEST(is_float_big_integer_exceeds_precision) {
   const sourcemeta::core::Decimal value{"16777217"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_small_value_with_exponent) {
+TEST(is_float_small_value_with_exponent) {
   const sourcemeta::core::Decimal value{"1.0e-10"};
   EXPECT_FALSE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_zero) {
+TEST(is_float_zero) {
   const sourcemeta::core::Decimal value{"0.0"};
   EXPECT_TRUE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_float_negative_zero) {
+TEST(is_float_negative_zero) {
   const sourcemeta::core::Decimal value{"-0.0"};
   EXPECT_TRUE(value.is_float());
 }
 
-TEST(Numeric_decimal, is_double_simple_values) {
+TEST(is_double_simple_values) {
   const sourcemeta::core::Decimal value1{3};
   const sourcemeta::core::Decimal value2{"3.14"};
   const sourcemeta::core::Decimal value3{"-2.5"};
@@ -673,7 +673,7 @@ TEST(Numeric_decimal, is_double_simple_values) {
   EXPECT_TRUE(value3.is_double());
 }
 
-TEST(Numeric_decimal, is_double_special_values) {
+TEST(is_double_special_values) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   const auto inf_value{sourcemeta::core::Decimal::infinity()};
   const auto neg_inf{sourcemeta::core::Decimal::negative_infinity()};
@@ -682,167 +682,167 @@ TEST(Numeric_decimal, is_double_special_values) {
   EXPECT_TRUE(neg_inf.is_double());
 }
 
-TEST(Numeric_decimal, is_double_high_precision_loss) {
+TEST(is_double_high_precision_loss) {
   const sourcemeta::core::Decimal value{
       "3.14159265358979323846264338327950288419716939937510"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_large_exponent_in_range) {
+TEST(is_double_large_exponent_in_range) {
   const sourcemeta::core::Decimal value{"1.5e100"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_large_negative_exponent_in_range) {
+TEST(is_double_large_negative_exponent_in_range) {
   const sourcemeta::core::Decimal value{"1.5e-100"};
   EXPECT_TRUE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_too_large) {
+TEST(is_double_too_large) {
   const sourcemeta::core::Decimal value{"1e500"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_too_small) {
+TEST(is_double_too_small) {
   const sourcemeta::core::Decimal value{"1e-500"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_near_max_double) {
+TEST(is_double_near_max_double) {
   const sourcemeta::core::Decimal value{"1.7e308"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_exceeds_max_double) {
+TEST(is_double_exceeds_max_double) {
   const sourcemeta::core::Decimal value{"2e308"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_near_min_double) {
+TEST(is_double_near_min_double) {
   const sourcemeta::core::Decimal value{"2.2e-308"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_below_min_double) {
+TEST(is_double_below_min_double) {
   const sourcemeta::core::Decimal value{"1e-400"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_15_significant_digits) {
+TEST(is_double_15_significant_digits) {
   const sourcemeta::core::Decimal value{"1.23456789012345"};
   EXPECT_TRUE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_16_significant_digits_no_loss) {
+TEST(is_double_16_significant_digits_no_loss) {
   const sourcemeta::core::Decimal value{"1.234567890123456"};
   EXPECT_TRUE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_many_digits_with_loss) {
+TEST(is_double_many_digits_with_loss) {
   const sourcemeta::core::Decimal value{"1.234567890123456789"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_big_integer_in_double_range) {
+TEST(is_double_big_integer_in_double_range) {
   const sourcemeta::core::Decimal value{"9007199254740992"};
   EXPECT_TRUE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_big_integer_exceeds_precision) {
+TEST(is_double_big_integer_exceeds_precision) {
   const sourcemeta::core::Decimal value{"9007199254740993"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_small_value_with_exponent) {
+TEST(is_double_small_value_with_exponent) {
   const sourcemeta::core::Decimal value{"1.0e-28"};
   EXPECT_FALSE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_zero) {
+TEST(is_double_zero) {
   const sourcemeta::core::Decimal value{"0.0"};
   EXPECT_TRUE(value.is_double());
 }
 
-TEST(Numeric_decimal, is_double_negative_zero) {
+TEST(is_double_negative_zero) {
   const sourcemeta::core::Decimal value{"-0.0"};
   EXPECT_TRUE(value.is_double());
 }
 
-TEST(Numeric_decimal, to_float_simple) {
+TEST(to_float_simple) {
   const sourcemeta::core::Decimal value{"3.14"};
   EXPECT_FLOAT_EQ(value.to_float(), 3.14f);
 }
 
-TEST(Numeric_decimal, to_float_integer) {
+TEST(to_float_integer) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_FLOAT_EQ(value.to_float(), 42.0f);
 }
 
-TEST(Numeric_decimal, to_double_simple) {
+TEST(to_double_simple) {
   const sourcemeta::core::Decimal value{"3.5"};
   EXPECT_DOUBLE_EQ(value.to_double(), 3.5);
 }
 
-TEST(Numeric_decimal, to_double_integer) {
+TEST(to_double_integer) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_DOUBLE_EQ(value.to_double(), 42.0);
 }
 
-TEST(Numeric_decimal, to_float_nan) {
+TEST(to_float_nan) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   const float result{nan_value.to_float()};
   EXPECT_TRUE(std::isnan(result));
 }
 
-TEST(Numeric_decimal, to_float_infinity) {
+TEST(to_float_infinity) {
   const auto inf_value{sourcemeta::core::Decimal::infinity()};
   const float result{inf_value.to_float()};
   EXPECT_TRUE(std::isinf(result));
   EXPECT_GT(result, 0.0f);
 }
 
-TEST(Numeric_decimal, to_float_negative_infinity) {
+TEST(to_float_negative_infinity) {
   const auto neg_inf{sourcemeta::core::Decimal::negative_infinity()};
   const float result{neg_inf.to_float()};
   EXPECT_TRUE(std::isinf(result));
   EXPECT_LT(result, 0.0f);
 }
 
-TEST(Numeric_decimal, to_double_nan) {
+TEST(to_double_nan) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   const double result{nan_value.to_double()};
   EXPECT_TRUE(std::isnan(result));
 }
 
-TEST(Numeric_decimal, to_double_infinity) {
+TEST(to_double_infinity) {
   const auto inf_value{sourcemeta::core::Decimal::infinity()};
   const double result{inf_value.to_double()};
   EXPECT_TRUE(std::isinf(result));
   EXPECT_GT(result, 0.0);
 }
 
-TEST(Numeric_decimal, to_double_negative_infinity) {
+TEST(to_double_negative_infinity) {
   const auto neg_inf{sourcemeta::core::Decimal::negative_infinity()};
   const double result{neg_inf.to_double()};
   EXPECT_TRUE(std::isinf(result));
   EXPECT_LT(result, 0.0);
 }
 
-TEST(Numeric_decimal, to_float_not_exactly_representable_gets_rounded) {
+TEST(to_float_not_exactly_representable_gets_rounded) {
   const sourcemeta::core::Decimal value{"3.2"};
   EXPECT_FALSE(value.is_float());
   const float result{value.to_float()};
   EXPECT_FLOAT_EQ(result, 3.2f);
 }
 
-TEST(Numeric_decimal, to_double_not_exactly_representable_gets_rounded) {
+TEST(to_double_not_exactly_representable_gets_rounded) {
   const sourcemeta::core::Decimal value{"3.2"};
   EXPECT_FALSE(value.is_double());
   const double result{value.to_double()};
   EXPECT_DOUBLE_EQ(result, 3.2);
 }
 
-TEST(Numeric_decimal, to_float_exceeds_max_float_throws) {
+TEST(to_float_exceeds_max_float_throws) {
   const sourcemeta::core::Decimal value{"1e100"};
   EXPECT_FALSE(value.is_float());
   try {
@@ -853,7 +853,7 @@ TEST(Numeric_decimal, to_float_exceeds_max_float_throws) {
   }
 }
 
-TEST(Numeric_decimal, to_double_exceeds_max_double_throws) {
+TEST(to_double_exceeds_max_double_throws) {
   const sourcemeta::core::Decimal value{"1e500"};
   EXPECT_FALSE(value.is_double());
   try {
@@ -864,7 +864,7 @@ TEST(Numeric_decimal, to_double_exceeds_max_double_throws) {
   }
 }
 
-TEST(Numeric_decimal, to_float_below_min_float_throws) {
+TEST(to_float_below_min_float_throws) {
   const sourcemeta::core::Decimal value{"1e-100"};
   EXPECT_FALSE(value.is_float());
   try {
@@ -875,7 +875,7 @@ TEST(Numeric_decimal, to_float_below_min_float_throws) {
   }
 }
 
-TEST(Numeric_decimal, to_double_below_min_double_throws) {
+TEST(to_double_below_min_double_throws) {
   const sourcemeta::core::Decimal value{"1e-500"};
   EXPECT_FALSE(value.is_double());
   try {
@@ -886,305 +886,304 @@ TEST(Numeric_decimal, to_double_below_min_double_throws) {
   }
 }
 
-TEST(Numeric_decimal, to_float_high_precision_gets_rounded) {
+TEST(to_float_high_precision_gets_rounded) {
   const sourcemeta::core::Decimal value{"1.23456789"};
   EXPECT_FALSE(value.is_float());
   const float result{value.to_float()};
   EXPECT_FLOAT_EQ(result, 1.23456789f);
 }
 
-TEST(Numeric_decimal, to_double_high_precision_gets_rounded) {
+TEST(to_double_high_precision_gets_rounded) {
   const sourcemeta::core::Decimal value{"1.234567890123456789"};
   EXPECT_FALSE(value.is_double());
   const double result{value.to_double()};
   EXPECT_DOUBLE_EQ(result, 1.234567890123456789);
 }
 
-TEST(Numeric_decimal, divisible_by_integer_true) {
+TEST(divisible_by_integer_true) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_integer_false) {
+TEST(divisible_by_integer_false) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_zero) {
+TEST(divisible_by_zero) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_decimal_true) {
+TEST(divisible_by_decimal_true) {
   const sourcemeta::core::Decimal dividend{"4.5"};
   const sourcemeta::core::Decimal divisor{"1.5"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_decimal_false) {
+TEST(divisible_by_decimal_false) {
   const sourcemeta::core::Decimal dividend{"5.0"};
   const sourcemeta::core::Decimal divisor{"1.3"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_half) {
+TEST(divisible_by_half) {
   const sourcemeta::core::Decimal dividend{7};
   const sourcemeta::core::Decimal divisor{"0.5"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_half_odd) {
+TEST(divisible_by_half_odd) {
   const sourcemeta::core::Decimal dividend{8};
   const sourcemeta::core::Decimal divisor{"0.5"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_self) {
+TEST(divisible_by_self) {
   const sourcemeta::core::Decimal value{"3.14159"};
   EXPECT_TRUE(value.divisible_by(value));
 }
 
-TEST(Numeric_decimal, divisible_by_one) {
+TEST(divisible_by_one) {
   const sourcemeta::core::Decimal dividend{123};
   const sourcemeta::core::Decimal divisor{1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_negative) {
+TEST(divisible_by_negative) {
   const sourcemeta::core::Decimal dividend{-10};
   const sourcemeta::core::Decimal divisor{5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_very_large_number_not_divisible_false) {
+TEST(divisible_by_very_large_number_not_divisible_false) {
   const sourcemeta::core::Decimal dividend{"1e308"};
   const sourcemeta::core::Decimal divisor{"0.123456789"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_very_large_number_divisible_true) {
+TEST(divisible_by_very_large_number_divisible_true) {
   const sourcemeta::core::Decimal dividend{"1e308"};
   const sourcemeta::core::Decimal divisor{"1e154"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal,
-     divisible_by_very_large_negative_number_not_divisible_false) {
+TEST(divisible_by_very_large_negative_number_not_divisible_false) {
   const sourcemeta::core::Decimal dividend{"-1e308"};
   const sourcemeta::core::Decimal divisor{"0.123456789"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_very_large_negative_number_divisible_true) {
+TEST(divisible_by_very_large_negative_number_divisible_true) {
   const sourcemeta::core::Decimal dividend{"-1e308"};
   const sourcemeta::core::Decimal divisor{"-1e154"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_very_small_fractional_not_divisible_false) {
+TEST(divisible_by_very_small_fractional_not_divisible_false) {
   const sourcemeta::core::Decimal dividend{"1e-100"};
   const sourcemeta::core::Decimal divisor{"3e-101"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_very_small_fractional_divisible_true) {
+TEST(divisible_by_very_small_fractional_divisible_true) {
   const sourcemeta::core::Decimal dividend{"1e-100"};
   const sourcemeta::core::Decimal divisor{"1e-200"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_large_fractional_not_divisible_false) {
+TEST(divisible_by_large_fractional_not_divisible_false) {
   const sourcemeta::core::Decimal dividend{"9999999999999999.9999999999999999"};
   const sourcemeta::core::Decimal divisor{"0.33333333333333"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_mixed_scale_not_divisible_false) {
+TEST(divisible_by_mixed_scale_not_divisible_false) {
   const sourcemeta::core::Decimal dividend{"1e100"};
   const sourcemeta::core::Decimal divisor{"0.3"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_mixed_scale_divisible_true) {
+TEST(divisible_by_mixed_scale_divisible_true) {
   const sourcemeta::core::Decimal dividend{"1e100"};
   const sourcemeta::core::Decimal divisor{"0.5"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, add_integer_to_decimal) {
+TEST(add_integer_to_decimal) {
   const sourcemeta::core::Decimal left{10};
   const sourcemeta::core::Decimal right{"2.5"};
   const sourcemeta::core::Decimal expected{"12.5"};
   EXPECT_EQ(left + right, expected);
 }
 
-TEST(Numeric_decimal, multiply_integer_by_decimal) {
+TEST(multiply_integer_by_decimal) {
   const sourcemeta::core::Decimal left{5};
   const sourcemeta::core::Decimal right{"1.5"};
   const sourcemeta::core::Decimal expected{"7.5"};
   EXPECT_EQ(left * right, expected);
 }
 
-TEST(Numeric_decimal, add_plain_int_to_decimal) {
+TEST(add_plain_int_to_decimal) {
   const sourcemeta::core::Decimal value{"10.5"};
   const sourcemeta::core::Decimal expected{"15.5"};
   EXPECT_EQ(value + 5, expected);
 }
 
-TEST(Numeric_decimal, add_decimal_to_plain_int) {
+TEST(add_decimal_to_plain_int) {
   const sourcemeta::core::Decimal value{"3.5"};
   const sourcemeta::core::Decimal expected{"13.5"};
   EXPECT_EQ(10 + value, expected);
 }
 
-TEST(Numeric_decimal, subtract_plain_int_from_decimal) {
+TEST(subtract_plain_int_from_decimal) {
   const sourcemeta::core::Decimal value{"20.5"};
   const sourcemeta::core::Decimal expected{"10.5"};
   EXPECT_EQ(value - 10, expected);
 }
 
-TEST(Numeric_decimal, subtract_decimal_from_plain_int) {
+TEST(subtract_decimal_from_plain_int) {
   const sourcemeta::core::Decimal value{"3.5"};
   const sourcemeta::core::Decimal expected{"6.5"};
   EXPECT_EQ(10 - value, expected);
 }
 
-TEST(Numeric_decimal, multiply_decimal_by_plain_int) {
+TEST(multiply_decimal_by_plain_int) {
   const sourcemeta::core::Decimal value{"4.5"};
   const sourcemeta::core::Decimal expected{"13.5"};
   EXPECT_EQ(value * 3, expected);
 }
 
-TEST(Numeric_decimal, multiply_plain_int_by_decimal) {
+TEST(multiply_plain_int_by_decimal) {
   const sourcemeta::core::Decimal value{"2.5"};
   const sourcemeta::core::Decimal expected{"10.0"};
   EXPECT_EQ(4 * value, expected);
 }
 
-TEST(Numeric_decimal, divide_decimal_by_plain_int) {
+TEST(divide_decimal_by_plain_int) {
   const sourcemeta::core::Decimal value{"15.0"};
   const sourcemeta::core::Decimal expected{"3.0"};
   EXPECT_EQ(value / 5, expected);
 }
 
-TEST(Numeric_decimal, divide_plain_int_by_decimal) {
+TEST(divide_plain_int_by_decimal) {
   const sourcemeta::core::Decimal value{"4.0"};
   const sourcemeta::core::Decimal expected{"5.0"};
   EXPECT_EQ(20 / value, expected);
 }
 
-TEST(Numeric_decimal, modulo_decimal_by_plain_int) {
+TEST(modulo_decimal_by_plain_int) {
   const sourcemeta::core::Decimal value{17};
   const sourcemeta::core::Decimal expected{2};
   EXPECT_EQ(value % 5, expected);
 }
 
-TEST(Numeric_decimal, modulo_plain_int_by_decimal) {
+TEST(modulo_plain_int_by_decimal) {
   const sourcemeta::core::Decimal value{5};
   const sourcemeta::core::Decimal expected{2};
   EXPECT_EQ(17 % value, expected);
 }
 
-TEST(Numeric_decimal, compare_decimal_equal_plain_int) {
+TEST(compare_decimal_equal_plain_int) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_TRUE(value == 42);
   EXPECT_TRUE(42 == value);
 }
 
-TEST(Numeric_decimal, compare_decimal_not_equal_plain_int) {
+TEST(compare_decimal_not_equal_plain_int) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_TRUE(value != 43);
   EXPECT_TRUE(43 != value);
 }
 
-TEST(Numeric_decimal, compare_decimal_less_than_plain_int) {
+TEST(compare_decimal_less_than_plain_int) {
   const sourcemeta::core::Decimal value{10};
   EXPECT_TRUE(value < 20);
   EXPECT_TRUE(5 < value);
 }
 
-TEST(Numeric_decimal, compare_decimal_greater_than_plain_int) {
+TEST(compare_decimal_greater_than_plain_int) {
   const sourcemeta::core::Decimal value{50};
   EXPECT_TRUE(value > 25);
   EXPECT_TRUE(75 > value);
 }
 
-TEST(Numeric_decimal, compare_decimal_with_negative_int) {
+TEST(compare_decimal_with_negative_int) {
   const sourcemeta::core::Decimal value{10};
   EXPECT_TRUE(value > -5);
   EXPECT_TRUE(-5 < value);
 }
 
-TEST(Numeric_decimal, mixed_operation_with_int64) {
+TEST(mixed_operation_with_int64) {
   const sourcemeta::core::Decimal value{"1000000000000"};
   const int64_t large{1000000000000LL};
   const sourcemeta::core::Decimal expected{"2000000000000"};
   EXPECT_EQ(value + large, expected);
 }
 
-TEST(Numeric_decimal, mixed_operation_with_uint32) {
+TEST(mixed_operation_with_uint32) {
   const sourcemeta::core::Decimal value{"100.5"};
   const uint32_t integer{50U};
   const sourcemeta::core::Decimal expected{"150.5"};
   EXPECT_EQ(value + integer, expected);
 }
 
-TEST(Numeric_decimal, prefix_increment_integer) {
+TEST(prefix_increment_integer) {
   sourcemeta::core::Decimal value{10};
   const sourcemeta::core::Decimal result{++value};
   EXPECT_EQ(value, sourcemeta::core::Decimal{11});
   EXPECT_EQ(result, sourcemeta::core::Decimal{11});
 }
 
-TEST(Numeric_decimal, postfix_increment_integer) {
+TEST(postfix_increment_integer) {
   sourcemeta::core::Decimal value{10};
   const sourcemeta::core::Decimal result{value++};
   EXPECT_EQ(value, sourcemeta::core::Decimal{11});
   EXPECT_EQ(result, sourcemeta::core::Decimal{10});
 }
 
-TEST(Numeric_decimal, prefix_decrement_integer) {
+TEST(prefix_decrement_integer) {
   sourcemeta::core::Decimal value{10};
   const sourcemeta::core::Decimal result{--value};
   EXPECT_EQ(value, sourcemeta::core::Decimal{9});
   EXPECT_EQ(result, sourcemeta::core::Decimal{9});
 }
 
-TEST(Numeric_decimal, postfix_decrement_integer) {
+TEST(postfix_decrement_integer) {
   sourcemeta::core::Decimal value{10};
   const sourcemeta::core::Decimal result{value--};
   EXPECT_EQ(value, sourcemeta::core::Decimal{9});
   EXPECT_EQ(result, sourcemeta::core::Decimal{10});
 }
 
-TEST(Numeric_decimal, prefix_increment_decimal) {
+TEST(prefix_increment_decimal) {
   sourcemeta::core::Decimal value{"5.5"};
   ++value;
   EXPECT_EQ(value, sourcemeta::core::Decimal{"6.5"});
 }
 
-TEST(Numeric_decimal, postfix_increment_decimal) {
+TEST(postfix_increment_decimal) {
   sourcemeta::core::Decimal value{"5.5"};
   value++;
   EXPECT_EQ(value, sourcemeta::core::Decimal{"6.5"});
 }
 
-TEST(Numeric_decimal, prefix_decrement_decimal) {
+TEST(prefix_decrement_decimal) {
   sourcemeta::core::Decimal value{"5.5"};
   --value;
   EXPECT_EQ(value, sourcemeta::core::Decimal{"4.5"});
 }
 
-TEST(Numeric_decimal, postfix_decrement_decimal) {
+TEST(postfix_decrement_decimal) {
   sourcemeta::core::Decimal value{"5.5"};
   value--;
   EXPECT_EQ(value, sourcemeta::core::Decimal{"4.5"});
 }
 
-TEST(Numeric_decimal, multiple_increments) {
+TEST(multiple_increments) {
   sourcemeta::core::Decimal value{0};
   ++value;
   ++value;
@@ -1192,7 +1191,7 @@ TEST(Numeric_decimal, multiple_increments) {
   EXPECT_EQ(value, sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_decimal, multiple_decrements) {
+TEST(multiple_decrements) {
   sourcemeta::core::Decimal value{10};
   value--;
   value--;
@@ -1200,45 +1199,45 @@ TEST(Numeric_decimal, multiple_decrements) {
   EXPECT_EQ(value, sourcemeta::core::Decimal{7});
 }
 
-TEST(Numeric_decimal, increment_negative_to_zero) {
+TEST(increment_negative_to_zero) {
   sourcemeta::core::Decimal value{-1};
   ++value;
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, decrement_to_negative) {
+TEST(decrement_to_negative) {
   sourcemeta::core::Decimal value{0};
   --value;
   EXPECT_EQ(value, sourcemeta::core::Decimal{-1});
 }
 
-TEST(Numeric_decimal, chained_prefix_operations) {
+TEST(chained_prefix_operations) {
   sourcemeta::core::Decimal value{5};
   const sourcemeta::core::Decimal result{++(++value)};
   EXPECT_EQ(value, sourcemeta::core::Decimal{7});
   EXPECT_EQ(result, sourcemeta::core::Decimal{7});
 }
 
-TEST(Numeric_decimal, default_constructor) {
+TEST(default_constructor) {
   const sourcemeta::core::Decimal value;
   EXPECT_TRUE(value.is_zero());
   EXPECT_EQ(value, sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, copy_constructor) {
+TEST(copy_constructor) {
   const sourcemeta::core::Decimal original{42};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_EQ(copy, original);
   EXPECT_EQ(copy, sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, copy_constructor_decimal_value) {
+TEST(copy_constructor_decimal_value) {
   const sourcemeta::core::Decimal original{"3.14159"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_EQ(copy, original);
 }
 
-TEST(Numeric_decimal, copy_assignment) {
+TEST(copy_assignment) {
   const sourcemeta::core::Decimal original{100};
   sourcemeta::core::Decimal copy{0};
   copy = original;
@@ -1246,26 +1245,26 @@ TEST(Numeric_decimal, copy_assignment) {
   EXPECT_EQ(copy, sourcemeta::core::Decimal{100});
 }
 
-TEST(Numeric_decimal, move_constructor) {
+TEST(move_constructor) {
   sourcemeta::core::Decimal original{999};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_EQ(moved, sourcemeta::core::Decimal{999});
 }
 
-TEST(Numeric_decimal, move_constructor_decimal_value) {
+TEST(move_constructor_decimal_value) {
   sourcemeta::core::Decimal original{"2.71828"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_EQ(moved, sourcemeta::core::Decimal{"2.71828"});
 }
 
-TEST(Numeric_decimal, move_assignment) {
+TEST(move_assignment) {
   sourcemeta::core::Decimal original{500};
   sourcemeta::core::Decimal moved{0};
   moved = std::move(original);
   EXPECT_EQ(moved, sourcemeta::core::Decimal{500});
 }
 
-TEST(Numeric_decimal, copy_then_modify) {
+TEST(copy_then_modify) {
   const sourcemeta::core::Decimal original{10};
   sourcemeta::core::Decimal copy{original};
   copy += sourcemeta::core::Decimal{5};
@@ -1273,7 +1272,7 @@ TEST(Numeric_decimal, copy_then_modify) {
   EXPECT_EQ(copy, sourcemeta::core::Decimal{15});
 }
 
-TEST(Numeric_decimal, multiple_copies) {
+TEST(multiple_copies) {
   const sourcemeta::core::Decimal value1{7};
   const sourcemeta::core::Decimal value2{value1};
   const sourcemeta::core::Decimal value3{value2};
@@ -1282,37 +1281,37 @@ TEST(Numeric_decimal, multiple_copies) {
   EXPECT_EQ(value1, value3);
 }
 
-TEST(Numeric_decimal, compound_assignment_add) {
+TEST(compound_assignment_add) {
   sourcemeta::core::Decimal value{10};
   value += sourcemeta::core::Decimal{5};
   EXPECT_EQ(value, sourcemeta::core::Decimal{15});
 }
 
-TEST(Numeric_decimal, compound_assignment_subtract) {
+TEST(compound_assignment_subtract) {
   sourcemeta::core::Decimal value{20};
   value -= sourcemeta::core::Decimal{8};
   EXPECT_EQ(value, sourcemeta::core::Decimal{12});
 }
 
-TEST(Numeric_decimal, compound_assignment_multiply) {
+TEST(compound_assignment_multiply) {
   sourcemeta::core::Decimal value{6};
   value *= sourcemeta::core::Decimal{7};
   EXPECT_EQ(value, sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, compound_assignment_divide) {
+TEST(compound_assignment_divide) {
   sourcemeta::core::Decimal value{100};
   value /= sourcemeta::core::Decimal{5};
   EXPECT_EQ(value, sourcemeta::core::Decimal{20});
 }
 
-TEST(Numeric_decimal, compound_assignment_modulo) {
+TEST(compound_assignment_modulo) {
   sourcemeta::core::Decimal value{17};
   value %= sourcemeta::core::Decimal{5};
   EXPECT_EQ(value, sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_decimal, compound_assignment_chain) {
+TEST(compound_assignment_chain) {
   sourcemeta::core::Decimal value{10};
   value += sourcemeta::core::Decimal{5};
   value *= sourcemeta::core::Decimal{2};
@@ -1320,111 +1319,111 @@ TEST(Numeric_decimal, compound_assignment_chain) {
   EXPECT_EQ(value, sourcemeta::core::Decimal{20});
 }
 
-TEST(Numeric_decimal, to_string_integer) {
+TEST(to_string_integer) {
   const sourcemeta::core::Decimal value{12345};
   EXPECT_EQ(value.to_string(), "12345");
 }
 
-TEST(Numeric_decimal, to_string_decimal) {
+TEST(to_string_decimal) {
   const sourcemeta::core::Decimal value{"123.456"};
   EXPECT_EQ(value.to_string(), "123.456");
 }
 
-TEST(Numeric_decimal, to_string_negative) {
+TEST(to_string_negative) {
   const sourcemeta::core::Decimal value{-999};
   EXPECT_EQ(value.to_string(), "-999");
 }
 
-TEST(Numeric_decimal, to_string_negative_decimal) {
+TEST(to_string_negative_decimal) {
   const sourcemeta::core::Decimal value{"-67.89"};
   EXPECT_EQ(value.to_string(), "-67.89");
 }
 
-TEST(Numeric_decimal, to_string_zero_fractional) {
+TEST(to_string_zero_fractional) {
   const sourcemeta::core::Decimal value{"7.0"};
   EXPECT_EQ(value.to_string(), "7.0");
 }
 
-TEST(Numeric_decimal, to_string_large_number) {
+TEST(to_string_large_number) {
   const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
   EXPECT_EQ(value.to_string(), "123456789012345678901234567890");
 }
 
-TEST(Numeric_decimal, construct_from_string_view) {
+TEST(construct_from_string_view) {
   const std::string_view view{"42.5"};
   const sourcemeta::core::Decimal value{view};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"42.5"});
 }
 
-TEST(Numeric_decimal, construct_from_string_view_large) {
+TEST(construct_from_string_view_large) {
   const std::string_view view{"999999999999999999999"};
   const sourcemeta::core::Decimal value{view};
   EXPECT_EQ(value.to_string(), "999999999999999999999");
 }
 
-TEST(Numeric_decimal, is_int32_true) {
+TEST(is_int32_true) {
   const sourcemeta::core::Decimal value{1000};
   EXPECT_TRUE(value.is_int32());
 }
 
-TEST(Numeric_decimal, is_int32_false_too_large) {
+TEST(is_int32_false_too_large) {
   const sourcemeta::core::Decimal value{"3000000000"};
   EXPECT_FALSE(value.is_int32());
 }
 
-TEST(Numeric_decimal, is_int32_min_max) {
+TEST(is_int32_min_max) {
   const sourcemeta::core::Decimal min{-2147483648LL};
   const sourcemeta::core::Decimal max{2147483647};
   EXPECT_TRUE(min.is_int32());
   EXPECT_TRUE(max.is_int32());
 }
 
-TEST(Numeric_decimal, is_int64_true) {
+TEST(is_int64_true) {
   const sourcemeta::core::Decimal value{123456789012345LL};
   EXPECT_TRUE(value.is_int64());
 }
 
-TEST(Numeric_decimal, is_int64_false_too_large) {
+TEST(is_int64_false_too_large) {
   const sourcemeta::core::Decimal value{"99999999999999999999"};
   EXPECT_FALSE(value.is_int64());
 }
 
-TEST(Numeric_decimal, is_uint32_true) {
+TEST(is_uint32_true) {
   const sourcemeta::core::Decimal value{4000000000U};
   EXPECT_TRUE(value.is_uint32());
 }
 
-TEST(Numeric_decimal, is_uint32_false_negative) {
+TEST(is_uint32_false_negative) {
   const sourcemeta::core::Decimal value{-1};
   EXPECT_FALSE(value.is_uint32());
 }
 
-TEST(Numeric_decimal, is_uint32_false_too_large) {
+TEST(is_uint32_false_too_large) {
   const sourcemeta::core::Decimal value{"5000000000"};
   EXPECT_FALSE(value.is_uint32());
 }
 
-TEST(Numeric_decimal, is_uint32_max) {
+TEST(is_uint32_max) {
   const sourcemeta::core::Decimal max{4294967295U};
   EXPECT_TRUE(max.is_uint32());
 }
 
-TEST(Numeric_decimal, is_uint64_true) {
+TEST(is_uint64_true) {
   const sourcemeta::core::Decimal value{"18446744073709551615"};
   EXPECT_TRUE(value.is_uint64());
 }
 
-TEST(Numeric_decimal, is_uint64_false_negative) {
+TEST(is_uint64_false_negative) {
   const sourcemeta::core::Decimal value{-100};
   EXPECT_FALSE(value.is_uint64());
 }
 
-TEST(Numeric_decimal, is_uint64_false_too_large) {
+TEST(is_uint64_false_too_large) {
   const sourcemeta::core::Decimal value{"18446744073709551616"};
   EXPECT_FALSE(value.is_uint64());
 }
 
-TEST(Numeric_decimal, exception_conversion_syntax_invalid_string) {
+TEST(exception_conversion_syntax_invalid_string) {
   try {
     const sourcemeta::core::Decimal value{"not_a_number"};
     FAIL();
@@ -1433,7 +1432,7 @@ TEST(Numeric_decimal, exception_conversion_syntax_invalid_string) {
   }
 }
 
-TEST(Numeric_decimal, exception_conversion_syntax_empty_string) {
+TEST(exception_conversion_syntax_empty_string) {
   try {
     const sourcemeta::core::Decimal value{""};
     FAIL();
@@ -1442,7 +1441,7 @@ TEST(Numeric_decimal, exception_conversion_syntax_empty_string) {
   }
 }
 
-TEST(Numeric_decimal, exception_conversion_syntax_invalid_exponent) {
+TEST(exception_conversion_syntax_invalid_exponent) {
   try {
     const sourcemeta::core::Decimal value{"123e"};
     FAIL();
@@ -1451,7 +1450,7 @@ TEST(Numeric_decimal, exception_conversion_syntax_invalid_exponent) {
   }
 }
 
-TEST(Numeric_decimal, exception_conversion_syntax_multiple_dots) {
+TEST(exception_conversion_syntax_multiple_dots) {
   try {
     const sourcemeta::core::Decimal value{"12.34.56"};
     FAIL();
@@ -1460,7 +1459,7 @@ TEST(Numeric_decimal, exception_conversion_syntax_multiple_dots) {
   }
 }
 
-TEST(Numeric_decimal, exception_division_by_zero_divide) {
+TEST(exception_division_by_zero_divide) {
   const sourcemeta::core::Decimal numerator{10};
   const sourcemeta::core::Decimal denominator{0};
   try {
@@ -1471,7 +1470,7 @@ TEST(Numeric_decimal, exception_division_by_zero_divide) {
   }
 }
 
-TEST(Numeric_decimal, exception_division_by_zero_divide_assign) {
+TEST(exception_division_by_zero_divide_assign) {
   sourcemeta::core::Decimal numerator{10};
   const sourcemeta::core::Decimal denominator{0};
   try {
@@ -1482,7 +1481,7 @@ TEST(Numeric_decimal, exception_division_by_zero_divide_assign) {
   }
 }
 
-TEST(Numeric_decimal, exception_invalid_operation_modulo_by_zero) {
+TEST(exception_invalid_operation_modulo_by_zero) {
   const sourcemeta::core::Decimal numerator{10};
   const sourcemeta::core::Decimal denominator{0};
   try {
@@ -1493,7 +1492,7 @@ TEST(Numeric_decimal, exception_invalid_operation_modulo_by_zero) {
   }
 }
 
-TEST(Numeric_decimal, exception_invalid_operation_modulo_assign_by_zero) {
+TEST(exception_invalid_operation_modulo_assign_by_zero) {
   sourcemeta::core::Decimal numerator{10};
   const sourcemeta::core::Decimal denominator{0};
   try {
@@ -1504,7 +1503,7 @@ TEST(Numeric_decimal, exception_invalid_operation_modulo_assign_by_zero) {
   }
 }
 
-TEST(Numeric_decimal, exception_invalid_operation_zero_divided_by_zero) {
+TEST(exception_invalid_operation_zero_divided_by_zero) {
   const sourcemeta::core::Decimal zero{0};
   try {
     const auto result = zero / zero;
@@ -1514,7 +1513,7 @@ TEST(Numeric_decimal, exception_invalid_operation_zero_divided_by_zero) {
   }
 }
 
-TEST(Numeric_decimal, exception_invalid_operation_zero_modulo_zero) {
+TEST(exception_invalid_operation_zero_modulo_zero) {
   const sourcemeta::core::Decimal zero{0};
   try {
     const auto result = zero % zero;
@@ -1524,7 +1523,7 @@ TEST(Numeric_decimal, exception_invalid_operation_zero_modulo_zero) {
   }
 }
 
-TEST(Numeric_decimal, exception_overflow_multiplication) {
+TEST(exception_overflow_multiplication) {
   const sourcemeta::core::Decimal large{"9e999999999999999999"};
   const sourcemeta::core::Decimal multiplier{10};
   try {
@@ -1535,7 +1534,7 @@ TEST(Numeric_decimal, exception_overflow_multiplication) {
   }
 }
 
-TEST(Numeric_decimal, exception_overflow_addition) {
+TEST(exception_overflow_addition) {
   const sourcemeta::core::Decimal large{"9e999999999999999999"};
   const sourcemeta::core::Decimal addend{"9e999999999999999999"};
   try {
@@ -1546,21 +1545,21 @@ TEST(Numeric_decimal, exception_overflow_addition) {
   }
 }
 
-TEST(Numeric_decimal, copy_constructor_preserves_negative_sign) {
+TEST(copy_constructor_preserves_negative_sign) {
   const sourcemeta::core::Decimal original{"-123.456"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_EQ(copy.to_string(), "-123.456");
   EXPECT_TRUE(copy.is_signed());
 }
 
-TEST(Numeric_decimal, move_constructor_preserves_negative_sign) {
+TEST(move_constructor_preserves_negative_sign) {
   sourcemeta::core::Decimal original{"-789.012"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_EQ(moved.to_string(), "-789.012");
   EXPECT_TRUE(moved.is_signed());
 }
 
-TEST(Numeric_decimal, copy_assignment_preserves_negative_sign) {
+TEST(copy_assignment_preserves_negative_sign) {
   const sourcemeta::core::Decimal original{"-999.999"};
   sourcemeta::core::Decimal target{42};
   target = original;
@@ -1568,7 +1567,7 @@ TEST(Numeric_decimal, copy_assignment_preserves_negative_sign) {
   EXPECT_TRUE(target.is_signed());
 }
 
-TEST(Numeric_decimal, move_assignment_preserves_negative_sign) {
+TEST(move_assignment_preserves_negative_sign) {
   sourcemeta::core::Decimal original{"-111.222"};
   sourcemeta::core::Decimal target{99};
   target = std::move(original);
@@ -1576,7 +1575,7 @@ TEST(Numeric_decimal, move_assignment_preserves_negative_sign) {
   EXPECT_TRUE(target.is_signed());
 }
 
-TEST(Numeric_decimal, multiple_copies_preserve_negative_sign) {
+TEST(multiple_copies_preserve_negative_sign) {
   const sourcemeta::core::Decimal first{"-55.55"};
   const sourcemeta::core::Decimal second{first};
   const sourcemeta::core::Decimal third{second};
@@ -1585,7 +1584,7 @@ TEST(Numeric_decimal, multiple_copies_preserve_negative_sign) {
   EXPECT_TRUE(fourth.is_signed());
 }
 
-TEST(Numeric_decimal, copy_then_move_preserves_negative_sign) {
+TEST(copy_then_move_preserves_negative_sign) {
   const sourcemeta::core::Decimal original{"-333.333"};
   sourcemeta::core::Decimal copy{original};
   const sourcemeta::core::Decimal moved{std::move(copy)};
@@ -1593,7 +1592,7 @@ TEST(Numeric_decimal, copy_then_move_preserves_negative_sign) {
   EXPECT_TRUE(moved.is_signed());
 }
 
-TEST(Numeric_decimal, move_then_copy_preserves_negative_sign) {
+TEST(move_then_copy_preserves_negative_sign) {
   sourcemeta::core::Decimal original{"-444.444"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   const sourcemeta::core::Decimal copy{moved};
@@ -1601,63 +1600,63 @@ TEST(Numeric_decimal, move_then_copy_preserves_negative_sign) {
   EXPECT_TRUE(copy.is_signed());
 }
 
-TEST(Numeric_decimal, negative_integer_copy) {
+TEST(negative_integer_copy) {
   const sourcemeta::core::Decimal original{-12345};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_EQ(copy.to_int64(), -12345);
   EXPECT_TRUE(copy.is_signed());
 }
 
-TEST(Numeric_decimal, negative_integer_move) {
+TEST(negative_integer_move) {
   sourcemeta::core::Decimal original{-98765};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_EQ(moved.to_int64(), -98765);
   EXPECT_TRUE(moved.is_signed());
 }
 
-TEST(Numeric_decimal, very_small_negative_copy) {
+TEST(very_small_negative_copy) {
   const sourcemeta::core::Decimal original{"-0.000000000000001"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_TRUE(copy.is_signed());
   EXPECT_TRUE(copy < sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, very_small_negative_move) {
+TEST(very_small_negative_move) {
   sourcemeta::core::Decimal original{"-0.000000000000001"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_TRUE(moved.is_signed());
   EXPECT_TRUE(moved < sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, large_negative_number_copy) {
+TEST(large_negative_number_copy) {
   const sourcemeta::core::Decimal original{"-999999999999999999999999999999"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_EQ(copy.to_string(), "-999999999999999999999999999999");
   EXPECT_TRUE(copy.is_signed());
 }
 
-TEST(Numeric_decimal, large_negative_number_move) {
+TEST(large_negative_number_move) {
   sourcemeta::core::Decimal original{"-888888888888888888888888888888"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_EQ(moved.to_string(), "-888888888888888888888888888888");
   EXPECT_TRUE(moved.is_signed());
 }
 
-TEST(Numeric_decimal, negative_scientific_notation_copy) {
+TEST(negative_scientific_notation_copy) {
   const sourcemeta::core::Decimal original{"-1.23e50"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_TRUE(copy.is_signed());
   EXPECT_TRUE(copy < sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, negative_scientific_notation_move) {
+TEST(negative_scientific_notation_move) {
   sourcemeta::core::Decimal original{"-9.87e-20"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_TRUE(moved.is_signed());
   EXPECT_TRUE(moved < sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, assignment_chain_with_negative) {
+TEST(assignment_chain_with_negative) {
   const sourcemeta::core::Decimal original{"-777.777"};
   sourcemeta::core::Decimal first{1};
   sourcemeta::core::Decimal second{2};
@@ -1669,32 +1668,32 @@ TEST(Numeric_decimal, assignment_chain_with_negative) {
   EXPECT_TRUE(third.is_signed());
 }
 
-TEST(Numeric_decimal, positive_not_signed_after_copy) {
+TEST(positive_not_signed_after_copy) {
   const sourcemeta::core::Decimal original{"123.456"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_FALSE(copy.is_signed());
 }
 
-TEST(Numeric_decimal, positive_not_signed_after_move) {
+TEST(positive_not_signed_after_move) {
   sourcemeta::core::Decimal original{"789.012"};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_FALSE(moved.is_signed());
 }
 
-TEST(Numeric_decimal, zero_not_signed_after_copy) {
+TEST(zero_not_signed_after_copy) {
   const sourcemeta::core::Decimal original{0};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_FALSE(copy.is_signed());
 }
 
-TEST(Numeric_decimal, negative_zero_preserves_sign) {
+TEST(negative_zero_preserves_sign) {
   const sourcemeta::core::Decimal original{"-0"};
   const sourcemeta::core::Decimal copy{original};
   EXPECT_TRUE(copy.is_signed());
   EXPECT_TRUE(copy.is_zero());
 }
 
-TEST(Numeric_decimal, construct_from_float_simple) {
+TEST(construct_from_float_simple) {
   const float value{3.5f};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_float());
@@ -1704,7 +1703,7 @@ TEST(Numeric_decimal, construct_from_float_simple) {
   EXPECT_EQ(decimal.to_string(), "3.5");
 }
 
-TEST(Numeric_decimal, construct_from_float_negative) {
+TEST(construct_from_float_negative) {
   const float value{-7.25f};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_float());
@@ -1714,7 +1713,7 @@ TEST(Numeric_decimal, construct_from_float_negative) {
   EXPECT_EQ(decimal.to_string(), "-7.25");
 }
 
-TEST(Numeric_decimal, construct_from_float_zero) {
+TEST(construct_from_float_zero) {
   const float value{0.0f};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_float());
@@ -1724,7 +1723,7 @@ TEST(Numeric_decimal, construct_from_float_zero) {
   EXPECT_EQ(decimal.to_double(), 0.0);
 }
 
-TEST(Numeric_decimal, construct_from_float_very_small) {
+TEST(construct_from_float_very_small) {
   const float value{0.125f};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_float());
@@ -1734,7 +1733,7 @@ TEST(Numeric_decimal, construct_from_float_very_small) {
   EXPECT_EQ(decimal.to_string(), "0.125");
 }
 
-TEST(Numeric_decimal, construct_from_double_simple) {
+TEST(construct_from_double_simple) {
   const double value{3.5};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_double());
@@ -1742,7 +1741,7 @@ TEST(Numeric_decimal, construct_from_double_simple) {
   EXPECT_EQ(decimal.to_string(), "3.5");
 }
 
-TEST(Numeric_decimal, construct_from_double_negative) {
+TEST(construct_from_double_negative) {
   const double value{-7.25};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_double());
@@ -1750,7 +1749,7 @@ TEST(Numeric_decimal, construct_from_double_negative) {
   EXPECT_EQ(decimal.to_string(), "-7.25");
 }
 
-TEST(Numeric_decimal, construct_from_double_zero) {
+TEST(construct_from_double_zero) {
   const double value{0.0};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_double());
@@ -1758,7 +1757,7 @@ TEST(Numeric_decimal, construct_from_double_zero) {
   EXPECT_EQ(decimal.to_double(), 0.0);
 }
 
-TEST(Numeric_decimal, construct_from_double_very_small) {
+TEST(construct_from_double_very_small) {
   const double value{0.125};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_double());
@@ -1766,7 +1765,7 @@ TEST(Numeric_decimal, construct_from_double_very_small) {
   EXPECT_EQ(decimal.to_string(), "0.125");
 }
 
-TEST(Numeric_decimal, construct_from_double_roundtrip) {
+TEST(construct_from_double_roundtrip) {
   const double value{3.2};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_double());
@@ -1774,7 +1773,7 @@ TEST(Numeric_decimal, construct_from_double_roundtrip) {
   EXPECT_EQ(roundtrip, value);
 }
 
-TEST(Numeric_decimal, construct_from_float_roundtrip) {
+TEST(construct_from_float_roundtrip) {
   const float value{3.2f};
   const sourcemeta::core::Decimal decimal{value};
   EXPECT_TRUE(decimal.is_float());
@@ -1782,21 +1781,21 @@ TEST(Numeric_decimal, construct_from_float_roundtrip) {
   EXPECT_EQ(roundtrip, value);
 }
 
-TEST(Numeric_decimal, construct_from_double_high_precision) {
+TEST(construct_from_double_high_precision) {
   const double value{1.234567890123456};
   const sourcemeta::core::Decimal decimal{value};
   const double roundtrip{decimal.to_double()};
   EXPECT_EQ(roundtrip, value);
 }
 
-TEST(Numeric_decimal, construct_from_float_high_precision) {
+TEST(construct_from_float_high_precision) {
   const float value{1.234567f};
   const sourcemeta::core::Decimal decimal{value};
   const float roundtrip{decimal.to_float()};
   EXPECT_EQ(roundtrip, value);
 }
 
-TEST(Numeric_decimal, multithreaded_construction) {
+TEST(multithreaded_construction) {
   constexpr int number_of_threads{4};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -1815,7 +1814,7 @@ TEST(Numeric_decimal, multithreaded_construction) {
   }
 }
 
-TEST(Numeric_decimal, factory_snan) {
+TEST(factory_snan) {
   const auto snan_value{sourcemeta::core::Decimal::snan()};
   EXPECT_TRUE(snan_value.is_nan());
   EXPECT_TRUE(snan_value.is_snan());
@@ -1824,7 +1823,7 @@ TEST(Numeric_decimal, factory_snan) {
   EXPECT_FALSE(snan_value.is_infinite());
 }
 
-TEST(Numeric_decimal, factory_nan_with_payload) {
+TEST(factory_nan_with_payload) {
   const auto nan_value{sourcemeta::core::Decimal::nan(123)};
   EXPECT_TRUE(nan_value.is_nan());
   EXPECT_TRUE(nan_value.is_qnan());
@@ -1832,7 +1831,7 @@ TEST(Numeric_decimal, factory_nan_with_payload) {
   EXPECT_EQ(nan_value.nan_payload(), 123);
 }
 
-TEST(Numeric_decimal, factory_snan_with_payload) {
+TEST(factory_snan_with_payload) {
   const auto snan_value{sourcemeta::core::Decimal::snan(456)};
   EXPECT_TRUE(snan_value.is_nan());
   EXPECT_TRUE(snan_value.is_snan());
@@ -1840,53 +1839,53 @@ TEST(Numeric_decimal, factory_snan_with_payload) {
   EXPECT_EQ(snan_value.nan_payload(), 456);
 }
 
-TEST(Numeric_decimal, is_snan_false_for_qnan) {
+TEST(is_snan_false_for_qnan) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_FALSE(nan_value.is_snan());
   EXPECT_TRUE(nan_value.is_qnan());
 }
 
-TEST(Numeric_decimal, is_qnan_false_for_snan) {
+TEST(is_qnan_false_for_snan) {
   const auto snan_value{sourcemeta::core::Decimal::snan()};
   EXPECT_FALSE(snan_value.is_qnan());
   EXPECT_TRUE(snan_value.is_snan());
 }
 
-TEST(Numeric_decimal, is_nan_true_for_both) {
+TEST(is_nan_true_for_both) {
   EXPECT_TRUE(sourcemeta::core::Decimal::nan().is_nan());
   EXPECT_TRUE(sourcemeta::core::Decimal::snan().is_nan());
 }
 
-TEST(Numeric_decimal, nan_payload_zero_for_plain_nan) {
+TEST(nan_payload_zero_for_plain_nan) {
   EXPECT_EQ(sourcemeta::core::Decimal::nan().nan_payload(), 0);
 }
 
-TEST(Numeric_decimal, nan_payload_zero_for_plain_snan) {
+TEST(nan_payload_zero_for_plain_snan) {
   EXPECT_EQ(sourcemeta::core::Decimal::snan().nan_payload(), 0);
 }
 
-TEST(Numeric_decimal, parse_snan_string) {
+TEST(parse_snan_string) {
   const sourcemeta::core::Decimal value{"sNaN"};
   EXPECT_TRUE(value.is_nan());
   EXPECT_TRUE(value.is_snan());
   EXPECT_EQ(value.nan_payload(), 0);
 }
 
-TEST(Numeric_decimal, parse_nan_with_payload_string) {
+TEST(parse_nan_with_payload_string) {
   const sourcemeta::core::Decimal value{"NaN123"};
   EXPECT_TRUE(value.is_nan());
   EXPECT_TRUE(value.is_qnan());
   EXPECT_EQ(value.nan_payload(), 123);
 }
 
-TEST(Numeric_decimal, parse_snan_with_payload_string) {
+TEST(parse_snan_with_payload_string) {
   const sourcemeta::core::Decimal value{"sNaN789"};
   EXPECT_TRUE(value.is_nan());
   EXPECT_TRUE(value.is_snan());
   EXPECT_EQ(value.nan_payload(), 789);
 }
 
-TEST(Numeric_decimal, snan_arithmetic_produces_qnan) {
+TEST(snan_arithmetic_produces_qnan) {
   const auto snan_value{sourcemeta::core::Decimal::snan()};
   const auto result{snan_value + sourcemeta::core::Decimal{1}};
   EXPECT_TRUE(result.is_nan());
@@ -1894,164 +1893,164 @@ TEST(Numeric_decimal, snan_arithmetic_produces_qnan) {
   EXPECT_FALSE(result.is_snan());
 }
 
-TEST(Numeric_decimal, equal_different_scale_integer) {
+TEST(equal_different_scale_integer) {
   EXPECT_EQ(sourcemeta::core::Decimal{"1.0"}, sourcemeta::core::Decimal{1});
   EXPECT_EQ(sourcemeta::core::Decimal{"2.00"}, sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_decimal, equal_different_scale_decimal) {
+TEST(equal_different_scale_decimal) {
   EXPECT_EQ(sourcemeta::core::Decimal{"0.10"},
             sourcemeta::core::Decimal{"0.1"});
 }
 
-TEST(Numeric_decimal, equal_different_scale_zero) {
+TEST(equal_different_scale_zero) {
   EXPECT_EQ(sourcemeta::core::Decimal{"0.0"}, sourcemeta::core::Decimal{0});
   EXPECT_EQ(sourcemeta::core::Decimal{"0.00"}, sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, equal_integer_vs_exponent_form) {
+TEST(equal_integer_vs_exponent_form) {
   EXPECT_EQ(sourcemeta::core::Decimal{100}, sourcemeta::core::Decimal{"1e2"});
 }
 
-TEST(Numeric_decimal, equal_decimal_vs_exponent_form) {
+TEST(equal_decimal_vs_exponent_form) {
   EXPECT_EQ(sourcemeta::core::Decimal{"0.1"},
             sourcemeta::core::Decimal{"1e-1"});
 }
 
-TEST(Numeric_decimal, compare_nan_not_equal_to_self) {
+TEST(compare_nan_not_equal_to_self) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_FALSE(nan_value == nan_value);
 }
 
-TEST(Numeric_decimal, compare_nan_not_equal_to_nan) {
+TEST(compare_nan_not_equal_to_nan) {
   EXPECT_FALSE(sourcemeta::core::Decimal::nan() ==
                sourcemeta::core::Decimal::nan());
 }
 
-TEST(Numeric_decimal, compare_nan_not_less_than_anything) {
+TEST(compare_nan_not_less_than_anything) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_FALSE(nan_value < sourcemeta::core::Decimal{5});
   EXPECT_FALSE(nan_value < sourcemeta::core::Decimal::infinity());
 }
 
-TEST(Numeric_decimal, compare_nan_not_greater_than_anything) {
+TEST(compare_nan_not_greater_than_anything) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_FALSE(nan_value > sourcemeta::core::Decimal{5});
   EXPECT_FALSE(nan_value > sourcemeta::core::Decimal::negative_infinity());
 }
 
-TEST(Numeric_decimal, compare_nan_not_less_equal_anything) {
+TEST(compare_nan_not_less_equal_anything) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_FALSE(nan_value <= sourcemeta::core::Decimal{5});
 }
 
-TEST(Numeric_decimal, compare_nan_not_greater_equal_anything) {
+TEST(compare_nan_not_greater_equal_anything) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_FALSE(nan_value >= sourcemeta::core::Decimal{5});
 }
 
-TEST(Numeric_decimal, compare_nan_not_equal_finite) {
+TEST(compare_nan_not_equal_finite) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_TRUE(nan_value != sourcemeta::core::Decimal{0});
   EXPECT_TRUE(nan_value != sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, compare_nan_not_equal_infinity) {
+TEST(compare_nan_not_equal_infinity) {
   const auto nan_value{sourcemeta::core::Decimal::nan()};
   EXPECT_TRUE(nan_value != sourcemeta::core::Decimal::infinity());
   EXPECT_TRUE(nan_value != sourcemeta::core::Decimal::negative_infinity());
 }
 
-TEST(Numeric_decimal, compare_infinity_equal_infinity) {
+TEST(compare_infinity_equal_infinity) {
   EXPECT_EQ(sourcemeta::core::Decimal::infinity(),
             sourcemeta::core::Decimal::infinity());
 }
 
-TEST(Numeric_decimal, compare_negative_infinity_equal_negative_infinity) {
+TEST(compare_negative_infinity_equal_negative_infinity) {
   EXPECT_EQ(sourcemeta::core::Decimal::negative_infinity(),
             sourcemeta::core::Decimal::negative_infinity());
 }
 
-TEST(Numeric_decimal, compare_infinity_not_equal_negative_infinity) {
+TEST(compare_infinity_not_equal_negative_infinity) {
   EXPECT_NE(sourcemeta::core::Decimal::infinity(),
             sourcemeta::core::Decimal::negative_infinity());
 }
 
-TEST(Numeric_decimal, compare_infinity_greater_than_finite) {
+TEST(compare_infinity_greater_than_finite) {
   EXPECT_TRUE(sourcemeta::core::Decimal::infinity() >
               sourcemeta::core::Decimal{999999});
 }
 
-TEST(Numeric_decimal, compare_negative_infinity_less_than_finite) {
+TEST(compare_negative_infinity_less_than_finite) {
   EXPECT_TRUE(sourcemeta::core::Decimal::negative_infinity() <
               sourcemeta::core::Decimal{-999999});
 }
 
-TEST(Numeric_decimal, compare_infinity_greater_than_large_number) {
+TEST(compare_infinity_greater_than_large_number) {
   EXPECT_TRUE(sourcemeta::core::Decimal::infinity() >
               sourcemeta::core::Decimal{"9e999999"});
 }
 
-TEST(Numeric_decimal, compare_negative_infinity_less_than_large_negative) {
+TEST(compare_negative_infinity_less_than_large_negative) {
   EXPECT_TRUE(sourcemeta::core::Decimal::negative_infinity() <
               sourcemeta::core::Decimal{"-9e999999"});
 }
 
-TEST(Numeric_decimal, compare_negative_zero_equal_zero) {
+TEST(compare_negative_zero_equal_zero) {
   EXPECT_EQ(sourcemeta::core::Decimal{"-0"}, sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, compare_negative_zero_less_equal_zero) {
+TEST(compare_negative_zero_less_equal_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"-0"} <= sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, compare_negative_zero_greater_equal_zero) {
+TEST(compare_negative_zero_greater_equal_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"-0"} >= sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, compare_very_different_magnitudes) {
+TEST(compare_very_different_magnitudes) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"1e-300"} <
               sourcemeta::core::Decimal{"1e300"});
 }
 
-TEST(Numeric_decimal, compare_adjacent_values) {
+TEST(compare_adjacent_values) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"1.000000000000000"} <
               sourcemeta::core::Decimal{"1.000000000000001"});
 }
 
-TEST(Numeric_decimal, compare_sign_difference) {
+TEST(compare_sign_difference) {
   EXPECT_TRUE(sourcemeta::core::Decimal{5} > sourcemeta::core::Decimal{-5});
   EXPECT_TRUE(sourcemeta::core::Decimal{-5} < sourcemeta::core::Decimal{5});
 }
 
-TEST(Numeric_decimal, compare_reflexive_zero) {
+TEST(compare_reflexive_zero) {
   const sourcemeta::core::Decimal value{0};
   EXPECT_EQ(value, value);
 }
 
-TEST(Numeric_decimal, compare_reflexive_positive) {
+TEST(compare_reflexive_positive) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_EQ(value, value);
 }
 
-TEST(Numeric_decimal, compare_reflexive_negative) {
+TEST(compare_reflexive_negative) {
   const sourcemeta::core::Decimal value{-1};
   EXPECT_EQ(value, value);
 }
 
-TEST(Numeric_decimal, compare_reflexive_decimal) {
+TEST(compare_reflexive_decimal) {
   const sourcemeta::core::Decimal value{"3.14"};
   EXPECT_EQ(value, value);
 }
 
-TEST(Numeric_decimal, compare_symmetric) {
+TEST(compare_symmetric) {
   const sourcemeta::core::Decimal small{3};
   const sourcemeta::core::Decimal large{7};
   EXPECT_TRUE(small < large);
   EXPECT_TRUE(large > small);
 }
 
-TEST(Numeric_decimal, compare_transitive) {
+TEST(compare_transitive) {
   const sourcemeta::core::Decimal first{1};
   const sourcemeta::core::Decimal second{5};
   const sourcemeta::core::Decimal third{10};
@@ -2060,403 +2059,401 @@ TEST(Numeric_decimal, compare_transitive) {
   EXPECT_TRUE(first < third);
 }
 
-TEST(Numeric_decimal, compare_positive_greater_than_zero) {
+TEST(compare_positive_greater_than_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{1} > sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, compare_negative_less_than_zero) {
+TEST(compare_negative_less_than_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{-1} < sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, compare_zero_equals_zero) {
+TEST(compare_zero_equals_zero) {
   EXPECT_EQ(sourcemeta::core::Decimal{0}, sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, divisible_by_zero_dividend_nonzero_divisor) {
+TEST(divisible_by_zero_dividend_nonzero_divisor) {
   const sourcemeta::core::Decimal dividend{0};
   const sourcemeta::core::Decimal divisor{5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_zero_dividend_zero_divisor) {
+TEST(divisible_by_zero_dividend_zero_divisor) {
   const sourcemeta::core::Decimal dividend{0};
   const sourcemeta::core::Decimal divisor{0};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_negative_divisor_true) {
+TEST(divisible_by_negative_divisor_true) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{-5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_negative_divisor_false) {
+TEST(divisible_by_negative_divisor_false) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{-3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_both_negative_true) {
+TEST(divisible_by_both_negative_true) {
   const sourcemeta::core::Decimal dividend{-10};
   const sourcemeta::core::Decimal divisor{-5};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_both_negative_false) {
+TEST(divisible_by_both_negative_false) {
   const sourcemeta::core::Decimal dividend{-7};
   const sourcemeta::core::Decimal divisor{-3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_fractional_tenth_true) {
+TEST(divisible_by_fractional_tenth_true) {
   const sourcemeta::core::Decimal dividend{"1.0"};
   const sourcemeta::core::Decimal divisor{"0.1"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_fractional_tenth_false_repeating) {
+TEST(divisible_by_fractional_tenth_false_repeating) {
   const sourcemeta::core::Decimal dividend{"1.0"};
   const sourcemeta::core::Decimal divisor{"0.3"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_fractional_quarter_true) {
+TEST(divisible_by_fractional_quarter_true) {
   const sourcemeta::core::Decimal dividend{"0.75"};
   const sourcemeta::core::Decimal divisor{"0.25"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_fractional_hundredth_true) {
+TEST(divisible_by_fractional_hundredth_true) {
   const sourcemeta::core::Decimal dividend{"0.1"};
   const sourcemeta::core::Decimal divisor{"0.01"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_one_tenth) {
+TEST(divisible_by_one_tenth) {
   const sourcemeta::core::Decimal dividend{1};
   const sourcemeta::core::Decimal divisor{"0.1"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_two_tenths) {
+TEST(divisible_by_two_tenths) {
   const sourcemeta::core::Decimal dividend{2};
   const sourcemeta::core::Decimal divisor{"0.1"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_three_tenths_true) {
+TEST(divisible_by_three_tenths_true) {
   const sourcemeta::core::Decimal dividend{"0.3"};
   const sourcemeta::core::Decimal divisor{"0.1"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_six_tenths_by_two_tenths_true) {
+TEST(divisible_by_six_tenths_by_two_tenths_true) {
   const sourcemeta::core::Decimal dividend{"0.6"};
   const sourcemeta::core::Decimal divisor{"0.2"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_twelve_tenths_by_four_tenths_true) {
+TEST(divisible_by_twelve_tenths_by_four_tenths_true) {
   const sourcemeta::core::Decimal dividend{"1.2"};
   const sourcemeta::core::Decimal divisor{"0.4"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_ten_by_tenth_true) {
+TEST(divisible_by_ten_by_tenth_true) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{"0.1"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_ten_by_third_false) {
+TEST(divisible_by_ten_by_third_false) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{"0.3"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_one_by_thousandth_true) {
+TEST(divisible_by_one_by_thousandth_true) {
   const sourcemeta::core::Decimal dividend{1};
   const sourcemeta::core::Decimal divisor{"0.001"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_hundredths_true) {
+TEST(divisible_by_hundredths_true) {
   const sourcemeta::core::Decimal dividend{"0.0075"};
   const sourcemeta::core::Decimal divisor{"0.0001"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_hundredths_false) {
+TEST(divisible_by_hundredths_false) {
   const sourcemeta::core::Decimal dividend{"0.00751"};
   const sourcemeta::core::Decimal divisor{"0.0001"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_hundred_by_hundredth_true) {
+TEST(divisible_by_hundred_by_hundredth_true) {
   const sourcemeta::core::Decimal dividend{100};
   const sourcemeta::core::Decimal divisor{"0.01"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_tiny_self_divisible) {
+TEST(divisible_by_tiny_self_divisible) {
   const sourcemeta::core::Decimal dividend{"0.0000001"};
   const sourcemeta::core::Decimal divisor{"0.0000001"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_large_integer_by_three_true) {
+TEST(divisible_by_large_integer_by_three_true) {
   const sourcemeta::core::Decimal dividend{"999999999999999999"};
   const sourcemeta::core::Decimal divisor{3};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_large_integer_by_three_false) {
+TEST(divisible_by_large_integer_by_three_false) {
   const sourcemeta::core::Decimal dividend{"999999999999999997"};
   const sourcemeta::core::Decimal divisor{3};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_large_quotient_exceeding_int64) {
+TEST(divisible_by_large_quotient_exceeding_int64) {
   const sourcemeta::core::Decimal dividend{"99999999999999999999999999"};
   const sourcemeta::core::Decimal divisor{1};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_different_scale_alignment) {
+TEST(divisible_by_different_scale_alignment) {
   const sourcemeta::core::Decimal dividend{"1000000.000000"};
   const sourcemeta::core::Decimal divisor{"0.000001"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_seven_point_five_by_two_point_five_true) {
+TEST(divisible_by_seven_point_five_by_two_point_five_true) {
   const sourcemeta::core::Decimal dividend{"7.5"};
   const sourcemeta::core::Decimal divisor{"2.5"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_mixed_integer_decimal_true) {
+TEST(divisible_by_mixed_integer_decimal_true) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{"2.5"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_mixed_integer_decimal_false) {
+TEST(divisible_by_mixed_integer_decimal_false) {
   const sourcemeta::core::Decimal dividend{10};
   const sourcemeta::core::Decimal divisor{"3.3"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal,
-     divisible_by_point_zero_zero_seven_five_by_point_zero_zero_zero_one_true) {
+TEST(divisible_by_point_zero_zero_seven_five_by_point_zero_zero_zero_one_true) {
   const sourcemeta::core::Decimal dividend{"0.0075"};
   const sourcemeta::core::Decimal divisor{"0.0001"};
   EXPECT_TRUE(dividend.divisible_by(divisor));
 }
 
 TEST(
-    Numeric_decimal,
     divisible_by_point_zero_zero_seven_five_one_by_point_zero_zero_zero_one_false) {
   const sourcemeta::core::Decimal dividend{"0.00751"};
   const sourcemeta::core::Decimal divisor{"0.0001"};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_infinity_dividend) {
+TEST(divisible_by_infinity_dividend) {
   const auto dividend{sourcemeta::core::Decimal::infinity()};
   const sourcemeta::core::Decimal divisor{5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_infinity_divisor) {
+TEST(divisible_by_infinity_divisor) {
   const sourcemeta::core::Decimal dividend{5};
   const auto divisor{sourcemeta::core::Decimal::infinity()};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, divisible_by_nan_dividend) {
+TEST(divisible_by_nan_dividend) {
   const auto dividend{sourcemeta::core::Decimal::nan()};
   const sourcemeta::core::Decimal divisor{5};
   EXPECT_FALSE(dividend.divisible_by(divisor));
 }
 
-TEST(Numeric_decimal, parse_leading_zeros) {
+TEST(parse_leading_zeros) {
   const sourcemeta::core::Decimal value{"007"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{7});
 }
 
-TEST(Numeric_decimal, parse_leading_zeros_decimal) {
+TEST(parse_leading_zeros_decimal) {
   const sourcemeta::core::Decimal value{"00.5"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"0.5"});
 }
 
-TEST(Numeric_decimal, parse_explicit_plus_sign) {
+TEST(parse_explicit_plus_sign) {
   const sourcemeta::core::Decimal value{"+123"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{123});
 }
 
-TEST(Numeric_decimal, parse_explicit_plus_zero) {
+TEST(parse_explicit_plus_zero) {
   const sourcemeta::core::Decimal value{"+0"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, parse_explicit_plus_decimal) {
+TEST(parse_explicit_plus_decimal) {
   const sourcemeta::core::Decimal value{"+1.5"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"1.5"});
 }
 
-TEST(Numeric_decimal, parse_scientific_uppercase_no_sign) {
+TEST(parse_scientific_uppercase_no_sign) {
   const sourcemeta::core::Decimal value{"1E10"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"10000000000"});
 }
 
-TEST(Numeric_decimal, parse_scientific_lowercase_no_sign) {
+TEST(parse_scientific_lowercase_no_sign) {
   const sourcemeta::core::Decimal value{"1e10"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"10000000000"});
 }
 
-TEST(Numeric_decimal, parse_scientific_uppercase_plus) {
+TEST(parse_scientific_uppercase_plus) {
   const sourcemeta::core::Decimal value{"1E+10"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"10000000000"});
 }
 
-TEST(Numeric_decimal, parse_scientific_lowercase_plus) {
+TEST(parse_scientific_lowercase_plus) {
   const sourcemeta::core::Decimal value{"1e+10"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"10000000000"});
 }
 
-TEST(Numeric_decimal, parse_scientific_uppercase_minus) {
+TEST(parse_scientific_uppercase_minus) {
   const sourcemeta::core::Decimal value{"1E-10"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"0.0000000001"});
 }
 
-TEST(Numeric_decimal, parse_scientific_lowercase_minus) {
+TEST(parse_scientific_lowercase_minus) {
   const sourcemeta::core::Decimal value{"1e-10"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"0.0000000001"});
 }
 
-TEST(Numeric_decimal, parse_bare_decimal_point_leading) {
+TEST(parse_bare_decimal_point_leading) {
   const sourcemeta::core::Decimal value{".5"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"0.5"});
 }
 
-TEST(Numeric_decimal, parse_bare_decimal_point_leading_negative) {
+TEST(parse_bare_decimal_point_leading_negative) {
   const sourcemeta::core::Decimal value{"-.5"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{"-0.5"});
 }
 
-TEST(Numeric_decimal, parse_bare_decimal_point_trailing) {
+TEST(parse_bare_decimal_point_trailing) {
   const sourcemeta::core::Decimal value{"5."};
   EXPECT_EQ(value, sourcemeta::core::Decimal{5});
 }
 
-TEST(Numeric_decimal, parse_bare_decimal_point_trailing_negative) {
+TEST(parse_bare_decimal_point_trailing_negative) {
   const sourcemeta::core::Decimal value{"-5."};
   EXPECT_EQ(value, sourcemeta::core::Decimal{-5});
 }
 
-TEST(Numeric_decimal, parse_zero_point_zero) {
+TEST(parse_zero_point_zero) {
   const sourcemeta::core::Decimal value{"0.0"};
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_zero_point_zero_zero) {
+TEST(parse_zero_point_zero_zero) {
   const sourcemeta::core::Decimal value{"0.00"};
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_zero_e_zero) {
+TEST(parse_zero_e_zero) {
   const sourcemeta::core::Decimal value{"0e0"};
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_negative_zero) {
+TEST(parse_negative_zero) {
   const sourcemeta::core::Decimal value{"-0"};
   EXPECT_TRUE(value.is_signed());
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_negative_zero_point_zero) {
+TEST(parse_negative_zero_point_zero) {
   const sourcemeta::core::Decimal value{"-0.0"};
   EXPECT_TRUE(value.is_signed());
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_plus_zero) {
+TEST(parse_plus_zero) {
   const sourcemeta::core::Decimal value{"+0"};
   EXPECT_EQ(value, sourcemeta::core::Decimal{0});
   EXPECT_FALSE(value.is_signed());
 }
 
-TEST(Numeric_decimal, parse_zero_with_large_positive_exponent) {
+TEST(parse_zero_with_large_positive_exponent) {
   const sourcemeta::core::Decimal value{"0e100"};
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_zero_with_large_negative_exponent) {
+TEST(parse_zero_with_large_negative_exponent) {
   const sourcemeta::core::Decimal value{"0e-100"};
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, parse_special_nan) {
+TEST(parse_special_nan) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"NaN"}.is_nan());
   EXPECT_TRUE(sourcemeta::core::Decimal{"nan"}.is_nan());
   EXPECT_TRUE(sourcemeta::core::Decimal{"NAN"}.is_nan());
 }
 
-TEST(Numeric_decimal, parse_special_infinity) {
+TEST(parse_special_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"Infinity"}.is_infinite());
   EXPECT_TRUE(sourcemeta::core::Decimal{"infinity"}.is_infinite());
   EXPECT_TRUE(sourcemeta::core::Decimal{"INFINITY"}.is_infinite());
 }
 
-TEST(Numeric_decimal, parse_special_negative_infinity) {
+TEST(parse_special_negative_infinity) {
   const sourcemeta::core::Decimal value{"-Infinity"};
   EXPECT_TRUE(value.is_infinite());
   EXPECT_TRUE(value.is_signed());
 }
 
-TEST(Numeric_decimal, parse_special_inf_shorthand) {
+TEST(parse_special_inf_shorthand) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"Inf"}.is_infinite());
 }
 
-TEST(Numeric_decimal, parse_special_negative_inf_shorthand) {
+TEST(parse_special_negative_inf_shorthand) {
   const sourcemeta::core::Decimal value{"-Inf"};
   EXPECT_TRUE(value.is_infinite());
   EXPECT_TRUE(value.is_signed());
 }
 
-TEST(Numeric_decimal, parse_special_plus_infinity) {
+TEST(parse_special_plus_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"+Infinity"}.is_infinite());
   EXPECT_TRUE(sourcemeta::core::Decimal{"+Inf"}.is_infinite());
 }
 
-TEST(Numeric_decimal, parse_many_digits_integer) {
+TEST(parse_many_digits_integer) {
   const sourcemeta::core::Decimal value{
       "12345678901234567890123456789012345678901234567890"};
   EXPECT_FALSE(value.is_zero());
   EXPECT_TRUE(value.is_finite());
 }
 
-TEST(Numeric_decimal, parse_many_digits_fractional) {
+TEST(parse_many_digits_fractional) {
   const sourcemeta::core::Decimal value{
       "0.12345678901234567890123456789012345678901234567890"};
   EXPECT_FALSE(value.is_zero());
   EXPECT_TRUE(value.is_finite());
 }
 
-TEST(Numeric_decimal, parse_very_large_exponent) {
+TEST(parse_very_large_exponent) {
   const sourcemeta::core::Decimal value{"1e999999"};
   EXPECT_FALSE(value.is_zero());
   EXPECT_TRUE(value.is_finite());
 }
 
-TEST(Numeric_decimal, parse_very_large_negative_exponent) {
+TEST(parse_very_large_negative_exponent) {
   const sourcemeta::core::Decimal value{"1e-999999"};
   EXPECT_FALSE(value.is_zero());
   EXPECT_TRUE(value.is_finite());
 }
 
-TEST(Numeric_decimal, parse_reject_whitespace_leading) {
+TEST(parse_reject_whitespace_leading) {
   try {
     const sourcemeta::core::Decimal value{" 123"};
     FAIL();
@@ -2465,7 +2462,7 @@ TEST(Numeric_decimal, parse_reject_whitespace_leading) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_whitespace_trailing) {
+TEST(parse_reject_whitespace_trailing) {
   try {
     const sourcemeta::core::Decimal value{"123 "};
     FAIL();
@@ -2474,7 +2471,7 @@ TEST(Numeric_decimal, parse_reject_whitespace_trailing) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_whitespace_both) {
+TEST(parse_reject_whitespace_both) {
   try {
     const sourcemeta::core::Decimal value{" 123 "};
     FAIL();
@@ -2483,7 +2480,7 @@ TEST(Numeric_decimal, parse_reject_whitespace_both) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_bare_dot) {
+TEST(parse_reject_bare_dot) {
   try {
     const sourcemeta::core::Decimal value{"."};
     FAIL();
@@ -2492,7 +2489,7 @@ TEST(Numeric_decimal, parse_reject_bare_dot) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_bare_e) {
+TEST(parse_reject_bare_e) {
   try {
     const sourcemeta::core::Decimal value{"e5"};
     FAIL();
@@ -2501,7 +2498,7 @@ TEST(Numeric_decimal, parse_reject_bare_e) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_double_dots) {
+TEST(parse_reject_double_dots) {
   try {
     const sourcemeta::core::Decimal value{"1.2.3"};
     FAIL();
@@ -2510,7 +2507,7 @@ TEST(Numeric_decimal, parse_reject_double_dots) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_double_negative) {
+TEST(parse_reject_double_negative) {
   try {
     const sourcemeta::core::Decimal value{"--1"};
     FAIL();
@@ -2519,7 +2516,7 @@ TEST(Numeric_decimal, parse_reject_double_negative) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_double_plus) {
+TEST(parse_reject_double_plus) {
   try {
     const sourcemeta::core::Decimal value{"++1"};
     FAIL();
@@ -2528,7 +2525,7 @@ TEST(Numeric_decimal, parse_reject_double_plus) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_e_plus_only) {
+TEST(parse_reject_e_plus_only) {
   try {
     const sourcemeta::core::Decimal value{"1e+"};
     FAIL();
@@ -2537,7 +2534,7 @@ TEST(Numeric_decimal, parse_reject_e_plus_only) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_e_minus_only) {
+TEST(parse_reject_e_minus_only) {
   try {
     const sourcemeta::core::Decimal value{"1e-"};
     FAIL();
@@ -2546,7 +2543,7 @@ TEST(Numeric_decimal, parse_reject_e_minus_only) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_double_e) {
+TEST(parse_reject_double_e) {
   try {
     const sourcemeta::core::Decimal value{"1ee5"};
     FAIL();
@@ -2555,7 +2552,7 @@ TEST(Numeric_decimal, parse_reject_double_e) {
   }
 }
 
-TEST(Numeric_decimal, parse_reject_trailing_alpha) {
+TEST(parse_reject_trailing_alpha) {
   try {
     const sourcemeta::core::Decimal value{"123abc"};
     FAIL();
@@ -2564,170 +2561,170 @@ TEST(Numeric_decimal, parse_reject_trailing_alpha) {
   }
 }
 
-TEST(Numeric_decimal, to_string_zero) {
+TEST(to_string_zero) {
   const sourcemeta::core::Decimal value{0};
   EXPECT_EQ(value.to_string(), "0");
 }
 
-TEST(Numeric_decimal, to_string_negative_zero) {
+TEST(to_string_negative_zero) {
   const sourcemeta::core::Decimal value{"-0"};
   EXPECT_EQ(value.to_string(), "-0");
 }
 
-TEST(Numeric_decimal, to_string_zero_point_zero) {
+TEST(to_string_zero_point_zero) {
   const sourcemeta::core::Decimal value{"0.0"};
   EXPECT_EQ(value.to_string(), "0.0");
 }
 
-TEST(Numeric_decimal, to_string_trailing_zeros_preserved) {
+TEST(to_string_trailing_zeros_preserved) {
   const sourcemeta::core::Decimal value{"1.000"};
   EXPECT_EQ(value.to_string(), "1.000");
 }
 
-TEST(Numeric_decimal, to_string_very_small_decimal) {
+TEST(to_string_very_small_decimal) {
   const sourcemeta::core::Decimal value{"0.000000001"};
   EXPECT_EQ(value.to_string(), "1e-9");
 }
 
-TEST(Numeric_decimal, to_string_nan) {
+TEST(to_string_nan) {
   EXPECT_EQ(sourcemeta::core::Decimal::nan().to_string(), "NaN");
 }
 
-TEST(Numeric_decimal, to_string_infinity) {
+TEST(to_string_infinity) {
   EXPECT_EQ(sourcemeta::core::Decimal::infinity().to_string(), "Infinity");
 }
 
-TEST(Numeric_decimal, to_string_negative_infinity) {
+TEST(to_string_negative_infinity) {
   EXPECT_EQ(sourcemeta::core::Decimal::negative_infinity().to_string(),
             "-Infinity");
 }
 
-TEST(Numeric_decimal, to_string_from_exponent_form) {
+TEST(to_string_from_exponent_form) {
   const sourcemeta::core::Decimal value{"1e5"};
   EXPECT_EQ(value.to_string(), "100e+3");
 }
 
-TEST(Numeric_decimal, to_scientific_string_large_integer) {
+TEST(to_scientific_string_large_integer) {
   const sourcemeta::core::Decimal value{1000000};
   EXPECT_EQ(value.to_scientific_string(), "1.000000e+6");
 }
 
-TEST(Numeric_decimal, to_scientific_string_small_decimal) {
+TEST(to_scientific_string_small_decimal) {
   const sourcemeta::core::Decimal value{"0.001"};
   EXPECT_EQ(value.to_scientific_string(), "1e-3");
 }
 
-TEST(Numeric_decimal, to_scientific_string_negative) {
+TEST(to_scientific_string_negative) {
   const sourcemeta::core::Decimal value{-42};
   EXPECT_EQ(value.to_scientific_string(), "-4.2e+1");
 }
 
-TEST(Numeric_decimal, to_scientific_string_nan) {
+TEST(to_scientific_string_nan) {
   EXPECT_EQ(sourcemeta::core::Decimal::nan().to_scientific_string(), "NaN");
 }
 
-TEST(Numeric_decimal, to_scientific_string_infinity) {
+TEST(to_scientific_string_infinity) {
   EXPECT_EQ(sourcemeta::core::Decimal::infinity().to_scientific_string(),
             "Infinity");
 }
 
-TEST(Numeric_decimal, to_scientific_string_negative_infinity) {
+TEST(to_scientific_string_negative_infinity) {
   EXPECT_EQ(
       sourcemeta::core::Decimal::negative_infinity().to_scientific_string(),
       "-Infinity");
 }
 
-TEST(Numeric_decimal, to_scientific_string_zero) {
+TEST(to_scientific_string_zero) {
   const sourcemeta::core::Decimal value{0};
   EXPECT_EQ(value.to_scientific_string(), "0e+0");
 }
 
-TEST(Numeric_decimal, roundtrip_to_string_parse_integer) {
+TEST(roundtrip_to_string_parse_integer) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_EQ(sourcemeta::core::Decimal{value.to_string()}, value);
 }
 
-TEST(Numeric_decimal, roundtrip_to_string_parse_decimal) {
+TEST(roundtrip_to_string_parse_decimal) {
   const sourcemeta::core::Decimal value{"3.14"};
   EXPECT_EQ(sourcemeta::core::Decimal{value.to_string()}, value);
 }
 
-TEST(Numeric_decimal, roundtrip_to_string_parse_negative) {
+TEST(roundtrip_to_string_parse_negative) {
   const sourcemeta::core::Decimal value{"-999.999"};
   EXPECT_EQ(sourcemeta::core::Decimal{value.to_string()}, value);
 }
 
-TEST(Numeric_decimal, roundtrip_to_string_parse_large) {
+TEST(roundtrip_to_string_parse_large) {
   const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
   EXPECT_EQ(sourcemeta::core::Decimal{value.to_string()}, value);
 }
 
-TEST(Numeric_decimal, roundtrip_to_string_parse_small) {
+TEST(roundtrip_to_string_parse_small) {
   const sourcemeta::core::Decimal value{"0.000000001"};
   EXPECT_EQ(sourcemeta::core::Decimal{value.to_string()}, value);
 }
 
-TEST(Numeric_decimal, add_infinity_to_infinity) {
+TEST(add_infinity_to_infinity) {
   const auto result{sourcemeta::core::Decimal::infinity() +
                     sourcemeta::core::Decimal::infinity()};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, add_infinity_to_finite) {
+TEST(add_infinity_to_finite) {
   const auto result{sourcemeta::core::Decimal::infinity() +
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, add_negative_infinity_to_negative_infinity) {
+TEST(add_negative_infinity_to_negative_infinity) {
   const auto result{sourcemeta::core::Decimal::negative_infinity() +
                     sourcemeta::core::Decimal::negative_infinity()};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_TRUE(result.is_signed());
 }
 
-TEST(Numeric_decimal, subtract_infinity_from_infinity_produces_nan) {
+TEST(subtract_infinity_from_infinity_produces_nan) {
   const auto result{sourcemeta::core::Decimal::infinity() -
                     sourcemeta::core::Decimal::infinity()};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, multiply_infinity_by_positive) {
+TEST(multiply_infinity_by_positive) {
   const auto result{sourcemeta::core::Decimal::infinity() *
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, multiply_infinity_by_negative) {
+TEST(multiply_infinity_by_negative) {
   const auto result{sourcemeta::core::Decimal::infinity() *
                     sourcemeta::core::Decimal{-5}};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_TRUE(result.is_signed());
 }
 
-TEST(Numeric_decimal, multiply_infinity_by_zero_produces_nan) {
+TEST(multiply_infinity_by_zero_produces_nan) {
   const auto result{sourcemeta::core::Decimal::infinity() *
                     sourcemeta::core::Decimal{0}};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, divide_finite_by_infinity) {
+TEST(divide_finite_by_infinity) {
   const auto result{sourcemeta::core::Decimal{5} /
                     sourcemeta::core::Decimal::infinity()};
   EXPECT_TRUE(result.is_zero());
 }
 
-TEST(Numeric_decimal, divide_infinity_by_finite) {
+TEST(divide_infinity_by_finite) {
   const auto result{sourcemeta::core::Decimal::infinity() /
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, divide_infinity_by_infinity_throws) {
+TEST(divide_infinity_by_infinity_throws) {
   try {
     const auto result{sourcemeta::core::Decimal::infinity() /
                       sourcemeta::core::Decimal::infinity()};
@@ -2737,31 +2734,31 @@ TEST(Numeric_decimal, divide_infinity_by_infinity_throws) {
   }
 }
 
-TEST(Numeric_decimal, add_nan_propagates) {
+TEST(add_nan_propagates) {
   const auto result{sourcemeta::core::Decimal::nan() +
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, multiply_nan_propagates) {
+TEST(multiply_nan_propagates) {
   const auto result{sourcemeta::core::Decimal::nan() *
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, divide_nan_propagates) {
+TEST(divide_nan_propagates) {
   const auto result{sourcemeta::core::Decimal::nan() /
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, subtract_nan_propagates) {
+TEST(subtract_nan_propagates) {
   const auto result{sourcemeta::core::Decimal::nan() -
                     sourcemeta::core::Decimal{5}};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, add_different_scales) {
+TEST(add_different_scales) {
   EXPECT_EQ(sourcemeta::core::Decimal{"1.0"} + sourcemeta::core::Decimal{2},
             sourcemeta::core::Decimal{3});
   EXPECT_EQ(sourcemeta::core::Decimal{"10.00"} -
@@ -2769,176 +2766,176 @@ TEST(Numeric_decimal, add_different_scales) {
             sourcemeta::core::Decimal{"0.10"});
 }
 
-TEST(Numeric_decimal, subtract_different_scales) {
+TEST(subtract_different_scales) {
   EXPECT_EQ(sourcemeta::core::Decimal{"10.000"} -
                 sourcemeta::core::Decimal{"0.1"},
             sourcemeta::core::Decimal{"9.900"});
 }
 
-TEST(Numeric_decimal, add_classic_fp_trouble_exact_in_decimal) {
+TEST(add_classic_fp_trouble_exact_in_decimal) {
   const auto result{sourcemeta::core::Decimal{"0.1"} +
                     sourcemeta::core::Decimal{"0.2"}};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"0.3"});
 }
 
-TEST(Numeric_decimal, commutativity_addition) {
+TEST(commutativity_addition) {
   const sourcemeta::core::Decimal first{"3.14"};
   const sourcemeta::core::Decimal second{"2.71"};
   EXPECT_EQ(first + second, second + first);
 }
 
-TEST(Numeric_decimal, commutativity_multiplication) {
+TEST(commutativity_multiplication) {
   const sourcemeta::core::Decimal first{"3.14"};
   const sourcemeta::core::Decimal second{"2.71"};
   EXPECT_EQ(first * second, second * first);
 }
 
-TEST(Numeric_decimal, additive_identity_positive) {
+TEST(additive_identity_positive) {
   EXPECT_EQ(sourcemeta::core::Decimal{42} + sourcemeta::core::Decimal{0},
             sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, additive_identity_negative) {
+TEST(additive_identity_negative) {
   EXPECT_EQ(sourcemeta::core::Decimal{-17} + sourcemeta::core::Decimal{0},
             sourcemeta::core::Decimal{-17});
 }
 
-TEST(Numeric_decimal, additive_identity_decimal) {
+TEST(additive_identity_decimal) {
   EXPECT_EQ(sourcemeta::core::Decimal{"3.14"} + sourcemeta::core::Decimal{0},
             sourcemeta::core::Decimal{"3.14"});
 }
 
-TEST(Numeric_decimal, additive_identity_large) {
+TEST(additive_identity_large) {
   EXPECT_EQ(sourcemeta::core::Decimal{"1e100"} + sourcemeta::core::Decimal{0},
             sourcemeta::core::Decimal{"1e100"});
 }
 
-TEST(Numeric_decimal, multiplicative_identity_positive) {
+TEST(multiplicative_identity_positive) {
   EXPECT_EQ(sourcemeta::core::Decimal{42} * sourcemeta::core::Decimal{1},
             sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, multiplicative_identity_negative) {
+TEST(multiplicative_identity_negative) {
   EXPECT_EQ(sourcemeta::core::Decimal{-17} * sourcemeta::core::Decimal{1},
             sourcemeta::core::Decimal{-17});
 }
 
-TEST(Numeric_decimal, multiplicative_identity_decimal) {
+TEST(multiplicative_identity_decimal) {
   EXPECT_EQ(sourcemeta::core::Decimal{"3.14"} * sourcemeta::core::Decimal{1},
             sourcemeta::core::Decimal{"3.14"});
 }
 
-TEST(Numeric_decimal, multiplicative_identity_large) {
+TEST(multiplicative_identity_large) {
   EXPECT_EQ(sourcemeta::core::Decimal{"1e100"} * sourcemeta::core::Decimal{1},
             sourcemeta::core::Decimal{"1e100"});
 }
 
-TEST(Numeric_decimal, subtract_from_zero_equals_negation) {
+TEST(subtract_from_zero_equals_negation) {
   const sourcemeta::core::Decimal zero{0};
   const sourcemeta::core::Decimal value{42};
   EXPECT_EQ(zero - value, -value);
 }
 
-TEST(Numeric_decimal, divide_self_equals_one_positive) {
+TEST(divide_self_equals_one_positive) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_EQ(value / value, sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_decimal, divide_self_equals_one_negative) {
+TEST(divide_self_equals_one_negative) {
   const sourcemeta::core::Decimal value{-17};
   EXPECT_EQ(value / value, sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_decimal, divide_self_equals_one_decimal) {
+TEST(divide_self_equals_one_decimal) {
   const sourcemeta::core::Decimal value{"3.14"};
   EXPECT_EQ(value / value, sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_decimal, divide_self_equals_one_small) {
+TEST(divide_self_equals_one_small) {
   const sourcemeta::core::Decimal value{"0.001"};
   EXPECT_EQ(value / value, sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_decimal, modulo_negative_divisor) {
+TEST(modulo_negative_divisor) {
   const sourcemeta::core::Decimal result{sourcemeta::core::Decimal{17} %
                                          sourcemeta::core::Decimal{-5}};
   EXPECT_EQ(result, sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_decimal, modulo_both_negative) {
+TEST(modulo_both_negative) {
   const sourcemeta::core::Decimal result{sourcemeta::core::Decimal{-17} %
                                          sourcemeta::core::Decimal{-5}};
   EXPECT_EQ(result, sourcemeta::core::Decimal{-2});
 }
 
-TEST(Numeric_decimal, modulo_decimal_operands) {
+TEST(modulo_decimal_operands) {
   EXPECT_EQ(sourcemeta::core::Decimal{"10.5"} % sourcemeta::core::Decimal{3},
             sourcemeta::core::Decimal{"1.5"});
   EXPECT_EQ(sourcemeta::core::Decimal{"7.5"} % sourcemeta::core::Decimal{"2.5"},
             sourcemeta::core::Decimal{"0.0"});
 }
 
-TEST(Numeric_decimal, modulo_result_zero) {
+TEST(modulo_result_zero) {
   EXPECT_EQ(sourcemeta::core::Decimal{100} % sourcemeta::core::Decimal{25},
             sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, modulo_zero_dividend) {
+TEST(modulo_zero_dividend) {
   EXPECT_EQ(sourcemeta::core::Decimal{0} % sourcemeta::core::Decimal{5},
             sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, modulo_dividend_less_than_divisor) {
+TEST(modulo_dividend_less_than_divisor) {
   EXPECT_EQ(sourcemeta::core::Decimal{3} % sourcemeta::core::Decimal{7},
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_decimal, modulo_dividend_equals_divisor) {
+TEST(modulo_dividend_equals_divisor) {
   EXPECT_EQ(sourcemeta::core::Decimal{7} % sourcemeta::core::Decimal{7},
             sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, is_int32_below_min_boundary) {
+TEST(is_int32_below_min_boundary) {
   const sourcemeta::core::Decimal value{"-2147483649"};
   EXPECT_FALSE(value.is_int32());
 }
 
-TEST(Numeric_decimal, is_int32_above_max_boundary) {
+TEST(is_int32_above_max_boundary) {
   const sourcemeta::core::Decimal value{"2147483648"};
   EXPECT_FALSE(value.is_int32());
 }
 
-TEST(Numeric_decimal, is_int64_at_min_boundary) {
+TEST(is_int64_at_min_boundary) {
   const sourcemeta::core::Decimal value{"-9223372036854775808"};
   EXPECT_TRUE(value.is_int64());
 }
 
-TEST(Numeric_decimal, is_int64_below_min_boundary) {
+TEST(is_int64_below_min_boundary) {
   const sourcemeta::core::Decimal value{"-9223372036854775809"};
   EXPECT_FALSE(value.is_int64());
 }
 
-TEST(Numeric_decimal, is_int64_at_max_boundary) {
+TEST(is_int64_at_max_boundary) {
   const sourcemeta::core::Decimal value{"9223372036854775807"};
   EXPECT_TRUE(value.is_int64());
 }
 
-TEST(Numeric_decimal, is_int64_above_max_boundary) {
+TEST(is_int64_above_max_boundary) {
   const sourcemeta::core::Decimal value{"9223372036854775808"};
   EXPECT_FALSE(value.is_int64());
 }
 
-TEST(Numeric_decimal, is_uint32_at_zero) {
+TEST(is_uint32_at_zero) {
   const sourcemeta::core::Decimal value{0};
   EXPECT_TRUE(value.is_uint32());
 }
 
-TEST(Numeric_decimal, is_uint64_at_zero) {
+TEST(is_uint64_at_zero) {
   const sourcemeta::core::Decimal value{0};
   EXPECT_TRUE(value.is_uint64());
 }
 
-TEST(Numeric_decimal, to_int32_at_boundaries) {
+TEST(to_int32_at_boundaries) {
   const sourcemeta::core::Decimal min_value{
       static_cast<std::int64_t>(std::numeric_limits<std::int32_t>::min())};
   const sourcemeta::core::Decimal max_value{
@@ -2947,14 +2944,14 @@ TEST(Numeric_decimal, to_int32_at_boundaries) {
   EXPECT_EQ(max_value.to_int32(), std::numeric_limits<std::int32_t>::max());
 }
 
-TEST(Numeric_decimal, to_int64_at_boundaries) {
+TEST(to_int64_at_boundaries) {
   const sourcemeta::core::Decimal min_value{"-9223372036854775808"};
   const sourcemeta::core::Decimal max_value{"9223372036854775807"};
   EXPECT_EQ(min_value.to_int64(), std::numeric_limits<std::int64_t>::min());
   EXPECT_EQ(max_value.to_int64(), std::numeric_limits<std::int64_t>::max());
 }
 
-TEST(Numeric_decimal, to_uint32_at_boundaries) {
+TEST(to_uint32_at_boundaries) {
   const sourcemeta::core::Decimal zero{0};
   const sourcemeta::core::Decimal max_value{
       std::numeric_limits<std::uint32_t>::max()};
@@ -2962,14 +2959,14 @@ TEST(Numeric_decimal, to_uint32_at_boundaries) {
   EXPECT_EQ(max_value.to_uint32(), std::numeric_limits<std::uint32_t>::max());
 }
 
-TEST(Numeric_decimal, to_uint64_at_boundaries) {
+TEST(to_uint64_at_boundaries) {
   const sourcemeta::core::Decimal zero{0};
   const sourcemeta::core::Decimal max_value{"18446744073709551615"};
   EXPECT_EQ(zero.to_uint64(), 0ULL);
   EXPECT_EQ(max_value.to_uint64(), std::numeric_limits<std::uint64_t>::max());
 }
 
-TEST(Numeric_decimal, int_conversion_value_with_exponent_resolves_to_boundary) {
+TEST(int_conversion_value_with_exponent_resolves_to_boundary) {
   const sourcemeta::core::Decimal value{"1e19"};
   EXPECT_FALSE(value.is_integer());
   EXPECT_TRUE(value.is_integral());
@@ -2977,20 +2974,20 @@ TEST(Numeric_decimal, int_conversion_value_with_exponent_resolves_to_boundary) {
   EXPECT_TRUE(value.is_uint64());
 }
 
-TEST(Numeric_decimal, int_conversion_negative_zero_gives_zero) {
+TEST(int_conversion_negative_zero_gives_zero) {
   const sourcemeta::core::Decimal value{"-0"};
   EXPECT_TRUE(value.is_integer());
   EXPECT_EQ(value.to_int64(), 0);
 }
 
-TEST(Numeric_decimal, int_conversion_power_of_ten_boundaries) {
+TEST(int_conversion_power_of_ten_boundaries) {
   const sourcemeta::core::Decimal value{"10000000000000000000"};
   EXPECT_TRUE(value.is_integer());
   EXPECT_FALSE(value.is_int64());
   EXPECT_TRUE(value.is_uint64());
 }
 
-TEST(Numeric_decimal, construct_from_int64_min) {
+TEST(construct_from_int64_min) {
   const sourcemeta::core::Decimal value{
       std::numeric_limits<std::int64_t>::min()};
   EXPECT_TRUE(value.is_signed());
@@ -2999,7 +2996,7 @@ TEST(Numeric_decimal, construct_from_int64_min) {
   EXPECT_EQ(value.to_int64(), std::numeric_limits<std::int64_t>::min());
 }
 
-TEST(Numeric_decimal, construct_from_int64_max) {
+TEST(construct_from_int64_max) {
   const sourcemeta::core::Decimal value{
       std::numeric_limits<std::int64_t>::max()};
   EXPECT_FALSE(value.is_signed());
@@ -3008,7 +3005,7 @@ TEST(Numeric_decimal, construct_from_int64_max) {
   EXPECT_EQ(value.to_int64(), std::numeric_limits<std::int64_t>::max());
 }
 
-TEST(Numeric_decimal, construct_from_uint64_max) {
+TEST(construct_from_uint64_max) {
   const sourcemeta::core::Decimal value{
       std::numeric_limits<std::uint64_t>::max()};
   EXPECT_FALSE(value.is_signed());
@@ -3017,59 +3014,59 @@ TEST(Numeric_decimal, construct_from_uint64_max) {
   EXPECT_EQ(value.to_uint64(), std::numeric_limits<std::uint64_t>::max());
 }
 
-TEST(Numeric_decimal, construct_from_int8) {
+TEST(construct_from_int8) {
   const sourcemeta::core::Decimal value{static_cast<std::int8_t>(-42)};
   EXPECT_EQ(value, sourcemeta::core::Decimal{-42});
 }
 
-TEST(Numeric_decimal, construct_from_int16) {
+TEST(construct_from_int16) {
   const sourcemeta::core::Decimal value{static_cast<std::int16_t>(-1000)};
   EXPECT_EQ(value, sourcemeta::core::Decimal{-1000});
 }
 
-TEST(Numeric_decimal, construct_from_uint8) {
+TEST(construct_from_uint8) {
   const sourcemeta::core::Decimal value{static_cast<std::uint8_t>(255)};
   EXPECT_EQ(value, sourcemeta::core::Decimal{255});
 }
 
-TEST(Numeric_decimal, construct_from_uint16) {
+TEST(construct_from_uint16) {
   const sourcemeta::core::Decimal value{static_cast<std::uint16_t>(65535)};
   EXPECT_EQ(value, sourcemeta::core::Decimal{65535});
 }
 
-TEST(Numeric_decimal, construct_from_int32) {
+TEST(construct_from_int32) {
   const sourcemeta::core::Decimal value{static_cast<std::int32_t>(-2000000)};
   EXPECT_EQ(value, sourcemeta::core::Decimal{-2000000});
 }
 
-TEST(Numeric_decimal, construct_from_uint32_explicit) {
+TEST(construct_from_uint32_explicit) {
   const sourcemeta::core::Decimal value{static_cast<std::uint32_t>(4000000000)};
   EXPECT_EQ(value.to_string(), "4000000000");
 }
 
-TEST(Numeric_decimal, construct_from_float_nan) {
+TEST(construct_from_float_nan) {
   const sourcemeta::core::Decimal value{std::nanf("")};
   EXPECT_TRUE(value.is_nan());
 }
 
-TEST(Numeric_decimal, construct_from_float_infinity) {
+TEST(construct_from_float_infinity) {
   const sourcemeta::core::Decimal value{INFINITY};
   EXPECT_TRUE(value.is_infinite());
   EXPECT_FALSE(value.is_signed());
 }
 
-TEST(Numeric_decimal, construct_from_double_nan) {
+TEST(construct_from_double_nan) {
   const sourcemeta::core::Decimal value{std::nan("")};
   EXPECT_TRUE(value.is_nan());
 }
 
-TEST(Numeric_decimal, construct_from_double_infinity) {
+TEST(construct_from_double_infinity) {
   const sourcemeta::core::Decimal value{static_cast<double>(INFINITY)};
   EXPECT_TRUE(value.is_infinite());
   EXPECT_FALSE(value.is_signed());
 }
 
-TEST(Numeric_decimal, self_copy_assignment) {
+TEST(self_copy_assignment) {
   sourcemeta::core::Decimal value{42};
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -3082,7 +3079,7 @@ TEST(Numeric_decimal, self_copy_assignment) {
   EXPECT_EQ(value, sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, self_move_assignment) {
+TEST(self_move_assignment) {
   sourcemeta::core::Decimal value{42};
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -3100,7 +3097,7 @@ TEST(Numeric_decimal, self_move_assignment) {
   EXPECT_EQ(value, sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_decimal, move_from_state_is_valid) {
+TEST(move_from_state_is_valid) {
   sourcemeta::core::Decimal original{42};
   const sourcemeta::core::Decimal moved{std::move(original)};
   EXPECT_EQ(moved, sourcemeta::core::Decimal{42});
@@ -3108,176 +3105,176 @@ TEST(Numeric_decimal, move_from_state_is_valid) {
   EXPECT_EQ(original, sourcemeta::core::Decimal{99});
 }
 
-TEST(Numeric_decimal, unary_minus_zero) {
+TEST(unary_minus_zero) {
   const sourcemeta::core::Decimal value{0};
   const auto result{-value};
   EXPECT_TRUE(result.is_zero());
 }
 
-TEST(Numeric_decimal, unary_minus_negative_zero) {
+TEST(unary_minus_negative_zero) {
   const sourcemeta::core::Decimal value{"-0"};
   const auto result{-value};
   EXPECT_TRUE(result.is_zero());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, unary_minus_nan) {
+TEST(unary_minus_nan) {
   const auto result{-sourcemeta::core::Decimal::nan()};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, unary_minus_infinity) {
+TEST(unary_minus_infinity) {
   const auto result{-sourcemeta::core::Decimal::infinity()};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_TRUE(result.is_signed());
 }
 
-TEST(Numeric_decimal, unary_minus_negative_infinity) {
+TEST(unary_minus_negative_infinity) {
   const auto result{-sourcemeta::core::Decimal::negative_infinity()};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, unary_plus_negative) {
+TEST(unary_plus_negative) {
   const sourcemeta::core::Decimal value{-5};
   EXPECT_EQ(+value, sourcemeta::core::Decimal{-5});
 }
 
-TEST(Numeric_decimal, unary_plus_nan) {
+TEST(unary_plus_nan) {
   const auto result{+sourcemeta::core::Decimal::nan()};
   EXPECT_TRUE(result.is_nan());
 }
 
-TEST(Numeric_decimal, unary_plus_infinity) {
+TEST(unary_plus_infinity) {
   const auto result{+sourcemeta::core::Decimal::infinity()};
   EXPECT_TRUE(result.is_infinite());
   EXPECT_FALSE(result.is_signed());
 }
 
-TEST(Numeric_decimal, double_negation_identity_positive) {
+TEST(double_negation_identity_positive) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_EQ(-(-value), value);
 }
 
-TEST(Numeric_decimal, double_negation_identity_negative) {
+TEST(double_negation_identity_negative) {
   const sourcemeta::core::Decimal value{-17};
   EXPECT_EQ(-(-value), value);
 }
 
-TEST(Numeric_decimal, double_negation_identity_decimal) {
+TEST(double_negation_identity_decimal) {
   const sourcemeta::core::Decimal value{"3.14"};
   EXPECT_EQ(-(-value), value);
 }
 
-TEST(Numeric_decimal, double_negation_identity_zero) {
+TEST(double_negation_identity_zero) {
   const sourcemeta::core::Decimal value{0};
   EXPECT_EQ(-(-value), value);
 }
 
-TEST(Numeric_decimal, is_zero_zero_point_zero) {
+TEST(is_zero_zero_point_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"0.0"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_zero_zero_point_zero_zero) {
+TEST(is_zero_zero_point_zero_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"0.00"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_zero_zero_e_five) {
+TEST(is_zero_zero_e_five) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"0e5"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_zero_negative_zero) {
+TEST(is_zero_negative_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"-0"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_zero_negative_zero_point_zero) {
+TEST(is_zero_negative_zero_point_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"-0.0"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_zero_zero_e_hundred) {
+TEST(is_zero_zero_e_hundred) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"0e100"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_zero_zero_e_negative_hundred) {
+TEST(is_zero_zero_e_negative_hundred) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"0e-100"}.is_zero());
 }
 
-TEST(Numeric_decimal, is_integral_via_positive_exponent) {
+TEST(is_integral_via_positive_exponent) {
   const sourcemeta::core::Decimal value{"1e10"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_via_negative_exponent_resolving) {
+TEST(is_integral_via_negative_exponent_resolving) {
   const sourcemeta::core::Decimal value{"100e-2"};
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integral_via_negative_exponent_not_resolving) {
+TEST(is_integral_via_negative_exponent_not_resolving) {
   const sourcemeta::core::Decimal value{"123e-3"};
   EXPECT_FALSE(value.is_integral());
 }
 
-TEST(Numeric_decimal, is_integer_vs_integral_distinction) {
+TEST(is_integer_vs_integral_distinction) {
   const sourcemeta::core::Decimal value{"3.0"};
   EXPECT_TRUE(value.is_integral());
   EXPECT_FALSE(value.is_integer());
 }
 
-TEST(Numeric_decimal, is_finite_nan) {
+TEST(is_finite_nan) {
   EXPECT_FALSE(sourcemeta::core::Decimal::nan().is_finite());
 }
 
-TEST(Numeric_decimal, is_finite_infinity) {
+TEST(is_finite_infinity) {
   EXPECT_FALSE(sourcemeta::core::Decimal::infinity().is_finite());
 }
 
-TEST(Numeric_decimal, is_finite_negative_infinity) {
+TEST(is_finite_negative_infinity) {
   EXPECT_FALSE(sourcemeta::core::Decimal::negative_infinity().is_finite());
 }
 
-TEST(Numeric_decimal, is_signed_nan) {
+TEST(is_signed_nan) {
   EXPECT_FALSE(sourcemeta::core::Decimal::nan().is_signed());
 }
 
-TEST(Numeric_decimal, is_signed_infinity) {
+TEST(is_signed_infinity) {
   EXPECT_FALSE(sourcemeta::core::Decimal::infinity().is_signed());
 }
 
-TEST(Numeric_decimal, is_signed_negative_infinity) {
+TEST(is_signed_negative_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal::negative_infinity().is_signed());
 }
 
-TEST(Numeric_decimal, compound_add_self_doubles) {
+TEST(compound_add_self_doubles) {
   sourcemeta::core::Decimal value{25};
   value += value;
   EXPECT_EQ(value, sourcemeta::core::Decimal{50});
 }
 
-TEST(Numeric_decimal, compound_subtract_self_zeros) {
+TEST(compound_subtract_self_zeros) {
   sourcemeta::core::Decimal value{25};
   value -= value;
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, compound_multiply_self_squares) {
+TEST(compound_multiply_self_squares) {
   sourcemeta::core::Decimal value{5};
   value *= value;
   EXPECT_EQ(value, sourcemeta::core::Decimal{25});
 }
 
-TEST(Numeric_decimal, compound_divide_self_gives_one) {
+TEST(compound_divide_self_gives_one) {
   sourcemeta::core::Decimal value{42};
   value /= value;
   EXPECT_EQ(value, sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_decimal, compound_modulo_self_gives_zero) {
+TEST(compound_modulo_self_gives_zero) {
   sourcemeta::core::Decimal value{42};
   value %= value;
   EXPECT_TRUE(value.is_zero());
 }
 
-TEST(Numeric_decimal, multithreaded_parsing) {
+TEST(multithreaded_parsing) {
   constexpr int number_of_threads{16};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -3295,7 +3292,7 @@ TEST(Numeric_decimal, multithreaded_parsing) {
   }
 }
 
-TEST(Numeric_decimal, multithreaded_stringification) {
+TEST(multithreaded_stringification) {
   constexpr int number_of_threads{16};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -3312,7 +3309,7 @@ TEST(Numeric_decimal, multithreaded_stringification) {
   }
 }
 
-TEST(Numeric_decimal, multithreaded_comparison) {
+TEST(multithreaded_comparison) {
   constexpr int number_of_threads{16};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -3332,7 +3329,7 @@ TEST(Numeric_decimal, multithreaded_comparison) {
   }
 }
 
-TEST(Numeric_decimal, multithreaded_divisibility) {
+TEST(multithreaded_divisibility) {
   constexpr int number_of_threads{16};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -3350,7 +3347,7 @@ TEST(Numeric_decimal, multithreaded_divisibility) {
   }
 }
 
-TEST(Numeric_decimal, multithreaded_mixed_operations) {
+TEST(multithreaded_mixed_operations) {
   constexpr int number_of_threads{16};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -3377,7 +3374,7 @@ TEST(Numeric_decimal, multithreaded_mixed_operations) {
   }
 }
 
-TEST(Numeric_decimal, multithreaded_high_thread_count) {
+TEST(multithreaded_high_thread_count) {
   constexpr int number_of_threads{32};
   std::vector<std::thread> threads;
   threads.reserve(number_of_threads);
@@ -3396,59 +3393,59 @@ TEST(Numeric_decimal, multithreaded_high_thread_count) {
   }
 }
 
-TEST(Numeric_decimal, reduce_strips_trailing_zeros) {
+TEST(reduce_strips_trailing_zeros) {
   const sourcemeta::core::Decimal value{"1.200"};
   const sourcemeta::core::Decimal expected{"1.2"};
   EXPECT_EQ(value.reduce(), expected);
 }
 
-TEST(Numeric_decimal, reduce_zero) {
+TEST(reduce_zero) {
   const sourcemeta::core::Decimal value{"0.00"};
   const sourcemeta::core::Decimal expected{0};
   EXPECT_EQ(value.reduce(), expected);
 }
 
-TEST(Numeric_decimal, reduce_integer) {
+TEST(reduce_integer) {
   const sourcemeta::core::Decimal value{"1200"};
   const sourcemeta::core::Decimal expected{"12E+2"};
   EXPECT_EQ(value.reduce(), expected);
 }
 
-TEST(Numeric_decimal, reduce_negative) {
+TEST(reduce_negative) {
   const sourcemeta::core::Decimal value{"-1.200"};
   const sourcemeta::core::Decimal expected{"-1.2"};
   EXPECT_EQ(value.reduce(), expected);
 }
 
-TEST(Numeric_decimal, reduce_infinity) {
+TEST(reduce_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal::infinity().reduce().is_infinite());
 }
 
-TEST(Numeric_decimal, reduce_nan) {
+TEST(reduce_nan) {
   EXPECT_TRUE(sourcemeta::core::Decimal::nan().reduce().is_nan());
 }
 
-TEST(Numeric_decimal, logb_positive) {
+TEST(logb_positive) {
   const sourcemeta::core::Decimal value{"250"};
   EXPECT_EQ(value.logb(), sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_decimal, logb_one) {
+TEST(logb_one) {
   const sourcemeta::core::Decimal value{1};
   EXPECT_EQ(value.logb(), sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, logb_fraction) {
+TEST(logb_fraction) {
   const sourcemeta::core::Decimal value{"0.001"};
   EXPECT_EQ(value.logb(), sourcemeta::core::Decimal{-3});
 }
 
-TEST(Numeric_decimal, logb_infinity) {
+TEST(logb_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal::infinity().logb().is_infinite());
   EXPECT_FALSE(sourcemeta::core::Decimal::infinity().logb().is_signed());
 }
 
-TEST(Numeric_decimal, logb_zero_throws) {
+TEST(logb_zero_throws) {
   try {
     static_cast<void>(sourcemeta::core::Decimal{0}.logb());
     FAIL();
@@ -3457,37 +3454,37 @@ TEST(Numeric_decimal, logb_zero_throws) {
   }
 }
 
-TEST(Numeric_decimal, logb_nan) {
+TEST(logb_nan) {
   EXPECT_TRUE(sourcemeta::core::Decimal::nan().logb().is_nan());
 }
 
-TEST(Numeric_decimal, scale_by_positive) {
+TEST(scale_by_positive) {
   const sourcemeta::core::Decimal value{"1.23"};
   const sourcemeta::core::Decimal scale{2};
   const sourcemeta::core::Decimal expected{"123"};
   EXPECT_EQ(value.scale_by(scale), expected);
 }
 
-TEST(Numeric_decimal, scale_by_negative) {
+TEST(scale_by_negative) {
   const sourcemeta::core::Decimal value{"123"};
   const sourcemeta::core::Decimal scale{-2};
   const sourcemeta::core::Decimal expected{"1.23"};
   EXPECT_EQ(value.scale_by(scale), expected);
 }
 
-TEST(Numeric_decimal, scale_by_zero) {
+TEST(scale_by_zero) {
   const sourcemeta::core::Decimal value{"1.23"};
   const sourcemeta::core::Decimal scale{0};
   EXPECT_EQ(value.scale_by(scale), value);
 }
 
-TEST(Numeric_decimal, scale_by_infinity_passthrough) {
+TEST(scale_by_infinity_passthrough) {
   const sourcemeta::core::Decimal scale{0};
   EXPECT_TRUE(
       sourcemeta::core::Decimal::infinity().scale_by(scale).is_infinite());
 }
 
-TEST(Numeric_decimal, scale_by_snan_throws) {
+TEST(scale_by_snan_throws) {
   const sourcemeta::core::Decimal value{1};
   try {
     static_cast<void>(value.scale_by(sourcemeta::core::Decimal::snan()));
@@ -3497,7 +3494,7 @@ TEST(Numeric_decimal, scale_by_snan_throws) {
   }
 }
 
-TEST(Numeric_decimal, scale_by_huge_scale_throws) {
+TEST(scale_by_huge_scale_throws) {
   const sourcemeta::core::Decimal value{"1.23"};
   const sourcemeta::core::Decimal scale{"99999999999999999999"};
   try {
@@ -3508,81 +3505,81 @@ TEST(Numeric_decimal, scale_by_huge_scale_throws) {
   }
 }
 
-TEST(Numeric_decimal, same_quantum_same_exponent) {
+TEST(same_quantum_same_exponent) {
   const sourcemeta::core::Decimal left{"1.23"};
   const sourcemeta::core::Decimal right{"4.56"};
   EXPECT_TRUE(left.same_quantum(right));
 }
 
-TEST(Numeric_decimal, same_quantum_different_exponent) {
+TEST(same_quantum_different_exponent) {
   const sourcemeta::core::Decimal left{"1.2"};
   const sourcemeta::core::Decimal right{"1.23"};
   EXPECT_FALSE(left.same_quantum(right));
 }
 
-TEST(Numeric_decimal, same_quantum_both_nan) {
+TEST(same_quantum_both_nan) {
   EXPECT_TRUE(sourcemeta::core::Decimal::nan().same_quantum(
       sourcemeta::core::Decimal::nan()));
 }
 
-TEST(Numeric_decimal, same_quantum_both_infinity) {
+TEST(same_quantum_both_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal::infinity().same_quantum(
       sourcemeta::core::Decimal::negative_infinity()));
 }
 
-TEST(Numeric_decimal, same_quantum_nan_and_number) {
+TEST(same_quantum_nan_and_number) {
   EXPECT_FALSE(sourcemeta::core::Decimal::nan().same_quantum(
       sourcemeta::core::Decimal{1}));
 }
 
-TEST(Numeric_decimal, compare_total_positive_ordering) {
+TEST(compare_total_positive_ordering) {
   const sourcemeta::core::Decimal left{7};
   const sourcemeta::core::Decimal right{10};
   EXPECT_EQ(left.compare_total(right), sourcemeta::core::Decimal{-1});
 }
 
-TEST(Numeric_decimal, compare_total_equal) {
+TEST(compare_total_equal) {
   const sourcemeta::core::Decimal value{5};
   EXPECT_EQ(value.compare_total(value), sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, compare_total_same_value_different_exponent) {
+TEST(compare_total_same_value_different_exponent) {
   const sourcemeta::core::Decimal left{"7.0"};
   const sourcemeta::core::Decimal right{7};
   EXPECT_EQ(left.compare_total(right), sourcemeta::core::Decimal{-1});
 }
 
-TEST(Numeric_decimal, compare_total_negative_less_than_positive) {
+TEST(compare_total_negative_less_than_positive) {
   const sourcemeta::core::Decimal left{-1};
   const sourcemeta::core::Decimal right{1};
   EXPECT_EQ(left.compare_total(right), sourcemeta::core::Decimal{-1});
 }
 
-TEST(Numeric_decimal, compare_total_nan_ordering) {
+TEST(compare_total_nan_ordering) {
   EXPECT_EQ(sourcemeta::core::Decimal::nan().compare_total(
                 sourcemeta::core::Decimal{1}),
             sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_decimal, divide_integer_exact) {
+TEST(divide_integer_exact) {
   const sourcemeta::core::Decimal left{7};
   const sourcemeta::core::Decimal right{2};
   EXPECT_EQ(left.divide_integer(right), sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_decimal, divide_integer_negative) {
+TEST(divide_integer_negative) {
   const sourcemeta::core::Decimal left{-7};
   const sourcemeta::core::Decimal right{2};
   EXPECT_EQ(left.divide_integer(right), sourcemeta::core::Decimal{-3});
 }
 
-TEST(Numeric_decimal, divide_integer_by_larger) {
+TEST(divide_integer_by_larger) {
   const sourcemeta::core::Decimal left{2};
   const sourcemeta::core::Decimal right{7};
   EXPECT_EQ(left.divide_integer(right), sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, divide_integer_by_zero_throws) {
+TEST(divide_integer_by_zero_throws) {
   try {
     static_cast<void>(sourcemeta::core::Decimal{1}.divide_integer(
         sourcemeta::core::Decimal{0}));
@@ -3592,7 +3589,7 @@ TEST(Numeric_decimal, divide_integer_by_zero_throws) {
   }
 }
 
-TEST(Numeric_decimal, divide_integer_infinity_by_infinity_throws) {
+TEST(divide_integer_infinity_by_infinity_throws) {
   try {
     static_cast<void>(sourcemeta::core::Decimal::infinity().divide_integer(
         sourcemeta::core::Decimal::infinity()));
@@ -3602,207 +3599,207 @@ TEST(Numeric_decimal, divide_integer_infinity_by_infinity_throws) {
   }
 }
 
-TEST(Numeric_decimal, divide_integer_with_decimals) {
+TEST(divide_integer_with_decimals) {
   const sourcemeta::core::Decimal left{"10.5"};
   const sourcemeta::core::Decimal right{"3.1"};
   EXPECT_EQ(left.divide_integer(right), sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_decimal, strict_from_positive_integer) {
+TEST(strict_from_positive_integer) {
   const auto result{sourcemeta::core::Decimal::strict_from(5.0)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{5});
 }
 
-TEST(Numeric_decimal, strict_from_negative_integer) {
+TEST(strict_from_negative_integer) {
   const auto result{sourcemeta::core::Decimal::strict_from(-3.0)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{-3});
 }
 
-TEST(Numeric_decimal, strict_from_zero) {
+TEST(strict_from_zero) {
   const auto result{sourcemeta::core::Decimal::strict_from(0.0)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_decimal, strict_from_positive_fractional) {
+TEST(strict_from_positive_fractional) {
   const auto result{sourcemeta::core::Decimal::strict_from(1.5)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"1.5"});
 }
 
-TEST(Numeric_decimal, strict_from_negative_fractional) {
+TEST(strict_from_negative_fractional) {
   const auto result{sourcemeta::core::Decimal::strict_from(-2.75)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"-2.75"});
 }
 
-TEST(Numeric_decimal, strict_from_0_1) {
+TEST(strict_from_0_1) {
   const auto result{sourcemeta::core::Decimal::strict_from(0.1)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"0.1"});
 }
 
-TEST(Numeric_decimal, strict_from_0_01) {
+TEST(strict_from_0_01) {
   const auto result{sourcemeta::core::Decimal::strict_from(0.01)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"0.01"});
 }
 
-TEST(Numeric_decimal, strict_from_0_001) {
+TEST(strict_from_0_001) {
   const auto result{sourcemeta::core::Decimal::strict_from(0.001)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"0.001"});
 }
 
-TEST(Numeric_decimal, strict_from_0_0001) {
+TEST(strict_from_0_0001) {
   const auto result{sourcemeta::core::Decimal::strict_from(0.0001)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"0.0001"});
 }
 
-TEST(Numeric_decimal, strict_from_1280_32) {
+TEST(strict_from_1280_32) {
   const auto result{sourcemeta::core::Decimal::strict_from(1280.32)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"1280.32"});
 }
 
-TEST(Numeric_decimal, strict_from_99_99) {
+TEST(strict_from_99_99) {
   const auto result{sourcemeta::core::Decimal::strict_from(99.99)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"99.99"});
 }
 
-TEST(Numeric_decimal, strict_from_large_value) {
+TEST(strict_from_large_value) {
   const auto result{sourcemeta::core::Decimal::strict_from(999999.99)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"999999.99"});
 }
 
-TEST(Numeric_decimal, strict_from_negative_1280_32) {
+TEST(strict_from_negative_1280_32) {
   const auto result{sourcemeta::core::Decimal::strict_from(-1280.32)};
   EXPECT_EQ(result, sourcemeta::core::Decimal{"-1280.32"});
 }
 
-TEST(Numeric_decimal, is_integer_string_lexical_positive) {
+TEST(is_integer_string_lexical_positive) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"5"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_lexical_negative) {
+TEST(is_integer_string_lexical_negative) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"-5"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_lexical_zero) {
+TEST(is_integer_string_lexical_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"0"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_lexical_negative_zero) {
+TEST(is_integer_string_lexical_negative_zero) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"-0"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_lexical_explicit_plus) {
+TEST(is_integer_string_lexical_explicit_plus) {
   EXPECT_TRUE(sourcemeta::core::Decimal{"+5"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_lexical_bignum) {
+TEST(is_integer_string_lexical_bignum) {
   const sourcemeta::core::Decimal value{
       "12345678910111213141516171819202122232425262728293031"};
   EXPECT_TRUE(value.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_exponent_lower_zero) {
+TEST(is_integer_string_exponent_lower_zero) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1e0"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_exponent_lower_positive) {
+TEST(is_integer_string_exponent_lower_positive) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1e2"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_exponent_lower_negative) {
+TEST(is_integer_string_exponent_lower_negative) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1e-2"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_exponent_upper) {
+TEST(is_integer_string_exponent_upper) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1E5"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_dot_with_exponent) {
+TEST(is_integer_string_dot_with_exponent) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1.5e2"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_resolved_via_negative_exponent) {
+TEST(is_integer_string_resolved_via_negative_exponent) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"30e-1"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_dot_zero_fraction) {
+TEST(is_integer_string_dot_zero_fraction) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1.0"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_dot_non_zero_fraction) {
+TEST(is_integer_string_dot_non_zero_fraction) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"3.5"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_string_dot_high_precision) {
+TEST(is_integer_string_dot_high_precision) {
   EXPECT_FALSE(sourcemeta::core::Decimal{"1.000000000000000001"}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_int_typed_constructor_int) {
+TEST(is_integer_int_typed_constructor_int) {
   EXPECT_TRUE(sourcemeta::core::Decimal{42}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_int_typed_constructor_negative) {
+TEST(is_integer_int_typed_constructor_negative) {
   EXPECT_TRUE(sourcemeta::core::Decimal{-1}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_int_typed_constructor_int64_max) {
+TEST(is_integer_int_typed_constructor_int64_max) {
   EXPECT_TRUE(
       sourcemeta::core::Decimal{std::numeric_limits<std::int64_t>::max()}
           .is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_int_typed_constructor_int64_min) {
+TEST(is_integer_int_typed_constructor_int64_min) {
   EXPECT_TRUE(
       sourcemeta::core::Decimal{std::numeric_limits<std::int64_t>::min()}
           .is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_int_typed_constructor_uint64) {
+TEST(is_integer_int_typed_constructor_uint64) {
   EXPECT_TRUE(
       sourcemeta::core::Decimal{std::numeric_limits<std::uint64_t>::max()}
           .is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_double_constructor_integer_valued) {
+TEST(is_integer_double_constructor_integer_valued) {
   EXPECT_FALSE(sourcemeta::core::Decimal{3.0}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_double_constructor_fractional) {
+TEST(is_integer_double_constructor_fractional) {
   EXPECT_FALSE(sourcemeta::core::Decimal{3.14}.is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_strict_from_double_integer_valued) {
+TEST(is_integer_strict_from_double_integer_valued) {
   EXPECT_FALSE(sourcemeta::core::Decimal::strict_from(3.0).is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_arithmetic_clears_flag) {
+TEST(is_integer_arithmetic_clears_flag) {
   const sourcemeta::core::Decimal sum{sourcemeta::core::Decimal{"5"} +
                                       sourcemeta::core::Decimal{"3"}};
   EXPECT_FALSE(sum.is_integer());
   EXPECT_TRUE(sum.is_integral());
 }
 
-TEST(Numeric_decimal, is_integer_nan) {
+TEST(is_integer_nan) {
   EXPECT_FALSE(sourcemeta::core::Decimal::nan().is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_snan) {
+TEST(is_integer_snan) {
   EXPECT_FALSE(sourcemeta::core::Decimal::snan().is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_infinity) {
+TEST(is_integer_infinity) {
   EXPECT_FALSE(sourcemeta::core::Decimal::infinity().is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_negative_infinity) {
+TEST(is_integer_negative_infinity) {
   EXPECT_FALSE(sourcemeta::core::Decimal::negative_infinity().is_integer());
 }
 
-TEST(Numeric_decimal, is_integer_implies_is_integral) {
+TEST(is_integer_implies_is_integral) {
   const sourcemeta::core::Decimal value{42};
   EXPECT_TRUE(value.is_integer());
   EXPECT_TRUE(value.is_integral());
 }
 
-TEST(Numeric_decimal, parse_digit_string_longer_than_inline_buffer) {
+TEST(parse_digit_string_longer_than_inline_buffer) {
   const std::string digits(1100, '9');
   const sourcemeta::core::Decimal value{digits};
   EXPECT_EQ(value.to_string(), digits);
@@ -3810,26 +3807,26 @@ TEST(Numeric_decimal, parse_digit_string_longer_than_inline_buffer) {
   EXPECT_EQ(value, again);
 }
 
-TEST(Numeric_decimal, big_integral_with_negative_exponent_to_uint64) {
+TEST(big_integral_with_negative_exponent_to_uint64) {
   const sourcemeta::core::Decimal value{"10000000000000000000e-1"};
   EXPECT_TRUE(value.is_integral());
   EXPECT_TRUE(value.is_uint64());
   EXPECT_EQ(value.to_uint64(), 1000000000000000000ULL);
 }
 
-TEST(Numeric_decimal, big_integral_with_negative_exponent_to_int64) {
+TEST(big_integral_with_negative_exponent_to_int64) {
   const sourcemeta::core::Decimal value{"-10000000000000000000e-1"};
   EXPECT_TRUE(value.is_integral());
   EXPECT_EQ(value.to_int64(), -1000000000000000000LL);
 }
 
-TEST(Numeric_decimal, nan_with_payload_longer_than_storage_saturates) {
+TEST(nan_with_payload_longer_than_storage_saturates) {
   const sourcemeta::core::Decimal value{"NaN99999999999999999999999"};
   EXPECT_TRUE(value.is_nan());
   EXPECT_EQ(value.nan_payload(), std::numeric_limits<std::int64_t>::max());
 }
 
-TEST(Numeric_decimal, parse_extreme_negative_exponent_does_not_overflow) {
+TEST(parse_extreme_negative_exponent_does_not_overflow) {
   const sourcemeta::core::Decimal value{"1.5e-2147483648"};
   EXPECT_TRUE(value.is_finite());
 }

--- a/test/numeric/numeric_parse_test.cc
+++ b/test/numeric/numeric_parse_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/numeric.h>
 
@@ -6,807 +6,807 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
-TEST(Numeric_parse, to_double_positive_integer) {
+TEST(to_double_positive_integer) {
   const std::string input{"42"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42.0);
 }
 
-TEST(Numeric_parse, to_double_negative_integer) {
+TEST(to_double_negative_integer) {
   const std::string input{"-42"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), -42.0);
 }
 
-TEST(Numeric_parse, to_double_positive_decimal) {
+TEST(to_double_positive_decimal) {
   const std::string input{"3.14159"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 3.14159);
 }
 
-TEST(Numeric_parse, to_double_negative_decimal) {
+TEST(to_double_negative_decimal) {
   const std::string input{"-2.71828"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), -2.71828);
 }
 
-TEST(Numeric_parse, to_double_zero) {
+TEST(to_double_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0.0);
 }
 
-TEST(Numeric_parse, to_double_scientific_notation) {
+TEST(to_double_scientific_notation) {
   const std::string input{"1.5e10"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 1.5e10);
 }
 
-TEST(Numeric_parse, to_double_negative_scientific_notation) {
+TEST(to_double_negative_scientific_notation) {
   const std::string input{"-2.5e-5"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), -2.5e-5);
 }
 
-TEST(Numeric_parse, to_double_very_small) {
+TEST(to_double_very_small) {
   const std::string input{"0.000001"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 0.000001);
 }
 
-TEST(Numeric_parse, to_double_very_large_with_decimal) {
+TEST(to_double_very_large_with_decimal) {
   const std::string input{"99999999999999999999999999999999999.1"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 9.9999999999999997e+34);
 }
 
-TEST(Numeric_parse, to_double_invalid_empty_string) {
+TEST(to_double_invalid_empty_string) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_non_numeric) {
+TEST(to_double_invalid_non_numeric) {
   const std::string input{"not_a_number"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_letters) {
+TEST(to_double_invalid_letters) {
   const std::string input{"abc123"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_only_dot) {
+TEST(to_double_invalid_only_dot) {
   const std::string input{"."};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_out_of_range_too_large) {
+TEST(to_double_out_of_range_too_large) {
   const std::string input{"1.8e308"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_out_of_range_too_small) {
+TEST(to_double_out_of_range_too_small) {
   const std::string input{"-1.8e308"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_trailing_junk) {
+TEST(to_double_invalid_trailing_junk) {
   const std::string input{"42abc"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_trailing_decimal_junk) {
+TEST(to_double_invalid_trailing_decimal_junk) {
   const std::string input{"42.5abc"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_trailing_whitespace) {
+TEST(to_double_invalid_trailing_whitespace) {
   const std::string input{"42 "};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_leading_whitespace) {
+TEST(to_double_invalid_leading_whitespace) {
   const std::string input{" 42"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_leading_plus) {
+TEST(to_double_invalid_leading_plus) {
   const std::string input{"+1"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_leading_plus_decimal) {
+TEST(to_double_invalid_leading_plus_decimal) {
   const std::string input{"+1.5"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_hexadecimal) {
+TEST(to_double_invalid_hexadecimal) {
   const std::string input{"0x10"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_infinity_lowercase) {
+TEST(to_double_invalid_infinity_lowercase) {
   const std::string input{"inf"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_infinity_negative) {
+TEST(to_double_invalid_infinity_negative) {
   const std::string input{"-infinity"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_not_a_number) {
+TEST(to_double_invalid_not_a_number) {
   const std::string input{"nan"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_invalid_incomplete_exponent) {
+TEST(to_double_invalid_incomplete_exponent) {
   const std::string input{"1e"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_exponent_with_explicit_plus) {
+TEST(to_double_exponent_with_explicit_plus) {
   const std::string input{"1e+10"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 1e10);
 }
 
-TEST(Numeric_parse, to_double_out_of_range_underflow_to_zero) {
+TEST(to_double_out_of_range_underflow_to_zero) {
   const std::string input{"1e-400"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_out_of_range_negative_underflow_to_zero) {
+TEST(to_double_out_of_range_negative_underflow_to_zero) {
   const std::string input{"-1e-400"};
   const auto result{sourcemeta::core::to_double(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_smallest_subnormal) {
+TEST(to_double_smallest_subnormal) {
   const std::string input{"5e-324"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 5e-324);
 }
 
-TEST(Numeric_parse, to_double_subnormal) {
+TEST(to_double_subnormal) {
   const std::string input{"1e-310"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 1e-310);
 }
 
-TEST(Numeric_parse, to_double_smallest_normal) {
+TEST(to_double_smallest_normal) {
   const std::string input{"2.2250738585072014e-308"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 2.2250738585072014e-308);
 }
 
-TEST(Numeric_parse, to_double_long_input) {
+TEST(to_double_long_input) {
   const std::string input{
       "0.00000000000000000000000000000000000000000000000000000000000000000000"
       "1"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 1e-69);
 }
 
-TEST(Numeric_parse, to_int64_t_positive) {
+TEST(to_int64_t_positive) {
   const std::string input{"123456"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 123456);
 }
 
-TEST(Numeric_parse, to_int64_t_negative) {
+TEST(to_int64_t_negative) {
   const std::string input{"-987654"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), -987654);
 }
 
-TEST(Numeric_parse, to_int64_t_zero) {
+TEST(to_int64_t_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_int64_t_max_value) {
+TEST(to_int64_t_max_value) {
   const std::string input{"9223372036854775807"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 9223372036854775807LL);
 }
 
-TEST(Numeric_parse, to_int64_t_min_value) {
+TEST(to_int64_t_min_value) {
   const std::string input{"-9223372036854775808"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), -9223372036854775807LL - 1);
 }
 
-TEST(Numeric_parse, to_int64_t_large_positive) {
+TEST(to_int64_t_large_positive) {
   const std::string input{"1000000000000"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 1000000000000LL);
 }
 
-TEST(Numeric_parse, to_int64_t_large_negative) {
+TEST(to_int64_t_large_negative) {
   const std::string input{"-1000000000000"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), -1000000000000LL);
 }
 
-TEST(Numeric_parse, to_int64_t_invalid_empty_string) {
+TEST(to_int64_t_invalid_empty_string) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_invalid_non_numeric) {
+TEST(to_int64_t_invalid_non_numeric) {
   const std::string input{"not_a_number"};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_invalid_letters) {
+TEST(to_int64_t_invalid_letters) {
   const std::string input{"abc123"};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_out_of_range_too_large) {
+TEST(to_int64_t_out_of_range_too_large) {
   const std::string input{"9223372036854775808"};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_out_of_range_too_small) {
+TEST(to_int64_t_out_of_range_too_small) {
   const std::string input{"-9223372036854775809"};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_out_of_range_way_too_large) {
+TEST(to_int64_t_out_of_range_way_too_large) {
   const std::string input{"99999999999999999999"};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_invalid_trailing_junk) {
+TEST(to_int64_t_invalid_trailing_junk) {
   const std::string input{"123abc"};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_invalid_trailing_whitespace) {
+TEST(to_int64_t_invalid_trailing_whitespace) {
   const std::string input{"42 "};
   const auto result{sourcemeta::core::to_int64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_base16_lowercase) {
+TEST(to_int64_t_base16_lowercase) {
   const std::string input{"ff"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 255);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_uppercase) {
+TEST(to_int64_t_base16_uppercase) {
   const std::string input{"FF"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 255);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_zero) {
+TEST(to_int64_t_base16_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_large) {
+TEST(to_int64_t_base16_large) {
   const std::string input{"7FFFFFFFFFFFFFFF"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 9223372036854775807LL);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_invalid) {
+TEST(to_int64_t_base16_invalid) {
   const std::string input{"xyz"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_base16_out_of_range) {
+TEST(to_int64_t_base16_out_of_range) {
   const std::string input{"FFFFFFFFFFFFFFFFFFFFFFFF"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_base8_simple) {
+TEST(to_int64_t_base8_simple) {
   const std::string input{"77"};
   const auto result{sourcemeta::core::to_int64_t(input, 8)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 63);
 }
 
-TEST(Numeric_parse, to_int64_t_base8_zero) {
+TEST(to_int64_t_base8_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_int64_t(input, 8)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_int64_t_base8_large) {
+TEST(to_int64_t_base8_large) {
   const std::string input{"777777777777777777777"};
   const auto result{sourcemeta::core::to_int64_t(input, 8)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 9223372036854775807LL);
 }
 
-TEST(Numeric_parse, to_int64_t_base8_invalid_digit) {
+TEST(to_int64_t_base8_invalid_digit) {
   const std::string input{"89"};
   const auto result{sourcemeta::core::to_int64_t(input, 8)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_base8_out_of_range) {
+TEST(to_int64_t_base8_out_of_range) {
   const std::string input{"7777777777777777777777777"};
   const auto result{sourcemeta::core::to_int64_t(input, 8)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_base10_explicit) {
+TEST(to_int64_t_base10_explicit) {
   const std::string input{"12345"};
   const auto result{sourcemeta::core::to_int64_t(input, 10)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 12345);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_mixed_case) {
+TEST(to_int64_t_base16_mixed_case) {
   const std::string input{"aB3f"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0xAB3F);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_empty) {
+TEST(to_int64_t_base16_empty) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_int64_t_base8_empty) {
+TEST(to_int64_t_base8_empty) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_int64_t(input, 8)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_zero) {
+TEST(to_uint64_t_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_uint64_t_positive) {
+TEST(to_uint64_t_positive) {
   const std::string input{"42"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42);
 }
 
-TEST(Numeric_parse, to_uint64_t_large_positive) {
+TEST(to_uint64_t_large_positive) {
   const std::string input{"1000000000000"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 1000000000000ULL);
 }
 
-TEST(Numeric_parse, to_uint64_t_max_value) {
+TEST(to_uint64_t_max_value) {
   const std::string input{"18446744073709551615"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 18446744073709551615ULL);
 }
 
-TEST(Numeric_parse, to_uint64_t_out_of_range_too_large) {
+TEST(to_uint64_t_out_of_range_too_large) {
   const std::string input{"18446744073709551616"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_out_of_range_way_too_large) {
+TEST(to_uint64_t_out_of_range_way_too_large) {
   const std::string input{"99999999999999999999999"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_empty_string) {
+TEST(to_uint64_t_invalid_empty_string) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_non_numeric) {
+TEST(to_uint64_t_invalid_non_numeric) {
   const std::string input{"not_a_number"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_letters) {
+TEST(to_uint64_t_invalid_letters) {
   const std::string input{"abc123"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_trailing_junk) {
+TEST(to_uint64_t_invalid_trailing_junk) {
   const std::string input{"42abc"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_negative) {
+TEST(to_uint64_t_invalid_negative) {
   const std::string input{"-1"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_leading_plus) {
+TEST(to_uint64_t_invalid_leading_plus) {
   const std::string input{"+1"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_leading_zero) {
+TEST(to_uint64_t_leading_zero) {
   const std::string input{"050"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 50);
 }
 
-TEST(Numeric_parse, to_uint64_t_all_zeros) {
+TEST(to_uint64_t_all_zeros) {
   const std::string input{"00"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_leading_whitespace) {
+TEST(to_uint64_t_invalid_leading_whitespace) {
   const std::string input{"  42"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint64_t_invalid_trailing_whitespace) {
+TEST(to_uint64_t_invalid_trailing_whitespace) {
   const std::string input{"42 "};
   const auto result{sourcemeta::core::to_uint64_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_double_string_view_input) {
+TEST(to_double_string_view_input) {
   const std::string_view input{"3.14"};
   const auto result{sourcemeta::core::to_double(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_DOUBLE_EQ(result.value(), 3.14);
 }
 
-TEST(Numeric_parse, to_double_string_view_substring_no_terminator) {
+TEST(to_double_string_view_substring_no_terminator) {
   const std::string_view input{"42abc"};
   const auto result{sourcemeta::core::to_double(input.substr(0, 2))};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42.0);
 }
 
-TEST(Numeric_parse, to_int64_t_string_view_input) {
+TEST(to_int64_t_string_view_input) {
   const std::string_view input{"-123"};
   const auto result{sourcemeta::core::to_int64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), -123);
 }
 
-TEST(Numeric_parse, to_int64_t_string_view_substring_no_terminator) {
+TEST(to_int64_t_string_view_substring_no_terminator) {
   const std::string_view input{"123abc"};
   const auto result{sourcemeta::core::to_int64_t(input.substr(0, 3))};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 123);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_string_view_input) {
+TEST(to_int64_t_base16_string_view_input) {
   const std::string_view input{"deadbeef"};
   const auto result{sourcemeta::core::to_int64_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0xDEADBEEF);
 }
 
-TEST(Numeric_parse, to_int64_t_base16_string_view_substring_no_terminator) {
+TEST(to_int64_t_base16_string_view_substring_no_terminator) {
   const std::string_view input{"ABCDxyz"};
   const auto result{sourcemeta::core::to_int64_t(input.substr(0, 4), 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0xABCD);
 }
 
-TEST(Numeric_parse, to_uint64_t_string_view_input) {
+TEST(to_uint64_t_string_view_input) {
   const std::string_view input{"42"};
   const auto result{sourcemeta::core::to_uint64_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42);
 }
 
-TEST(Numeric_parse, to_uint64_t_string_view_substring_no_terminator) {
+TEST(to_uint64_t_string_view_substring_no_terminator) {
   const std::string_view input{"99xyz"};
   const auto result{sourcemeta::core::to_uint64_t(input.substr(0, 2))};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 99);
 }
 
-TEST(Numeric_parse, to_uint32_t_zero) {
+TEST(to_uint32_t_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_uint32_t_positive) {
+TEST(to_uint32_t_positive) {
   const std::string input{"42"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42);
 }
 
-TEST(Numeric_parse, to_uint32_t_max_value) {
+TEST(to_uint32_t_max_value) {
   const std::string input{"4294967295"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 4294967295U);
 }
 
-TEST(Numeric_parse, to_uint32_t_out_of_range_too_large) {
+TEST(to_uint32_t_out_of_range_too_large) {
   const std::string input{"4294967296"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_out_of_range_way_too_large) {
+TEST(to_uint32_t_out_of_range_way_too_large) {
   const std::string input{"99999999999"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_empty_string) {
+TEST(to_uint32_t_invalid_empty_string) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_non_numeric) {
+TEST(to_uint32_t_invalid_non_numeric) {
   const std::string input{"not_a_number"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_trailing_junk) {
+TEST(to_uint32_t_invalid_trailing_junk) {
   const std::string input{"42abc"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_negative) {
+TEST(to_uint32_t_invalid_negative) {
   const std::string input{"-1"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_leading_plus) {
+TEST(to_uint32_t_invalid_leading_plus) {
   const std::string input{"+1"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_leading_whitespace) {
+TEST(to_uint32_t_invalid_leading_whitespace) {
   const std::string input{" 42"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_invalid_trailing_whitespace) {
+TEST(to_uint32_t_invalid_trailing_whitespace) {
   const std::string input{"42 "};
   const auto result{sourcemeta::core::to_uint32_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_string_view_input) {
+TEST(to_uint32_t_string_view_input) {
   const std::string_view input{"42"};
   const auto result{sourcemeta::core::to_uint32_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42U);
 }
 
-TEST(Numeric_parse, to_uint32_t_string_view_substring_no_terminator) {
+TEST(to_uint32_t_string_view_substring_no_terminator) {
   const std::string_view input{"99xyz"};
   const auto result{sourcemeta::core::to_uint32_t(input.substr(0, 2))};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 99U);
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_lowercase) {
+TEST(to_uint32_t_base16_lowercase) {
   const std::string input{"ff"};
   const auto result{sourcemeta::core::to_uint32_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 255U);
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_uppercase) {
+TEST(to_uint32_t_base16_uppercase) {
   const std::string input{"FF"};
   const auto result{sourcemeta::core::to_uint32_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 255U);
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_max) {
+TEST(to_uint32_t_base16_max) {
   const std::string input{"FFFFFFFF"};
   const auto result{sourcemeta::core::to_uint32_t(input, 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 4294967295U);
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_out_of_range) {
+TEST(to_uint32_t_base16_out_of_range) {
   const std::string input{"100000000"};
   const auto result{sourcemeta::core::to_uint32_t(input, 16)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_base8_simple) {
+TEST(to_uint32_t_base8_simple) {
   const std::string input{"77"};
   const auto result{sourcemeta::core::to_uint32_t(input, 8)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 63U);
 }
 
-TEST(Numeric_parse, to_uint32_t_base8_invalid_digit) {
+TEST(to_uint32_t_base8_invalid_digit) {
   const std::string input{"89"};
   const auto result{sourcemeta::core::to_uint32_t(input, 8)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_empty) {
+TEST(to_uint32_t_base16_empty) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_uint32_t(input, 16)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_string_view_substring_no_terminator) {
+TEST(to_uint32_t_base16_string_view_substring_no_terminator) {
   const std::string_view input{"ABCDxyz"};
   const auto result{sourcemeta::core::to_uint32_t(input.substr(0, 4), 16)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0xABCDU);
 }
 
-TEST(Numeric_parse, to_uint32_t_base16_invalid_negative) {
+TEST(to_uint32_t_base16_invalid_negative) {
   const std::string input{"-1"};
   const auto result{sourcemeta::core::to_uint32_t(input, 16)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_zero) {
+TEST(to_uint16_t_zero) {
   const std::string input{"0"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 0);
 }
 
-TEST(Numeric_parse, to_uint16_t_positive) {
+TEST(to_uint16_t_positive) {
   const std::string input{"42"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42);
 }
 
-TEST(Numeric_parse, to_uint16_t_max_value) {
+TEST(to_uint16_t_max_value) {
   const std::string input{"65535"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 65535);
 }
 
-TEST(Numeric_parse, to_uint16_t_out_of_range_too_large) {
+TEST(to_uint16_t_out_of_range_too_large) {
   const std::string input{"65536"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_out_of_range_way_too_large) {
+TEST(to_uint16_t_out_of_range_way_too_large) {
   const std::string input{"99999999999"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_empty_string) {
+TEST(to_uint16_t_invalid_empty_string) {
   const std::string input{""};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_non_numeric) {
+TEST(to_uint16_t_invalid_non_numeric) {
   const std::string input{"not_a_number"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_trailing_junk) {
+TEST(to_uint16_t_invalid_trailing_junk) {
   const std::string input{"42abc"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_negative) {
+TEST(to_uint16_t_invalid_negative) {
   const std::string input{"-1"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_leading_plus) {
+TEST(to_uint16_t_invalid_leading_plus) {
   const std::string input{"+1"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_leading_whitespace) {
+TEST(to_uint16_t_invalid_leading_whitespace) {
   const std::string input{" 42"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_invalid_trailing_whitespace) {
+TEST(to_uint16_t_invalid_trailing_whitespace) {
   const std::string input{"42 "};
   const auto result{sourcemeta::core::to_uint16_t(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Numeric_parse, to_uint16_t_string_view_input) {
+TEST(to_uint16_t_string_view_input) {
   const std::string_view input{"42"};
   const auto result{sourcemeta::core::to_uint16_t(input)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42);
 }
 
-TEST(Numeric_parse, to_uint16_t_string_view_substring_no_terminator) {
+TEST(to_uint16_t_string_view_substring_no_terminator) {
   const std::string_view input{"99xyz"};
   const auto result{sourcemeta::core::to_uint16_t(input.substr(0, 2))};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 99);
 }

--- a/test/numeric/numeric_uint128_test.cc
+++ b/test/numeric/numeric_uint128_test.cc
@@ -1,20 +1,20 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/numeric.h>
 
 #include <cstdint> // std::uint64_t, std::int64_t
 
-TEST(Numeric_uint128, default_construction) {
+TEST(default_construction) {
   const sourcemeta::core::uint128_t value{};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 0);
 }
 
-TEST(Numeric_uint128, construct_from_int) {
+TEST(construct_from_int) {
   const sourcemeta::core::uint128_t value{42};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 42);
 }
 
-TEST(Numeric_uint128, construct_from_negative_int) {
+TEST(construct_from_negative_int) {
   // unsigned __int128(-1) on GCC/Clang yields 2^128 - 1 (all bits set)
   const sourcemeta::core::uint128_t value{
       static_cast<sourcemeta::core::uint128_t>(-1)};
@@ -23,76 +23,76 @@ TEST(Numeric_uint128, construct_from_negative_int) {
   EXPECT_TRUE(value > sourcemeta::core::uint128_t{UINT64_MAX});
 }
 
-TEST(Numeric_uint128, construct_from_unsigned_int) {
+TEST(construct_from_unsigned_int) {
   const sourcemeta::core::uint128_t value{42u};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 42);
 }
 
-TEST(Numeric_uint128, construct_from_uint64) {
+TEST(construct_from_uint64) {
   const sourcemeta::core::uint128_t value{
       static_cast<std::uint64_t>(1000000000000ULL)};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 1000000000000ULL);
 }
 
-TEST(Numeric_uint128, construct_from_int64) {
+TEST(construct_from_int64) {
   const sourcemeta::core::uint128_t value{static_cast<std::int64_t>(99)};
   EXPECT_EQ(static_cast<std::int64_t>(value), 99);
 }
 
-TEST(Numeric_uint128, construct_from_negative_int64) {
+TEST(construct_from_negative_int64) {
   const sourcemeta::core::uint128_t value{
       static_cast<sourcemeta::core::uint128_t>(static_cast<std::int64_t>(-1))};
   EXPECT_EQ(static_cast<std::uint64_t>(value), UINT64_MAX);
   EXPECT_TRUE(value > sourcemeta::core::uint128_t{UINT64_MAX});
 }
 
-TEST(Numeric_uint128, explicit_cast_to_uint64) {
+TEST(explicit_cast_to_uint64) {
   const sourcemeta::core::uint128_t value{12345ULL};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 12345ULL);
 }
 
-TEST(Numeric_uint128, explicit_cast_to_int64) {
+TEST(explicit_cast_to_int64) {
   const sourcemeta::core::uint128_t value{789};
   EXPECT_EQ(static_cast<std::int64_t>(value), 789);
 }
 
-TEST(Numeric_uint128, explicit_cast_to_bool_zero) {
+TEST(explicit_cast_to_bool_zero) {
   const sourcemeta::core::uint128_t value{0};
   EXPECT_FALSE(static_cast<bool>(value));
 }
 
-TEST(Numeric_uint128, explicit_cast_to_bool_nonzero) {
+TEST(explicit_cast_to_bool_nonzero) {
   const sourcemeta::core::uint128_t value{1};
   EXPECT_TRUE(static_cast<bool>(value));
 }
 
-TEST(Numeric_uint128, addition) {
+TEST(addition) {
   const sourcemeta::core::uint128_t left{100};
   const sourcemeta::core::uint128_t right{200};
   const auto result = left + right;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 300);
 }
 
-TEST(Numeric_uint128, addition_assignment) {
+TEST(addition_assignment) {
   sourcemeta::core::uint128_t value{100};
   value += sourcemeta::core::uint128_t{50};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 150);
 }
 
-TEST(Numeric_uint128, subtraction) {
+TEST(subtraction) {
   const sourcemeta::core::uint128_t left{300};
   const sourcemeta::core::uint128_t right{100};
   const auto result = left - right;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 200);
 }
 
-TEST(Numeric_uint128, subtraction_assignment) {
+TEST(subtraction_assignment) {
   sourcemeta::core::uint128_t value{150};
   value -= sourcemeta::core::uint128_t{50};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 100);
 }
 
-TEST(Numeric_uint128, subtraction_borrow_from_high_bits) {
+TEST(subtraction_borrow_from_high_bits) {
   // 2^64 - 1 borrows from the high word, leaving all ones in the low word
   const auto value = sourcemeta::core::uint128_t{1} << 64;
   const auto result = value - sourcemeta::core::uint128_t{1};
@@ -100,43 +100,43 @@ TEST(Numeric_uint128, subtraction_borrow_from_high_bits) {
   EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0);
 }
 
-TEST(Numeric_uint128, subtraction_to_zero) {
+TEST(subtraction_to_zero) {
   const sourcemeta::core::uint128_t value{42};
   EXPECT_FALSE(static_cast<bool>(value - value));
 }
 
-TEST(Numeric_uint128, multiplication) {
+TEST(multiplication) {
   const sourcemeta::core::uint128_t left{1000};
   const sourcemeta::core::uint128_t right{2000};
   const auto result = left * right;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 2000000);
 }
 
-TEST(Numeric_uint128, multiplication_assignment) {
+TEST(multiplication_assignment) {
   sourcemeta::core::uint128_t value{500};
   value *= sourcemeta::core::uint128_t{3};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 1500);
 }
 
-TEST(Numeric_uint128, division_by_uint64) {
+TEST(division_by_uint64) {
   const sourcemeta::core::uint128_t dividend{100};
   const auto result = dividend / static_cast<std::uint64_t>(10);
   EXPECT_EQ(static_cast<std::uint64_t>(result), 10);
 }
 
-TEST(Numeric_uint128, modulo_by_uint64) {
+TEST(modulo_by_uint64) {
   const sourcemeta::core::uint128_t dividend{17};
   const auto result = dividend % static_cast<std::uint64_t>(5);
   EXPECT_EQ(static_cast<std::uint64_t>(result), 2);
 }
 
-TEST(Numeric_uint128, modulo_assignment) {
+TEST(modulo_assignment) {
   sourcemeta::core::uint128_t value{17};
   value %= sourcemeta::core::uint128_t{5};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 2);
 }
 
-TEST(Numeric_uint128, modulo_assignment_high_word) {
+TEST(modulo_assignment_high_word) {
   // 2^64 + 3 has a non-zero high word, exercising the high-word division path.
   // 2^64 mod 7 == 2 (since 2^3 == 1 mod 7 and 64 == 1 mod 3), so the result is
   // 5
@@ -146,33 +146,33 @@ TEST(Numeric_uint128, modulo_assignment_high_word) {
   EXPECT_EQ(static_cast<std::uint64_t>(value), 5);
 }
 
-TEST(Numeric_uint128, equal) {
+TEST(equal) {
   const sourcemeta::core::uint128_t left{42};
   const sourcemeta::core::uint128_t right{42};
   EXPECT_TRUE(left == right);
 }
 
-TEST(Numeric_uint128, not_equal) {
+TEST(not_equal) {
   const sourcemeta::core::uint128_t left{42};
   const sourcemeta::core::uint128_t right{43};
   EXPECT_TRUE(left != right);
 }
 
-TEST(Numeric_uint128, less_than) {
+TEST(less_than) {
   const sourcemeta::core::uint128_t left{10};
   const sourcemeta::core::uint128_t right{20};
   EXPECT_TRUE(left < right);
   EXPECT_FALSE(right < left);
 }
 
-TEST(Numeric_uint128, greater_than) {
+TEST(greater_than) {
   const sourcemeta::core::uint128_t left{20};
   const sourcemeta::core::uint128_t right{10};
   EXPECT_TRUE(left > right);
   EXPECT_FALSE(right > left);
 }
 
-TEST(Numeric_uint128, less_than_or_equal) {
+TEST(less_than_or_equal) {
   const sourcemeta::core::uint128_t left{10};
   const sourcemeta::core::uint128_t right{10};
   const sourcemeta::core::uint128_t bigger{20};
@@ -181,7 +181,7 @@ TEST(Numeric_uint128, less_than_or_equal) {
   EXPECT_FALSE(bigger <= left);
 }
 
-TEST(Numeric_uint128, greater_than_or_equal) {
+TEST(greater_than_or_equal) {
   const sourcemeta::core::uint128_t left{10};
   const sourcemeta::core::uint128_t right{10};
   const sourcemeta::core::uint128_t smaller{5};
@@ -190,7 +190,7 @@ TEST(Numeric_uint128, greater_than_or_equal) {
   EXPECT_FALSE(smaller >= left);
 }
 
-TEST(Numeric_uint128, addition_overflow_into_high_bits) {
+TEST(addition_overflow_into_high_bits) {
   const sourcemeta::core::uint128_t max_low{UINT64_MAX};
   const sourcemeta::core::uint128_t one{1};
   const auto result = max_low + one;
@@ -199,7 +199,7 @@ TEST(Numeric_uint128, addition_overflow_into_high_bits) {
   EXPECT_TRUE(static_cast<bool>(result));
 }
 
-TEST(Numeric_uint128, large_multiplication_roundtrip) {
+TEST(large_multiplication_roundtrip) {
   // 10^18 * 5 = 5 * 10^18, which fits in 64 bits
   const sourcemeta::core::uint128_t base{1000000000000000000ULL};
   const sourcemeta::core::uint128_t factor{5};
@@ -207,7 +207,7 @@ TEST(Numeric_uint128, large_multiplication_roundtrip) {
   EXPECT_EQ(static_cast<std::uint64_t>(product), 5000000000000000000ULL);
 }
 
-TEST(Numeric_uint128, large_multiply_then_divide) {
+TEST(large_multiply_then_divide) {
   // (10^18 * 7) / 7 should give back 10^18
   const sourcemeta::core::uint128_t base{1000000000000000000ULL};
   const sourcemeta::core::uint128_t factor{7};
@@ -216,14 +216,14 @@ TEST(Numeric_uint128, large_multiply_then_divide) {
   EXPECT_EQ(static_cast<std::uint64_t>(back), 1000000000000000000ULL);
 }
 
-TEST(Numeric_uint128, modulo_large_value) {
+TEST(modulo_large_value) {
   // 10^18 % 7
   const sourcemeta::core::uint128_t value{1000000000000000000ULL};
   const auto result = value % static_cast<std::uint64_t>(7);
   EXPECT_EQ(static_cast<std::uint64_t>(result), 1000000000000000000ULL % 7ULL);
 }
 
-TEST(Numeric_uint128, overflow_multiply_then_divide) {
+TEST(overflow_multiply_then_divide) {
   // UINT64_MAX * 3 overflows 64 bits, then divide by 3 should recover
   const sourcemeta::core::uint128_t large{UINT64_MAX};
   const sourcemeta::core::uint128_t three{3};
@@ -232,19 +232,19 @@ TEST(Numeric_uint128, overflow_multiply_then_divide) {
   EXPECT_EQ(static_cast<std::uint64_t>(back), UINT64_MAX);
 }
 
-TEST(Numeric_uint128, addition_commutativity) {
+TEST(addition_commutativity) {
   const sourcemeta::core::uint128_t left{123456789ULL};
   const sourcemeta::core::uint128_t right{987654321ULL};
   EXPECT_TRUE((left + right) == (right + left));
 }
 
-TEST(Numeric_uint128, multiplication_commutativity) {
+TEST(multiplication_commutativity) {
   const sourcemeta::core::uint128_t left{12345ULL};
   const sourcemeta::core::uint128_t right{67890ULL};
   EXPECT_TRUE((left * right) == (right * left));
 }
 
-TEST(Numeric_uint128, multiply_by_zero) {
+TEST(multiply_by_zero) {
   const sourcemeta::core::uint128_t value{999999ULL};
   const sourcemeta::core::uint128_t zero{0};
   const auto result = value * zero;
@@ -252,39 +252,39 @@ TEST(Numeric_uint128, multiply_by_zero) {
   EXPECT_FALSE(static_cast<bool>(result));
 }
 
-TEST(Numeric_uint128, add_zero) {
+TEST(add_zero) {
   const sourcemeta::core::uint128_t value{42};
   const sourcemeta::core::uint128_t zero{0};
   EXPECT_TRUE((value + zero) == value);
 }
 
-TEST(Numeric_uint128, division_by_uint128) {
+TEST(division_by_uint128) {
   const sourcemeta::core::uint128_t dividend{100};
   const sourcemeta::core::uint128_t divisor{10};
   const auto result = dividend / divisor;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 10);
 }
 
-TEST(Numeric_uint128, modulo_by_uint128) {
+TEST(modulo_by_uint128) {
   const sourcemeta::core::uint128_t dividend{17};
   const sourcemeta::core::uint128_t divisor{5};
   const auto result = dividend % divisor;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 2);
 }
 
-TEST(Numeric_uint128, left_shift_zero) {
+TEST(left_shift_zero) {
   const sourcemeta::core::uint128_t value{0xFF};
   const auto result = value << 0;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0xFF);
 }
 
-TEST(Numeric_uint128, left_shift_small) {
+TEST(left_shift_small) {
   const sourcemeta::core::uint128_t value{1};
   const auto result = value << 8;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 256);
 }
 
-TEST(Numeric_uint128, left_shift_by_64) {
+TEST(left_shift_by_64) {
   const sourcemeta::core::uint128_t value{0xAB};
   const auto result = value << 64;
   // Low bits should be zero, high bits should hold 0xAB
@@ -292,7 +292,7 @@ TEST(Numeric_uint128, left_shift_by_64) {
   EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0xAB);
 }
 
-TEST(Numeric_uint128, left_shift_by_96) {
+TEST(left_shift_by_96) {
   const sourcemeta::core::uint128_t value{0x1};
   const auto result = value << 96;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0);
@@ -300,7 +300,7 @@ TEST(Numeric_uint128, left_shift_by_96) {
             static_cast<std::uint64_t>(0x1) << 32);
 }
 
-TEST(Numeric_uint128, left_shift_by_127) {
+TEST(left_shift_by_127) {
   const sourcemeta::core::uint128_t value{1};
   const auto result = value << 127;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0);
@@ -308,46 +308,46 @@ TEST(Numeric_uint128, left_shift_by_127) {
             static_cast<std::uint64_t>(1) << 63);
 }
 
-TEST(Numeric_uint128, right_shift_zero) {
+TEST(right_shift_zero) {
   const sourcemeta::core::uint128_t value{0xFF};
   const auto result = value >> 0;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0xFF);
 }
 
-TEST(Numeric_uint128, right_shift_small) {
+TEST(right_shift_small) {
   const sourcemeta::core::uint128_t value{256};
   const auto result = value >> 8;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 1);
 }
 
-TEST(Numeric_uint128, right_shift_by_64) {
+TEST(right_shift_by_64) {
   const sourcemeta::core::uint128_t value{sourcemeta::core::uint128_t{0xAB}
                                           << 64};
   const auto result = value >> 64;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0xAB);
 }
 
-TEST(Numeric_uint128, right_shift_by_127) {
+TEST(right_shift_by_127) {
   const sourcemeta::core::uint128_t value{sourcemeta::core::uint128_t{1}
                                           << 127};
   const auto result = value >> 127;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 1);
 }
 
-TEST(Numeric_uint128, shift_left_then_right_roundtrip) {
+TEST(shift_left_then_right_roundtrip) {
   const sourcemeta::core::uint128_t value{0xDEADBEEF};
   const auto result = (value << 64) >> 64;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0xDEADBEEF);
 }
 
-TEST(Numeric_uint128, bitwise_or) {
+TEST(bitwise_or) {
   const sourcemeta::core::uint128_t left{0xF0};
   const sourcemeta::core::uint128_t right{0x0F};
   const auto result = left | right;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0xFF);
 }
 
-TEST(Numeric_uint128, bitwise_or_high_and_low) {
+TEST(bitwise_or_high_and_low) {
   const auto high = sourcemeta::core::uint128_t{0xAA} << 64;
   const sourcemeta::core::uint128_t low{0xBB};
   const auto result = high | low;
@@ -355,20 +355,20 @@ TEST(Numeric_uint128, bitwise_or_high_and_low) {
   EXPECT_EQ(static_cast<std::uint64_t>(result >> 64), 0xAA);
 }
 
-TEST(Numeric_uint128, bitwise_or_assignment) {
+TEST(bitwise_or_assignment) {
   sourcemeta::core::uint128_t value{0xF0};
   value |= sourcemeta::core::uint128_t{0x0F};
   EXPECT_EQ(static_cast<std::uint64_t>(value), 0xFF);
 }
 
-TEST(Numeric_uint128, bitwise_and) {
+TEST(bitwise_and) {
   const sourcemeta::core::uint128_t left{0xFF};
   const sourcemeta::core::uint128_t right{0x0F};
   const auto result = left & right;
   EXPECT_EQ(static_cast<std::uint64_t>(result), 0x0F);
 }
 
-TEST(Numeric_uint128, bitwise_and_mask_low_byte) {
+TEST(bitwise_and_mask_low_byte) {
   const auto value = (sourcemeta::core::uint128_t{0xAB} << 64) |
                      sourcemeta::core::uint128_t{0x12FF};
   const auto result = value & sourcemeta::core::uint128_t{0xFF};

--- a/test/numeric/numeric_util_test.cc
+++ b/test/numeric/numeric_util_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/numeric.h>
 
@@ -6,506 +6,474 @@
 #include <cstdint> // std::int64_t, std::uint64_t, std::uint8_t
 #include <limits>  // std::numeric_limits
 
-TEST(Numeric_util, is_digit_zero) {
-  EXPECT_TRUE(sourcemeta::core::is_digit('0'));
-}
+TEST(is_digit_zero) { EXPECT_TRUE(sourcemeta::core::is_digit('0')); }
 
-TEST(Numeric_util, is_digit_nine) {
-  EXPECT_TRUE(sourcemeta::core::is_digit('9'));
-}
+TEST(is_digit_nine) { EXPECT_TRUE(sourcemeta::core::is_digit('9')); }
 
-TEST(Numeric_util, is_digit_five) {
-  EXPECT_TRUE(sourcemeta::core::is_digit('5'));
-}
+TEST(is_digit_five) { EXPECT_TRUE(sourcemeta::core::is_digit('5')); }
 
-TEST(Numeric_util, is_digit_lowercase_letter) {
+TEST(is_digit_lowercase_letter) {
   EXPECT_FALSE(sourcemeta::core::is_digit('a'));
 }
 
-TEST(Numeric_util, is_digit_uppercase_letter) {
+TEST(is_digit_uppercase_letter) {
   EXPECT_FALSE(sourcemeta::core::is_digit('Z'));
 }
 
-TEST(Numeric_util, is_digit_space) {
-  EXPECT_FALSE(sourcemeta::core::is_digit(' '));
-}
+TEST(is_digit_space) { EXPECT_FALSE(sourcemeta::core::is_digit(' ')); }
 
-TEST(Numeric_util, is_digit_slash) {
-  EXPECT_FALSE(sourcemeta::core::is_digit('/'));
-}
+TEST(is_digit_slash) { EXPECT_FALSE(sourcemeta::core::is_digit('/')); }
 
-TEST(Numeric_util, is_digit_colon) {
-  EXPECT_FALSE(sourcemeta::core::is_digit(':'));
-}
+TEST(is_digit_colon) { EXPECT_FALSE(sourcemeta::core::is_digit(':')); }
 
-TEST(Numeric_util, is_digit_null) {
-  EXPECT_FALSE(sourcemeta::core::is_digit('\0'));
-}
+TEST(is_digit_null) { EXPECT_FALSE(sourcemeta::core::is_digit('\0')); }
 
-TEST(Numeric_util, is_digit_minus) {
-  EXPECT_FALSE(sourcemeta::core::is_digit('-'));
-}
+TEST(is_digit_minus) { EXPECT_FALSE(sourcemeta::core::is_digit('-')); }
 
-TEST(Numeric_util, is_positive_digit_zero) {
+TEST(is_positive_digit_zero) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit('0'));
 }
 
-TEST(Numeric_util, is_positive_digit_one) {
+TEST(is_positive_digit_one) {
   EXPECT_TRUE(sourcemeta::core::is_positive_digit('1'));
 }
 
-TEST(Numeric_util, is_positive_digit_five) {
+TEST(is_positive_digit_five) {
   EXPECT_TRUE(sourcemeta::core::is_positive_digit('5'));
 }
 
-TEST(Numeric_util, is_positive_digit_nine) {
+TEST(is_positive_digit_nine) {
   EXPECT_TRUE(sourcemeta::core::is_positive_digit('9'));
 }
 
-TEST(Numeric_util, is_positive_digit_lowercase_letter) {
+TEST(is_positive_digit_lowercase_letter) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit('a'));
 }
 
-TEST(Numeric_util, is_positive_digit_slash) {
+TEST(is_positive_digit_slash) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit('/'));
 }
 
-TEST(Numeric_util, is_positive_digit_colon) {
+TEST(is_positive_digit_colon) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit(':'));
 }
 
-TEST(Numeric_util, is_positive_digit_space) {
+TEST(is_positive_digit_space) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit(' '));
 }
 
-TEST(Numeric_util, is_positive_digit_minus) {
+TEST(is_positive_digit_minus) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit('-'));
 }
 
-TEST(Numeric_util, is_positive_digit_null) {
+TEST(is_positive_digit_null) {
   EXPECT_FALSE(sourcemeta::core::is_positive_digit('\0'));
 }
 
-TEST(Numeric_util, is_hex_digit_zero) {
-  EXPECT_TRUE(sourcemeta::core::is_hex_digit('0'));
-}
+TEST(is_hex_digit_zero) { EXPECT_TRUE(sourcemeta::core::is_hex_digit('0')); }
 
-TEST(Numeric_util, is_hex_digit_nine) {
-  EXPECT_TRUE(sourcemeta::core::is_hex_digit('9'));
-}
+TEST(is_hex_digit_nine) { EXPECT_TRUE(sourcemeta::core::is_hex_digit('9')); }
 
-TEST(Numeric_util, is_hex_digit_lowercase_a) {
+TEST(is_hex_digit_lowercase_a) {
   EXPECT_TRUE(sourcemeta::core::is_hex_digit('a'));
 }
 
-TEST(Numeric_util, is_hex_digit_lowercase_f) {
+TEST(is_hex_digit_lowercase_f) {
   EXPECT_TRUE(sourcemeta::core::is_hex_digit('f'));
 }
 
-TEST(Numeric_util, is_hex_digit_uppercase_a) {
+TEST(is_hex_digit_uppercase_a) {
   EXPECT_TRUE(sourcemeta::core::is_hex_digit('A'));
 }
 
-TEST(Numeric_util, is_hex_digit_uppercase_f) {
+TEST(is_hex_digit_uppercase_f) {
   EXPECT_TRUE(sourcemeta::core::is_hex_digit('F'));
 }
 
-TEST(Numeric_util, is_hex_digit_lowercase_g) {
+TEST(is_hex_digit_lowercase_g) {
   EXPECT_FALSE(sourcemeta::core::is_hex_digit('g'));
 }
 
-TEST(Numeric_util, is_hex_digit_uppercase_g) {
+TEST(is_hex_digit_uppercase_g) {
   EXPECT_FALSE(sourcemeta::core::is_hex_digit('G'));
 }
 
-TEST(Numeric_util, is_hex_digit_uppercase_z) {
+TEST(is_hex_digit_uppercase_z) {
   EXPECT_FALSE(sourcemeta::core::is_hex_digit('Z'));
 }
 
-TEST(Numeric_util, is_hex_digit_space) {
-  EXPECT_FALSE(sourcemeta::core::is_hex_digit(' '));
-}
+TEST(is_hex_digit_space) { EXPECT_FALSE(sourcemeta::core::is_hex_digit(' ')); }
 
-TEST(Numeric_util, is_hex_digit_slash) {
-  EXPECT_FALSE(sourcemeta::core::is_hex_digit('/'));
-}
+TEST(is_hex_digit_slash) { EXPECT_FALSE(sourcemeta::core::is_hex_digit('/')); }
 
-TEST(Numeric_util, is_hex_digit_colon) {
-  EXPECT_FALSE(sourcemeta::core::is_hex_digit(':'));
-}
+TEST(is_hex_digit_colon) { EXPECT_FALSE(sourcemeta::core::is_hex_digit(':')); }
 
-TEST(Numeric_util, is_hex_digit_at_sign) {
+TEST(is_hex_digit_at_sign) {
   EXPECT_FALSE(sourcemeta::core::is_hex_digit('@'));
 }
 
-TEST(Numeric_util, is_hex_digit_backtick) {
+TEST(is_hex_digit_backtick) {
   EXPECT_FALSE(sourcemeta::core::is_hex_digit('`'));
 }
 
-TEST(Numeric_util, is_hex_digit_null) {
-  EXPECT_FALSE(sourcemeta::core::is_hex_digit('\0'));
-}
+TEST(is_hex_digit_null) { EXPECT_FALSE(sourcemeta::core::is_hex_digit('\0')); }
 
-TEST(Numeric_util, is_byte_zero) { EXPECT_TRUE(sourcemeta::core::is_byte(0)); }
+TEST(is_byte_zero) { EXPECT_TRUE(sourcemeta::core::is_byte(0)); }
 
-TEST(Numeric_util, is_byte_255) { EXPECT_TRUE(sourcemeta::core::is_byte(255)); }
+TEST(is_byte_255) { EXPECT_TRUE(sourcemeta::core::is_byte(255)); }
 
-TEST(Numeric_util, is_byte_256) {
-  EXPECT_FALSE(sourcemeta::core::is_byte(256));
-}
+TEST(is_byte_256) { EXPECT_FALSE(sourcemeta::core::is_byte(256)); }
 
-TEST(Numeric_util, is_byte_negative) {
-  EXPECT_FALSE(sourcemeta::core::is_byte(-1));
-}
+TEST(is_byte_negative) { EXPECT_FALSE(sourcemeta::core::is_byte(-1)); }
 
-TEST(Numeric_util, is_byte_decimal_zero) {
+TEST(is_byte_decimal_zero) {
   EXPECT_TRUE(sourcemeta::core::is_byte(sourcemeta::core::Decimal{0}));
 }
 
-TEST(Numeric_util, is_byte_decimal_255) {
+TEST(is_byte_decimal_255) {
   EXPECT_TRUE(sourcemeta::core::is_byte(sourcemeta::core::Decimal{255}));
 }
 
-TEST(Numeric_util, is_byte_decimal_256) {
+TEST(is_byte_decimal_256) {
   EXPECT_FALSE(sourcemeta::core::is_byte(sourcemeta::core::Decimal{256}));
 }
 
-TEST(Numeric_util, is_byte_decimal_non_integral) {
+TEST(is_byte_decimal_non_integral) {
   EXPECT_FALSE(
       sourcemeta::core::is_byte(sourcemeta::core::Decimal{std::string{"1.5"}}));
 }
 
-TEST(Numeric_util, uint_max_2) { EXPECT_EQ(sourcemeta::core::uint_max<2>, 3); }
+TEST(uint_max_2) { EXPECT_EQ(sourcemeta::core::uint_max<2>, 3); }
 
-TEST(Numeric_util, uint_max_3) { EXPECT_EQ(sourcemeta::core::uint_max<3>, 7); }
+TEST(uint_max_3) { EXPECT_EQ(sourcemeta::core::uint_max<3>, 7); }
 
-TEST(Numeric_util, uint_max_5) { EXPECT_EQ(sourcemeta::core::uint_max<5>, 31); }
+TEST(uint_max_5) { EXPECT_EQ(sourcemeta::core::uint_max<5>, 31); }
 
-TEST(Numeric_util, uint_max_8) {
+TEST(uint_max_8) {
   EXPECT_EQ(sourcemeta::core::uint_max<8>,
             std::numeric_limits<std::uint8_t>::max());
 }
 
-TEST(Numeric_util, uint_max_16) {
+TEST(uint_max_16) {
   EXPECT_EQ(sourcemeta::core::uint_max<16>,
             std::numeric_limits<std::uint16_t>::max());
 }
 
-TEST(Numeric_util, uint_max_32) {
+TEST(uint_max_32) {
   EXPECT_EQ(sourcemeta::core::uint_max<32>,
             std::numeric_limits<std::uint32_t>::max());
 }
 
-TEST(Numeric_util, is_within_in_range) {
+TEST(is_within_in_range) {
   EXPECT_TRUE(
       sourcemeta::core::is_within(5, std::int64_t{1}, std::int64_t{10}));
 }
 
-TEST(Numeric_util, is_within_at_lower_bound) {
+TEST(is_within_at_lower_bound) {
   EXPECT_TRUE(
       sourcemeta::core::is_within(1, std::int64_t{1}, std::int64_t{10}));
 }
 
-TEST(Numeric_util, is_within_at_upper_bound) {
+TEST(is_within_at_upper_bound) {
   EXPECT_TRUE(
       sourcemeta::core::is_within(10, std::int64_t{1}, std::int64_t{10}));
 }
 
-TEST(Numeric_util, is_within_below_range) {
+TEST(is_within_below_range) {
   EXPECT_FALSE(
       sourcemeta::core::is_within(0, std::int64_t{1}, std::int64_t{10}));
 }
 
-TEST(Numeric_util, is_within_above_range) {
+TEST(is_within_above_range) {
   EXPECT_FALSE(
       sourcemeta::core::is_within(11, std::int64_t{1}, std::int64_t{10}));
 }
 
-TEST(Numeric_util, is_within_unsigned_in_range) {
+TEST(is_within_unsigned_in_range) {
   EXPECT_TRUE(
       sourcemeta::core::is_within(5, std::uint64_t{1}, std::uint64_t{10}));
 }
 
-TEST(Numeric_util, is_within_unsigned_negative_value) {
+TEST(is_within_unsigned_negative_value) {
   EXPECT_FALSE(
       sourcemeta::core::is_within(-1, std::uint64_t{0}, std::uint64_t{10}));
 }
 
-TEST(Numeric_util, is_within_decimal_in_range) {
+TEST(is_within_decimal_in_range) {
   EXPECT_TRUE(sourcemeta::core::is_within(sourcemeta::core::Decimal{5},
                                           sourcemeta::core::Decimal{1},
                                           sourcemeta::core::Decimal{10}));
 }
 
-TEST(Numeric_util, is_within_decimal_below) {
+TEST(is_within_decimal_below) {
   EXPECT_FALSE(sourcemeta::core::is_within(sourcemeta::core::Decimal{0},
                                            sourcemeta::core::Decimal{1},
                                            sourcemeta::core::Decimal{10}));
 }
 
-TEST(Numeric_util, is_within_decimal_above) {
+TEST(is_within_decimal_above) {
   EXPECT_FALSE(sourcemeta::core::is_within(sourcemeta::core::Decimal{11},
                                            sourcemeta::core::Decimal{1},
                                            sourcemeta::core::Decimal{10}));
 }
 
-TEST(Numeric_util, abs_positive) {
+TEST(abs_positive) {
   EXPECT_EQ(sourcemeta::core::abs(std::int64_t{42}), std::uint64_t{42});
 }
 
-TEST(Numeric_util, abs_zero) {
+TEST(abs_zero) {
   EXPECT_EQ(sourcemeta::core::abs(std::int64_t{0}), std::uint64_t{0});
 }
 
-TEST(Numeric_util, abs_negative) {
+TEST(abs_negative) {
   EXPECT_EQ(sourcemeta::core::abs(std::int64_t{-42}), std::uint64_t{42});
 }
 
-TEST(Numeric_util, abs_int64_min_plus_one) {
+TEST(abs_int64_min_plus_one) {
   EXPECT_EQ(
       sourcemeta::core::abs(std::numeric_limits<std::int64_t>::min() + 1),
       static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()));
 }
 
-TEST(Numeric_util, abs_int64_min) {
+TEST(abs_int64_min) {
   EXPECT_EQ(
       sourcemeta::core::abs(std::numeric_limits<std::int64_t>::min()),
       static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1);
 }
 
-TEST(Numeric_util, abs_decimal_positive) {
+TEST(abs_decimal_positive) {
   EXPECT_EQ(sourcemeta::core::abs(sourcemeta::core::Decimal{42}),
             sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_util, abs_decimal_zero) {
+TEST(abs_decimal_zero) {
   EXPECT_EQ(sourcemeta::core::abs(sourcemeta::core::Decimal{0}),
             sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_util, abs_decimal_negative) {
+TEST(abs_decimal_negative) {
   EXPECT_EQ(sourcemeta::core::abs(sourcemeta::core::Decimal{-42}),
             sourcemeta::core::Decimal{42});
 }
 
-TEST(Numeric_util, divide_ceil_simple_positive) {
+TEST(divide_ceil_simple_positive) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{10}, std::uint64_t{5}),
             std::int64_t{2});
 }
 
-TEST(Numeric_util, divide_ceil_simple_negative) {
+TEST(divide_ceil_simple_negative) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{-10}, std::uint64_t{5}),
             std::int64_t{-2});
 }
 
-TEST(Numeric_util, divide_ceil_small_positive) {
+TEST(divide_ceil_small_positive) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{11}, std::uint64_t{5}),
             std::int64_t{3});
 }
 
-TEST(Numeric_util, divide_ceil_small_negative) {
+TEST(divide_ceil_small_negative) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{-11}, std::uint64_t{5}),
             std::int64_t{-2});
 }
 
-TEST(Numeric_util, divide_ceil_positive_large_divisor) {
+TEST(divide_ceil_positive_large_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{11}, std::uint64_t{20}),
             std::int64_t{1});
 }
 
-TEST(Numeric_util, divide_ceil_negative_large_divisor) {
+TEST(divide_ceil_negative_large_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{-11}, std::uint64_t{20}),
             std::int64_t{0});
 }
 
-TEST(Numeric_util, divide_ceil_max_dividend_min_divisor) {
+TEST(divide_ceil_max_dividend_min_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(
                 std::numeric_limits<std::int64_t>::max(), std::uint64_t{1}),
             std::numeric_limits<std::int64_t>::max());
 }
 
-TEST(Numeric_util, divide_ceil_min_dividend_min_divisor) {
+TEST(divide_ceil_min_dividend_min_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(
                 std::numeric_limits<std::int64_t>::min(), std::uint64_t{1}),
             std::numeric_limits<std::int64_t>::min());
 }
 
-TEST(Numeric_util, divide_ceil_int64_min_by_2) {
+TEST(divide_ceil_int64_min_by_2) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(
                 std::numeric_limits<std::int64_t>::min(), std::uint64_t{2}),
             std::int64_t{-4611686018427387904});
 }
 
-TEST(Numeric_util, divide_ceil_max_dividend_max_divisor) {
+TEST(divide_ceil_max_dividend_max_divisor) {
   EXPECT_EQ(
       sourcemeta::core::divide_ceil(std::numeric_limits<std::int64_t>::max(),
                                     std::numeric_limits<std::uint64_t>::max()),
       std::int64_t{1});
 }
 
-TEST(Numeric_util, divide_ceil_min_dividend_max_divisor) {
+TEST(divide_ceil_min_dividend_max_divisor) {
   EXPECT_EQ(
       sourcemeta::core::divide_ceil(std::numeric_limits<std::int64_t>::min(),
                                     std::numeric_limits<std::uint64_t>::max()),
       std::int64_t{0});
 }
 
-TEST(Numeric_util, divide_ceil_decimal_simple_positive) {
+TEST(divide_ceil_decimal_simple_positive) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(sourcemeta::core::Decimal{10},
                                           sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_util, divide_ceil_decimal_simple_negative) {
+TEST(divide_ceil_decimal_simple_negative) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(sourcemeta::core::Decimal{-10},
                                           sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{-2});
 }
 
-TEST(Numeric_util, divide_ceil_decimal_inexact_positive) {
+TEST(divide_ceil_decimal_inexact_positive) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(sourcemeta::core::Decimal{11},
                                           sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_util, divide_ceil_decimal_inexact_negative) {
+TEST(divide_ceil_decimal_inexact_negative) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(sourcemeta::core::Decimal{-11},
                                           sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{-2});
 }
 
-TEST(Numeric_util, divide_ceil_mixed_decimal_and_int) {
+TEST(divide_ceil_mixed_decimal_and_int) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(sourcemeta::core::Decimal{11},
                                           std::uint64_t{5}),
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_util, divide_ceil_mixed_int_and_decimal) {
+TEST(divide_ceil_mixed_int_and_decimal) {
   EXPECT_EQ(sourcemeta::core::divide_ceil(std::int64_t{11},
                                           sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_util, divide_floor_simple_positive) {
+TEST(divide_floor_simple_positive) {
   EXPECT_EQ(sourcemeta::core::divide_floor(std::int64_t{10}, std::uint64_t{5}),
             std::int64_t{2});
 }
 
-TEST(Numeric_util, divide_floor_simple_negative) {
+TEST(divide_floor_simple_negative) {
   EXPECT_EQ(sourcemeta::core::divide_floor(std::int64_t{-10}, std::uint64_t{5}),
             std::int64_t{-2});
 }
 
-TEST(Numeric_util, divide_floor_small_positive) {
+TEST(divide_floor_small_positive) {
   EXPECT_EQ(sourcemeta::core::divide_floor(std::int64_t{11}, std::uint64_t{5}),
             std::int64_t{2});
 }
 
-TEST(Numeric_util, divide_floor_small_negative) {
+TEST(divide_floor_small_negative) {
   EXPECT_EQ(sourcemeta::core::divide_floor(std::int64_t{-11}, std::uint64_t{5}),
             std::int64_t{-3});
 }
 
-TEST(Numeric_util, divide_floor_positive_large_divisor) {
+TEST(divide_floor_positive_large_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_floor(std::int64_t{11}, std::uint64_t{20}),
             std::int64_t{0});
 }
 
-TEST(Numeric_util, divide_floor_negative_large_divisor) {
+TEST(divide_floor_negative_large_divisor) {
   EXPECT_EQ(
       sourcemeta::core::divide_floor(std::int64_t{-11}, std::uint64_t{20}),
       std::int64_t{-1});
 }
 
-TEST(Numeric_util, divide_floor_max_dividend_min_divisor) {
+TEST(divide_floor_max_dividend_min_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_floor(
                 std::numeric_limits<std::int64_t>::max(), std::uint64_t{1}),
             std::numeric_limits<std::int64_t>::max());
 }
 
-TEST(Numeric_util, divide_floor_min_dividend_min_divisor) {
+TEST(divide_floor_min_dividend_min_divisor) {
   EXPECT_EQ(sourcemeta::core::divide_floor(
                 std::numeric_limits<std::int64_t>::min(), std::uint64_t{1}),
             std::numeric_limits<std::int64_t>::min());
 }
 
-TEST(Numeric_util, divide_floor_int64_min_by_2) {
+TEST(divide_floor_int64_min_by_2) {
   EXPECT_EQ(sourcemeta::core::divide_floor(
                 std::numeric_limits<std::int64_t>::min(), std::uint64_t{2}),
             std::int64_t{-4611686018427387904});
 }
 
-TEST(Numeric_util, divide_floor_max_dividend_max_divisor) {
+TEST(divide_floor_max_dividend_max_divisor) {
   EXPECT_EQ(
       sourcemeta::core::divide_floor(std::numeric_limits<std::int64_t>::max(),
                                      std::numeric_limits<std::uint64_t>::max()),
       std::int64_t{0});
 }
 
-TEST(Numeric_util, divide_floor_min_dividend_max_divisor) {
+TEST(divide_floor_min_dividend_max_divisor) {
   EXPECT_EQ(
       sourcemeta::core::divide_floor(std::numeric_limits<std::int64_t>::min(),
                                      std::numeric_limits<std::uint64_t>::max()),
       std::int64_t{-1});
 }
 
-TEST(Numeric_util, divide_floor_decimal_simple_positive) {
+TEST(divide_floor_decimal_simple_positive) {
   EXPECT_EQ(sourcemeta::core::divide_floor(sourcemeta::core::Decimal{10},
                                            sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_util, divide_floor_decimal_simple_negative) {
+TEST(divide_floor_decimal_simple_negative) {
   EXPECT_EQ(sourcemeta::core::divide_floor(sourcemeta::core::Decimal{-10},
                                            sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{-2});
 }
 
-TEST(Numeric_util, divide_floor_decimal_inexact_positive) {
+TEST(divide_floor_decimal_inexact_positive) {
   EXPECT_EQ(sourcemeta::core::divide_floor(sourcemeta::core::Decimal{11},
                                            sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_util, divide_floor_decimal_inexact_negative) {
+TEST(divide_floor_decimal_inexact_negative) {
   EXPECT_EQ(sourcemeta::core::divide_floor(sourcemeta::core::Decimal{-11},
                                            sourcemeta::core::Decimal{5}),
             sourcemeta::core::Decimal{-3});
 }
 
-TEST(Numeric_util, divide_floor_mixed_decimal_and_int) {
+TEST(divide_floor_mixed_decimal_and_int) {
   EXPECT_EQ(sourcemeta::core::divide_floor(sourcemeta::core::Decimal{11},
                                            std::uint64_t{5}),
             sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_util, count_multiples_positive_range) {
+TEST(count_multiples_positive_range) {
   EXPECT_EQ(sourcemeta::core::count_multiples(std::int64_t{1}, std::int64_t{10},
                                               std::int64_t{3}),
             std::uint64_t{3});
 }
 
-TEST(Numeric_util, count_multiples_single_element) {
+TEST(count_multiples_single_element) {
   EXPECT_EQ(sourcemeta::core::count_multiples(std::int64_t{3}, std::int64_t{3},
                                               std::int64_t{3}),
             std::uint64_t{1});
 }
 
-TEST(Numeric_util, count_multiples_negative_range) {
+TEST(count_multiples_negative_range) {
   // Multiples of 3 in [-9, -1]: -9, -6, -3 = 3
   EXPECT_EQ(sourcemeta::core::count_multiples(
                 std::int64_t{-9}, std::int64_t{-1}, std::int64_t{3}),
             std::uint64_t{3});
 }
 
-TEST(Numeric_util, count_multiples_minimum_is_int64_min) {
+TEST(count_multiples_minimum_is_int64_min) {
   EXPECT_EQ(sourcemeta::core::count_multiples(
                 std::numeric_limits<std::int64_t>::min(),
                 std::numeric_limits<std::int64_t>::min(), std::int64_t{1}),
             std::uint64_t{1});
 }
 
-TEST(Numeric_util, count_multiples_range_from_int64_min) {
+TEST(count_multiples_range_from_int64_min) {
   // Multiples of 2 in [INT64_MIN, INT64_MIN + 5]: INT64_MIN, +2, +4 = 3
   EXPECT_EQ(sourcemeta::core::count_multiples(
                 std::numeric_limits<std::int64_t>::min(),
@@ -513,78 +481,78 @@ TEST(Numeric_util, count_multiples_range_from_int64_min) {
             std::uint64_t{3});
 }
 
-TEST(Numeric_util, count_multiples_mixed_range) {
+TEST(count_multiples_mixed_range) {
   // Multiples of 3 in [-7, 5]: -6, -3, 0, 3 = 4
   EXPECT_EQ(sourcemeta::core::count_multiples(std::int64_t{-7}, std::int64_t{5},
                                               std::int64_t{3}),
             std::uint64_t{4});
 }
 
-TEST(Numeric_util, count_multiples_decimal_positive_range) {
+TEST(count_multiples_decimal_positive_range) {
   EXPECT_EQ(sourcemeta::core::count_multiples(sourcemeta::core::Decimal{1},
                                               sourcemeta::core::Decimal{10},
                                               sourcemeta::core::Decimal{3}),
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_util, count_multiples_decimal_negative_range) {
+TEST(count_multiples_decimal_negative_range) {
   EXPECT_EQ(sourcemeta::core::count_multiples(sourcemeta::core::Decimal{-9},
                                               sourcemeta::core::Decimal{-1},
                                               sourcemeta::core::Decimal{3}),
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_util, count_multiples_decimal_mixed_range) {
+TEST(count_multiples_decimal_mixed_range) {
   EXPECT_EQ(sourcemeta::core::count_multiples(sourcemeta::core::Decimal{-7},
                                               sourcemeta::core::Decimal{5},
                                               sourcemeta::core::Decimal{3}),
             sourcemeta::core::Decimal{4});
 }
 
-TEST(Numeric_util, closest_smallest_exponent_2_2_1_2) {
+TEST(closest_smallest_exponent_2_2_1_2) {
   EXPECT_EQ(sourcemeta::core::closest_smallest_exponent(2, 2, 1, 2), 1);
 }
 
-TEST(Numeric_util, closest_smallest_exponent_20_2_1_6) {
+TEST(closest_smallest_exponent_20_2_1_6) {
   EXPECT_EQ(sourcemeta::core::closest_smallest_exponent(20, 2, 1, 6), 4);
 }
 
-TEST(Numeric_util, closest_smallest_exponent_20_3_1_6) {
+TEST(closest_smallest_exponent_20_3_1_6) {
   EXPECT_EQ(sourcemeta::core::closest_smallest_exponent(20, 3, 1, 6), 2);
 }
 
-TEST(Numeric_util, correct_ieee754_snap_up_double) {
+TEST(correct_ieee754_snap_up_double) {
   EXPECT_DOUBLE_EQ(sourcemeta::core::correct_ieee754(2.9999999999), 3.0);
 }
 
-TEST(Numeric_util, correct_ieee754_snap_down_double) {
+TEST(correct_ieee754_snap_down_double) {
   EXPECT_DOUBLE_EQ(sourcemeta::core::correct_ieee754(3.0000000001), 3.0);
 }
 
-TEST(Numeric_util, correct_ieee754_no_correction_double) {
+TEST(correct_ieee754_no_correction_double) {
   EXPECT_DOUBLE_EQ(sourcemeta::core::correct_ieee754(2.5), 2.5);
 }
 
-TEST(Numeric_util, correct_ieee754_snap_up_float) {
+TEST(correct_ieee754_snap_up_float) {
   EXPECT_FLOAT_EQ(sourcemeta::core::correct_ieee754(2.9999999999f), 3.0f);
 }
 
-TEST(Numeric_util, correct_ieee754_snap_down_float) {
+TEST(correct_ieee754_snap_down_float) {
   EXPECT_FLOAT_EQ(sourcemeta::core::correct_ieee754(3.0000000001f), 3.0f);
 }
 
-TEST(Numeric_util, correct_ieee754_no_correction_float) {
+TEST(correct_ieee754_no_correction_float) {
   EXPECT_FLOAT_EQ(sourcemeta::core::correct_ieee754(2.5f), 2.5f);
 }
 
-TEST(Numeric_util, real_digits_whole_number) {
+TEST(real_digits_whole_number) {
   std::uint64_t position{0};
   const auto digits{sourcemeta::core::real_digits<std::int64_t>(5.0, position)};
   EXPECT_EQ(digits, 5);
   EXPECT_EQ(position, 0);
 }
 
-TEST(Numeric_util, real_digits_simple_decimal) {
+TEST(real_digits_simple_decimal) {
   std::uint64_t position{0};
   const auto digits{
       sourcemeta::core::real_digits<std::int64_t>(3.14, position)};
@@ -592,89 +560,89 @@ TEST(Numeric_util, real_digits_simple_decimal) {
   EXPECT_EQ(position, 2);
 }
 
-TEST(Numeric_util, real_digits_small_fractional_part) {
+TEST(real_digits_small_fractional_part) {
   std::uint64_t position{0};
   const auto digits{sourcemeta::core::real_digits<std::int64_t>(1.5, position)};
   EXPECT_EQ(digits, 15);
   EXPECT_EQ(position, 1);
 }
 
-TEST(Numeric_util, real_equal_double_identical) {
+TEST(real_equal_double_identical) {
   EXPECT_TRUE(sourcemeta::core::real_equal(1.5, 1.5));
 }
 
-TEST(Numeric_util, real_equal_double_within_rounding) {
+TEST(real_equal_double_within_rounding) {
   EXPECT_TRUE(sourcemeta::core::real_equal(0.1 + 0.2, 0.3));
 }
 
-TEST(Numeric_util, real_equal_double_clearly_unequal) {
+TEST(real_equal_double_clearly_unequal) {
   EXPECT_FALSE(sourcemeta::core::real_equal(1.0, 2.0));
 }
 
-TEST(Numeric_util, real_equal_double_negative_identical) {
+TEST(real_equal_double_negative_identical) {
   EXPECT_TRUE(sourcemeta::core::real_equal(-1.5, -1.5));
 }
 
-TEST(Numeric_util, real_equal_double_opposite_signs) {
+TEST(real_equal_double_opposite_signs) {
   EXPECT_FALSE(sourcemeta::core::real_equal(1.0, -1.0));
 }
 
-TEST(Numeric_util, real_equal_double_zero) {
+TEST(real_equal_double_zero) {
   EXPECT_TRUE(sourcemeta::core::real_equal(0.0, 0.0));
 }
 
-TEST(Numeric_util, real_equal_double_positive_and_negative_zero) {
+TEST(real_equal_double_positive_and_negative_zero) {
   EXPECT_TRUE(sourcemeta::core::real_equal(0.0, -0.0));
 }
 
-TEST(Numeric_util, real_equal_double_adjacent_values) {
+TEST(real_equal_double_adjacent_values) {
   EXPECT_TRUE(sourcemeta::core::real_equal(1.0, std::nextafter(1.0, 2.0)));
 }
 
-TEST(Numeric_util, real_equal_double_nan_not_equal_to_itself) {
+TEST(real_equal_double_nan_not_equal_to_itself) {
   const double nan{std::numeric_limits<double>::quiet_NaN()};
   EXPECT_FALSE(sourcemeta::core::real_equal(nan, nan));
 }
 
-TEST(Numeric_util, real_equal_double_nan_not_equal_to_value) {
+TEST(real_equal_double_nan_not_equal_to_value) {
   const double nan{std::numeric_limits<double>::quiet_NaN()};
   EXPECT_FALSE(sourcemeta::core::real_equal(nan, 1.0));
 }
 
-TEST(Numeric_util, real_equal_double_infinities_equal) {
+TEST(real_equal_double_infinities_equal) {
   const double infinity{std::numeric_limits<double>::infinity()};
   EXPECT_TRUE(sourcemeta::core::real_equal(infinity, infinity));
 }
 
-TEST(Numeric_util, real_equal_double_infinity_not_equal_to_value) {
+TEST(real_equal_double_infinity_not_equal_to_value) {
   const double infinity{std::numeric_limits<double>::infinity()};
   EXPECT_FALSE(sourcemeta::core::real_equal(infinity, 1.0));
 }
 
-TEST(Numeric_util, real_equal_double_infinity_not_equal_to_maximum) {
+TEST(real_equal_double_infinity_not_equal_to_maximum) {
   const double infinity{std::numeric_limits<double>::infinity()};
   const double maximum{std::numeric_limits<double>::max()};
   EXPECT_FALSE(sourcemeta::core::real_equal(infinity, maximum));
 }
 
-TEST(Numeric_util, real_equal_float_identical) {
+TEST(real_equal_float_identical) {
   EXPECT_TRUE(sourcemeta::core::real_equal(1.5F, 1.5F));
 }
 
-TEST(Numeric_util, real_equal_float_within_rounding) {
+TEST(real_equal_float_within_rounding) {
   EXPECT_TRUE(sourcemeta::core::real_equal(0.1F + 0.2F, 0.3F));
 }
 
-TEST(Numeric_util, real_equal_float_clearly_unequal) {
+TEST(real_equal_float_clearly_unequal) {
   EXPECT_FALSE(sourcemeta::core::real_equal(1.0F, 2.0F));
 }
 
-TEST(Numeric_util, real_equal_float_nan_not_equal_to_itself) {
+TEST(real_equal_float_nan_not_equal_to_itself) {
   const float nan{std::numeric_limits<float>::quiet_NaN()};
   EXPECT_FALSE(sourcemeta::core::real_equal(nan, nan));
 }
 
-TEST(Numeric_error, out_of_range_message) {
+TEST(out_of_range_message) {
   const sourcemeta::core::NumericOutOfRangeError error;
   EXPECT_STREQ(error.what(), "Numeric value is out of range");
 }

--- a/test/numeric/numeric_zigzag_test.cc
+++ b/test/numeric/numeric_zigzag_test.cc
@@ -1,161 +1,161 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/numeric.h>
 
 #include <cstdint> // std::int64_t, std::uint64_t
 #include <limits>  // std::numeric_limits
 
-TEST(Numeric_zigzag, encode_int_0_to_0) {
+TEST(encode_int_0_to_0) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(0), std::uint64_t{0});
 }
 
-TEST(Numeric_zigzag, encode_int_minus_1_to_1) {
+TEST(encode_int_minus_1_to_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(-1), std::uint64_t{1});
 }
 
-TEST(Numeric_zigzag, encode_int_1_to_2) {
+TEST(encode_int_1_to_2) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(1), std::uint64_t{2});
 }
 
-TEST(Numeric_zigzag, encode_int_minus_2_to_3) {
+TEST(encode_int_minus_2_to_3) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(-2), std::uint64_t{3});
 }
 
-TEST(Numeric_zigzag, encode_int64_0_to_0) {
+TEST(encode_int64_0_to_0) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(std::int64_t{0}), std::uint64_t{0});
 }
 
-TEST(Numeric_zigzag, encode_int64_minus_1_to_1) {
+TEST(encode_int64_minus_1_to_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(std::int64_t{-1}),
             std::uint64_t{1});
 }
 
-TEST(Numeric_zigzag, encode_int64_1_to_2) {
+TEST(encode_int64_1_to_2) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(std::int64_t{1}), std::uint64_t{2});
 }
 
-TEST(Numeric_zigzag, encode_int64_minus_2_to_3) {
+TEST(encode_int64_minus_2_to_3) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(std::int64_t{-2}),
             std::uint64_t{3});
 }
 
-TEST(Numeric_zigzag, encode_int64_max) {
+TEST(encode_int64_max) {
   const std::int64_t value{std::numeric_limits<std::int64_t>::max()};
   EXPECT_EQ(sourcemeta::core::zigzag_encode(value),
             std::uint64_t{18446744073709551614U});
 }
 
-TEST(Numeric_zigzag, encode_int64_min_plus_one) {
+TEST(encode_int64_min_plus_one) {
   const std::int64_t value{std::numeric_limits<std::int64_t>::min() + 1};
   EXPECT_EQ(sourcemeta::core::zigzag_encode(value),
             std::uint64_t{18446744073709551613U});
 }
 
-TEST(Numeric_zigzag, encode_int64_min) {
+TEST(encode_int64_min) {
   EXPECT_EQ(
       sourcemeta::core::zigzag_encode(std::numeric_limits<std::int64_t>::min()),
       std::numeric_limits<std::uint64_t>::max());
 }
 
-TEST(Numeric_zigzag, decode_int_0_to_0) {
+TEST(decode_int_0_to_0) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(0U), std::int64_t{0});
 }
 
-TEST(Numeric_zigzag, decode_int_1_to_minus_1) {
+TEST(decode_int_1_to_minus_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(1U), std::int64_t{-1});
 }
 
-TEST(Numeric_zigzag, decode_int_2_to_1) {
+TEST(decode_int_2_to_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(2U), std::int64_t{1});
 }
 
-TEST(Numeric_zigzag, decode_int_3_to_minus_2) {
+TEST(decode_int_3_to_minus_2) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(3U), std::int64_t{-2});
 }
 
-TEST(Numeric_zigzag, decode_int64_0_to_0) {
+TEST(decode_int64_0_to_0) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(std::uint64_t{0}), std::int64_t{0});
 }
 
-TEST(Numeric_zigzag, decode_int64_1_to_minus_1) {
+TEST(decode_int64_1_to_minus_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(std::uint64_t{1}),
             std::int64_t{-1});
 }
 
-TEST(Numeric_zigzag, decode_int64_2_to_1) {
+TEST(decode_int64_2_to_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(std::uint64_t{2}), std::int64_t{1});
 }
 
-TEST(Numeric_zigzag, decode_int64_3_to_minus_2) {
+TEST(decode_int64_3_to_minus_2) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(std::uint64_t{3}),
             std::int64_t{-2});
 }
 
-TEST(Numeric_zigzag, decode_int64_max_encoded) {
+TEST(decode_int64_max_encoded) {
   EXPECT_EQ(
       sourcemeta::core::zigzag_decode(std::uint64_t{18446744073709551614U}),
       std::numeric_limits<std::int64_t>::max());
 }
 
-TEST(Numeric_zigzag, decode_int64_min_plus_one_encoded) {
+TEST(decode_int64_min_plus_one_encoded) {
   const std::int64_t expected{std::numeric_limits<std::int64_t>::min() + 1};
   EXPECT_EQ(
       sourcemeta::core::zigzag_decode(std::uint64_t{18446744073709551613U}),
       expected);
 }
 
-TEST(Numeric_zigzag, decode_uint64_max_to_int64_min) {
+TEST(decode_uint64_max_to_int64_min) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(
                 std::numeric_limits<std::uint64_t>::max()),
             std::numeric_limits<std::int64_t>::min());
 }
 
-TEST(Numeric_zigzag, encode_decimal_0_to_0) {
+TEST(encode_decimal_0_to_0) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(sourcemeta::core::Decimal{0}),
             sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_zigzag, encode_decimal_minus_1_to_1) {
+TEST(encode_decimal_minus_1_to_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(sourcemeta::core::Decimal{-1}),
             sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_zigzag, encode_decimal_1_to_2) {
+TEST(encode_decimal_1_to_2) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(sourcemeta::core::Decimal{1}),
             sourcemeta::core::Decimal{2});
 }
 
-TEST(Numeric_zigzag, encode_decimal_minus_2_to_3) {
+TEST(encode_decimal_minus_2_to_3) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(sourcemeta::core::Decimal{-2}),
             sourcemeta::core::Decimal{3});
 }
 
-TEST(Numeric_zigzag, encode_decimal_large_positive) {
+TEST(encode_decimal_large_positive) {
   EXPECT_EQ(sourcemeta::core::zigzag_encode(sourcemeta::core::Decimal{1000000}),
             sourcemeta::core::Decimal{2000000});
 }
 
-TEST(Numeric_zigzag, decode_decimal_0_to_0) {
+TEST(decode_decimal_0_to_0) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(sourcemeta::core::Decimal{0}),
             sourcemeta::core::Decimal{0});
 }
 
-TEST(Numeric_zigzag, decode_decimal_1_to_minus_1) {
+TEST(decode_decimal_1_to_minus_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(sourcemeta::core::Decimal{1}),
             sourcemeta::core::Decimal{-1});
 }
 
-TEST(Numeric_zigzag, decode_decimal_2_to_1) {
+TEST(decode_decimal_2_to_1) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(sourcemeta::core::Decimal{2}),
             sourcemeta::core::Decimal{1});
 }
 
-TEST(Numeric_zigzag, decode_decimal_3_to_minus_2) {
+TEST(decode_decimal_3_to_minus_2) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(sourcemeta::core::Decimal{3}),
             sourcemeta::core::Decimal{-2});
 }
 
-TEST(Numeric_zigzag, decode_decimal_large_even) {
+TEST(decode_decimal_large_even) {
   EXPECT_EQ(sourcemeta::core::zigzag_decode(sourcemeta::core::Decimal{2000000}),
             sourcemeta::core::Decimal{1000000});
 }

--- a/test/options/CMakeLists.txt
+++ b/test/options/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME options
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME options
   SOURCES options_test.cc)
 
 target_link_libraries(sourcemeta_core_options_unit

--- a/test/options/options_test.cc
+++ b/test/options/options_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/options.h>
 
-TEST(Options, long_option_equals_parses_value_with_equal_sign) {
+TEST(long_option_equals_parses_value_with_equal_sign) {
   sourcemeta::core::Options app;
   app.option("foo", {"f"});
 
@@ -19,7 +19,7 @@ TEST(Options, long_option_equals_parses_value_with_equal_sign) {
   EXPECT_TRUE(app.contains("foo"));
 }
 
-TEST(Options, long_option_space_parses_value_after_space) {
+TEST(long_option_space_parses_value_after_space) {
   sourcemeta::core::Options app;
   app.option("foo", {"f"});
 
@@ -36,7 +36,7 @@ TEST(Options, long_option_space_parses_value_after_space) {
   EXPECT_EQ(app.at("foo")[0], "bar");
 }
 
-TEST(Options, short_option_space_parses_short_option_with_space_value) {
+TEST(short_option_space_parses_short_option_with_space_value) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -53,7 +53,7 @@ TEST(Options, short_option_space_parses_short_option_with_space_value) {
   EXPECT_EQ(app.at("file")[0], "path/to/x");
 }
 
-TEST(Options, short_option_attached_value_parses_short_option_attached_value) {
+TEST(short_option_attached_value_parses_short_option_attached_value) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -69,7 +69,7 @@ TEST(Options, short_option_attached_value_parses_short_option_attached_value) {
   EXPECT_EQ(app.at("file")[0], "path");
 }
 
-TEST(Options, combined_flags_parses_combined_short_flags) {
+TEST(combined_flags_parses_combined_short_flags) {
   sourcemeta::core::Options app;
   app.flag("alpha", {"a"});
   app.flag("beta", {"b"});
@@ -89,7 +89,6 @@ TEST(Options, combined_flags_parses_combined_short_flags) {
 }
 
 TEST(
-    Options,
     combined_flags_and_option_with_value_parses_combined_flags_and_option_value) {
   sourcemeta::core::Options app;
   app.flag("alpha", {"a"});
@@ -108,7 +107,7 @@ TEST(
   EXPECT_EQ(app.at("bopt")[0], "value");
 }
 
-TEST(Options, repeated_options_preserved_order) {
+TEST(repeated_options_preserved_order) {
   sourcemeta::core::Options app;
   app.option("foo", {"f"});
 
@@ -130,7 +129,7 @@ TEST(Options, repeated_options_preserved_order) {
   EXPECT_EQ(app.at("foo")[2], "three");
 }
 
-TEST(Options, flags_count_multiple_occurrences) {
+TEST(flags_count_multiple_occurrences) {
   sourcemeta::core::Options app;
   app.flag("exclude", {"x"});
 
@@ -147,7 +146,7 @@ TEST(Options, flags_count_multiple_occurrences) {
   EXPECT_TRUE(app.contains("exclude"));
 }
 
-TEST(Options, unknown_option_throws) {
+TEST(unknown_option_throws) {
   sourcemeta::core::Options app;
   app.option("foo", {"f"});
 
@@ -164,7 +163,7 @@ TEST(Options, unknown_option_throws) {
   }
 }
 
-TEST(Options, flag_given_value_throws) {
+TEST(flag_given_value_throws) {
   sourcemeta::core::Options app;
   app.flag("verbose", {"v"});
 
@@ -181,7 +180,7 @@ TEST(Options, flag_given_value_throws) {
   }
 }
 
-TEST(Options, positional_after_double_dash) {
+TEST(positional_after_double_dash) {
   sourcemeta::core::Options app;
   app.option("foo", {"f"});
   app.flag("x", {"x"});
@@ -200,7 +199,7 @@ TEST(Options, positional_after_double_dash) {
   EXPECT_EQ(app.positional()[1], "pos2");
 }
 
-TEST(Options, positional_before_options) {
+TEST(positional_before_options) {
   sourcemeta::core::Options app;
   app.option("foo", {"foo"});
 
@@ -219,7 +218,7 @@ TEST(Options, positional_before_options) {
   EXPECT_EQ(app.at("foo")[0], "bar");
 }
 
-TEST(Options, skip_parameter_works) {
+TEST(skip_parameter_works) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -237,7 +236,7 @@ TEST(Options, skip_parameter_works) {
   EXPECT_EQ(app.at("file")[0], "file.txt");
 }
 
-TEST(Options, alias_mapping_recognizes_aliases) {
+TEST(alias_mapping_recognizes_aliases) {
   sourcemeta::core::Options app;
   app.option("file", {"f", "a"});
 
@@ -254,7 +253,7 @@ TEST(Options, alias_mapping_recognizes_aliases) {
   EXPECT_EQ(app.at("file")[0], "ok");
 }
 
-TEST(Options, option_value) {
+TEST(option_value) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
   app.flag("other", {"o"});
@@ -273,7 +272,7 @@ TEST(Options, option_value) {
   EXPECT_EQ(app.at("other").size(), 0);
 }
 
-TEST(Options, long_option_without_value) {
+TEST(long_option_without_value) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -290,7 +289,7 @@ TEST(Options, long_option_without_value) {
   }
 }
 
-TEST(Options, short_option_without_value) {
+TEST(short_option_without_value) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -307,7 +306,7 @@ TEST(Options, short_option_without_value) {
   }
 }
 
-TEST(Options, single_dash_is_consumed_as_value) {
+TEST(single_dash_is_consumed_as_value) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -324,7 +323,7 @@ TEST(Options, single_dash_is_consumed_as_value) {
   EXPECT_EQ(app.at("file")[0], "-");
 }
 
-TEST(Options, empty_result_for_missing_option) {
+TEST(empty_result_for_missing_option) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 
@@ -337,7 +336,7 @@ TEST(Options, empty_result_for_missing_option) {
   EXPECT_TRUE(app.positional().empty());
 }
 
-TEST(Options, mixed_complex_scenario_parses_complex_mixture_correctly) {
+TEST(mixed_complex_scenario_parses_complex_mixture_correctly) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
   app.flag("verbose", {"v"});
@@ -376,7 +375,7 @@ TEST(Options, mixed_complex_scenario_parses_complex_mixture_correctly) {
   EXPECT_EQ(app.positional()[2], "--also-pos");
 }
 
-TEST(Options, no_skip_includes_program_name_as_positional) {
+TEST(no_skip_includes_program_name_as_positional) {
   sourcemeta::core::Options app;
   app.option("foo", {"f"});
 
@@ -393,7 +392,7 @@ TEST(Options, no_skip_includes_program_name_as_positional) {
   EXPECT_EQ(app.at("foo")[0], "bar");
 }
 
-TEST(Options, no_skip_treats_program_name_as_option_if_prefixed) {
+TEST(no_skip_treats_program_name_as_option_if_prefixed) {
   sourcemeta::core::Options app;
   app.option("file", {"f"});
 

--- a/test/parallel/CMakeLists.txt
+++ b/test/parallel/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME parallel
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME parallel
   SOURCES parallel_for_each_test.cc)
 
 target_link_libraries(sourcemeta_core_parallel_unit PRIVATE sourcemeta::core::parallel)

--- a/test/parallel/parallel_for_each_test.cc
+++ b/test/parallel/parallel_for_each_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/parallel.h>
 
@@ -7,11 +7,12 @@
 #include <chrono>
 #include <mutex>
 #include <numeric>
+#include <set>
 #include <stdexcept>
 #include <thread>
 #include <vector>
 
-TEST(Parallel_for_each, processes_all_elements_once) {
+TEST(processes_all_elements_once) {
   std::vector<std::size_t> items;
   for (std::size_t index = 0; index < 20; index++) {
     items.push_back(index);
@@ -32,7 +33,7 @@ TEST(Parallel_for_each, processes_all_elements_once) {
   EXPECT_EQ(processed, items);
 }
 
-TEST(Parallel_for_each, processes_all_elements_once_concurrency_1) {
+TEST(processes_all_elements_once_concurrency_1) {
   std::vector<std::size_t> items;
   for (std::size_t index = 0; index < 20; index++) {
     items.push_back(index);
@@ -62,7 +63,7 @@ TEST(Parallel_for_each, processes_all_elements_once_concurrency_1) {
   EXPECT_EQ(cursors, items);
 }
 
-TEST(Parallel_for_each, single_element) {
+TEST(single_element) {
   std::vector<std::size_t> items{42};
 
   std::vector<std::size_t> processed;
@@ -85,7 +86,7 @@ TEST(Parallel_for_each, single_element) {
             std::max<std::size_t>(std::thread::hardware_concurrency(), 1));
 }
 
-TEST(Parallel_for_each, empty_range) {
+TEST(empty_range) {
   std::vector<std::size_t> items;
   std::atomic<std::size_t> touched{0};
   sourcemeta::core::parallel_for_each(
@@ -97,7 +98,7 @@ TEST(Parallel_for_each, empty_range) {
   EXPECT_EQ(touched.load(), 0);
 }
 
-TEST(Parallel_for_each, work_callback_throw) {
+TEST(work_callback_throw) {
   std::vector<std::size_t> items{1, 2, 3, 4, 5};
 
   try {

--- a/test/process/CMakeLists.txt
+++ b/test/process/CMakeLists.txt
@@ -3,13 +3,13 @@ if(WIN32)
     COMMAND powershell -ExecutionPolicy Bypass -File
       "${CMAKE_CURRENT_SOURCE_DIR}/process_spawn_test.ps1"
       "$<TARGET_FILE:sourcemeta_core_process_unit_spawn_main>")
-  sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME process
+  sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME process
     SOURCES process_spawn_test_windows.cc)
 else()
   add_test(NAME core.process.spawn.e2e
     COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/process_spawn_test.sh"
       "$<TARGET_FILE:sourcemeta_core_process_unit_spawn_main>")
-  sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME process
+  sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME process
     SOURCES process_spawn_test_unix.cc)
 endif()
 

--- a/test/process/process_spawn_test_unix.cc
+++ b/test/process/process_spawn_test_unix.cc
@@ -1,45 +1,45 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/process.h>
 
 #include <filesystem> // std::filesystem::path
 
-TEST(Process_spawn, usr_bin_true_returns_zero) {
+TEST(usr_bin_true_returns_zero) {
   const int exit_code{sourcemeta::core::spawn("/usr/bin/true", {})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, usr_bin_false_returns_one) {
+TEST(usr_bin_false_returns_one) {
   const int exit_code{sourcemeta::core::spawn("/usr/bin/false", {})};
   EXPECT_EQ(exit_code, 1);
 }
 
-TEST(Process_spawn, true_without_path_returns_zero) {
+TEST(true_without_path_returns_zero) {
   const int exit_code{sourcemeta::core::spawn("true", {})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, sh_exit_with_specific_code) {
+TEST(sh_exit_with_specific_code) {
   const int exit_code{sourcemeta::core::spawn("/bin/sh", {"-c", "exit 42"})};
   EXPECT_EQ(exit_code, 42);
 }
 
-TEST(Process_spawn, sh_exit_with_different_code) {
+TEST(sh_exit_with_different_code) {
   const int exit_code{sourcemeta::core::spawn("/bin/sh", {"-c", "exit 7"})};
   EXPECT_EQ(exit_code, 7);
 }
 
-TEST(Process_spawn, test_command_failing_condition) {
+TEST(test_command_failing_condition) {
   const int exit_code{sourcemeta::core::spawn("/bin/test", {"1", "-eq", "2"})};
   EXPECT_EQ(exit_code, 1);
 }
 
-TEST(Process_spawn, test_command_passing_condition) {
+TEST(test_command_passing_condition) {
   const int exit_code{sourcemeta::core::spawn("/bin/test", {"1", "-eq", "1"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, nonexistent_program_throws_exception) {
+TEST(nonexistent_program_throws_exception) {
   const auto program{"/bin/this_program_definitely_does_not_exist"};
   try {
     sourcemeta::core::spawn(program, {});
@@ -49,12 +49,12 @@ TEST(Process_spawn, nonexistent_program_throws_exception) {
   }
 }
 
-TEST(Process_spawn, echo_with_arguments) {
+TEST(echo_with_arguments) {
   const int exit_code{sourcemeta::core::spawn("/bin/echo", {"hello", "world"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, argument_with_spaces_is_a_single_argument) {
+TEST(argument_with_spaces_is_a_single_argument) {
   const int exit_code{sourcemeta::core::spawn(
       "/bin/sh",
       {"-c", "test \"$#\" -eq 1 && test \"$1\" = \"alpha beta gamma\"", "sh",
@@ -62,20 +62,20 @@ TEST(Process_spawn, argument_with_spaces_is_a_single_argument) {
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, empty_argument_is_preserved) {
+TEST(empty_argument_is_preserved) {
   const int exit_code{sourcemeta::core::spawn(
       "/bin/sh",
       {"-c", "test \"$#\" -eq 2 && test -z \"$1\"", "sh", "", "second"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, pwd_with_custom_directory) {
+TEST(pwd_with_custom_directory) {
   const int exit_code{
       sourcemeta::core::spawn("pwd", {}, std::filesystem::path{"/tmp"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, pwd_with_current_directory) {
+TEST(pwd_with_current_directory) {
   const int exit_code{sourcemeta::core::spawn("pwd", {})};
   EXPECT_EQ(exit_code, 0);
 }

--- a/test/process/process_spawn_test_windows.cc
+++ b/test/process/process_spawn_test_windows.cc
@@ -1,43 +1,43 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/process.h>
 
 #include <filesystem> // std::filesystem::path
 
-TEST(Process_spawn, cmd_exit_zero_returns_zero) {
+TEST(cmd_exit_zero_returns_zero) {
   const int exit_code{sourcemeta::core::spawn("cmd.exe", {"/c", "exit 0"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, cmd_exit_one_returns_one) {
+TEST(cmd_exit_one_returns_one) {
   const int exit_code{sourcemeta::core::spawn("cmd.exe", {"/c", "exit 1"})};
   EXPECT_EQ(exit_code, 1);
 }
 
-TEST(Process_spawn, cmd_exit_with_specific_code) {
+TEST(cmd_exit_with_specific_code) {
   const int exit_code{sourcemeta::core::spawn("cmd.exe", {"/c", "exit 42"})};
   EXPECT_EQ(exit_code, 42);
 }
 
-TEST(Process_spawn, cmd_exit_with_different_code) {
+TEST(cmd_exit_with_different_code) {
   const int exit_code{sourcemeta::core::spawn("cmd.exe", {"/c", "exit 7"})};
   EXPECT_EQ(exit_code, 7);
 }
 
-TEST(Process_spawn, where_command_success) {
+TEST(where_command_success) {
   // where.exe should successfully find cmd.exe
   const int exit_code{sourcemeta::core::spawn("where.exe", {"cmd.exe"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, where_command_not_found) {
+TEST(where_command_not_found) {
   // where.exe should fail to find a nonexistent program
   const int exit_code{sourcemeta::core::spawn(
       "where.exe", {"this_program_definitely_does_not_exist"})};
   EXPECT_NE(exit_code, 0);
 }
 
-TEST(Process_spawn, nonexistent_program_throws_exception) {
+TEST(nonexistent_program_throws_exception) {
   const auto program{"this_program_definitely_does_not_exist.exe"};
   try {
     sourcemeta::core::spawn(program, {});
@@ -47,13 +47,13 @@ TEST(Process_spawn, nonexistent_program_throws_exception) {
   }
 }
 
-TEST(Process_spawn, cmd_echo_with_arguments) {
+TEST(cmd_echo_with_arguments) {
   const int exit_code{
       sourcemeta::core::spawn("cmd.exe", {"/c", "echo hello world"})};
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, cmd_cd_with_custom_directory) {
+TEST(cmd_cd_with_custom_directory) {
   // Get the Windows temp directory
   const auto temp_dir = std::filesystem::temp_directory_path();
   const int exit_code{
@@ -61,7 +61,7 @@ TEST(Process_spawn, cmd_cd_with_custom_directory) {
   EXPECT_EQ(exit_code, 0);
 }
 
-TEST(Process_spawn, cmd_cd_with_current_directory) {
+TEST(cmd_cd_with_current_directory) {
   const int exit_code{sourcemeta::core::spawn("cmd.exe", {"/c", "cd"})};
   EXPECT_EQ(exit_code, 0);
 }

--- a/test/punycode/CMakeLists.txt
+++ b/test/punycode/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME punycode
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME punycode
   SOURCES punycode_encode_test.cc punycode_decode_test.cc)
 
 target_link_libraries(sourcemeta_core_punycode_unit

--- a/test/punycode/punycode_decode_test.cc
+++ b/test/punycode/punycode_decode_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/punycode.h>
 
@@ -9,7 +9,7 @@
 // See https://www.rfc-editor.org/rfc/rfc3492#section-7.1
 
 // (A) Arabic (Egyptian)
-TEST(Punycode_decode, rfc3492_sample_a_arabic) {
+TEST(rfc3492_sample_a_arabic) {
   const std::u32string expected{0x0644, 0x064A, 0x0647, 0x0645, 0x0627, 0x0628,
                                 0x062A, 0x0643, 0x0644, 0x0645, 0x0648, 0x0634,
                                 0x0639, 0x0631, 0x0628, 0x064A, 0x061F};
@@ -18,7 +18,7 @@ TEST(Punycode_decode, rfc3492_sample_a_arabic) {
 }
 
 // (B) Chinese (simplified)
-TEST(Punycode_decode, rfc3492_sample_b_chinese_simplified) {
+TEST(rfc3492_sample_b_chinese_simplified) {
   const std::u32string expected{0x4ED6, 0x4EEC, 0x4E3A, 0x4EC0, 0x4E48,
                                 0x4E0D, 0x8BF4, 0x4E2D, 0x6587};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("ihqwcrb4cv8a8dqg056pqjye"),
@@ -26,7 +26,7 @@ TEST(Punycode_decode, rfc3492_sample_b_chinese_simplified) {
 }
 
 // (C) Chinese (traditional)
-TEST(Punycode_decode, rfc3492_sample_c_chinese_traditional) {
+TEST(rfc3492_sample_c_chinese_traditional) {
   const std::u32string expected{0x4ED6, 0x5011, 0x7232, 0x4EC0, 0x9EBD,
                                 0x4E0D, 0x8AAA, 0x4E2D, 0x6587};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("ihqwctvzc91f659drss3x8bo0yb"),
@@ -34,7 +34,7 @@ TEST(Punycode_decode, rfc3492_sample_c_chinese_traditional) {
 }
 
 // (D) Czech
-TEST(Punycode_decode, rfc3492_sample_d_czech) {
+TEST(rfc3492_sample_d_czech) {
   const std::u32string expected{0x0050, 0x0072, 0x006F, 0x010D, 0x0070, 0x0072,
                                 0x006F, 0x0073, 0x0074, 0x011B, 0x006E, 0x0065,
                                 0x006D, 0x006C, 0x0075, 0x0076, 0x00ED, 0x010D,
@@ -45,7 +45,7 @@ TEST(Punycode_decode, rfc3492_sample_d_czech) {
 }
 
 // (E) Hebrew
-TEST(Punycode_decode, rfc3492_sample_e_hebrew) {
+TEST(rfc3492_sample_e_hebrew) {
   const std::u32string expected{0x05DC, 0x05DE, 0x05D4, 0x05D4, 0x05DD, 0x05E4,
                                 0x05E9, 0x05D5, 0x05D8, 0x05DC, 0x05D0, 0x05DE,
                                 0x05D3, 0x05D1, 0x05E8, 0x05D9, 0x05DD, 0x05E2,
@@ -55,7 +55,7 @@ TEST(Punycode_decode, rfc3492_sample_e_hebrew) {
 }
 
 // (F) Hindi (Devanagari)
-TEST(Punycode_decode, rfc3492_sample_f_hindi) {
+TEST(rfc3492_sample_f_hindi) {
   const std::u32string expected{0x092F, 0x0939, 0x0932, 0x094B, 0x0917, 0x0939,
                                 0x093F, 0x0928, 0x094D, 0x0926, 0x0940, 0x0915,
                                 0x094D, 0x092F, 0x094B, 0x0902, 0x0928, 0x0939,
@@ -67,7 +67,7 @@ TEST(Punycode_decode, rfc3492_sample_f_hindi) {
 }
 
 // (G) Japanese (kanji and hiragana)
-TEST(Punycode_decode, rfc3492_sample_g_japanese) {
+TEST(rfc3492_sample_g_japanese) {
   const std::u32string expected{0x306A, 0x305C, 0x307F, 0x3093, 0x306A, 0x65E5,
                                 0x672C, 0x8A9E, 0x3092, 0x8A71, 0x3057, 0x3066,
                                 0x304F, 0x308C, 0x306A, 0x3044, 0x306E, 0x304B};
@@ -77,7 +77,7 @@ TEST(Punycode_decode, rfc3492_sample_g_japanese) {
 }
 
 // (H) Korean (Hangul syllables)
-TEST(Punycode_decode, rfc3492_sample_h_korean) {
+TEST(rfc3492_sample_h_korean) {
   const std::u32string expected{0xC138, 0xACC4, 0xC758, 0xBAA8, 0xB4E0, 0xC0AC,
                                 0xB78C, 0xB4E4, 0xC774, 0xD55C, 0xAD6D, 0xC5B4,
                                 0xB97C, 0xC774, 0xD574, 0xD55C, 0xB2E4, 0xBA74,
@@ -90,7 +90,7 @@ TEST(Punycode_decode, rfc3492_sample_h_korean) {
 }
 
 // (I) Russian (Cyrillic)
-TEST(Punycode_decode, rfc3492_sample_i_russian) {
+TEST(rfc3492_sample_i_russian) {
   const std::u32string expected{0x043F, 0x043E, 0x0447, 0x0435, 0x043C, 0x0443,
                                 0x0436, 0x0435, 0x043E, 0x043D, 0x0438, 0x043D,
                                 0x0435, 0x0433, 0x043E, 0x0432, 0x043E, 0x0440,
@@ -102,7 +102,7 @@ TEST(Punycode_decode, rfc3492_sample_i_russian) {
 }
 
 // (J) Spanish
-TEST(Punycode_decode, rfc3492_sample_j_spanish) {
+TEST(rfc3492_sample_j_spanish) {
   const std::u32string expected{
       0x0050, 0x006F, 0x0072, 0x0071, 0x0075, 0x00E9, 0x006E, 0x006F,
       0x0070, 0x0075, 0x0065, 0x0064, 0x0065, 0x006E, 0x0073, 0x0069,
@@ -115,7 +115,7 @@ TEST(Punycode_decode, rfc3492_sample_j_spanish) {
 }
 
 // (K) Vietnamese
-TEST(Punycode_decode, rfc3492_sample_k_vietnamese) {
+TEST(rfc3492_sample_k_vietnamese) {
   const std::u32string expected{
       0x0054, 0x1EA1, 0x0069, 0x0073, 0x0061, 0x006F, 0x0068, 0x1ECD,
       0x006B, 0x0068, 0x00F4, 0x006E, 0x0067, 0x0074, 0x0068, 0x1EC3,
@@ -127,7 +127,7 @@ TEST(Punycode_decode, rfc3492_sample_k_vietnamese) {
 }
 
 // (L) 3nen B gumi Kinpachi sensei (Japanese)
-TEST(Punycode_decode, rfc3492_sample_l_japanese_3b) {
+TEST(rfc3492_sample_l_japanese_3b) {
   const std::u32string expected{0x0033, 0x5E74, 0x0042, 0x7D44,
                                 0x91D1, 0x516B, 0x5148, 0x751F};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("3B-ww4c5e180e575a65lsy2b"),
@@ -135,7 +135,7 @@ TEST(Punycode_decode, rfc3492_sample_l_japanese_3b) {
 }
 
 // (M) Amuro Namie with Super Monkeys (Japanese)
-TEST(Punycode_decode, rfc3492_sample_m_japanese_monkeys) {
+TEST(rfc3492_sample_m_japanese_monkeys) {
   const std::u32string expected{0x5B89, 0x5BA4, 0x5948, 0x7F8E, 0x6075, 0x002D,
                                 0x0077, 0x0069, 0x0074, 0x0068, 0x002D, 0x0053,
                                 0x0055, 0x0050, 0x0045, 0x0052, 0x002D, 0x004D,
@@ -146,7 +146,7 @@ TEST(Punycode_decode, rfc3492_sample_m_japanese_monkeys) {
 }
 
 // (N) Hello-Another-Way-...(Japanese)
-TEST(Punycode_decode, rfc3492_sample_n_japanese_hello) {
+TEST(rfc3492_sample_n_japanese_hello) {
   const std::u32string expected{
       0x0048, 0x0065, 0x006C, 0x006C, 0x006F, 0x002D, 0x0041, 0x006E, 0x006F,
       0x0074, 0x0068, 0x0065, 0x0072, 0x002D, 0x0057, 0x0061, 0x0079, 0x002D,
@@ -157,7 +157,7 @@ TEST(Punycode_decode, rfc3492_sample_n_japanese_hello) {
 }
 
 // (O) hitotsuyanenoshita2 (Japanese)
-TEST(Punycode_decode, rfc3492_sample_o_japanese_hitotsu) {
+TEST(rfc3492_sample_o_japanese_hitotsu) {
   const std::u32string expected{0x3072, 0x3068, 0x3064, 0x5C4B,
                                 0x6839, 0x306E, 0x4E0B, 0x0032};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("2-u9tlzr9756bt3uc0v"),
@@ -165,7 +165,7 @@ TEST(Punycode_decode, rfc3492_sample_o_japanese_hitotsu) {
 }
 
 // (P) MaijideKoisuru5byoumae (Japanese)
-TEST(Punycode_decode, rfc3492_sample_p_japanese_maji) {
+TEST(rfc3492_sample_p_japanese_maji) {
   const std::u32string expected{0x004D, 0x0061, 0x006A, 0x0069, 0x3067,
                                 0x004B, 0x006F, 0x0069, 0x3059, 0x308B,
                                 0x0035, 0x79D2, 0x524D};
@@ -174,87 +174,87 @@ TEST(Punycode_decode, rfc3492_sample_p_japanese_maji) {
 }
 
 // (Q) PafyiideRunba (Japanese katakana)
-TEST(Punycode_decode, rfc3492_sample_q_japanese_pafyii) {
+TEST(rfc3492_sample_q_japanese_pafyii) {
   const std::u32string expected{0x30D1, 0x30D5, 0x30A3, 0x30FC, 0x0064,
                                 0x0065, 0x30EB, 0x30F3, 0x30D0};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("de-jg4avhby1noc0d"), expected);
 }
 
 // (R) Sono Speed de (Japanese hiragana/katakana)
-TEST(Punycode_decode, rfc3492_sample_r_japanese_sono) {
+TEST(rfc3492_sample_r_japanese_sono) {
   const std::u32string expected{0x305D, 0x306E, 0x30B9, 0x30D4,
                                 0x30FC, 0x30C9, 0x3067};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("d9juau41awczczp"), expected);
 }
 
 // (S) Pure ASCII -> $1.00 <-
-TEST(Punycode_decode, rfc3492_sample_s_ascii) {
+TEST(rfc3492_sample_s_ascii) {
   const std::u32string expected{0x002D, 0x003E, 0x0020, 0x0024, 0x0031, 0x002E,
                                 0x0030, 0x0030, 0x0020, 0x003C, 0x002D};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("-> $1.00 <--"), expected);
 }
 
 // Edge cases using UTF-32 API
-TEST(Punycode_decode, empty_string) {
+TEST(empty_string) {
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32(""), std::u32string{});
 }
 
-TEST(Punycode_decode, pure_ascii_simple) {
+TEST(pure_ascii_simple) {
   const std::u32string expected{0x0068, 0x0065, 0x006C, 0x006C, 0x006F};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("hello-"), expected);
 }
 
-TEST(Punycode_decode, pure_ascii_no_non_basic) {
+TEST(pure_ascii_no_non_basic) {
   const std::u32string expected{0x0061, 0x0062, 0x0063};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("abc-"), expected);
 }
 
-TEST(Punycode_decode, single_non_ascii) {
+TEST(single_non_ascii) {
   const std::u32string expected{0x00FC};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("tda"), expected);
 }
 
-TEST(Punycode_decode, mixed_ascii_and_non_ascii) {
+TEST(mixed_ascii_and_non_ascii) {
   const std::u32string expected{0x004D, 0x00FC, 0x006E, 0x0063,
                                 0x0068, 0x0065, 0x006E};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("Mnchen-3ya"), expected);
 }
 
-TEST(Punycode_decode, emoji_single) {
+TEST(emoji_single) {
   const std::u32string expected{0x1F600};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("e28h"), expected);
 }
 
-TEST(Punycode_decode, mixed_with_emoji) {
+TEST(mixed_with_emoji) {
   // hi + grinning face emoji
   const std::u32string expected{0x0068, 0x0069, 0x1F600};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("hi-oo82a"), expected);
 }
 
-TEST(Punycode_decode, supplementary_plane) {
+TEST(supplementary_plane) {
   // LINEAR B SYLLABLE B008 A (U+10000)
   const std::u32string expected{0x10000};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("2n7c"), expected);
 }
 
-TEST(Punycode_decode, multiple_hyphens_in_basic) {
+TEST(multiple_hyphens_in_basic) {
   const std::u32string expected{0x0061, 0x002D, 0x0062, 0x002D, 0x0063};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("a-b-c-"), expected);
 }
 
-TEST(Punycode_decode, only_non_basic) {
+TEST(only_non_basic) {
   const std::u32string expected{0x00E4, 0x00F6, 0x00FC};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("4ca0bs"), expected);
 }
 
-TEST(Punycode_decode, long_string_non_ascii) {
+TEST(long_string_non_ascii) {
   // 中文 repeated 5 times
   const std::u32string expected{0x4E2D, 0x6587, 0x4E2D, 0x6587, 0x4E2D,
                                 0x6587, 0x4E2D, 0x6587, 0x4E2D, 0x6587};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("fiqaaaa8796ababbb"), expected);
 }
 
-TEST(Punycode_decode, error_invalid_digit) {
+TEST(error_invalid_digit) {
   try {
     sourcemeta::core::punycode_to_utf32("abc!def");
     FAIL();
@@ -263,7 +263,7 @@ TEST(Punycode_decode, error_invalid_digit) {
   }
 }
 
-TEST(Punycode_decode, error_non_basic_before_delimiter) {
+TEST(error_non_basic_before_delimiter) {
   // Non-ASCII character (0x80+) before the delimiter
   try {
     sourcemeta::core::punycode_to_utf32("\x80-abc");
@@ -273,7 +273,7 @@ TEST(Punycode_decode, error_non_basic_before_delimiter) {
   }
 }
 
-TEST(Punycode_decode, error_leading_delimiter_only) {
+TEST(error_leading_delimiter_only) {
   try {
     sourcemeta::core::punycode_to_utf32("-");
     FAIL();
@@ -282,7 +282,7 @@ TEST(Punycode_decode, error_leading_delimiter_only) {
   }
 }
 
-TEST(Punycode_decode, error_leading_delimiter_with_body) {
+TEST(error_leading_delimiter_with_body) {
   try {
     sourcemeta::core::punycode_to_utf32("-abc");
     FAIL();
@@ -291,12 +291,12 @@ TEST(Punycode_decode, error_leading_delimiter_with_body) {
   }
 }
 
-TEST(Punycode_decode, trailing_delimiter_basic_only) {
+TEST(trailing_delimiter_basic_only) {
   const std::u32string expected{0x0061};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("a-"), expected);
 }
 
-TEST(Punycode_decode, case_insensitive_basic_portion_preserved) {
+TEST(case_insensitive_basic_portion_preserved) {
   // The basic portion (before delimiter) preserves original case
   const std::u32string expected_lower{0x0061, 0x0062, 0x0063};
   const std::u32string expected_upper{0x0041, 0x0042, 0x0043};
@@ -304,30 +304,30 @@ TEST(Punycode_decode, case_insensitive_basic_portion_preserved) {
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("ABC-"), expected_upper);
 }
 
-TEST(Punycode_decode, case_insensitive_extended_digits) {
+TEST(case_insensitive_extended_digits) {
   // Digit values a-z and A-Z are equivalent per RFC 3492
   const std::u32string expected{0x00FC};
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("tda"), expected);
   EXPECT_EQ(sourcemeta::core::punycode_to_utf32("TDA"), expected);
 }
 
-TEST(Punycode_decode, utf8_api_simple) {
+TEST(utf8_api_simple) {
   EXPECT_EQ(sourcemeta::core::punycode_to_utf8("hello-"), "hello");
 }
 
-TEST(Punycode_decode, utf8_api_with_non_ascii) {
+TEST(utf8_api_with_non_ascii) {
   // Decodes to "München" in UTF-8
   EXPECT_EQ(sourcemeta::core::punycode_to_utf8("Mnchen-3ya"), "M\xC3\xBCnchen");
 }
 
-TEST(Punycode_decode, utf8_stream_api_simple) {
+TEST(utf8_stream_api_simple) {
   std::istringstream input{"hello-"};
   std::ostringstream output;
   sourcemeta::core::punycode_to_utf8(input, output);
   EXPECT_EQ(output.str(), "hello");
 }
 
-TEST(Punycode_decode, utf8_stream_api_with_non_ascii) {
+TEST(utf8_stream_api_with_non_ascii) {
   std::istringstream input{"Mnchen-3ya"};
   std::ostringstream output;
   sourcemeta::core::punycode_to_utf8(input, output);

--- a/test/punycode/punycode_encode_test.cc
+++ b/test/punycode/punycode_encode_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/punycode.h>
 
@@ -9,7 +9,7 @@
 // See https://www.rfc-editor.org/rfc/rfc3492#section-7.1
 
 // (A) Arabic (Egyptian)
-TEST(Punycode_encode, rfc3492_sample_a_arabic) {
+TEST(rfc3492_sample_a_arabic) {
   const std::u32string input{0x0644, 0x064A, 0x0647, 0x0645, 0x0627, 0x0628,
                              0x062A, 0x0643, 0x0644, 0x0645, 0x0648, 0x0634,
                              0x0639, 0x0631, 0x0628, 0x064A, 0x061F};
@@ -18,7 +18,7 @@ TEST(Punycode_encode, rfc3492_sample_a_arabic) {
 }
 
 // (B) Chinese (simplified)
-TEST(Punycode_encode, rfc3492_sample_b_chinese_simplified) {
+TEST(rfc3492_sample_b_chinese_simplified) {
   const std::u32string input{0x4ED6, 0x4EEC, 0x4E3A, 0x4EC0, 0x4E48,
                              0x4E0D, 0x8BF4, 0x4E2D, 0x6587};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input),
@@ -26,7 +26,7 @@ TEST(Punycode_encode, rfc3492_sample_b_chinese_simplified) {
 }
 
 // (C) Chinese (traditional)
-TEST(Punycode_encode, rfc3492_sample_c_chinese_traditional) {
+TEST(rfc3492_sample_c_chinese_traditional) {
   const std::u32string input{0x4ED6, 0x5011, 0x7232, 0x4EC0, 0x9EBD,
                              0x4E0D, 0x8AAA, 0x4E2D, 0x6587};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input),
@@ -34,7 +34,7 @@ TEST(Punycode_encode, rfc3492_sample_c_chinese_traditional) {
 }
 
 // (D) Czech
-TEST(Punycode_encode, rfc3492_sample_d_czech) {
+TEST(rfc3492_sample_d_czech) {
   const std::u32string input{0x0050, 0x0072, 0x006F, 0x010D, 0x0070, 0x0072,
                              0x006F, 0x0073, 0x0074, 0x011B, 0x006E, 0x0065,
                              0x006D, 0x006C, 0x0075, 0x0076, 0x00ED, 0x010D,
@@ -44,7 +44,7 @@ TEST(Punycode_encode, rfc3492_sample_d_czech) {
 }
 
 // (E) Hebrew
-TEST(Punycode_encode, rfc3492_sample_e_hebrew) {
+TEST(rfc3492_sample_e_hebrew) {
   const std::u32string input{0x05DC, 0x05DE, 0x05D4, 0x05D4, 0x05DD, 0x05E4,
                              0x05E9, 0x05D5, 0x05D8, 0x05DC, 0x05D0, 0x05DE,
                              0x05D3, 0x05D1, 0x05E8, 0x05D9, 0x05DD, 0x05E2,
@@ -54,7 +54,7 @@ TEST(Punycode_encode, rfc3492_sample_e_hebrew) {
 }
 
 // (F) Hindi (Devanagari)
-TEST(Punycode_encode, rfc3492_sample_f_hindi) {
+TEST(rfc3492_sample_f_hindi) {
   const std::u32string input{0x092F, 0x0939, 0x0932, 0x094B, 0x0917, 0x0939,
                              0x093F, 0x0928, 0x094D, 0x0926, 0x0940, 0x0915,
                              0x094D, 0x092F, 0x094B, 0x0902, 0x0928, 0x0939,
@@ -65,7 +65,7 @@ TEST(Punycode_encode, rfc3492_sample_f_hindi) {
 }
 
 // (G) Japanese (kanji and hiragana)
-TEST(Punycode_encode, rfc3492_sample_g_japanese) {
+TEST(rfc3492_sample_g_japanese) {
   const std::u32string input{0x306A, 0x305C, 0x307F, 0x3093, 0x306A, 0x65E5,
                              0x672C, 0x8A9E, 0x3092, 0x8A71, 0x3057, 0x3066,
                              0x304F, 0x308C, 0x306A, 0x3044, 0x306E, 0x304B};
@@ -74,7 +74,7 @@ TEST(Punycode_encode, rfc3492_sample_g_japanese) {
 }
 
 // (H) Korean (Hangul syllables)
-TEST(Punycode_encode, rfc3492_sample_h_korean) {
+TEST(rfc3492_sample_h_korean) {
   const std::u32string input{0xC138, 0xACC4, 0xC758, 0xBAA8, 0xB4E0, 0xC0AC,
                              0xB78C, 0xB4E4, 0xC774, 0xD55C, 0xAD6D, 0xC5B4,
                              0xB97C, 0xC774, 0xD574, 0xD55C, 0xB2E4, 0xBA74,
@@ -85,7 +85,7 @@ TEST(Punycode_encode, rfc3492_sample_h_korean) {
 }
 
 // (I) Russian (Cyrillic)
-TEST(Punycode_encode, rfc3492_sample_i_russian) {
+TEST(rfc3492_sample_i_russian) {
   const std::u32string input{0x043F, 0x043E, 0x0447, 0x0435, 0x043C, 0x0443,
                              0x0436, 0x0435, 0x043E, 0x043D, 0x0438, 0x043D,
                              0x0435, 0x0433, 0x043E, 0x0432, 0x043E, 0x0440,
@@ -96,7 +96,7 @@ TEST(Punycode_encode, rfc3492_sample_i_russian) {
 }
 
 // (J) Spanish
-TEST(Punycode_encode, rfc3492_sample_j_spanish) {
+TEST(rfc3492_sample_j_spanish) {
   const std::u32string input{
       0x0050, 0x006F, 0x0072, 0x0071, 0x0075, 0x00E9, 0x006E, 0x006F,
       0x0070, 0x0075, 0x0065, 0x0064, 0x0065, 0x006E, 0x0073, 0x0069,
@@ -108,7 +108,7 @@ TEST(Punycode_encode, rfc3492_sample_j_spanish) {
 }
 
 // (K) Vietnamese
-TEST(Punycode_encode, rfc3492_sample_k_vietnamese) {
+TEST(rfc3492_sample_k_vietnamese) {
   const std::u32string input{
       0x0054, 0x1EA1, 0x0069, 0x0073, 0x0061, 0x006F, 0x0068, 0x1ECD,
       0x006B, 0x0068, 0x00F4, 0x006E, 0x0067, 0x0074, 0x0068, 0x1EC3,
@@ -119,7 +119,7 @@ TEST(Punycode_encode, rfc3492_sample_k_vietnamese) {
 }
 
 // (L) 3nen B gumi Kinpachi sensei (Japanese)
-TEST(Punycode_encode, rfc3492_sample_l_japanese_3b) {
+TEST(rfc3492_sample_l_japanese_3b) {
   const std::u32string input{0x0033, 0x5E74, 0x0042, 0x7D44,
                              0x91D1, 0x516B, 0x5148, 0x751F};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input),
@@ -127,7 +127,7 @@ TEST(Punycode_encode, rfc3492_sample_l_japanese_3b) {
 }
 
 // (M) Amuro Namie with Super Monkeys (Japanese)
-TEST(Punycode_encode, rfc3492_sample_m_japanese_monkeys) {
+TEST(rfc3492_sample_m_japanese_monkeys) {
   const std::u32string input{0x5B89, 0x5BA4, 0x5948, 0x7F8E, 0x6075, 0x002D,
                              0x0077, 0x0069, 0x0074, 0x0068, 0x002D, 0x0053,
                              0x0055, 0x0050, 0x0045, 0x0052, 0x002D, 0x004D,
@@ -137,7 +137,7 @@ TEST(Punycode_encode, rfc3492_sample_m_japanese_monkeys) {
 }
 
 // (N) Hello-Another-Way-...(Japanese)
-TEST(Punycode_encode, rfc3492_sample_n_japanese_hello) {
+TEST(rfc3492_sample_n_japanese_hello) {
   const std::u32string input{
       0x0048, 0x0065, 0x006C, 0x006C, 0x006F, 0x002D, 0x0041, 0x006E, 0x006F,
       0x0074, 0x0068, 0x0065, 0x0072, 0x002D, 0x0057, 0x0061, 0x0079, 0x002D,
@@ -147,14 +147,14 @@ TEST(Punycode_encode, rfc3492_sample_n_japanese_hello) {
 }
 
 // (O) hitotsuyanenoshita2 (Japanese)
-TEST(Punycode_encode, rfc3492_sample_o_japanese_hitotsu) {
+TEST(rfc3492_sample_o_japanese_hitotsu) {
   const std::u32string input{0x3072, 0x3068, 0x3064, 0x5C4B,
                              0x6839, 0x306E, 0x4E0B, 0x0032};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "2-u9tlzr9756bt3uc0v");
 }
 
 // (P) MaijideKoisuru5byoumae (Japanese)
-TEST(Punycode_encode, rfc3492_sample_p_japanese_maji) {
+TEST(rfc3492_sample_p_japanese_maji) {
   const std::u32string input{0x004D, 0x0061, 0x006A, 0x0069, 0x3067,
                              0x004B, 0x006F, 0x0069, 0x3059, 0x308B,
                              0x0035, 0x79D2, 0x524D};
@@ -163,89 +163,87 @@ TEST(Punycode_encode, rfc3492_sample_p_japanese_maji) {
 }
 
 // (Q) PafyiideRunba (Japanese katakana)
-TEST(Punycode_encode, rfc3492_sample_q_japanese_pafyii) {
+TEST(rfc3492_sample_q_japanese_pafyii) {
   const std::u32string input{0x30D1, 0x30D5, 0x30A3, 0x30FC, 0x0064,
                              0x0065, 0x30EB, 0x30F3, 0x30D0};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "de-jg4avhby1noc0d");
 }
 
 // (R) Sono Speed de (Japanese hiragana/katakana)
-TEST(Punycode_encode, rfc3492_sample_r_japanese_sono) {
+TEST(rfc3492_sample_r_japanese_sono) {
   const std::u32string input{0x305D, 0x306E, 0x30B9, 0x30D4,
                              0x30FC, 0x30C9, 0x3067};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "d9juau41awczczp");
 }
 
 // (S) Pure ASCII -> $1.00 <-
-TEST(Punycode_encode, rfc3492_sample_s_ascii) {
+TEST(rfc3492_sample_s_ascii) {
   const std::u32string input{0x002D, 0x003E, 0x0020, 0x0024, 0x0031, 0x002E,
                              0x0030, 0x0030, 0x0020, 0x003C, 0x002D};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "-> $1.00 <--");
 }
 
 // Edge cases using UTF-32 API
-TEST(Punycode_encode, empty_string) {
-  EXPECT_EQ(sourcemeta::core::utf32_to_punycode(U""), "");
-}
+TEST(empty_string) { EXPECT_EQ(sourcemeta::core::utf32_to_punycode(U""), ""); }
 
-TEST(Punycode_encode, pure_ascii_simple) {
+TEST(pure_ascii_simple) {
   const std::u32string input{0x0068, 0x0065, 0x006C, 0x006C, 0x006F};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "hello-");
 }
 
-TEST(Punycode_encode, pure_ascii_no_hyphen) {
+TEST(pure_ascii_no_hyphen) {
   const std::u32string input{0x0061, 0x0062, 0x0063};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "abc-");
 }
 
-TEST(Punycode_encode, single_non_ascii) {
+TEST(single_non_ascii) {
   const std::u32string input{0x00FC};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "tda");
 }
 
-TEST(Punycode_encode, mixed_ascii_and_non_ascii) {
+TEST(mixed_ascii_and_non_ascii) {
   // Munchen with umlaut
   const std::u32string input{0x004D, 0x00FC, 0x006E, 0x0063,
                              0x0068, 0x0065, 0x006E};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "Mnchen-3ya");
 }
 
-TEST(Punycode_encode, emoji_single) {
+TEST(emoji_single) {
   // Grinning face emoji
   const std::u32string input{0x1F600};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "e28h");
 }
 
-TEST(Punycode_encode, mixed_with_emoji) {
+TEST(mixed_with_emoji) {
   // hi + grinning face emoji
   const std::u32string input{0x0068, 0x0069, 0x1F600};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "hi-oo82a");
 }
 
-TEST(Punycode_encode, supplementary_plane) {
+TEST(supplementary_plane) {
   // LINEAR B SYLLABLE B008 A (U+10000)
   const std::u32string input{0x10000};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "2n7c");
 }
 
-TEST(Punycode_encode, multiple_hyphens_in_basic) {
+TEST(multiple_hyphens_in_basic) {
   const std::u32string input{0x0061, 0x002D, 0x0062, 0x002D, 0x0063};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "a-b-c-");
 }
 
-TEST(Punycode_encode, only_non_basic) {
+TEST(only_non_basic) {
   const std::u32string input{0x00E4, 0x00F6, 0x00FC};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "4ca0bs");
 }
 
-TEST(Punycode_encode, long_string_non_ascii) {
+TEST(long_string_non_ascii) {
   // 中文 repeated 5 times
   const std::u32string input{0x4E2D, 0x6587, 0x4E2D, 0x6587, 0x4E2D,
                              0x6587, 0x4E2D, 0x6587, 0x4E2D, 0x6587};
   EXPECT_EQ(sourcemeta::core::utf32_to_punycode(input), "fiqaaaa8796ababbb");
 }
 
-TEST(Punycode_encode, error_surrogate_code_point) {
+TEST(error_surrogate_code_point) {
   const std::u32string input{0xD800};
   try {
     sourcemeta::core::utf32_to_punycode(input);
@@ -255,7 +253,7 @@ TEST(Punycode_encode, error_surrogate_code_point) {
   }
 }
 
-TEST(Punycode_encode, error_code_point_above_maximum) {
+TEST(error_code_point_above_maximum) {
   const std::u32string input{0x110000};
   try {
     sourcemeta::core::utf32_to_punycode(input);
@@ -265,7 +263,7 @@ TEST(Punycode_encode, error_code_point_above_maximum) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_bad_start_byte) {
+TEST(error_utf8_bad_start_byte) {
   // 0xFF is never valid as a UTF-8 start byte
   try {
     sourcemeta::core::utf8_to_punycode("\xFF");
@@ -275,7 +273,7 @@ TEST(Punycode_encode, error_utf8_bad_start_byte) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_incomplete_2byte_sequence) {
+TEST(error_utf8_incomplete_2byte_sequence) {
   // 0xC3 starts a 2-byte sequence but no continuation follows
   try {
     sourcemeta::core::utf8_to_punycode("\xC3");
@@ -285,7 +283,7 @@ TEST(Punycode_encode, error_utf8_incomplete_2byte_sequence) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_incomplete_3byte_sequence) {
+TEST(error_utf8_incomplete_3byte_sequence) {
   // 0xE2 starts a 3-byte sequence but only one continuation follows
   try {
     sourcemeta::core::utf8_to_punycode("\xE2\x80");
@@ -295,7 +293,7 @@ TEST(Punycode_encode, error_utf8_incomplete_3byte_sequence) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_incomplete_4byte_sequence) {
+TEST(error_utf8_incomplete_4byte_sequence) {
   // 0xF0 starts a 4-byte sequence but only two continuations follow
   try {
     sourcemeta::core::utf8_to_punycode("\xF0\x9F\x98");
@@ -305,7 +303,7 @@ TEST(Punycode_encode, error_utf8_incomplete_4byte_sequence) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_bad_continuation_byte) {
+TEST(error_utf8_bad_continuation_byte) {
   // 0xC3 expects a continuation byte (0x80-0xBF), not 0x00
   try {
     sourcemeta::core::utf8_to_punycode("\xC3\x00");
@@ -315,7 +313,7 @@ TEST(Punycode_encode, error_utf8_bad_continuation_byte) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_overlong_2byte) {
+TEST(error_utf8_overlong_2byte) {
   // Overlong encoding of ASCII character (should be single byte)
   try {
     sourcemeta::core::utf8_to_punycode("\xC0\x80");
@@ -325,7 +323,7 @@ TEST(Punycode_encode, error_utf8_overlong_2byte) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_overlong_3byte) {
+TEST(error_utf8_overlong_3byte) {
   // Overlong 3-byte encoding of a character that fits in 2 bytes
   try {
     sourcemeta::core::utf8_to_punycode("\xE0\x80\x80");
@@ -335,7 +333,7 @@ TEST(Punycode_encode, error_utf8_overlong_3byte) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_overlong_4byte) {
+TEST(error_utf8_overlong_4byte) {
   // Overlong 4-byte encoding of a character that fits in 3 bytes
   try {
     sourcemeta::core::utf8_to_punycode("\xF0\x80\x80\x80");
@@ -345,7 +343,7 @@ TEST(Punycode_encode, error_utf8_overlong_4byte) {
   }
 }
 
-TEST(Punycode_encode, error_utf8_surrogate_code_point) {
+TEST(error_utf8_surrogate_code_point) {
   // UTF-8 encoding of surrogate U+D800 (invalid)
   try {
     sourcemeta::core::utf8_to_punycode("\xED\xA0\x80");
@@ -355,23 +353,23 @@ TEST(Punycode_encode, error_utf8_surrogate_code_point) {
   }
 }
 
-TEST(Punycode_encode, utf8_api_simple) {
+TEST(utf8_api_simple) {
   EXPECT_EQ(sourcemeta::core::utf8_to_punycode("hello"), "hello-");
 }
 
-TEST(Punycode_encode, utf8_api_with_non_ascii) {
+TEST(utf8_api_with_non_ascii) {
   // "München" in UTF-8
   EXPECT_EQ(sourcemeta::core::utf8_to_punycode("M\xC3\xBCnchen"), "Mnchen-3ya");
 }
 
-TEST(Punycode_encode, utf8_stream_api_simple) {
+TEST(utf8_stream_api_simple) {
   std::istringstream input{"hello"};
   std::ostringstream output;
   sourcemeta::core::utf8_to_punycode(input, output);
   EXPECT_EQ(output.str(), "hello-");
 }
 
-TEST(Punycode_encode, utf8_stream_api_with_non_ascii) {
+TEST(utf8_stream_api_with_non_ascii) {
   std::istringstream input{"M\xC3\xBCnchen"};
   std::ostringstream output;
   sourcemeta::core::utf8_to_punycode(input, output);

--- a/test/regex/CMakeLists.txt
+++ b/test/regex/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME regex
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME regex
   SOURCES
     regex_matches_if_valid_test.cc
     regex_matches_ecma262_test.cc

--- a/test/regex/regex_is_ecma_test.cc
+++ b/test/regex/regex_is_ecma_test.cc
@@ -1,313 +1,287 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/regex.h>
 
-TEST(Regex_is_ecma, suite_valid_basic) {
+TEST(suite_valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("([abc])+\\s+$"));
 }
 
-TEST(Regex_is_ecma, suite_invalid_unclosed_paren) {
+TEST(suite_invalid_unclosed_paren) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("^(abc]"));
 }
 
-TEST(Regex_is_ecma, suite_invalid_perl_extension_alarm) {
+TEST(suite_invalid_perl_extension_alarm) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\a"));
 }
 
-TEST(Regex_is_ecma, valid_empty) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma(""));
-}
+TEST(valid_empty) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("")); }
 
-TEST(Regex_is_ecma, valid_anchor_start) {
+TEST(valid_anchor_start) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo"));
 }
 
-TEST(Regex_is_ecma, valid_anchor_end) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$"));
-}
+TEST(valid_anchor_end) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$")); }
 
-TEST(Regex_is_ecma, valid_anchor_both) {
+TEST(valid_anchor_both) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo$"));
 }
 
-TEST(Regex_is_ecma, valid_character_class) {
+TEST(valid_character_class) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc]"));
 }
 
-TEST(Regex_is_ecma, valid_negated_class) {
+TEST(valid_negated_class) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^abc]"));
 }
 
-TEST(Regex_is_ecma, valid_range_class) {
+TEST(valid_range_class) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]"));
 }
 
-TEST(Regex_is_ecma, invalid_unclosed_class) {
+TEST(invalid_unclosed_class) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[abc"));
 }
 
-TEST(Regex_is_ecma, valid_empty_class) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[]"));
-}
+TEST(valid_empty_class) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[]")); }
 
-TEST(Regex_is_ecma, valid_empty_class_negated) {
+TEST(valid_empty_class_negated) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]"));
 }
 
-TEST(Regex_is_ecma, valid_digit_escape) {
+TEST(valid_digit_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d"));
 }
 
-TEST(Regex_is_ecma, valid_word_escape) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\w"));
-}
+TEST(valid_word_escape) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\w")); }
 
-TEST(Regex_is_ecma, valid_space_escape) {
+TEST(valid_space_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\s"));
 }
 
-TEST(Regex_is_ecma, valid_word_boundary) {
+TEST(valid_word_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bfoo\\b"));
 }
 
-TEST(Regex_is_ecma, valid_newline_escape) {
+TEST(valid_newline_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\n"));
 }
 
-TEST(Regex_is_ecma, valid_tab_escape) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\t"));
-}
+TEST(valid_tab_escape) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\t")); }
 
-TEST(Regex_is_ecma, valid_carriage_return_escape) {
+TEST(valid_carriage_return_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\r"));
 }
 
-TEST(Regex_is_ecma, valid_form_feed_escape) {
+TEST(valid_form_feed_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\f"));
 }
 
-TEST(Regex_is_ecma, valid_vertical_tab_escape) {
+TEST(valid_vertical_tab_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\v"));
 }
 
-TEST(Regex_is_ecma, valid_null_escape) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\0"));
-}
+TEST(valid_null_escape) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\0")); }
 
-TEST(Regex_is_ecma, valid_hex_escape) {
+TEST(valid_hex_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\x41"));
 }
 
-TEST(Regex_is_ecma, valid_unicode_4digit) {
+TEST(valid_unicode_4digit) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\u0041"));
 }
 
-TEST(Regex_is_ecma, valid_unicode_braced) {
+TEST(valid_unicode_braced) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\u{1F600}"));
 }
 
-TEST(Regex_is_ecma, valid_control_escape) {
+TEST(valid_control_escape) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\cA"));
 }
 
-TEST(Regex_is_ecma, valid_unicode_property) {
+TEST(valid_unicode_property) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Letter}"));
 }
 
-TEST(Regex_is_ecma, invalid_alarm_escape) {
+TEST(invalid_alarm_escape) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\a"));
 }
 
-TEST(Regex_is_ecma, invalid_escape_e) {
-  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\e"));
-}
+TEST(invalid_escape_e) { EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\e")); }
 
-TEST(Regex_is_ecma, invalid_escape_h) {
-  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\h"));
-}
+TEST(invalid_escape_h) { EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\h")); }
 
-TEST(Regex_is_ecma, invalid_escape_q) {
-  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\q"));
-}
+TEST(invalid_escape_q) { EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\q")); }
 
-TEST(Regex_is_ecma, valid_quantifier_star) {
+TEST(valid_quantifier_star) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a*"));
 }
 
-TEST(Regex_is_ecma, valid_quantifier_plus) {
+TEST(valid_quantifier_plus) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a+"));
 }
 
-TEST(Regex_is_ecma, valid_quantifier_optional) {
+TEST(valid_quantifier_optional) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a?"));
 }
 
-TEST(Regex_is_ecma, valid_quantifier_range) {
+TEST(valid_quantifier_range) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,5}"));
 }
 
-TEST(Regex_is_ecma, valid_quantifier_exact) {
+TEST(valid_quantifier_exact) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{3}"));
 }
 
-TEST(Regex_is_ecma, valid_quantifier_open) {
+TEST(valid_quantifier_open) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{3,}"));
 }
 
-TEST(Regex_is_ecma, invalid_quantifier_reversed) {
+TEST(invalid_quantifier_reversed) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a{5,2}"));
 }
 
-TEST(Regex_is_ecma, invalid_quantifier_no_target) {
+TEST(invalid_quantifier_no_target) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("+"));
 }
 
-TEST(Regex_is_ecma, valid_group) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(foo)"));
-}
+TEST(valid_group) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(foo)")); }
 
-TEST(Regex_is_ecma, valid_non_capturing_group) {
+TEST(valid_non_capturing_group) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:foo)"));
 }
 
-TEST(Regex_is_ecma, valid_alternation) {
+TEST(valid_alternation) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo|bar"));
 }
 
-TEST(Regex_is_ecma, invalid_unclosed_group) {
+TEST(invalid_unclosed_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(foo"));
 }
 
-TEST(Regex_is_ecma, invalid_unopened_group) {
+TEST(invalid_unopened_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("foo)"));
 }
 
-TEST(Regex_is_ecma, valid_lookahead) {
+TEST(valid_lookahead) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo(?=bar)"));
 }
 
-TEST(Regex_is_ecma, valid_negative_lookahead) {
+TEST(valid_negative_lookahead) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo(?!bar)"));
 }
 
-TEST(Regex_is_ecma, valid_lookbehind) {
+TEST(valid_lookbehind) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=foo)bar"));
 }
 
-TEST(Regex_is_ecma, valid_negative_lookbehind) {
+TEST(valid_negative_lookbehind) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<!foo)bar"));
 }
 
-TEST(Regex_is_ecma, valid_dot_star) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*"));
-}
+TEST(valid_dot_star) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*")); }
 
-TEST(Regex_is_ecma, valid_anchored_dot_star) {
+TEST(valid_anchored_dot_star) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.*$"));
 }
 
-TEST(Regex_is_ecma, valid_dot_plus) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".+"));
-}
+TEST(valid_dot_plus) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".+")); }
 
-TEST(Regex_is_ecma, valid_single_dot) {
-  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
-}
+TEST(valid_single_dot) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".")); }
 
-TEST(Regex_is_ecma, valid_uuid_pattern) {
+TEST(valid_uuid_pattern) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"));
 }
 
-TEST(Regex_is_ecma, valid_email_loose) {
+TEST(valid_email_loose) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"));
 }
 
-TEST(Regex_is_ecma, valid_iso_date) {
+TEST(valid_iso_date) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d{4}-\\d{2}-\\d{2}$"));
 }
 
-TEST(Regex_is_ecma, valid_named_group) {
+TEST(valid_named_group) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<name>foo)"));
 }
 
-TEST(Regex_is_ecma, valid_named_backreference) {
+TEST(valid_named_backreference) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<name>foo)\\k<name>"));
 }
 
-TEST(Regex_is_ecma, invalid_python_named_group) {
+TEST(invalid_python_named_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?P<name>foo)"));
 }
 
-TEST(Regex_is_ecma, invalid_atomic_group) {
+TEST(invalid_atomic_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?>foo)"));
 }
 
-TEST(Regex_is_ecma, invalid_inline_option_group) {
+TEST(invalid_inline_option_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?i)foo"));
 }
 
-TEST(Regex_is_ecma, invalid_inline_option_scoped) {
+TEST(invalid_inline_option_scoped) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?i:foo)"));
 }
 
-TEST(Regex_is_ecma, invalid_branch_reset_group) {
+TEST(invalid_branch_reset_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?|a|b)"));
 }
 
-TEST(Regex_is_ecma, invalid_conditional_group) {
+TEST(invalid_conditional_group) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?(1)yes|no)"));
 }
 
-TEST(Regex_is_ecma, invalid_subroutine_call) {
+TEST(invalid_subroutine_call) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?&name)"));
 }
 
-TEST(Regex_is_ecma, invalid_recursion) {
+TEST(invalid_recursion) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(?R)"));
 }
 
-TEST(Regex_is_ecma, invalid_backreference_uppercase_k) {
+TEST(invalid_backreference_uppercase_k) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("foo\\Kbar"));
 }
 
-TEST(Regex_is_ecma, invalid_line_break_escape) {
+TEST(invalid_line_break_escape) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\R"));
 }
 
-TEST(Regex_is_ecma, invalid_quote_sequence) {
+TEST(invalid_quote_sequence) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\Qfoo\\E"));
 }
 
-TEST(Regex_is_ecma, invalid_posix_class_alpha) {
+TEST(invalid_posix_class_alpha) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[:alpha:]]"));
 }
 
-TEST(Regex_is_ecma, invalid_possessive_quantifier) {
+TEST(invalid_possessive_quantifier) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a*+"));
 }
 
-TEST(Regex_is_ecma, invalid_backtracking_control) {
+TEST(invalid_backtracking_control) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(*FAIL)"));
 }
 
-TEST(Regex_is_ecma, invalid_perl_g_backreference) {
+TEST(invalid_perl_g_backreference) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(foo)\\g{1}"));
 }
 
-TEST(Regex_is_ecma, valid_literal_open_bracket_colon_in_class) {
+TEST(valid_literal_open_bracket_colon_in_class) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[:abc]"));
 }
 
-TEST(Regex_is_ecma, valid_literal_colon_inside_class) {
+TEST(valid_literal_colon_inside_class) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a:b]"));
 }
 
-TEST(Regex_is_ecma, invalid_unterminated_named_backreference) {
+TEST(invalid_unterminated_named_backreference) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\k<name"));
 }
 
-TEST(Regex_is_ecma, invalid_empty_named_backreference) {
+TEST(invalid_empty_named_backreference) {
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\k<>"));
 }

--- a/test/regex/regex_matches_ecma262_test.cc
+++ b/test/regex/regex_matches_ecma262_test.cc
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/regex.h>
 
 #include <string>
 
-TEST(Regex_matches, ecma262_anchor_start) {
+TEST(ecma262_anchor_start) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo"));
@@ -13,7 +13,7 @@ TEST(Regex_matches, ecma262_anchor_start) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "barfoo"));
 }
 
-TEST(Regex_matches, ecma262_anchor_end) {
+TEST(ecma262_anchor_end) {
   const auto regex{sourcemeta::core::to_regex("foo$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$"));
@@ -22,7 +22,7 @@ TEST(Regex_matches, ecma262_anchor_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both) {
+TEST(ecma262_anchor_both) {
   const auto regex{sourcemeta::core::to_regex("^foo$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo$"));
@@ -31,7 +31,7 @@ TEST(Regex_matches, ecma262_anchor_both) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "barfoo"));
 }
 
-TEST(Regex_matches, ecma262_anchor_start_with_alternation) {
+TEST(ecma262_anchor_start_with_alternation) {
   const auto regex{sourcemeta::core::to_regex("^(foo|bar)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^(foo|bar)"));
@@ -40,7 +40,7 @@ TEST(Regex_matches, ecma262_anchor_start_with_alternation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "baz"));
 }
 
-TEST(Regex_matches, ecma262_digit_escape) {
+TEST(ecma262_digit_escape) {
   const auto regex{sourcemeta::core::to_regex("\\d+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d+"));
@@ -50,7 +50,7 @@ TEST(Regex_matches, ecma262_digit_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_non_digit_escape) {
+TEST(ecma262_non_digit_escape) {
   const auto regex{sourcemeta::core::to_regex("\\D+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\D+"));
@@ -59,7 +59,7 @@ TEST(Regex_matches, ecma262_non_digit_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123"));
 }
 
-TEST(Regex_matches, ecma262_word_escape) {
+TEST(ecma262_word_escape) {
   const auto regex{sourcemeta::core::to_regex("\\w+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\w+"));
@@ -70,7 +70,7 @@ TEST(Regex_matches, ecma262_word_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "!!!"));
 }
 
-TEST(Regex_matches, ecma262_non_word_escape) {
+TEST(ecma262_non_word_escape) {
   const auto regex{sourcemeta::core::to_regex("\\W+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\W+"));
@@ -79,7 +79,7 @@ TEST(Regex_matches, ecma262_non_word_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_whitespace_escape) {
+TEST(ecma262_whitespace_escape) {
   const auto regex{sourcemeta::core::to_regex("\\s+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\s+"));
@@ -90,7 +90,7 @@ TEST(Regex_matches, ecma262_whitespace_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_non_whitespace_escape) {
+TEST(ecma262_non_whitespace_escape) {
   const auto regex{sourcemeta::core::to_regex("\\S+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\S+"));
@@ -99,7 +99,7 @@ TEST(Regex_matches, ecma262_non_whitespace_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "   "));
 }
 
-TEST(Regex_matches, ecma262_word_boundary_start) {
+TEST(ecma262_word_boundary_start) {
   const auto regex{sourcemeta::core::to_regex("\\bfoo")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bfoo"));
@@ -109,7 +109,7 @@ TEST(Regex_matches, ecma262_word_boundary_start) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xfoo"));
 }
 
-TEST(Regex_matches, ecma262_word_boundary_end) {
+TEST(ecma262_word_boundary_end) {
   const auto regex{sourcemeta::core::to_regex("foo\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo\\b"));
@@ -119,7 +119,7 @@ TEST(Regex_matches, ecma262_word_boundary_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foox"));
 }
 
-TEST(Regex_matches, ecma262_word_boundary_both) {
+TEST(ecma262_word_boundary_both) {
   const auto regex{sourcemeta::core::to_regex("\\bfoo\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bfoo\\b"));
@@ -129,7 +129,7 @@ TEST(Regex_matches, ecma262_word_boundary_both) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
-TEST(Regex_matches, ecma262_non_word_boundary) {
+TEST(ecma262_non_word_boundary) {
   const auto regex{sourcemeta::core::to_regex("\\Boo")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\Boo"));
@@ -137,7 +137,7 @@ TEST(Regex_matches, ecma262_non_word_boundary) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "oo"));
 }
 
-TEST(Regex_matches, ecma262_hex_escape_2digit) {
+TEST(ecma262_hex_escape_2digit) {
   const auto regex{sourcemeta::core::to_regex("\\x41")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\x41"));
@@ -145,7 +145,7 @@ TEST(Regex_matches, ecma262_hex_escape_2digit) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "B"));
 }
 
-TEST(Regex_matches, ecma262_hex_escape_in_pattern) {
+TEST(ecma262_hex_escape_in_pattern) {
   const auto regex{sourcemeta::core::to_regex("a\\x20b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\x20b"));
@@ -153,7 +153,7 @@ TEST(Regex_matches, ecma262_hex_escape_in_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_unicode_escape_4digit) {
+TEST(ecma262_unicode_escape_4digit) {
   const auto regex{sourcemeta::core::to_regex("\\u0041")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\u0041"));
@@ -161,7 +161,7 @@ TEST(Regex_matches, ecma262_unicode_escape_4digit) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "B"));
 }
 
-TEST(Regex_matches, ecma262_unicode_escape_brace) {
+TEST(ecma262_unicode_escape_brace) {
   const auto regex{sourcemeta::core::to_regex("\\u{1F600}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\u{1F600}"));
@@ -169,7 +169,7 @@ TEST(Regex_matches, ecma262_unicode_escape_brace) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, ecma262_null_escape) {
+TEST(ecma262_null_escape) {
   const auto regex{sourcemeta::core::to_regex("a\\0b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\0b"));
@@ -177,7 +177,7 @@ TEST(Regex_matches, ecma262_null_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_non_capturing_group) {
+TEST(ecma262_non_capturing_group) {
   const auto regex{sourcemeta::core::to_regex("(?:abc)+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:abc)+"));
@@ -186,7 +186,7 @@ TEST(Regex_matches, ecma262_non_capturing_group) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_lookahead_positive) {
+TEST(ecma262_lookahead_positive) {
   const auto regex{sourcemeta::core::to_regex("foo(?=bar)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo(?=bar)"));
@@ -194,7 +194,7 @@ TEST(Regex_matches, ecma262_lookahead_positive) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foobaz"));
 }
 
-TEST(Regex_matches, ecma262_lookahead_negative) {
+TEST(ecma262_lookahead_negative) {
   const auto regex{sourcemeta::core::to_regex("foo(?!bar)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo(?!bar)"));
@@ -202,7 +202,7 @@ TEST(Regex_matches, ecma262_lookahead_negative) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
-TEST(Regex_matches, ecma262_lookbehind_positive) {
+TEST(ecma262_lookbehind_positive) {
   const auto regex{sourcemeta::core::to_regex("(?<=foo)bar")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=foo)bar"));
@@ -210,7 +210,7 @@ TEST(Regex_matches, ecma262_lookbehind_positive) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bazbar"));
 }
 
-TEST(Regex_matches, ecma262_lookbehind_negative) {
+TEST(ecma262_lookbehind_negative) {
   const auto regex{sourcemeta::core::to_regex("(?<!foo)bar")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<!foo)bar"));
@@ -218,7 +218,7 @@ TEST(Regex_matches, ecma262_lookbehind_negative) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
-TEST(Regex_matches, ecma262_combined_digit_word_anchors) {
+TEST(ecma262_combined_digit_word_anchors) {
   const auto regex{sourcemeta::core::to_regex("^\\w+@\\w+\\.\\w+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\w+@\\w+\\.\\w+$"));
@@ -226,7 +226,7 @@ TEST(Regex_matches, ecma262_combined_digit_word_anchors) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "invalid"));
 }
 
-TEST(Regex_matches, ecma262_digit_range_pattern) {
+TEST(ecma262_digit_range_pattern) {
   const auto regex{sourcemeta::core::to_regex("\\d{3}-\\d{2}-\\d{4}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d{3}-\\d{2}-\\d{4}"));
@@ -234,7 +234,7 @@ TEST(Regex_matches, ecma262_digit_range_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc-de-fghi"));
 }
 
-TEST(Regex_matches, ecma262_mixed_escapes) {
+TEST(ecma262_mixed_escapes) {
   const auto regex{sourcemeta::core::to_regex("\\w+\\s+\\d+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\w+\\s+\\d+"));
@@ -243,7 +243,7 @@ TEST(Regex_matches, ecma262_mixed_escapes) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "hello"));
 }
 
-TEST(Regex_matches, ecma262_anchor_with_digit) {
+TEST(ecma262_anchor_with_digit) {
   const auto regex{sourcemeta::core::to_regex("^\\d+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d+$"));
@@ -252,7 +252,7 @@ TEST(Regex_matches, ecma262_anchor_with_digit) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123abc"));
 }
 
-TEST(Regex_matches, ecma262_word_boundary_with_digit) {
+TEST(ecma262_word_boundary_with_digit) {
   const auto regex{sourcemeta::core::to_regex("\\b\\d{3}\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\b\\d{3}\\b"));
@@ -261,7 +261,7 @@ TEST(Regex_matches, ecma262_word_boundary_with_digit) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "1234"));
 }
 
-TEST(Regex_matches, ecma262_whitespace_variants) {
+TEST(ecma262_whitespace_variants) {
   const auto regex{sourcemeta::core::to_regex("a\\sb")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\sb"));
@@ -272,7 +272,7 @@ TEST(Regex_matches, ecma262_whitespace_variants) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_complex_email_pattern) {
+TEST(ecma262_complex_email_pattern) {
   const auto regex{
       sourcemeta::core::to_regex("^[\\w.+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$")};
   EXPECT_TRUE(regex.has_value());
@@ -284,7 +284,7 @@ TEST(Regex_matches, ecma262_complex_email_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "@example.com"));
 }
 
-TEST(Regex_matches, ecma262_complex_url_pattern) {
+TEST(ecma262_complex_url_pattern) {
   const auto regex{
       sourcemeta::core::to_regex("^https?://[\\w.-]+\\.[a-z]{2,}")};
   EXPECT_TRUE(regex.has_value());
@@ -296,7 +296,7 @@ TEST(Regex_matches, ecma262_complex_url_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ftp://example.com"));
 }
 
-TEST(Regex_matches, ecma262_phone_number_pattern) {
+TEST(ecma262_phone_number_pattern) {
   const auto regex{
       sourcemeta::core::to_regex("^\\(\\d{3}\\)\\s*\\d{3}-\\d{4}$")};
   EXPECT_TRUE(regex.has_value());
@@ -307,7 +307,7 @@ TEST(Regex_matches, ecma262_phone_number_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123-456-7890"));
 }
 
-TEST(Regex_matches, ecma262_hex_color_with_anchor) {
+TEST(ecma262_hex_color_with_anchor) {
   const auto regex{sourcemeta::core::to_regex("^#[0-9a-fA-F]{6}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^#[0-9a-fA-F]{6}$"));
@@ -316,7 +316,7 @@ TEST(Regex_matches, ecma262_hex_color_with_anchor) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "#FF57"));
 }
 
-TEST(Regex_matches, ecma262_non_capturing_with_alternation) {
+TEST(ecma262_non_capturing_with_alternation) {
   const auto regex{sourcemeta::core::to_regex("(?:red|green|blue)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:red|green|blue)"));
@@ -326,7 +326,7 @@ TEST(Regex_matches, ecma262_non_capturing_with_alternation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "yellow"));
 }
 
-TEST(Regex_matches, ecma262_lookahead_with_quantifier) {
+TEST(ecma262_lookahead_with_quantifier) {
   const auto regex{sourcemeta::core::to_regex("\\d+(?=px)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d+(?=px)"));
@@ -335,7 +335,7 @@ TEST(Regex_matches, ecma262_lookahead_with_quantifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "100em"));
 }
 
-TEST(Regex_matches, ecma262_multiple_word_boundaries) {
+TEST(ecma262_multiple_word_boundaries) {
   const auto regex{sourcemeta::core::to_regex("\\btest\\b.*\\bcase\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\btest\\b.*\\bcase\\b"));
@@ -344,7 +344,7 @@ TEST(Regex_matches, ecma262_multiple_word_boundaries) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "testing cases"));
 }
 
-TEST(Regex_matches, ecma262_unicode_with_anchors) {
+TEST(ecma262_unicode_with_anchors) {
   const auto regex{sourcemeta::core::to_regex("^\\u{1F600}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\u{1F600}+$"));
@@ -353,7 +353,7 @@ TEST(Regex_matches, ecma262_unicode_with_anchors) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A😀"));
 }
 
-TEST(Regex_matches, ecma262_word_ascii_only_in_charclass) {
+TEST(ecma262_word_ascii_only_in_charclass) {
   const auto regex{sourcemeta::core::to_regex("^[\\w.-]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\w.-]+$"));
@@ -362,7 +362,7 @@ TEST(Regex_matches, ecma262_word_ascii_only_in_charclass) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "café"));
 }
 
-TEST(Regex_matches, ecma262_digit_ascii_only_in_charclass) {
+TEST(ecma262_digit_ascii_only_in_charclass) {
   const auto regex{sourcemeta::core::to_regex("^[\\d.-]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\d.-]+$"));
@@ -370,7 +370,7 @@ TEST(Regex_matches, ecma262_digit_ascii_only_in_charclass) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\u07C0"));
 }
 
-TEST(Regex_matches, ecma262_whitespace_in_charclass) {
+TEST(ecma262_whitespace_in_charclass) {
   const auto regex{sourcemeta::core::to_regex("^[\\s]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\s]+$"));
@@ -378,7 +378,7 @@ TEST(Regex_matches, ecma262_whitespace_in_charclass) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_dollar_anchor_no_trailing_newline) {
+TEST(ecma262_dollar_anchor_no_trailing_newline) {
   const auto regex{sourcemeta::core::to_regex("^abc$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^abc$"));
@@ -386,7 +386,7 @@ TEST(Regex_matches, ecma262_dollar_anchor_no_trailing_newline) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc\n"));
 }
 
-TEST(Regex_matches, ecma262_tab_escape) {
+TEST(ecma262_tab_escape) {
   const auto regex{sourcemeta::core::to_regex("^\\t$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\t$"));
@@ -394,7 +394,7 @@ TEST(Regex_matches, ecma262_tab_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\\t"));
 }
 
-TEST(Regex_matches, ecma262_control_escape_upper) {
+TEST(ecma262_control_escape_upper) {
   const auto regex{sourcemeta::core::to_regex("^\\cC$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\cC$"));
@@ -402,7 +402,7 @@ TEST(Regex_matches, ecma262_control_escape_upper) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\\cC"));
 }
 
-TEST(Regex_matches, ecma262_control_escape_lower) {
+TEST(ecma262_control_escape_lower) {
   const auto regex{sourcemeta::core::to_regex("^\\cc$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\cc$"));
@@ -410,7 +410,7 @@ TEST(Regex_matches, ecma262_control_escape_lower) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\\cc"));
 }
 
-TEST(Regex_matches, ecma262_whitespace_unicode_nbsp) {
+TEST(ecma262_whitespace_unicode_nbsp) {
   const auto regex{sourcemeta::core::to_regex("^\\s$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\s$"));
@@ -427,7 +427,7 @@ TEST(Regex_matches, ecma262_whitespace_unicode_nbsp) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\u2013"));
 }
 
-TEST(Regex_matches, ecma262_non_whitespace_unicode) {
+TEST(ecma262_non_whitespace_unicode) {
   const auto regex{sourcemeta::core::to_regex("^\\S$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\S$"));
@@ -444,7 +444,7 @@ TEST(Regex_matches, ecma262_non_whitespace_unicode) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u2013"));
 }
 
-TEST(Regex_matches, ecma262_digit_not_bengali) {
+TEST(ecma262_digit_not_bengali) {
   const auto regex{sourcemeta::core::to_regex("^\\d+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d+$"));
@@ -453,7 +453,7 @@ TEST(Regex_matches, ecma262_digit_not_bengali) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "৪২"));
 }
 
-TEST(Regex_matches, ecma262_unicode_digit_property) {
+TEST(ecma262_unicode_digit_property) {
   const auto regex{sourcemeta::core::to_regex("^\\p{Nd}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Nd}+$"));
@@ -462,7 +462,7 @@ TEST(Regex_matches, ecma262_unicode_digit_property) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "৪২"));
 }
 
-TEST(Regex_matches, ecma262_unicode_digit_property_lowercase) {
+TEST(ecma262_unicode_digit_property_lowercase) {
   const auto regex{sourcemeta::core::to_regex("^\\p{digit}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{digit}+$"));
@@ -471,7 +471,7 @@ TEST(Regex_matches, ecma262_unicode_digit_property_lowercase) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "৪২"));
 }
 
-TEST(Regex_matches, ecma262_unicode_space_property_lowercase) {
+TEST(ecma262_unicode_space_property_lowercase) {
   const auto regex{sourcemeta::core::to_regex("^\\p{space}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{space}+$"));
@@ -479,7 +479,7 @@ TEST(Regex_matches, ecma262_unicode_space_property_lowercase) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_unicode_ASCII_property) {
+TEST(ecma262_unicode_ASCII_property) {
   const auto regex{sourcemeta::core::to_regex("^\\p{ASCII}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{ASCII}+$"));
@@ -487,7 +487,7 @@ TEST(Regex_matches, ecma262_unicode_ASCII_property) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "café"));
 }
 
-TEST(Regex_matches, ecma262_unicode_Hex_Digit_property) {
+TEST(ecma262_unicode_Hex_Digit_property) {
   const auto regex{sourcemeta::core::to_regex("^\\p{Hex_Digit}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Hex_Digit}+$"));
@@ -496,7 +496,7 @@ TEST(Regex_matches, ecma262_unicode_Hex_Digit_property) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xyz"));
 }
 
-TEST(Regex_matches, ecma262_unicode_Alphabetic_property) {
+TEST(ecma262_unicode_Alphabetic_property) {
   const auto regex{sourcemeta::core::to_regex("^\\p{Alphabetic}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Alphabetic}+$"));
@@ -505,7 +505,7 @@ TEST(Regex_matches, ecma262_unicode_Alphabetic_property) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123"));
 }
 
-TEST(Regex_matches, ecma262_unicode_White_Space_property) {
+TEST(ecma262_unicode_White_Space_property) {
   const auto regex{sourcemeta::core::to_regex("^\\p{White_Space}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{White_Space}+$"));
@@ -513,7 +513,7 @@ TEST(Regex_matches, ecma262_unicode_White_Space_property) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_escaped_backslash_before_charclass) {
+TEST(ecma262_escaped_backslash_before_charclass) {
   const auto regex{sourcemeta::core::to_regex("\\\\[abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\[abc]"));
@@ -524,7 +524,7 @@ TEST(Regex_matches, ecma262_escaped_backslash_before_charclass) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "[abc]"));
 }
 
-TEST(Regex_matches, ecma262_escaped_backslash_before_digit_class) {
+TEST(ecma262_escaped_backslash_before_digit_class) {
   const auto regex{sourcemeta::core::to_regex("\\\\d")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\d"));
@@ -532,7 +532,7 @@ TEST(Regex_matches, ecma262_escaped_backslash_before_digit_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_digit_hyphen_in_charclass) {
+TEST(ecma262_digit_hyphen_in_charclass) {
   const auto regex{sourcemeta::core::to_regex("^[\\d-]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\d-]+$"));
@@ -543,7 +543,7 @@ TEST(Regex_matches, ecma262_digit_hyphen_in_charclass) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ":"));
 }
 
-TEST(Regex_matches, ecma262_word_boundary_ascii_only) {
+TEST(ecma262_word_boundary_ascii_only) {
   const auto regex{sourcemeta::core::to_regex("\\bcafé\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bcafé\\b"));
@@ -552,7 +552,7 @@ TEST(Regex_matches, ecma262_word_boundary_ascii_only) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "café123"));
 }
 
-TEST(Regex_matches, ecma262_non_greedy_quantifiers) {
+TEST(ecma262_non_greedy_quantifiers) {
   const auto regex{sourcemeta::core::to_regex("^a+?b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a+?b"));
@@ -561,7 +561,7 @@ TEST(Regex_matches, ecma262_non_greedy_quantifiers) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_quantifier_exact) {
+TEST(ecma262_quantifier_exact) {
   const auto regex{sourcemeta::core::to_regex("^a{3}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a{3}$"));
@@ -570,7 +570,7 @@ TEST(Regex_matches, ecma262_quantifier_exact) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "aaaa"));
 }
 
-TEST(Regex_matches, ecma262_quantifier_range) {
+TEST(ecma262_quantifier_range) {
   const auto regex{sourcemeta::core::to_regex("^a{2,4}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a{2,4}$"));
@@ -581,7 +581,7 @@ TEST(Regex_matches, ecma262_quantifier_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "aaaaa"));
 }
 
-TEST(Regex_matches, ecma262_quantifier_min_only) {
+TEST(ecma262_quantifier_min_only) {
   const auto regex{sourcemeta::core::to_regex("^a{2,}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a{2,}$"));
@@ -590,7 +590,7 @@ TEST(Regex_matches, ecma262_quantifier_min_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_negated_charclass) {
+TEST(ecma262_negated_charclass) {
   const auto regex{sourcemeta::core::to_regex("^[^abc]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[^abc]+$"));
@@ -600,7 +600,7 @@ TEST(Regex_matches, ecma262_negated_charclass) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xaz"));
 }
 
-TEST(Regex_matches, ecma262_escaped_metacharacters) {
+TEST(ecma262_escaped_metacharacters) {
   const auto regex{sourcemeta::core::to_regex("^\\.\\.\\.$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\.\\.\\.$"));
@@ -608,7 +608,7 @@ TEST(Regex_matches, ecma262_escaped_metacharacters) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_hex_escape_hi) {
+TEST(ecma262_hex_escape_hi) {
   const auto regex{sourcemeta::core::to_regex("^\\x48\\x69$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\x48\\x69$"));
@@ -616,7 +616,7 @@ TEST(Regex_matches, ecma262_hex_escape_hi) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\\x48\\x69"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_letter_all) {
+TEST(ecma262_unicode_property_letter_all) {
   const auto regex{sourcemeta::core::to_regex("^\\p{L}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{L}+$"));
@@ -626,7 +626,7 @@ TEST(Regex_matches, ecma262_unicode_property_letter_all) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_letter_uppercase) {
+TEST(ecma262_unicode_property_letter_uppercase) {
   const auto regex{sourcemeta::core::to_regex("^\\p{Lu}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Lu}+$"));
@@ -635,7 +635,7 @@ TEST(Regex_matches, ecma262_unicode_property_letter_uppercase) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "Abc"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_letter_lowercase) {
+TEST(ecma262_unicode_property_letter_lowercase) {
   const auto regex{sourcemeta::core::to_regex("^\\p{Ll}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Ll}+$"));
@@ -643,7 +643,7 @@ TEST(Regex_matches, ecma262_unicode_property_letter_lowercase) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ABC"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_mark) {
+TEST(ecma262_unicode_property_mark) {
   const auto regex{sourcemeta::core::to_regex("\\p{M}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{M}"));
@@ -651,7 +651,7 @@ TEST(Regex_matches, ecma262_unicode_property_mark) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "é"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_number) {
+TEST(ecma262_unicode_property_number) {
   const auto regex{sourcemeta::core::to_regex("^\\p{N}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{N}+$"));
@@ -660,7 +660,7 @@ TEST(Regex_matches, ecma262_unicode_property_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_punctuation) {
+TEST(ecma262_unicode_property_punctuation) {
   const auto regex{sourcemeta::core::to_regex("^\\p{P}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{P}+$"));
@@ -668,7 +668,7 @@ TEST(Regex_matches, ecma262_unicode_property_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_symbol) {
+TEST(ecma262_unicode_property_symbol) {
   const auto regex{sourcemeta::core::to_regex("\\p{S}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{S}"));
@@ -677,7 +677,7 @@ TEST(Regex_matches, ecma262_unicode_property_symbol) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "€"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_separator) {
+TEST(ecma262_unicode_property_separator) {
   const auto regex{sourcemeta::core::to_regex("\\p{Z}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Z}"));
@@ -685,7 +685,7 @@ TEST(Regex_matches, ecma262_unicode_property_separator) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u00A0"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_other) {
+TEST(ecma262_unicode_property_other) {
   const auto regex{sourcemeta::core::to_regex("\\p{C}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{C}"));
@@ -693,7 +693,7 @@ TEST(Regex_matches, ecma262_unicode_property_other) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0001"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_negated_letter) {
+TEST(ecma262_unicode_property_negated_letter) {
   const auto regex{sourcemeta::core::to_regex("^\\P{L}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\P{L}+$"));
@@ -702,7 +702,7 @@ TEST(Regex_matches, ecma262_unicode_property_negated_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_negated_number) {
+TEST(ecma262_unicode_property_negated_number) {
   const auto regex{sourcemeta::core::to_regex("^\\P{N}+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\P{N}+$"));
@@ -711,7 +711,7 @@ TEST(Regex_matches, ecma262_unicode_property_negated_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "৪২"));
 }
 
-TEST(Regex_matches, ecma262_quantifier_star_any_string) {
+TEST(ecma262_quantifier_star_any_string) {
   const auto regex{sourcemeta::core::to_regex(".*")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*"));
@@ -719,7 +719,7 @@ TEST(Regex_matches, ecma262_quantifier_star_any_string) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_quantifier_plus_non_empty) {
+TEST(ecma262_quantifier_plus_non_empty) {
   const auto regex{sourcemeta::core::to_regex(".+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".+"));
@@ -727,21 +727,21 @@ TEST(Regex_matches, ecma262_quantifier_plus_non_empty) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_dot_matches_newline) {
+TEST(ecma262_dot_matches_newline) {
   const auto regex{sourcemeta::core::to_regex(".")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, ecma262_dot_matches_carriage_return) {
+TEST(ecma262_dot_matches_carriage_return) {
   const auto regex{sourcemeta::core::to_regex(".")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\r"));
 }
 
-TEST(Regex_matches, ecma262_unicode_range_4byte_deseret) {
+TEST(ecma262_unicode_range_4byte_deseret) {
   const auto regex{sourcemeta::core::to_regex("[\\u{10400}-\\u{1044F}]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\u{10400}-\\u{1044F}]"));
@@ -750,7 +750,7 @@ TEST(Regex_matches, ecma262_unicode_range_4byte_deseret) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, ecma262_anchor_start_prefix_match) {
+TEST(ecma262_anchor_start_prefix_match) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo"));
@@ -758,21 +758,21 @@ TEST(Regex_matches, ecma262_anchor_start_prefix_match) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bar"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both_full_match) {
+TEST(ecma262_anchor_both_full_match) {
   const auto regex{sourcemeta::core::to_regex("^.*$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.*$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both_with_group) {
+TEST(ecma262_anchor_both_with_group) {
   const auto regex{sourcemeta::core::to_regex("^(.*)$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^(.*)$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
-TEST(Regex_matches, ecma262_anchor_start_slash_path) {
+TEST(ecma262_anchor_start_slash_path) {
   const auto regex{sourcemeta::core::to_regex("^/.*")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^/.*"));
@@ -781,7 +781,7 @@ TEST(Regex_matches, ecma262_anchor_start_slash_path) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foo/bar"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both_length_range) {
+TEST(ecma262_anchor_both_length_range) {
   const auto regex{sourcemeta::core::to_regex("^.{1,256}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.{1,256}$"));
@@ -791,7 +791,7 @@ TEST(Regex_matches, ecma262_anchor_both_length_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), std::string(257, 'x')));
 }
 
-TEST(Regex_matches, ecma262_anchor_start_at_sign) {
+TEST(ecma262_anchor_start_at_sign) {
   const auto regex{sourcemeta::core::to_regex("^@")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^@"));
@@ -799,7 +799,7 @@ TEST(Regex_matches, ecma262_anchor_start_at_sign) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foo"));
 }
 
-TEST(Regex_matches, ecma262_anchor_end_letter_o) {
+TEST(ecma262_anchor_end_letter_o) {
   const auto regex{sourcemeta::core::to_regex("o$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("o$"));
@@ -807,14 +807,14 @@ TEST(Regex_matches, ecma262_anchor_end_letter_o) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bar"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both_identifier_pattern) {
+TEST(ecma262_anchor_both_identifier_pattern) {
   const auto regex{sourcemeta::core::to_regex("^[a-z][a-z0-9-_]{1,63}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[a-z][a-z0-9-_]{1,63}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abcd"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both_package_name) {
+TEST(ecma262_anchor_both_package_name) {
   const auto regex{
       sourcemeta::core::to_regex("^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$")};
   EXPECT_TRUE(regex.has_value());
@@ -823,14 +823,14 @@ TEST(Regex_matches, ecma262_anchor_both_package_name) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "@namespace/mypackage"));
 }
 
-TEST(Regex_matches, ecma262_anchor_both_multiline_string) {
+TEST(ecma262_anchor_both_multiline_string) {
   const auto regex{sourcemeta::core::to_regex("^.+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo\nbar\r"));
 }
 
-TEST(Regex_matches, ecma262_unicode_escape_4digit_arabic_digit_range) {
+TEST(ecma262_unicode_escape_4digit_arabic_digit_range) {
   const auto regex{sourcemeta::core::to_regex("[\\u0660-\\u0669]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\u0660-\\u0669]"));
@@ -839,7 +839,7 @@ TEST(Regex_matches, ecma262_unicode_escape_4digit_arabic_digit_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_letter_identifier) {
+TEST(ecma262_unicode_property_letter_identifier) {
   const auto regex{
       sourcemeta::core::to_regex("^\\p{Letter}[\\p{Letter}\\p{Number}]*$")};
   EXPECT_TRUE(regex.has_value());
@@ -853,7 +853,7 @@ TEST(Regex_matches, ecma262_unicode_property_letter_identifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123hello"));
 }
 
-TEST(Regex_matches, ecma262_unicode_property_negative_lookahead_identifier) {
+TEST(ecma262_unicode_property_negative_lookahead_identifier) {
   const auto regex{sourcemeta::core::to_regex(
       "^(?!\\p{Number})\\p{Letter}[\\p{Letter}\\p{Number}\\-_.]*$")};
   EXPECT_TRUE(regex.has_value());
@@ -865,7 +865,7 @@ TEST(Regex_matches, ecma262_unicode_property_negative_lookahead_identifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0element"));
 }
 
-TEST(Regex_matches, ecma262_unicode_dot_single_codepoint) {
+TEST(ecma262_unicode_dot_single_codepoint) {
   const auto regex{sourcemeta::core::to_regex("^.$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.$"));
@@ -875,7 +875,7 @@ TEST(Regex_matches, ecma262_unicode_dot_single_codepoint) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\U00010400"));
 }
 
-TEST(Regex_matches, ecma262_unicode_quantifier_three_codepoints) {
+TEST(ecma262_unicode_quantifier_three_codepoints) {
   const auto regex{sourcemeta::core::to_regex("^.{3}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.{3}$"));
@@ -886,7 +886,7 @@ TEST(Regex_matches, ecma262_unicode_quantifier_three_codepoints) {
                                         "\U00010400\U00010401\U00010402"));
 }
 
-TEST(Regex_matches, ecma262_digit_class_ascii_only) {
+TEST(ecma262_digit_class_ascii_only) {
   const auto regex{sourcemeta::core::to_regex("^\\d$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d$"));
@@ -894,7 +894,7 @@ TEST(Regex_matches, ecma262_digit_class_ascii_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\u07C0"));
 }
 
-TEST(Regex_matches, ecma262_word_class_ascii_only) {
+TEST(ecma262_word_class_ascii_only) {
   const auto regex{sourcemeta::core::to_regex("^\\w$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\w$"));
@@ -902,7 +902,7 @@ TEST(Regex_matches, ecma262_word_class_ascii_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "é"));
 }
 
-TEST(Regex_matches, ecma262_nonbmp_emoji_quantifier_codepoint) {
+TEST(ecma262_nonbmp_emoji_quantifier_codepoint) {
   const auto regex{sourcemeta::core::to_regex("^\U0001F432*$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\U0001F432*$"));
@@ -913,7 +913,7 @@ TEST(Regex_matches, ecma262_nonbmp_emoji_quantifier_codepoint) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "D"));
 }
 
-TEST(Regex_matches, ecma262_nonbmp_literal_exact_match) {
+TEST(ecma262_nonbmp_literal_exact_match) {
   const auto regex{sourcemeta::core::to_regex("^\U0001F432$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\U0001F432$"));
@@ -923,7 +923,7 @@ TEST(Regex_matches, ecma262_nonbmp_literal_exact_match) {
       sourcemeta::core::matches(regex.value(), "\U0001F432\U0001F432"));
 }
 
-TEST(Regex_matches, ecma262_xml_ncname_unicode_identifier) {
+TEST(ecma262_xml_ncname_unicode_identifier) {
   const auto regex{sourcemeta::core::to_regex(
       "^(?![:\\p{Nd}])[\\p{L}_][\\p{L}\\p{Nd}\\-._·]*$")};
   EXPECT_TRUE(regex.has_value());
@@ -942,7 +942,7 @@ TEST(Regex_matches, ecma262_xml_ncname_unicode_identifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\U000104A0element"));
 }
 
-TEST(Regex_matches, ecma262_escaped_backslash_before_bracket) {
+TEST(ecma262_escaped_backslash_before_bracket) {
   const auto regex{sourcemeta::core::to_regex("\\\\[abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\[abc]"));
@@ -953,7 +953,7 @@ TEST(Regex_matches, ecma262_escaped_backslash_before_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_triple_backslash_before_bracket) {
+TEST(ecma262_triple_backslash_before_bracket) {
   const auto regex{sourcemeta::core::to_regex("\\\\\\[")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\["));
@@ -962,7 +962,7 @@ TEST(Regex_matches, ecma262_triple_backslash_before_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "["));
 }
 
-TEST(Regex_matches, ecma262_dollar_in_middle_never_matches) {
+TEST(ecma262_dollar_in_middle_never_matches) {
   const auto regex{sourcemeta::core::to_regex("foo$bar")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$bar"));
@@ -971,7 +971,7 @@ TEST(Regex_matches, ecma262_dollar_in_middle_never_matches) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foo"));
 }
 
-TEST(Regex_matches, ecma262_dollar_in_character_class) {
+TEST(ecma262_dollar_in_character_class) {
   const auto regex{sourcemeta::core::to_regex("[$]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[$]"));
@@ -979,7 +979,7 @@ TEST(Regex_matches, ecma262_dollar_in_character_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_escaped_dollar) {
+TEST(ecma262_escaped_dollar) {
   const auto regex{sourcemeta::core::to_regex("\\$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\$"));
@@ -987,7 +987,7 @@ TEST(Regex_matches, ecma262_escaped_dollar) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_multiple_dollars) {
+TEST(ecma262_multiple_dollars) {
   const auto regex{sourcemeta::core::to_regex("$$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$$"));
@@ -995,7 +995,7 @@ TEST(Regex_matches, ecma262_multiple_dollars) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "anything"));
 }
 
-TEST(Regex_matches, ecma262_negated_digit_in_char_class) {
+TEST(ecma262_negated_digit_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\D]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\D]"));
@@ -1005,7 +1005,7 @@ TEST(Regex_matches, ecma262_negated_digit_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_negated_word_in_char_class) {
+TEST(ecma262_negated_word_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\W]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\W]"));
@@ -1017,7 +1017,7 @@ TEST(Regex_matches, ecma262_negated_word_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_negated_space_in_char_class) {
+TEST(ecma262_negated_space_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\S]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\S]"));
@@ -1029,7 +1029,7 @@ TEST(Regex_matches, ecma262_negated_space_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, ecma262_mixed_escapes_in_char_class) {
+TEST(ecma262_mixed_escapes_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\d\\D]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d\\D]"));
@@ -1039,7 +1039,7 @@ TEST(Regex_matches, ecma262_mixed_escapes_in_char_class) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
 }
 
-TEST(Regex_matches, ecma262_escaped_bracket_in_char_class) {
+TEST(ecma262_escaped_bracket_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\]]"));
@@ -1048,7 +1048,7 @@ TEST(Regex_matches, ecma262_escaped_bracket_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_backslash_in_char_class) {
+TEST(ecma262_backslash_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\\\]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\\\]"));
@@ -1056,7 +1056,7 @@ TEST(Regex_matches, ecma262_backslash_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_complex_char_class_with_escaped_chars) {
+TEST(ecma262_complex_char_class_with_escaped_chars) {
   const auto regex{sourcemeta::core::to_regex("[a\\]b\\\\c]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a\\]b\\\\c]"));
@@ -1069,25 +1069,25 @@ TEST(Regex_matches, ecma262_complex_char_class_with_escaped_chars) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "["));
 }
 
-TEST(Regex_matches, ecma262_incomplete_unicode_property) {
+TEST(ecma262_incomplete_unicode_property) {
   const auto regex{sourcemeta::core::to_regex("\\p{Letter")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\p{Letter"));
 }
 
-TEST(Regex_matches, ecma262_incomplete_unicode_escape) {
+TEST(ecma262_incomplete_unicode_escape) {
   const auto regex{sourcemeta::core::to_regex("\\u{DEAD")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\u{DEAD"));
 }
 
-TEST(Regex_matches, ecma262_backslash_at_end) {
+TEST(ecma262_backslash_at_end) {
   const auto regex{sourcemeta::core::to_regex("foo\\")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("foo\\"));
 }
 
-TEST(Regex_matches, ecma262_nested_char_class_attempt) {
+TEST(ecma262_nested_char_class_attempt) {
   const auto regex{sourcemeta::core::to_regex("[[abc]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]]"));
@@ -1099,7 +1099,7 @@ TEST(Regex_matches, ecma262_nested_char_class_attempt) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "]"));
 }
 
-TEST(Regex_matches, ecma262_dollar_before_alternation) {
+TEST(ecma262_dollar_before_alternation) {
   const auto regex{sourcemeta::core::to_regex("foo$|bar")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$|bar"));
@@ -1109,7 +1109,7 @@ TEST(Regex_matches, ecma262_dollar_before_alternation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foox"));
 }
 
-TEST(Regex_matches, ecma262_multiple_backslashes_complex) {
+TEST(ecma262_multiple_backslashes_complex) {
   const auto regex{sourcemeta::core::to_regex("\\\\\\\\\\\\\\\\")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\\\\\\\\\\\"));
@@ -1117,7 +1117,7 @@ TEST(Regex_matches, ecma262_multiple_backslashes_complex) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\\\\"));
 }
 
-TEST(Regex_matches, ecma262_right_bracket_as_first_char_in_class) {
+TEST(ecma262_right_bracket_as_first_char_in_class) {
   const auto regex{sourcemeta::core::to_regex("[]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[]]"));
@@ -1127,7 +1127,7 @@ TEST(Regex_matches, ecma262_right_bracket_as_first_char_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_right_bracket_negated_class) {
+TEST(ecma262_right_bracket_negated_class) {
   const auto regex{sourcemeta::core::to_regex("[^]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]]"));
@@ -1139,7 +1139,7 @@ TEST(Regex_matches, ecma262_right_bracket_negated_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_dollar_before_opening_paren) {
+TEST(ecma262_dollar_before_opening_paren) {
   const auto regex{sourcemeta::core::to_regex("$(abc)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$(abc)"));
@@ -1147,7 +1147,7 @@ TEST(Regex_matches, ecma262_dollar_before_opening_paren) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_caret_not_at_start_of_class) {
+TEST(ecma262_caret_not_at_start_of_class) {
   const auto regex{sourcemeta::core::to_regex("[a^b]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a^b]"));
@@ -1157,7 +1157,7 @@ TEST(Regex_matches, ecma262_caret_not_at_start_of_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "c"));
 }
 
-TEST(Regex_matches, ecma262_caret_in_middle_of_pattern) {
+TEST(ecma262_caret_in_middle_of_pattern) {
   const auto regex{sourcemeta::core::to_regex("a^b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a^b"));
@@ -1166,7 +1166,7 @@ TEST(Regex_matches, ecma262_caret_in_middle_of_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_backslash_before_digit_escape) {
+TEST(ecma262_backslash_before_digit_escape) {
   const auto regex{sourcemeta::core::to_regex("\\\\\\d")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\d"));
@@ -1175,7 +1175,7 @@ TEST(Regex_matches, ecma262_backslash_before_digit_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_dash_at_end_of_class) {
+TEST(ecma262_dash_at_end_of_class) {
   const auto regex{sourcemeta::core::to_regex("[abc-]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc-]"));
@@ -1184,7 +1184,7 @@ TEST(Regex_matches, ecma262_dash_at_end_of_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, ecma262_dash_at_start_of_class) {
+TEST(ecma262_dash_at_start_of_class) {
   const auto regex{sourcemeta::core::to_regex("[-abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-abc]"));
@@ -1193,7 +1193,7 @@ TEST(Regex_matches, ecma262_dash_at_start_of_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, ecma262_double_caret) {
+TEST(ecma262_double_caret) {
   const auto regex{sourcemeta::core::to_regex("^^abc")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^^abc"));
@@ -1203,7 +1203,7 @@ TEST(Regex_matches, ecma262_double_caret) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xabc"));
 }
 
-TEST(Regex_matches, ecma262_caret_after_alternation) {
+TEST(ecma262_caret_after_alternation) {
   const auto regex{sourcemeta::core::to_regex("a|^b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|^b"));
@@ -1212,7 +1212,7 @@ TEST(Regex_matches, ecma262_caret_after_alternation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xb"));
 }
 
-TEST(Regex_matches, ecma262_caret_after_opening_paren) {
+TEST(ecma262_caret_after_opening_paren) {
   const auto regex{sourcemeta::core::to_regex("(^abc)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(^abc)"));
@@ -1220,7 +1220,7 @@ TEST(Regex_matches, ecma262_caret_after_opening_paren) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xabc"));
 }
 
-TEST(Regex_matches, ecma262_dollar_then_caret) {
+TEST(ecma262_dollar_then_caret) {
   const auto regex{sourcemeta::core::to_regex("a$^b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a$^b"));
@@ -1228,7 +1228,7 @@ TEST(Regex_matches, ecma262_dollar_then_caret) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_backspace_in_char_class) {
+TEST(ecma262_backspace_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[\\b]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\b]"));
@@ -1236,7 +1236,7 @@ TEST(Regex_matches, ecma262_backspace_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_whitespace_and_non_whitespace_class) {
+TEST(ecma262_whitespace_and_non_whitespace_class) {
   const auto regex{sourcemeta::core::to_regex("[\\s\\S]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\s\\S]"));
@@ -1246,7 +1246,7 @@ TEST(Regex_matches, ecma262_whitespace_and_non_whitespace_class) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, ecma262_word_boundary_outside_class) {
+TEST(ecma262_word_boundary_outside_class) {
   const auto regex{sourcemeta::core::to_regex("\\bword\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bword\\b"));
@@ -1256,25 +1256,25 @@ TEST(Regex_matches, ecma262_word_boundary_outside_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "words"));
 }
 
-TEST(Regex_matches, ecma262_unmatched_closing_paren) {
+TEST(ecma262_unmatched_closing_paren) {
   const auto regex{sourcemeta::core::to_regex("abc)")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("abc)"));
 }
 
-TEST(Regex_matches, ecma262_unmatched_opening_paren) {
+TEST(ecma262_unmatched_opening_paren) {
   const auto regex{sourcemeta::core::to_regex("(abc")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(abc"));
 }
 
-TEST(Regex_matches, ecma262_quantifier_on_assertion) {
+TEST(ecma262_quantifier_on_assertion) {
   const auto regex{sourcemeta::core::to_regex("^*")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("^*"));
 }
 
-TEST(Regex_matches, ecma262_escaped_closing_bracket_in_class) {
+TEST(ecma262_escaped_closing_bracket_in_class) {
   const auto regex{sourcemeta::core::to_regex("[a\\]b]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a\\]b]"));
@@ -1284,13 +1284,13 @@ TEST(Regex_matches, ecma262_escaped_closing_bracket_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "c"));
 }
 
-TEST(Regex_matches, ecma262_unicode_hex_too_large) {
+TEST(ecma262_unicode_hex_too_large) {
   const auto regex{sourcemeta::core::to_regex("\\u{110000}")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\u{110000}"));
 }
 
-TEST(Regex_matches, ecma262_multiple_backslashes_before_d) {
+TEST(ecma262_multiple_backslashes_before_d) {
   const auto regex{sourcemeta::core::to_regex("\\\\\\\\d")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\\\d"));
@@ -1298,13 +1298,13 @@ TEST(Regex_matches, ecma262_multiple_backslashes_before_d) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\\\\5"));
 }
 
-TEST(Regex_matches, ecma262_backslash_before_closing_bracket) {
+TEST(ecma262_backslash_before_closing_bracket) {
   const auto regex{sourcemeta::core::to_regex("[abc\\]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[abc\\]"));
 }
 
-TEST(Regex_matches, ecma262_empty_alternation_branch) {
+TEST(ecma262_empty_alternation_branch) {
   const auto regex{sourcemeta::core::to_regex("a||b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a||b"));
@@ -1313,7 +1313,7 @@ TEST(Regex_matches, ecma262_empty_alternation_branch) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_pipe_at_start) {
+TEST(ecma262_pipe_at_start) {
   const auto regex{sourcemeta::core::to_regex("|abc")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("|abc"));
@@ -1321,7 +1321,7 @@ TEST(Regex_matches, ecma262_pipe_at_start) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_pipe_at_end) {
+TEST(ecma262_pipe_at_end) {
   const auto regex{sourcemeta::core::to_regex("abc|")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("abc|"));
@@ -1329,7 +1329,7 @@ TEST(Regex_matches, ecma262_pipe_at_end) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, ecma262_dot_matches_any_except_newline) {
+TEST(ecma262_dot_matches_any_except_newline) {
   const auto regex{sourcemeta::core::to_regex("a.b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a.b"));
@@ -1338,7 +1338,7 @@ TEST(Regex_matches, ecma262_dot_matches_any_except_newline) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a b"));
 }
 
-TEST(Regex_matches, ecma262_escaped_dot_in_char_class) {
+TEST(ecma262_escaped_dot_in_char_class) {
   const auto regex{sourcemeta::core::to_regex("[.]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[.]"));
@@ -1346,7 +1346,7 @@ TEST(Regex_matches, ecma262_escaped_dot_in_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_non_greedy_star) {
+TEST(ecma262_non_greedy_star) {
   const auto regex{sourcemeta::core::to_regex("a*?")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a*?"));
@@ -1355,7 +1355,7 @@ TEST(Regex_matches, ecma262_non_greedy_star) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaa"));
 }
 
-TEST(Regex_matches, ecma262_non_greedy_plus) {
+TEST(ecma262_non_greedy_plus) {
   const auto regex{sourcemeta::core::to_regex("a+?")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a+?"));
@@ -1364,7 +1364,7 @@ TEST(Regex_matches, ecma262_non_greedy_plus) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaa"));
 }
 
-TEST(Regex_matches, ecma262_lowercase_range) {
+TEST(ecma262_lowercase_range) {
   const auto regex{sourcemeta::core::to_regex("[a-z]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]"));
@@ -1375,7 +1375,7 @@ TEST(Regex_matches, ecma262_lowercase_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_hex_escape) {
+TEST(ecma262_hex_escape) {
   const auto regex{sourcemeta::core::to_regex("\\x41")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\x41"));
@@ -1383,7 +1383,7 @@ TEST(Regex_matches, ecma262_hex_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "B"));
 }
 
-TEST(Regex_matches, ecma262_dollar_before_bracket) {
+TEST(ecma262_dollar_before_bracket) {
   const auto regex{sourcemeta::core::to_regex("$[abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$[abc]"));
@@ -1392,7 +1392,7 @@ TEST(Regex_matches, ecma262_dollar_before_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_quantifier_on_group) {
+TEST(ecma262_quantifier_on_group) {
   const auto regex{sourcemeta::core::to_regex("(ab)+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(ab)+"));
@@ -1401,7 +1401,7 @@ TEST(Regex_matches, ecma262_quantifier_on_group) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_nested_groups) {
+TEST(ecma262_nested_groups) {
   const auto regex{sourcemeta::core::to_regex("((abc))")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((abc))"));
@@ -1409,7 +1409,7 @@ TEST(Regex_matches, ecma262_nested_groups) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_escaped_pipe) {
+TEST(ecma262_escaped_pipe) {
   const auto regex{sourcemeta::core::to_regex("a\\|b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\|b"));
@@ -1418,7 +1418,7 @@ TEST(Regex_matches, ecma262_escaped_pipe) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_escaped_paren) {
+TEST(ecma262_escaped_paren) {
   const auto regex{sourcemeta::core::to_regex("\\(abc\\)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\(abc\\)"));
@@ -1426,7 +1426,7 @@ TEST(Regex_matches, ecma262_escaped_paren) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_dollar_at_start) {
+TEST(ecma262_dollar_at_start) {
   const auto regex{sourcemeta::core::to_regex("$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$"));
@@ -1434,7 +1434,7 @@ TEST(Regex_matches, ecma262_dollar_at_start) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "anything"));
 }
 
-TEST(Regex_matches, ecma262_caret_at_end) {
+TEST(ecma262_caret_at_end) {
   const auto regex{sourcemeta::core::to_regex("abc^")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("abc^"));
@@ -1442,7 +1442,7 @@ TEST(Regex_matches, ecma262_caret_at_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_escaped_quantifiers) {
+TEST(ecma262_escaped_quantifiers) {
   const auto regex{sourcemeta::core::to_regex("\\*\\+\\?")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\*\\+\\?"));
@@ -1450,7 +1450,7 @@ TEST(Regex_matches, ecma262_escaped_quantifiers) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_escaped_curly_brace) {
+TEST(ecma262_escaped_curly_brace) {
   const auto regex{sourcemeta::core::to_regex("\\{3\\}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\{3\\}"));
@@ -1458,7 +1458,7 @@ TEST(Regex_matches, ecma262_escaped_curly_brace) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "333"));
 }
 
-TEST(Regex_matches, ecma262_question_quantifier) {
+TEST(ecma262_question_quantifier) {
   const auto regex{sourcemeta::core::to_regex("ab?c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab?c"));
@@ -1467,7 +1467,7 @@ TEST(Regex_matches, ecma262_question_quantifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abbc"));
 }
 
-TEST(Regex_matches, ecma262_zero_quantifier) {
+TEST(ecma262_zero_quantifier) {
   const auto regex{sourcemeta::core::to_regex("a{0}b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0}b"));
@@ -1476,7 +1476,7 @@ TEST(Regex_matches, ecma262_zero_quantifier) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xyzb"));
 }
 
-TEST(Regex_matches, ecma262_spaces_are_literal) {
+TEST(ecma262_spaces_are_literal) {
   const auto regex{sourcemeta::core::to_regex("a b c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a b c"));
@@ -1484,7 +1484,7 @@ TEST(Regex_matches, ecma262_spaces_are_literal) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
 }
 
-TEST(Regex_matches, ecma262_tab_is_literal) {
+TEST(ecma262_tab_is_literal) {
   const auto regex{sourcemeta::core::to_regex("a\tb")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\tb"));
@@ -1492,13 +1492,13 @@ TEST(Regex_matches, ecma262_tab_is_literal) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_backslash_before_closing_paren) {
+TEST(ecma262_backslash_before_closing_paren) {
   const auto regex{sourcemeta::core::to_regex("(abc\\)")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(abc\\)"));
 }
 
-TEST(Regex_matches, ecma262_caret_dollar_together) {
+TEST(ecma262_caret_dollar_together) {
   const auto regex{sourcemeta::core::to_regex("^$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^$"));
@@ -1506,7 +1506,7 @@ TEST(Regex_matches, ecma262_caret_dollar_together) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_multiple_carets_at_start) {
+TEST(ecma262_multiple_carets_at_start) {
   const auto regex{sourcemeta::core::to_regex("^^^abc")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^^^abc"));
@@ -1516,7 +1516,7 @@ TEST(Regex_matches, ecma262_multiple_carets_at_start) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xabc"));
 }
 
-TEST(Regex_matches, ecma262_multiple_dollars_at_end) {
+TEST(ecma262_multiple_dollars_at_end) {
   const auto regex{sourcemeta::core::to_regex("abc$$$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("abc$$$"));
@@ -1524,7 +1524,7 @@ TEST(Regex_matches, ecma262_multiple_dollars_at_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc$"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_set_subtraction) {
+TEST(ecma262_v_flag_set_subtraction) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--a]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--a]"));
@@ -1533,7 +1533,7 @@ TEST(Regex_matches, ecma262_v_flag_set_subtraction) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_set_intersection) {
+TEST(ecma262_v_flag_set_intersection) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[0-5]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[0-5]]"));
@@ -1542,7 +1542,7 @@ TEST(Regex_matches, ecma262_v_flag_set_intersection) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_vowels) {
+TEST(ecma262_v_flag_subtract_vowels) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]]"));
@@ -1556,7 +1556,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_vowels) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "u"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_range) {
+TEST(ecma262_v_flag_subtract_range) {
   const auto regex{sourcemeta::core::to_regex("[[0-9]--[3-7]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9]--[3-7]]"));
@@ -1570,7 +1570,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "7"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_digit) {
+TEST(ecma262_v_flag_subtract_from_digit) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]--[0]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[0]]"));
@@ -1580,7 +1580,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_digit) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_word) {
+TEST(ecma262_v_flag_subtract_from_word) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]--[0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[0-9]]"));
@@ -1592,7 +1592,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_word) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "!"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_word_lowercase) {
+TEST(ecma262_v_flag_intersect_word_lowercase) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]&&[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]&&[a-z]]"));
@@ -1603,7 +1603,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_word_lowercase) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_even_digits) {
+TEST(ecma262_v_flag_intersect_even_digits) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[02468]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[02468]]"));
@@ -1614,7 +1614,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_even_digits) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_uppercase) {
+TEST(ecma262_v_flag_subtract_uppercase) {
   const auto regex{sourcemeta::core::to_regex("[[A-Za-z]--[A-Z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[A-Za-z]--[A-Z]]"));
@@ -1624,7 +1624,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_uppercase) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "Z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_same_char) {
+TEST(ecma262_v_flag_subtract_same_char) {
   const auto regex{sourcemeta::core::to_regex("[[a]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]--[a]]"));
@@ -1632,7 +1632,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_same_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_same_range) {
+TEST(ecma262_v_flag_intersect_same_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]&&[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[a-z]]"));
@@ -1642,7 +1642,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_same_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_disjoint) {
+TEST(ecma262_v_flag_intersect_disjoint) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]&&[x-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]&&[x-z]]"));
@@ -1651,7 +1651,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_disjoint) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "m"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_hex_letters) {
+TEST(ecma262_v_flag_subtract_hex_letters) {
   const auto regex{sourcemeta::core::to_regex("[[0-9a-f]--[a-f]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9a-f]--[a-f]]"));
@@ -1661,7 +1661,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_hex_letters) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "f"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_partial_overlap) {
+TEST(ecma262_v_flag_intersect_partial_overlap) {
   const auto regex{sourcemeta::core::to_regex("[[a-m]&&[h-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-m]&&[h-z]]"));
@@ -1674,7 +1674,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_partial_overlap) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_start_of_range) {
+TEST(ecma262_v_flag_subtract_start_of_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-e]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[a]]"));
@@ -1683,7 +1683,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_start_of_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_end_of_range) {
+TEST(ecma262_v_flag_subtract_end_of_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-e]--[e]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[e]]"));
@@ -1692,7 +1692,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_end_of_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_middle_of_range) {
+TEST(ecma262_v_flag_subtract_middle_of_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-e]--[c]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[c]]"));
@@ -1703,7 +1703,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_middle_of_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "c"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_single_char) {
+TEST(ecma262_v_flag_intersect_single_char) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]&&[m]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[m]]"));
@@ -1712,7 +1712,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_single_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtraction_in_pattern) {
+TEST(ecma262_v_flag_subtraction_in_pattern) {
   const auto regex{sourcemeta::core::to_regex("^[[a-z]--[aeiou]]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]]+$"));
@@ -1722,7 +1722,7 @@ TEST(Regex_matches, ecma262_v_flag_subtraction_in_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "aaa"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersection_in_pattern) {
+TEST(ecma262_v_flag_intersection_in_pattern) {
   const auto regex{sourcemeta::core::to_regex("^[\\d&&[0-5]]+$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\d&&[0-5]]+$"));
@@ -1732,7 +1732,7 @@ TEST(Regex_matches, ecma262_v_flag_intersection_in_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123456"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_digit_from_word) {
+TEST(ecma262_v_flag_subtract_digit_from_word) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]--[\\d]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[\\d]]"));
@@ -1743,7 +1743,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_digit_from_word) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_digit_word) {
+TEST(ecma262_v_flag_intersect_digit_word) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\w]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\w]]"));
@@ -1753,7 +1753,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_digit_word) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_specific_punct) {
+TEST(ecma262_v_flag_subtract_specific_punct) {
   const auto regex{sourcemeta::core::to_regex("[[\\!-\\/]--[#$%]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\!-\\/]--[#$%]]"));
@@ -1766,7 +1766,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_specific_punct) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "%"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_empty) {
+TEST(ecma262_v_flag_subtract_empty) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]--[x-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[x-z]]"));
@@ -1776,7 +1776,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_empty) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "x"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_printable_alpha) {
+TEST(ecma262_v_flag_intersect_printable_alpha) {
   const auto regex{sourcemeta::core::to_regex("[[ -~]&&[A-Z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[ -~]&&[A-Z]]"));
@@ -1788,7 +1788,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_printable_alpha) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), " "));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_multiple_ranges) {
+TEST(ecma262_v_flag_subtract_multiple_ranges) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[a-cx-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[a-cx-z]]"));
@@ -1803,7 +1803,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_multiple_ranges) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_space) {
+TEST(ecma262_v_flag_subtract_space) {
   const auto regex{sourcemeta::core::to_regex("[[ -\\/]--[ ]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[ -\\/]--[ ]]"));
@@ -1812,7 +1812,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_space) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), " "));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_to_single) {
+TEST(ecma262_v_flag_intersect_to_single) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]&&[c-e]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]&&[c-e]]"));
@@ -1823,7 +1823,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_to_single) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtraction_with_quantifier) {
+TEST(ecma262_v_flag_subtraction_with_quantifier) {
   const auto regex{sourcemeta::core::to_regex("^[[0-9]--[0]]{3}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[0-9]--[0]]{3}$"));
@@ -1834,7 +1834,7 @@ TEST(Regex_matches, ecma262_v_flag_subtraction_with_quantifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "12"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_caret) {
+TEST(ecma262_v_flag_subtract_caret) {
   const auto regex{sourcemeta::core::to_regex("[[!-@]--[\\^]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[!-@]--[\\^]]"));
@@ -1843,7 +1843,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_caret) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "^"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_alphanum_upper) {
+TEST(ecma262_v_flag_intersect_alphanum_upper) {
   const auto regex{sourcemeta::core::to_regex("[[0-9A-Za-z]&&[A-Z0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9A-Za-z]&&[A-Z0-9]]"));
@@ -1854,7 +1854,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_alphanum_upper) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_entire_range) {
+TEST(ecma262_v_flag_subtract_entire_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]--[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[a-z]]"));
@@ -1864,7 +1864,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_entire_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_multiple_set_ops_pattern) {
+TEST(ecma262_v_flag_multiple_set_ops_pattern) {
   const auto regex{
       sourcemeta::core::to_regex("^[[a-z]--[aeiou]][[0-9]--[0]]$")};
   EXPECT_TRUE(regex.has_value());
@@ -1877,7 +1877,7 @@ TEST(Regex_matches, ecma262_v_flag_multiple_set_ops_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e5"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_digit_ranges) {
+TEST(ecma262_v_flag_intersect_digit_ranges) {
   const auto regex{sourcemeta::core::to_regex("[[0-5]&&[3-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-5]&&[3-9]]"));
@@ -1890,7 +1890,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_digit_ranges) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_preserving_hyphen) {
+TEST(ecma262_v_flag_subtract_preserving_hyphen) {
   const auto regex{sourcemeta::core::to_regex("[[0-9\\-]--[5-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9\\-]--[5-9]]"));
@@ -1901,7 +1901,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_preserving_hyphen) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_word_underscore) {
+TEST(ecma262_v_flag_intersect_word_underscore) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]&&[_]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]&&[_]]"));
@@ -1910,7 +1910,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_word_underscore) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_union) {
+TEST(ecma262_v_flag_subtract_from_union) {
   const auto regex{sourcemeta::core::to_regex("[[a-zA-Z0-9]--[A-Z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-zA-Z0-9]--[A-Z]]"));
@@ -1921,7 +1921,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_union) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "Z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_large_subtraction) {
+TEST(ecma262_v_flag_large_subtraction) {
   const auto regex{sourcemeta::core::to_regex("[[\\x20-\\x7e]--[a-zA-Z0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x20-\\x7e]--[a-zA-Z0-9]]"));
@@ -1934,7 +1934,7 @@ TEST(Regex_matches, ecma262_v_flag_large_subtraction) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_hex_range_subtract_literal) {
+TEST(ecma262_v_flag_hex_range_subtract_literal) {
   const auto regex{sourcemeta::core::to_regex("[[\\x61-\\x7a]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x61-\\x7a]--[aeiou]]"));
@@ -1944,7 +1944,7 @@ TEST(Regex_matches, ecma262_v_flag_hex_range_subtract_literal) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_single_from_single) {
+TEST(ecma262_v_flag_subtract_single_from_single) {
   const auto regex{sourcemeta::core::to_regex("[[a]--[b]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]--[b]]"));
@@ -1952,7 +1952,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_single_from_single) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_single_chars_same) {
+TEST(ecma262_v_flag_intersect_single_chars_same) {
   const auto regex{sourcemeta::core::to_regex("[[a]&&[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]&&[a]]"));
@@ -1960,7 +1960,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_single_chars_same) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_single_chars_different) {
+TEST(ecma262_v_flag_intersect_single_chars_different) {
   const auto regex{sourcemeta::core::to_regex("[[a]&&[b]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]&&[b]]"));
@@ -1968,7 +1968,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_single_chars_different) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_hex_intersect_hex) {
+TEST(ecma262_v_flag_hex_intersect_hex) {
   const auto regex{
       sourcemeta::core::to_regex("[[\\x30-\\x39]&&[\\x33-\\x37]]")};
   EXPECT_TRUE(regex.has_value());
@@ -1983,7 +1983,7 @@ TEST(Regex_matches, ecma262_v_flag_hex_intersect_hex) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_all_digits_from_word) {
+TEST(ecma262_v_flag_subtract_all_digits_from_word) {
   const auto regex{sourcemeta::core::to_regex("[[[\\w]--[\\d]]--[_]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[\\w]--[\\d]]--[_]]"));
@@ -1993,7 +1993,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_all_digits_from_word) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_with_escaped_backslash) {
+TEST(ecma262_v_flag_intersect_with_escaped_backslash) {
   const auto regex{sourcemeta::core::to_regex("[[\\\\a-z]&&[\\\\]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\\\a-z]&&[\\\\]]"));
@@ -2002,7 +2002,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_with_escaped_backslash) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_control_chars) {
+TEST(ecma262_v_flag_subtract_control_chars) {
   const auto regex{
       sourcemeta::core::to_regex("[[\\x00-\\x1f]--[\\x00-\\x08]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2014,7 +2014,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_control_chars) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\x08"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_with_tab_newline) {
+TEST(ecma262_v_flag_intersect_with_tab_newline) {
   const auto regex{sourcemeta::core::to_regex("[[\\t\\n\\r ]&&[\\t\\n]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\t\\n\\r ]&&[\\t\\n]]"));
@@ -2024,7 +2024,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_with_tab_newline) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), " "));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_leaves_single) {
+TEST(ecma262_v_flag_subtract_leaves_single) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]--[ab]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[ab]]"));
@@ -2033,7 +2033,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_leaves_single) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_overlapping_three_char) {
+TEST(ecma262_v_flag_intersect_overlapping_three_char) {
   const auto regex{sourcemeta::core::to_regex("[[abc]&&[bcd]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]&&[bcd]]"));
@@ -2043,7 +2043,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_overlapping_three_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_mixed_hex_and_literal_in_subtract) {
+TEST(ecma262_v_flag_mixed_hex_and_literal_in_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[\\x41-\\x5a]--[AEIOU]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x41-\\x5a]--[AEIOU]]"));
@@ -2054,7 +2054,7 @@ TEST(Regex_matches, ecma262_v_flag_mixed_hex_and_literal_in_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_boundary_chars) {
+TEST(ecma262_v_flag_subtract_boundary_chars) {
   const auto regex{sourcemeta::core::to_regex("[[!-~]--[!~]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[!-~]--[!~]]"));
@@ -2065,7 +2065,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_boundary_chars) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "~"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_complement_like) {
+TEST(ecma262_v_flag_intersect_complement_like) {
   const auto regex{
       sourcemeta::core::to_regex("[[\\x00-\\x60\\x7b-\\x7f]&&[\\x00-\\x7f]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2078,7 +2078,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_complement_like) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_shorthand_with_hex) {
+TEST(ecma262_v_flag_subtract_from_shorthand_with_hex) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]--[\\x30-\\x34]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[\\x30-\\x34]]"));
@@ -2088,7 +2088,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_shorthand_with_hex) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "4"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_complex_alphanumeric_filter) {
+TEST(ecma262_v_flag_complex_alphanumeric_filter) {
   const auto regex{sourcemeta::core::to_regex("[[0-9A-Fa-f]--[g-zG-Z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9A-Fa-f]--[g-zG-Z]]"));
@@ -2102,7 +2102,7 @@ TEST(Regex_matches, ecma262_v_flag_complex_alphanumeric_filter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "G"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_ranges_at_boundary) {
+TEST(ecma262_v_flag_intersect_ranges_at_boundary) {
   const auto regex{sourcemeta::core::to_regex("[[a-f]&&[f-k]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-f]&&[f-k]]"));
@@ -2113,7 +2113,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_ranges_at_boundary) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "k"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_all_but_one_from_range) {
+TEST(ecma262_v_flag_subtract_all_but_one_from_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-e]--[abde]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[abde]]"));
@@ -2124,7 +2124,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_all_but_one_from_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_multiple_hex_escapes_in_subtraction) {
+TEST(ecma262_v_flag_multiple_hex_escapes_in_subtraction) {
   const auto regex{sourcemeta::core::to_regex(
       "[[\\x20-\\x7e]--[\\x30-\\x39]--[\\x41-\\x5a]--[\\x61-\\x7a]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2138,7 +2138,7 @@ TEST(Regex_matches, ecma262_v_flag_multiple_hex_escapes_in_subtraction) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_mixed_subtract_then_intersect) {
+TEST(ecma262_v_flag_mixed_subtract_then_intersect) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z]--[aeiou]]&&[a-m]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]--[aeiou]]&&[a-m]]"));
@@ -2149,7 +2149,7 @@ TEST(Regex_matches, ecma262_v_flag_mixed_subtract_then_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_mixed_intersect_then_subtract) {
+TEST(ecma262_v_flag_mixed_intersect_then_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z]&&[a-m]]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]&&[a-m]]--[aeiou]]"));
@@ -2160,7 +2160,7 @@ TEST(Regex_matches, ecma262_v_flag_mixed_intersect_then_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "n"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_nested_class_in_operand) {
+TEST(ecma262_v_flag_nested_class_in_operand) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z][0-9]]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z][0-9]]--[aeiou]]"));
@@ -2170,7 +2170,7 @@ TEST(Regex_matches, ecma262_v_flag_nested_class_in_operand) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_deeply_nested_brackets) {
+TEST(ecma262_v_flag_deeply_nested_brackets) {
   const auto regex{sourcemeta::core::to_regex("[[[[a-z]]]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[[a-z]]]]"));
@@ -2180,7 +2180,7 @@ TEST(Regex_matches, ecma262_v_flag_deeply_nested_brackets) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_nested_from_nested) {
+TEST(ecma262_v_flag_subtract_nested_from_nested) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z]]--[[x-z]]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]]--[[x-z]]]"));
@@ -2190,7 +2190,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_nested_from_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_nested_subtract) {
+TEST(ecma262_v_flag_shorthand_nested_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[[\\d]]--[0]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[\\d]]--[0]]"));
@@ -2199,7 +2199,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_nested_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_triple_chained_intersection) {
+TEST(ecma262_v_flag_triple_chained_intersection) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]&&[a-m]&&[f-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[a-m]&&[f-z]]"));
@@ -2211,7 +2211,7 @@ TEST(Regex_matches, ecma262_v_flag_triple_chained_intersection) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_empty_result_in_chain) {
+TEST(ecma262_v_flag_subtract_empty_result_in_chain) {
   const auto regex{sourcemeta::core::to_regex("[[a]--[a]--[b]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]--[a]--[b]]"));
@@ -2219,7 +2219,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_empty_result_in_chain) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_empty_result_in_chain) {
+TEST(ecma262_v_flag_intersect_empty_result_in_chain) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]&&[x-z]&&[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]&&[x-z]&&[a-z]]"));
@@ -2227,7 +2227,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_empty_result_in_chain) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "x"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_operator_inside_nested_not_toplevel) {
+TEST(ecma262_v_flag_operator_inside_nested_not_toplevel) {
   const auto regex{sourcemeta::core::to_regex("[[a\\-\\-b]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a\\-\\-b]]"));
@@ -2236,7 +2236,7 @@ TEST(Regex_matches, ecma262_v_flag_operator_inside_nested_not_toplevel) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_alternation_after_set_op) {
+TEST(ecma262_v_flag_alternation_after_set_op) {
   const auto regex{sourcemeta::core::to_regex("^([[a-z]--[aeiou]]|[0-9])$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^([[a-z]--[aeiou]]|[0-9])$"));
@@ -2246,7 +2246,7 @@ TEST(Regex_matches, ecma262_v_flag_alternation_after_set_op) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_set_op_with_dot_star) {
+TEST(ecma262_v_flag_set_op_with_dot_star) {
   const auto regex{sourcemeta::core::to_regex("^.*[[a-z]--[aeiou]]$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.*[[a-z]--[aeiou]]$"));
@@ -2256,7 +2256,7 @@ TEST(Regex_matches, ecma262_v_flag_set_op_with_dot_star) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_only_intersection) {
+TEST(ecma262_v_flag_shorthand_only_intersection) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\w]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\w]]"));
@@ -2266,7 +2266,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_only_intersection) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_double_nested_with_subtract) {
+TEST(ecma262_v_flag_double_nested_with_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z]]--[[aeiou]]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]]--[[aeiou]]]"));
@@ -2276,7 +2276,7 @@ TEST(Regex_matches, ecma262_v_flag_double_nested_with_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_union_in_nested) {
+TEST(ecma262_v_flag_union_in_nested) {
   const auto regex{sourcemeta::core::to_regex("[[[a-c][x-z]]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-c][x-z]]]"));
@@ -2288,7 +2288,7 @@ TEST(Regex_matches, ecma262_v_flag_union_in_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "w"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_union_nested) {
+TEST(ecma262_v_flag_subtract_from_union_nested) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z][0-9]]--[aeiou0]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z][0-9]]--[aeiou0]]"));
@@ -2300,7 +2300,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_union_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_four_way_intersection) {
+TEST(ecma262_v_flag_four_way_intersection) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]&&[a-m]&&[f-z]&&[g-l]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[a-m]&&[f-z]&&[g-l]]"));
@@ -2311,7 +2311,7 @@ TEST(Regex_matches, ecma262_v_flag_four_way_intersection) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_alternating_ops) {
+TEST(ecma262_v_flag_alternating_ops) {
   const auto regex{
       sourcemeta::core::to_regex("[[[[a-z]--[aeiou]]&&[a-m]]--[klm]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2324,7 +2324,7 @@ TEST(Regex_matches, ecma262_v_flag_alternating_ops) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "n"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_repeated_char_class) {
+TEST(ecma262_v_flag_repeated_char_class) {
   const auto regex{sourcemeta::core::to_regex("^[[a-c]][[d-f]]$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-c]][[d-f]]$"));
@@ -2335,7 +2335,7 @@ TEST(Regex_matches, ecma262_v_flag_repeated_char_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_whitespace_subtract_space) {
+TEST(ecma262_v_flag_whitespace_subtract_space) {
   const auto regex{sourcemeta::core::to_regex("[[\\s]--[ ]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\s]--[ ]]"));
@@ -2345,7 +2345,7 @@ TEST(Regex_matches, ecma262_v_flag_whitespace_subtract_space) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_negated_digit_intersect) {
+TEST(ecma262_v_flag_negated_digit_intersect) {
   const auto regex{sourcemeta::core::to_regex("[[\\D]&&[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\D]&&[a-z]]"));
@@ -2355,7 +2355,7 @@ TEST(Regex_matches, ecma262_v_flag_negated_digit_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_negated_word_intersect) {
+TEST(ecma262_v_flag_negated_word_intersect) {
   const auto regex{sourcemeta::core::to_regex("[[\\W]&&[\\!-\\/]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\W]&&[\\!-\\/]]"));
@@ -2365,7 +2365,7 @@ TEST(Regex_matches, ecma262_v_flag_negated_word_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_negated_space_intersect) {
+TEST(ecma262_v_flag_negated_space_intersect) {
   const auto regex{sourcemeta::core::to_regex("[[\\S]&&[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\S]&&[a-z]]"));
@@ -2375,7 +2375,7 @@ TEST(Regex_matches, ecma262_v_flag_negated_space_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\t"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_caret_negation_with_subtract) {
+TEST(ecma262_v_flag_caret_negation_with_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[^a-z]--[0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[^a-z]--[0-9]]"));
@@ -2385,7 +2385,7 @@ TEST(Regex_matches, ecma262_v_flag_caret_negation_with_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_single_char_range) {
+TEST(ecma262_v_flag_single_char_range) {
   const auto regex{sourcemeta::core::to_regex("[[a-a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-a]]"));
@@ -2393,7 +2393,7 @@ TEST(Regex_matches, ecma262_v_flag_single_char_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_literal_hyphen_at_end) {
+TEST(ecma262_v_flag_literal_hyphen_at_end) {
   const auto regex{sourcemeta::core::to_regex("[[a-z\\-]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z\\-]--[aeiou]]"));
@@ -2403,7 +2403,7 @@ TEST(Regex_matches, ecma262_v_flag_literal_hyphen_at_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_literal_hyphen_at_start) {
+TEST(ecma262_v_flag_literal_hyphen_at_start) {
   const auto regex{sourcemeta::core::to_regex("[[\\-a-z]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\-a-z]--[aeiou]]"));
@@ -2412,7 +2412,7 @@ TEST(Regex_matches, ecma262_v_flag_literal_hyphen_at_start) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_with_caret_in_operand) {
+TEST(ecma262_v_flag_subtract_with_caret_in_operand) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[^aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[^aeiou]]"));
@@ -2422,7 +2422,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_with_caret_in_operand) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_with_caret_in_operand) {
+TEST(ecma262_v_flag_intersect_with_caret_in_operand) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]&&[^x-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[^x-z]]"));
@@ -2432,7 +2432,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_with_caret_in_operand) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_unicode_escape_4digit_subtract) {
+TEST(ecma262_v_flag_unicode_escape_4digit_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[\\u0041-\\u005A]--[ABC]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\u0041-\\u005A]--[ABC]]"));
@@ -2443,7 +2443,7 @@ TEST(Regex_matches, ecma262_v_flag_unicode_escape_4digit_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "C"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_unicode_escape_brace_subtract) {
+TEST(ecma262_v_flag_unicode_escape_brace_subtract) {
   const auto regex{
       sourcemeta::core::to_regex("[[\\u{0041}-\\u{005A}]--[ABC]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2456,7 +2456,7 @@ TEST(Regex_matches, ecma262_v_flag_unicode_escape_brace_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "C"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_backspace_in_class) {
+TEST(ecma262_v_flag_backspace_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[\\b]--[\\x08]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\b]--[\\x08]]"));
@@ -2464,7 +2464,7 @@ TEST(Regex_matches, ecma262_v_flag_backspace_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_control_escape_intersect) {
+TEST(ecma262_v_flag_control_escape_intersect) {
   const auto regex{sourcemeta::core::to_regex("[[\\cA-\\cZ]&&[\\x01-\\x03]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\cA-\\cZ]&&[\\x01-\\x03]]"));
@@ -2474,25 +2474,25 @@ TEST(Regex_matches, ecma262_v_flag_control_escape_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_empty_first_operand) {
+TEST(ecma262_v_flag_empty_first_operand) {
   const auto regex{sourcemeta::core::to_regex("[--[a-z]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[--[a-z]]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_empty_second_operand) {
+TEST(ecma262_v_flag_empty_second_operand) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z]--]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_double_operator_subtraction) {
+TEST(ecma262_v_flag_double_operator_subtraction) {
   const auto regex{sourcemeta::core::to_regex("[a-z----abc]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[a-z----abc]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_abc_from_az) {
+TEST(ecma262_v_flag_subtract_abc_from_az) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[abc]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[abc]]"));
@@ -2503,7 +2503,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_abc_from_az) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "c"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_rightbracket_first_in_nested) {
+TEST(ecma262_v_flag_rightbracket_first_in_nested) {
   const auto regex{sourcemeta::core::to_regex("[[\\]-a]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\]-a]--[a]]"));
@@ -2511,7 +2511,7 @@ TEST(Regex_matches, ecma262_v_flag_rightbracket_first_in_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_single_shorthand) {
+TEST(ecma262_v_flag_subtract_from_single_shorthand) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]--[5]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[5]]"));
@@ -2521,7 +2521,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_single_shorthand) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_two_shorthands) {
+TEST(ecma262_v_flag_intersect_two_shorthands) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\w]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\w]]"));
@@ -2531,7 +2531,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_two_shorthands) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_shorthand_from_shorthand) {
+TEST(ecma262_v_flag_subtract_shorthand_from_shorthand) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]--[\\d]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[\\d]]"));
@@ -2542,7 +2542,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_shorthand_from_shorthand) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_triple_nested_subtract) {
+TEST(ecma262_v_flag_triple_nested_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[[a-z]]--[[aeiou]]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]]--[[aeiou]]]"));
@@ -2552,7 +2552,7 @@ TEST(Regex_matches, ecma262_v_flag_triple_nested_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_empty_nested) {
+TEST(ecma262_v_flag_subtract_empty_nested) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[]]"));
@@ -2561,7 +2561,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_empty_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_word_minus_alphanumeric) {
+TEST(ecma262_v_flag_word_minus_alphanumeric) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]--[a-zA-Z0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[a-zA-Z0-9]]"));
@@ -2570,7 +2570,7 @@ TEST(Regex_matches, ecma262_v_flag_word_minus_alphanumeric) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_multiple_escape_sequences_subtract) {
+TEST(ecma262_v_flag_multiple_escape_sequences_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[[\\t\\n\\r]]--[\\t]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[\\t\\n\\r]]--[\\t]]"));
@@ -2579,7 +2579,7 @@ TEST(Regex_matches, ecma262_v_flag_multiple_escape_sequences_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\t"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_mixed_unicode_escape_types) {
+TEST(ecma262_v_flag_mixed_unicode_escape_types) {
   const auto regex{sourcemeta::core::to_regex("[[\\u0041-\\u{005A}]--[ABC]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\u0041-\\u{005A}]--[ABC]]"));
@@ -2589,7 +2589,7 @@ TEST(Regex_matches, ecma262_v_flag_mixed_unicode_escape_types) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "B"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_control_char_range_intersect) {
+TEST(ecma262_v_flag_control_char_range_intersect) {
   const auto regex{
       sourcemeta::core::to_regex("[[\\x00-\\x1F]&&[\\x00-\\x0F]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2601,7 +2601,7 @@ TEST(Regex_matches, ecma262_v_flag_control_char_range_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\x1F"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_del_char_subtract) {
+TEST(ecma262_v_flag_del_char_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[\\x7E-\\x7F]--[\\x7E]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x7E-\\x7F]--[\\x7E]]"));
@@ -2610,7 +2610,7 @@ TEST(Regex_matches, ecma262_v_flag_del_char_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_form_feed_and_vertical_tab) {
+TEST(ecma262_v_flag_form_feed_and_vertical_tab) {
   const auto regex{sourcemeta::core::to_regex("[[\\f\\v]--[\\f]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\f\\v]--[\\f]]"));
@@ -2618,7 +2618,7 @@ TEST(Regex_matches, ecma262_v_flag_form_feed_and_vertical_tab) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\f"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_null_char_in_operation) {
+TEST(ecma262_v_flag_null_char_in_operation) {
   const auto regex{sourcemeta::core::to_regex("[[\\x00-\\x02]--[\\x00]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x00-\\x02]--[\\x00]]"));
@@ -2628,7 +2628,7 @@ TEST(Regex_matches, ecma262_v_flag_null_char_in_operation) {
       sourcemeta::core::matches(regex.value(), std::string("\x00", 1)));
 }
 
-TEST(Regex_matches, ecma262_v_flag_printable_minus_alphanumeric) {
+TEST(ecma262_v_flag_printable_minus_alphanumeric) {
   const auto regex{sourcemeta::core::to_regex("[[\\x20-\\x7E]--[a-zA-Z0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x20-\\x7E]--[a-zA-Z0-9]]"));
@@ -2639,7 +2639,7 @@ TEST(Regex_matches, ecma262_v_flag_printable_minus_alphanumeric) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_five_way_chained_intersection) {
+TEST(ecma262_v_flag_five_way_chained_intersection) {
   const auto regex{
       sourcemeta::core::to_regex("[[a-z]&&[a-w]&&[a-t]&&[a-q]&&[a-n]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2651,7 +2651,7 @@ TEST(Regex_matches, ecma262_v_flag_five_way_chained_intersection) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_lowercase_control_escape) {
+TEST(ecma262_v_flag_lowercase_control_escape) {
   const auto regex{sourcemeta::core::to_regex("[[\\ca-\\cz]&&[\\x01-\\x03]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\ca-\\cz]&&[\\x01-\\x03]]"));
@@ -2660,7 +2660,7 @@ TEST(Regex_matches, ecma262_v_flag_lowercase_control_escape) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\x04"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_all_word_chars) {
+TEST(ecma262_v_flag_subtract_all_word_chars) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]--[\\w]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[\\w]]"));
@@ -2669,7 +2669,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_all_word_chars) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_with_itself) {
+TEST(ecma262_v_flag_intersect_with_itself) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\d]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\d]]"));
@@ -2678,7 +2678,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_with_itself) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_double_backslash_in_operation) {
+TEST(ecma262_v_flag_double_backslash_in_operation) {
   const auto regex{sourcemeta::core::to_regex("[[\\\\]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\\\]--[a]]"));
@@ -2686,7 +2686,7 @@ TEST(Regex_matches, ecma262_v_flag_double_backslash_in_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_from_full_ascii_printable) {
+TEST(ecma262_v_flag_subtract_from_full_ascii_printable) {
   const auto regex{
       sourcemeta::core::to_regex("[[[[[[\\x20-\\x7E]--[\\x20-\\x2F]]--[\\x3A-"
                                  "\\x40]]--[\\x5B-\\x60]]--[\\x7"
@@ -2704,7 +2704,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_from_full_ascii_printable) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "@"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_all_hex_digits_only) {
+TEST(ecma262_v_flag_all_hex_digits_only) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[a-fA-F0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[a-fA-F0-9]]"));
@@ -2714,7 +2714,7 @@ TEST(Regex_matches, ecma262_v_flag_all_hex_digits_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "F"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_hex_letter_only) {
+TEST(ecma262_v_flag_hex_letter_only) {
   const auto regex{sourcemeta::core::to_regex("[[a-fA-F0-9]--[\\d]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-fA-F0-9]--[\\d]]"));
@@ -2727,7 +2727,7 @@ TEST(Regex_matches, ecma262_v_flag_hex_letter_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "g"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_escaped_special_regex_chars) {
+TEST(ecma262_v_flag_escaped_special_regex_chars) {
   const auto regex{sourcemeta::core::to_regex("[[.+*?]--[.]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[.+*?]--[.]]"));
@@ -2738,7 +2738,7 @@ TEST(Regex_matches, ecma262_v_flag_escaped_special_regex_chars) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_escaped_open_bracket) {
+TEST(ecma262_v_flag_escaped_open_bracket) {
   const auto regex{sourcemeta::core::to_regex("[[\\[]--[x]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\[]--[x]]"));
@@ -2747,7 +2747,7 @@ TEST(Regex_matches, ecma262_v_flag_escaped_open_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_only_special_punctuation) {
+TEST(ecma262_v_flag_only_special_punctuation) {
   const auto regex{sourcemeta::core::to_regex("[[\\!-\\/]&&[\\(-+]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\!-\\/]&&[\\(-+]]"));
@@ -2759,7 +2759,7 @@ TEST(Regex_matches, ecma262_v_flag_only_special_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "/"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_range_with_same_start_end) {
+TEST(ecma262_v_flag_range_with_same_start_end) {
   const auto regex{sourcemeta::core::to_regex("[[a-a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-a]]"));
@@ -2767,7 +2767,7 @@ TEST(Regex_matches, ecma262_v_flag_range_with_same_start_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_at_sign_and_backtick) {
+TEST(ecma262_v_flag_at_sign_and_backtick) {
   const auto regex{sourcemeta::core::to_regex("[[@`]--[@]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[@`]--[@]]"));
@@ -2775,7 +2775,7 @@ TEST(Regex_matches, ecma262_v_flag_at_sign_and_backtick) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "@"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_escaped_hyphen_subtract) {
+TEST(ecma262_v_flag_escaped_hyphen_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[a\\-z]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a\\-z]--[a]]"));
@@ -2785,7 +2785,7 @@ TEST(Regex_matches, ecma262_v_flag_escaped_hyphen_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_hex_to_literal_range) {
+TEST(ecma262_v_flag_hex_to_literal_range) {
   const auto regex{sourcemeta::core::to_regex("[[\\x41-Z]--[ABC]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x41-Z]--[ABC]]"));
@@ -2795,7 +2795,7 @@ TEST(Regex_matches, ecma262_v_flag_hex_to_literal_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "C"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_literal_to_hex_range) {
+TEST(ecma262_v_flag_literal_to_hex_range) {
   const auto regex{sourcemeta::core::to_regex("[[A-\\x5A]--[ABC]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[A-\\x5A]--[ABC]]"));
@@ -2805,7 +2805,7 @@ TEST(Regex_matches, ecma262_v_flag_literal_to_hex_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "C"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_multiple_char_classes_in_pattern) {
+TEST(ecma262_v_flag_multiple_char_classes_in_pattern) {
   const auto regex{
       sourcemeta::core::to_regex("[[a-z]--[aeiou]][[A-Z]--[AEIOU]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2817,7 +2817,7 @@ TEST(Regex_matches, ecma262_v_flag_multiple_char_classes_in_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bE"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_in_group) {
+TEST(ecma262_v_flag_in_group) {
   const auto regex{sourcemeta::core::to_regex("(x[[a-z]--[aeiou]]y)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(x[[a-z]--[aeiou]]y)"));
@@ -2827,7 +2827,7 @@ TEST(Regex_matches, ecma262_v_flag_in_group) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xey"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_with_quantifier_range) {
+TEST(ecma262_v_flag_with_quantifier_range) {
   const auto regex{sourcemeta::core::to_regex("^[[a-z]--[aeiou]]{2,4}$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]]{2,4}$"));
@@ -2837,7 +2837,7 @@ TEST(Regex_matches, ecma262_v_flag_with_quantifier_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bcdfg"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_anchored_both_ends) {
+TEST(ecma262_v_flag_anchored_both_ends) {
   const auto regex{sourcemeta::core::to_regex("^[[a-z]--[aeiou]]$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]]$"));
@@ -2847,7 +2847,7 @@ TEST(Regex_matches, ecma262_v_flag_anchored_both_ends) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bb"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_alternation_both_branches) {
+TEST(ecma262_v_flag_alternation_both_branches) {
   const auto regex{
       sourcemeta::core::to_regex("[[a-m]--[aeiou]]|[[n-z]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2859,7 +2859,7 @@ TEST(Regex_matches, ecma262_v_flag_alternation_both_branches) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "o"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_ten_way_chained_subtraction) {
+TEST(ecma262_v_flag_ten_way_chained_subtraction) {
   const auto regex{sourcemeta::core::to_regex(
       "[[a-z]--[a]--[b]--[c]--[d]--[e]--[f]--[g]--[h]--[i]--[j]]")};
   EXPECT_TRUE(regex.has_value());
@@ -2871,7 +2871,7 @@ TEST(Regex_matches, ecma262_v_flag_ten_way_chained_subtraction) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "j"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_single_char_minus_single_char_same) {
+TEST(ecma262_v_flag_single_char_minus_single_char_same) {
   const auto regex{sourcemeta::core::to_regex("[[x]--[x]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[x]--[x]]"));
@@ -2879,7 +2879,7 @@ TEST(Regex_matches, ecma262_v_flag_single_char_minus_single_char_same) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "y"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_single_char_minus_single_char_different) {
+TEST(ecma262_v_flag_single_char_minus_single_char_different) {
   const auto regex{sourcemeta::core::to_regex("[[x]--[y]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[x]--[y]]"));
@@ -2887,7 +2887,7 @@ TEST(Regex_matches, ecma262_v_flag_single_char_minus_single_char_different) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "y"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_caret_not_at_start_in_nested) {
+TEST(ecma262_v_flag_caret_not_at_start_in_nested) {
   const auto regex{sourcemeta::core::to_regex("[[a^b]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a^b]--[a]]"));
@@ -2896,7 +2896,7 @@ TEST(Regex_matches, ecma262_v_flag_caret_not_at_start_in_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_dollar_in_class) {
+TEST(ecma262_v_flag_dollar_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[$a]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[$a]--[a]]"));
@@ -2904,7 +2904,7 @@ TEST(Regex_matches, ecma262_v_flag_dollar_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_pipe_in_class) {
+TEST(ecma262_v_flag_pipe_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[\\|a]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\|a]--[a]]"));
@@ -2912,7 +2912,7 @@ TEST(Regex_matches, ecma262_v_flag_pipe_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_lookahead_with_operation) {
+TEST(ecma262_v_flag_lookahead_with_operation) {
   const auto regex{sourcemeta::core::to_regex("(?=[[a-z]--[aeiou]]).")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?=[[a-z]--[aeiou]])."));
@@ -2922,7 +2922,7 @@ TEST(Regex_matches, ecma262_v_flag_lookahead_with_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "e"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_lookbehind_with_operation) {
+TEST(ecma262_v_flag_lookbehind_with_operation) {
   const auto regex{sourcemeta::core::to_regex("(?<=[[a-z]--[aeiou]])x")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=[[a-z]--[aeiou]])x"));
@@ -2931,7 +2931,7 @@ TEST(Regex_matches, ecma262_v_flag_lookbehind_with_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ex"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_full_ascii_intersect_to_alpha) {
+TEST(ecma262_v_flag_full_ascii_intersect_to_alpha) {
   const auto regex{sourcemeta::core::to_regex("[[\\x00-\\x7F]&&[a-zA-Z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x00-\\x7F]&&[a-zA-Z]]"));
@@ -2941,7 +2941,7 @@ TEST(Regex_matches, ecma262_v_flag_full_ascii_intersect_to_alpha) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "!"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_to_result_one_char) {
+TEST(ecma262_v_flag_subtract_to_result_one_char) {
   const auto regex{sourcemeta::core::to_regex("[[a-c]--[ab]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[ab]]"));
@@ -2951,7 +2951,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_to_result_one_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_to_result_one_char) {
+TEST(ecma262_v_flag_intersect_to_result_one_char) {
   const auto regex{sourcemeta::core::to_regex("[[abc]&&[cde]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]&&[cde]]"));
@@ -2960,7 +2960,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_to_result_one_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_space_in_operation) {
+TEST(ecma262_v_flag_space_in_operation) {
   const auto regex{sourcemeta::core::to_regex("[[ a]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[ a]--[a]]"));
@@ -2968,7 +2968,7 @@ TEST(Regex_matches, ecma262_v_flag_space_in_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_bell_char_subtract) {
+TEST(ecma262_v_flag_bell_char_subtract) {
   const auto regex{sourcemeta::core::to_regex("[[\\x07-\\x09]--[\\x08]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x07-\\x09]--[\\x08]]"));
@@ -2977,7 +2977,7 @@ TEST(Regex_matches, ecma262_v_flag_bell_char_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\b"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_escape_sequence_vs_hex) {
+TEST(ecma262_v_flag_escape_sequence_vs_hex) {
   const auto regex{sourcemeta::core::to_regex("[\\t--[\\x09]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\t--[\\x09]]"));
@@ -2985,7 +2985,7 @@ TEST(Regex_matches, ecma262_v_flag_escape_sequence_vs_hex) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "t"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_carriage_return_line_feed) {
+TEST(ecma262_v_flag_carriage_return_line_feed) {
   const auto regex{sourcemeta::core::to_regex("[[\\r\\n]--[\\n]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\r\\n]--[\\n]]"));
@@ -2993,7 +2993,7 @@ TEST(Regex_matches, ecma262_v_flag_carriage_return_line_feed) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_repeated_same_subtraction) {
+TEST(ecma262_v_flag_repeated_same_subtraction) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]--[aeiou]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]--[aeiou]]"));
@@ -3001,7 +3001,7 @@ TEST(Regex_matches, ecma262_v_flag_repeated_same_subtraction) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_quadruple_nested) {
+TEST(ecma262_v_flag_quadruple_nested) {
   const auto regex{sourcemeta::core::to_regex("[[[[a-z]]]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[[a-z]]]]"));
@@ -3010,7 +3010,7 @@ TEST(Regex_matches, ecma262_v_flag_quadruple_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_subtract_superset) {
+TEST(ecma262_v_flag_subtract_superset) {
   const auto regex{sourcemeta::core::to_regex("[[abc]--[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]--[a-z]]"));
@@ -3019,7 +3019,7 @@ TEST(Regex_matches, ecma262_v_flag_subtract_superset) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "c"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_intersect_disjoint_sets) {
+TEST(ecma262_v_flag_intersect_disjoint_sets) {
   const auto regex{sourcemeta::core::to_regex("[[abc]&&[xyz]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]&&[xyz]]"));
@@ -3027,7 +3027,7 @@ TEST(Regex_matches, ecma262_v_flag_intersect_disjoint_sets) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "x"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_negative_lookahead_with_operation) {
+TEST(ecma262_v_flag_negative_lookahead_with_operation) {
   const auto regex{sourcemeta::core::to_regex("a(?![[a-z]--[aeiou]])")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a(?![[a-z]--[aeiou]])"));
@@ -3037,7 +3037,7 @@ TEST(Regex_matches, ecma262_v_flag_negative_lookahead_with_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "az"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_negative_lookbehind_with_operation) {
+TEST(ecma262_v_flag_negative_lookbehind_with_operation) {
   const auto regex{sourcemeta::core::to_regex("(?<![[a-z]--[aeiou]])x")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<![[a-z]--[aeiou]])x"));
@@ -3047,7 +3047,7 @@ TEST(Regex_matches, ecma262_v_flag_negative_lookbehind_with_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "zx"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_non_capturing_group) {
+TEST(ecma262_v_flag_non_capturing_group) {
   const auto regex{sourcemeta::core::to_regex("(?:[[a-z]--[aeiou]])+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:[[a-z]--[aeiou]])+"));
@@ -3055,7 +3055,7 @@ TEST(Regex_matches, ecma262_v_flag_non_capturing_group) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "aeiou"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_nested_groups_with_operation) {
+TEST(ecma262_v_flag_nested_groups_with_operation) {
   const auto regex{sourcemeta::core::to_regex("(([[a-z]--[aeiou]]))")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(([[a-z]--[aeiou]]))"));
@@ -3063,13 +3063,13 @@ TEST(Regex_matches, ecma262_v_flag_nested_groups_with_operation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_unknown_escape_sequence) {
+TEST(ecma262_v_flag_unknown_escape_sequence) {
   const auto regex{sourcemeta::core::to_regex("[[\\q]--[x]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[\\q]--[x]]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_tilde_and_special_chars) {
+TEST(ecma262_v_flag_tilde_and_special_chars) {
   const auto regex{sourcemeta::core::to_regex("[[~!@#]--[~]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[~!@#]--[~]]"));
@@ -3079,7 +3079,7 @@ TEST(Regex_matches, ecma262_v_flag_tilde_and_special_chars) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "~"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_equals_and_less_greater) {
+TEST(ecma262_v_flag_equals_and_less_greater) {
   const auto regex{sourcemeta::core::to_regex("[[<=>]--[=]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[<=>]--[=]]"));
@@ -3088,7 +3088,7 @@ TEST(Regex_matches, ecma262_v_flag_equals_and_less_greater) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "="));
 }
 
-TEST(Regex_matches, ecma262_v_flag_curly_braces_in_class) {
+TEST(ecma262_v_flag_curly_braces_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[\\{\\}]--[\\{]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\{\\}]--[\\{]]"));
@@ -3096,7 +3096,7 @@ TEST(Regex_matches, ecma262_v_flag_curly_braces_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "{"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_parentheses_in_class) {
+TEST(ecma262_v_flag_parentheses_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[\\(\\)]--[\\(]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\(\\)]--[\\(]]"));
@@ -3104,7 +3104,7 @@ TEST(Regex_matches, ecma262_v_flag_parentheses_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "("));
 }
 
-TEST(Regex_matches, ecma262_v_flag_complex_subtract_intersect_subtract) {
+TEST(ecma262_v_flag_complex_subtract_intersect_subtract) {
   const auto regex{
       sourcemeta::core::to_regex("[[[[a-z]--[aeiou]]&&[b-y]]--[xyz]]")};
   EXPECT_TRUE(regex.has_value());
@@ -3117,7 +3117,7 @@ TEST(Regex_matches, ecma262_v_flag_complex_subtract_intersect_subtract) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_ampersand_in_class) {
+TEST(ecma262_v_flag_ampersand_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[&a]--[a]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[&a]--[a]]"));
@@ -3125,7 +3125,7 @@ TEST(Regex_matches, ecma262_v_flag_ampersand_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_percent_and_hash) {
+TEST(ecma262_v_flag_percent_and_hash) {
   const auto regex{sourcemeta::core::to_regex("[[%#]--[%]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[%#]--[%]]"));
@@ -3133,7 +3133,7 @@ TEST(Regex_matches, ecma262_v_flag_percent_and_hash) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "%"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_colon_semicolon_comma) {
+TEST(ecma262_v_flag_colon_semicolon_comma) {
   const auto regex{sourcemeta::core::to_regex("[[:;,]--[;]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[:;,]--[;]]"));
@@ -3142,7 +3142,7 @@ TEST(Regex_matches, ecma262_v_flag_colon_semicolon_comma) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ";"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_question_exclamation) {
+TEST(ecma262_v_flag_question_exclamation) {
   const auto regex{sourcemeta::core::to_regex("[[?!]--[?]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[?!]--[?]]"));
@@ -3150,7 +3150,7 @@ TEST(Regex_matches, ecma262_v_flag_question_exclamation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "?"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_underscore_intersect) {
+TEST(ecma262_v_flag_underscore_intersect) {
   const auto regex{sourcemeta::core::to_regex("[[\\w]&&[^a-zA-Z0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]&&[^a-zA-Z0-9]]"));
@@ -3159,7 +3159,7 @@ TEST(Regex_matches, ecma262_v_flag_underscore_intersect) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_digits_odd_only) {
+TEST(ecma262_v_flag_digits_odd_only) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]--[02468]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[02468]]"));
@@ -3170,7 +3170,7 @@ TEST(Regex_matches, ecma262_v_flag_digits_odd_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "8"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_digits_even_only) {
+TEST(ecma262_v_flag_digits_even_only) {
   const auto regex{sourcemeta::core::to_regex("[[\\d]&&[02468]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[02468]]"));
@@ -3181,7 +3181,7 @@ TEST(Regex_matches, ecma262_v_flag_digits_even_only) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "9"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_single_quote_double_quote) {
+TEST(ecma262_v_flag_single_quote_double_quote) {
   const auto regex{sourcemeta::core::to_regex("[['\"']--[']]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[['\"']--[']]"));
@@ -3189,7 +3189,7 @@ TEST(Regex_matches, ecma262_v_flag_single_quote_double_quote) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "'"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_forward_slash_backslash) {
+TEST(ecma262_v_flag_forward_slash_backslash) {
   const auto regex{sourcemeta::core::to_regex("[[\\\\]--[\\/]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\\\]--[\\/]]"));
@@ -3197,19 +3197,19 @@ TEST(Regex_matches, ecma262_v_flag_forward_slash_backslash) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "/"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_invalid_unbalanced_parens) {
+TEST(ecma262_v_flag_invalid_unbalanced_parens) {
   const auto regex{sourcemeta::core::to_regex("([[a-z]--[aeiou]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("([[a-z]--[aeiou]]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_invalid_bad_quantifier) {
+TEST(ecma262_v_flag_invalid_bad_quantifier) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]]{5,2}")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]]{5,2}"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_intersection_valid) {
+TEST(ecma262_v_flag_shorthand_intersection_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\d&&[0-5]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d&&[0-5]]"));
@@ -3217,7 +3217,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_intersection_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "7"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_subtraction_valid) {
+TEST(ecma262_v_flag_shorthand_subtraction_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\w--[0-9]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w--[0-9]]"));
@@ -3225,7 +3225,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_subtraction_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_intersection_with_range_valid) {
+TEST(ecma262_v_flag_shorthand_intersection_with_range_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\w&&[a-z]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w&&[a-z]]"));
@@ -3233,7 +3233,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_intersection_with_range_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "B"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_subtract_single_valid) {
+TEST(ecma262_v_flag_shorthand_subtract_single_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\d--[0]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d--[0]]"));
@@ -3241,7 +3241,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_subtract_single_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_to_shorthand_subtract_valid) {
+TEST(ecma262_v_flag_shorthand_to_shorthand_subtract_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\w--\\d]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w--\\d]"));
@@ -3249,7 +3249,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_to_shorthand_subtract_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_shorthand_to_shorthand_intersect_valid) {
+TEST(ecma262_v_flag_shorthand_to_shorthand_intersect_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\d&&\\w]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d&&\\w]"));
@@ -3257,7 +3257,7 @@ TEST(Regex_matches, ecma262_v_flag_shorthand_to_shorthand_intersect_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_chained_shorthand_ops_valid) {
+TEST(ecma262_v_flag_chained_shorthand_ops_valid) {
   const auto regex{sourcemeta::core::to_regex("[\\w--\\d--[_]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w--\\d--[_]]"));
@@ -3266,31 +3266,31 @@ TEST(Regex_matches, ecma262_v_flag_chained_shorthand_ops_valid) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "_"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_invalid_range_without_nesting) {
+TEST(ecma262_v_flag_invalid_range_without_nesting) {
   const auto regex{sourcemeta::core::to_regex("[\\x61-\\x7a--[aeiou]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[\\x61-\\x7a--[aeiou]]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_invalid_mixed_ops_without_nesting) {
+TEST(ecma262_v_flag_invalid_mixed_ops_without_nesting) {
   const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]&&[a-m]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]&&[a-m]]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_invalid_unescaped_hyphen_in_class) {
+TEST(ecma262_v_flag_invalid_unescaped_hyphen_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[a-z-]--[x]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z-]--[x]]"));
 }
 
-TEST(Regex_matches, ecma262_v_flag_invalid_unescaped_pipe) {
+TEST(ecma262_v_flag_invalid_unescaped_pipe) {
   const auto regex{sourcemeta::core::to_regex("[[|a]--[a]]")};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[|a]--[a]]"));
 }
 
-TEST(Regex_matches, ecma262_lookahead_with_negated_class) {
+TEST(ecma262_lookahead_with_negated_class) {
   const auto regex{
       sourcemeta::core::to_regex(R"(^(?=[^!*,;{}[\]~\n]+$)(?=(.*\w)).+$)")};
   EXPECT_TRUE(regex.has_value());
@@ -3302,7 +3302,7 @@ TEST(Regex_matches, ecma262_lookahead_with_negated_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "no,comma"));
 }
 
-TEST(Regex_matches, ecma262_literal_open_bracket_in_class) {
+TEST(ecma262_literal_open_bracket_in_class) {
   const auto regex{sourcemeta::core::to_regex("[[(]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[(]"));
@@ -3311,7 +3311,7 @@ TEST(Regex_matches, ecma262_literal_open_bracket_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_literal_close_bracket_in_class) {
+TEST(ecma262_literal_close_bracket_in_class) {
   const auto regex{sourcemeta::core::to_regex(R"([)\]])")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(R"([)\]])"));
@@ -3320,7 +3320,7 @@ TEST(Regex_matches, ecma262_literal_close_bracket_in_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, ecma262_bracket_classes_in_complex_pattern) {
+TEST(ecma262_bracket_classes_in_complex_pattern) {
   const auto regex{sourcemeta::core::to_regex(R"(^[[(]\d+,\d+[)\]]$)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(R"(^[[(]\d+,\d+[)\]]$)"));
@@ -3331,7 +3331,7 @@ TEST(Regex_matches, ecma262_bracket_classes_in_complex_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "1,2"));
 }
 
-TEST(Regex_matches, ecma262_datetime_range_pattern) {
+TEST(ecma262_datetime_range_pattern) {
   const auto regex{sourcemeta::core::to_regex(
       R"(^((\d{4}-\d{2}-\d{2})|([[(](((\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?),(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)?)|(,(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)))[)\]]))$)")};
   EXPECT_TRUE(regex.has_value());
@@ -3357,7 +3357,7 @@ TEST(Regex_matches, ecma262_datetime_range_pattern) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "2023"));
 }
 
-TEST(Regex_matches, ecma262_empty_class) {
+TEST(ecma262_empty_class) {
   const auto regex{sourcemeta::core::to_regex("[]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[]"));
@@ -3367,7 +3367,7 @@ TEST(Regex_matches, ecma262_empty_class) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, ecma262_empty_class_negated) {
+TEST(ecma262_empty_class_negated) {
   const auto regex{sourcemeta::core::to_regex("[^]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]"));
@@ -3378,7 +3378,7 @@ TEST(Regex_matches, ecma262_empty_class_negated) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, ecma262_empty_class_negated_anchored) {
+TEST(ecma262_empty_class_negated_anchored) {
   const auto regex{sourcemeta::core::to_regex("^[^]$")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[^]$"));
@@ -3388,7 +3388,7 @@ TEST(Regex_matches, ecma262_empty_class_negated_anchored) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, ecma262_empty_class_negated_quantified) {
+TEST(ecma262_empty_class_negated_quantified) {
   const auto regex{sourcemeta::core::to_regex("[^]+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]+"));

--- a/test/regex/regex_matches_if_valid_test.cc
+++ b/test/regex/regex_matches_if_valid_test.cc
@@ -1,13 +1,13 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/regex.h>
 
 #include <string>
 
-TEST(Regex_matches_if_valid, match_pattern_true) {
+TEST(match_pattern_true) {
   EXPECT_TRUE(sourcemeta::core::matches_if_valid("^foo", "foobar"));
 }
 
-TEST(Regex_matches_if_valid, match_pattern_false) {
+TEST(match_pattern_false) {
   EXPECT_FALSE(sourcemeta::core::matches_if_valid("^bar", "foobar"));
 }

--- a/test/regex/regex_matches_rfc9485_test.cc
+++ b/test/regex/regex_matches_rfc9485_test.cc
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/regex.h>
 
 #include <string>
 
-TEST(Regex_matches, rfc9485_edge_dollar_literal) {
+TEST(rfc9485_edge_dollar_literal) {
   // NOTE: This test deviates from RFC 9485, which allows $ as literal in
   // middle. We prefer ECMA-262 compliance where $ is ALWAYS an assertion.
   const auto regex{sourcemeta::core::to_regex("a$b")};
@@ -17,7 +17,7 @@ TEST(Regex_matches, rfc9485_edge_dollar_literal) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_preprocessing_escaped_backslash_dollar) {
+TEST(rfc9485_preprocessing_escaped_backslash_dollar) {
   // NOTE: This test deviates from RFC 9485, which treats $ as literal in
   // middle. We prefer ECMA-262 compliance where $ is ALWAYS an assertion.
   const auto regex{sourcemeta::core::to_regex("\\\\$foo")};
@@ -30,7 +30,7 @@ TEST(Regex_matches, rfc9485_preprocessing_escaped_backslash_dollar) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "$foo"));
 }
 
-TEST(Regex_matches, rfc9485_literal_single_char) {
+TEST(rfc9485_literal_single_char) {
   const auto regex{sourcemeta::core::to_regex("a")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a"));
@@ -39,7 +39,7 @@ TEST(Regex_matches, rfc9485_literal_single_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xyz"));
 }
 
-TEST(Regex_matches, rfc9485_literal_sequence) {
+TEST(rfc9485_literal_sequence) {
   const auto regex{sourcemeta::core::to_regex("hello")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("hello"));
@@ -48,7 +48,7 @@ TEST(Regex_matches, rfc9485_literal_sequence) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "world"));
 }
 
-TEST(Regex_matches, rfc9485_dot_wildcard) {
+TEST(rfc9485_dot_wildcard) {
   const auto regex{sourcemeta::core::to_regex("a.c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a.c"));
@@ -58,7 +58,7 @@ TEST(Regex_matches, rfc9485_dot_wildcard) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ac"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_star) {
+TEST(rfc9485_quantifier_star) {
   const auto regex{sourcemeta::core::to_regex("ab*c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab*c"));
@@ -69,7 +69,7 @@ TEST(Regex_matches, rfc9485_quantifier_star) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "adc"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_plus) {
+TEST(rfc9485_quantifier_plus) {
   const auto regex{sourcemeta::core::to_regex("ab+c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab+c"));
@@ -79,7 +79,7 @@ TEST(Regex_matches, rfc9485_quantifier_plus) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ac"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_question) {
+TEST(rfc9485_quantifier_question) {
   const auto regex{sourcemeta::core::to_regex("ab?c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab?c"));
@@ -88,7 +88,7 @@ TEST(Regex_matches, rfc9485_quantifier_question) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abbc"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_exact) {
+TEST(rfc9485_quantifier_exact) {
   const auto regex{sourcemeta::core::to_regex("a{3}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{3}"));
@@ -97,7 +97,7 @@ TEST(Regex_matches, rfc9485_quantifier_exact) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "aa"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_at_least) {
+TEST(rfc9485_quantifier_at_least) {
   const auto regex{sourcemeta::core::to_regex("a{2,}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,}"));
@@ -107,7 +107,7 @@ TEST(Regex_matches, rfc9485_quantifier_at_least) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_range) {
+TEST(rfc9485_quantifier_range) {
   const auto regex{sourcemeta::core::to_regex("a{2,4}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,4}"));
@@ -118,7 +118,7 @@ TEST(Regex_matches, rfc9485_quantifier_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_alternation_simple) {
+TEST(rfc9485_alternation_simple) {
   const auto regex{sourcemeta::core::to_regex("cat|dog")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("cat|dog"));
@@ -127,7 +127,7 @@ TEST(Regex_matches, rfc9485_alternation_simple) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bird"));
 }
 
-TEST(Regex_matches, rfc9485_alternation_multiple) {
+TEST(rfc9485_alternation_multiple) {
   const auto regex{sourcemeta::core::to_regex("red|green|blue")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("red|green|blue"));
@@ -137,7 +137,7 @@ TEST(Regex_matches, rfc9485_alternation_multiple) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "yellow"));
 }
 
-TEST(Regex_matches, rfc9485_alternation_empty_branch) {
+TEST(rfc9485_alternation_empty_branch) {
   const auto regex{sourcemeta::core::to_regex("a|")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|"));
@@ -146,7 +146,7 @@ TEST(Regex_matches, rfc9485_alternation_empty_branch) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xyz"));
 }
 
-TEST(Regex_matches, rfc9485_charclass_simple) {
+TEST(rfc9485_charclass_simple) {
   const auto regex{sourcemeta::core::to_regex("[abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc]"));
@@ -156,7 +156,7 @@ TEST(Regex_matches, rfc9485_charclass_simple) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "d"));
 }
 
-TEST(Regex_matches, rfc9485_charclass_range) {
+TEST(rfc9485_charclass_range) {
   const auto regex{sourcemeta::core::to_regex("[a-z]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]"));
@@ -167,7 +167,7 @@ TEST(Regex_matches, rfc9485_charclass_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "0"));
 }
 
-TEST(Regex_matches, rfc9485_charclass_multiple_ranges) {
+TEST(rfc9485_charclass_multiple_ranges) {
   const auto regex{sourcemeta::core::to_regex("[a-zA-Z0-9]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-zA-Z0-9]"));
@@ -177,7 +177,7 @@ TEST(Regex_matches, rfc9485_charclass_multiple_ranges) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "-"));
 }
 
-TEST(Regex_matches, rfc9485_charclass_negated) {
+TEST(rfc9485_charclass_negated) {
   const auto regex{sourcemeta::core::to_regex("[^abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^abc]"));
@@ -188,7 +188,7 @@ TEST(Regex_matches, rfc9485_charclass_negated) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, rfc9485_charclass_dash_at_start) {
+TEST(rfc9485_charclass_dash_at_start) {
   const auto regex{sourcemeta::core::to_regex("[-abc]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-abc]"));
@@ -197,7 +197,7 @@ TEST(Regex_matches, rfc9485_charclass_dash_at_start) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "x"));
 }
 
-TEST(Regex_matches, rfc9485_charclass_dash_at_end) {
+TEST(rfc9485_charclass_dash_at_end) {
   const auto regex{sourcemeta::core::to_regex("[abc-]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc-]"));
@@ -206,7 +206,7 @@ TEST(Regex_matches, rfc9485_charclass_dash_at_end) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "x"));
 }
 
-TEST(Regex_matches, rfc9485_escape_left_paren) {
+TEST(rfc9485_escape_left_paren) {
   const auto regex{sourcemeta::core::to_regex("\\(test")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\(test"));
@@ -214,7 +214,7 @@ TEST(Regex_matches, rfc9485_escape_left_paren) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test"));
 }
 
-TEST(Regex_matches, rfc9485_escape_right_paren) {
+TEST(rfc9485_escape_right_paren) {
   const auto regex{sourcemeta::core::to_regex("test\\)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("test\\)"));
@@ -222,7 +222,7 @@ TEST(Regex_matches, rfc9485_escape_right_paren) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test"));
 }
 
-TEST(Regex_matches, rfc9485_escape_left_bracket) {
+TEST(rfc9485_escape_left_bracket) {
   const auto regex{sourcemeta::core::to_regex("\\[test")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\[test"));
@@ -230,7 +230,7 @@ TEST(Regex_matches, rfc9485_escape_left_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test"));
 }
 
-TEST(Regex_matches, rfc9485_escape_right_bracket) {
+TEST(rfc9485_escape_right_bracket) {
   const auto regex{sourcemeta::core::to_regex("test\\]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("test\\]"));
@@ -238,7 +238,7 @@ TEST(Regex_matches, rfc9485_escape_right_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test"));
 }
 
-TEST(Regex_matches, rfc9485_escape_left_brace) {
+TEST(rfc9485_escape_left_brace) {
   const auto regex{sourcemeta::core::to_regex("\\{test")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\{test"));
@@ -246,7 +246,7 @@ TEST(Regex_matches, rfc9485_escape_left_brace) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test"));
 }
 
-TEST(Regex_matches, rfc9485_escape_right_brace) {
+TEST(rfc9485_escape_right_brace) {
   const auto regex{sourcemeta::core::to_regex("test\\}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("test\\}"));
@@ -254,7 +254,7 @@ TEST(Regex_matches, rfc9485_escape_right_brace) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test"));
 }
 
-TEST(Regex_matches, rfc9485_escape_asterisk) {
+TEST(rfc9485_escape_asterisk) {
   const auto regex{sourcemeta::core::to_regex("a\\*b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\*b"));
@@ -263,7 +263,7 @@ TEST(Regex_matches, rfc9485_escape_asterisk) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "aab"));
 }
 
-TEST(Regex_matches, rfc9485_escape_plus) {
+TEST(rfc9485_escape_plus) {
   const auto regex{sourcemeta::core::to_regex("a\\+b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\+b"));
@@ -271,7 +271,7 @@ TEST(Regex_matches, rfc9485_escape_plus) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_escape_question) {
+TEST(rfc9485_escape_question) {
   const auto regex{sourcemeta::core::to_regex("a\\?b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\?b"));
@@ -279,7 +279,7 @@ TEST(Regex_matches, rfc9485_escape_question) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_escape_dot) {
+TEST(rfc9485_escape_dot) {
   const auto regex{sourcemeta::core::to_regex("a\\.b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\.b"));
@@ -287,7 +287,7 @@ TEST(Regex_matches, rfc9485_escape_dot) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "axb"));
 }
 
-TEST(Regex_matches, rfc9485_escape_dash) {
+TEST(rfc9485_escape_dash) {
   const auto regex{sourcemeta::core::to_regex("a\\-b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\-b"));
@@ -295,7 +295,7 @@ TEST(Regex_matches, rfc9485_escape_dash) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_escape_newline) {
+TEST(rfc9485_escape_newline) {
   const auto regex{sourcemeta::core::to_regex("a\\nb")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\nb"));
@@ -303,7 +303,7 @@ TEST(Regex_matches, rfc9485_escape_newline) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "anb"));
 }
 
-TEST(Regex_matches, rfc9485_escape_carriage_return) {
+TEST(rfc9485_escape_carriage_return) {
   const auto regex{sourcemeta::core::to_regex("a\\rb")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\rb"));
@@ -311,7 +311,7 @@ TEST(Regex_matches, rfc9485_escape_carriage_return) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "arb"));
 }
 
-TEST(Regex_matches, rfc9485_escape_tab) {
+TEST(rfc9485_escape_tab) {
   const auto regex{sourcemeta::core::to_regex("a\\tb")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\tb"));
@@ -319,7 +319,7 @@ TEST(Regex_matches, rfc9485_escape_tab) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "atb"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_letter) {
+TEST(rfc9485_unicode_property_letter) {
   const auto regex{sourcemeta::core::to_regex("\\p{L}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{L}"));
@@ -331,7 +331,7 @@ TEST(Regex_matches, rfc9485_unicode_property_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "!"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_uppercase_letter) {
+TEST(rfc9485_unicode_property_uppercase_letter) {
   const auto regex{sourcemeta::core::to_regex("\\p{Lu}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lu}"));
@@ -341,7 +341,7 @@ TEST(Regex_matches, rfc9485_unicode_property_uppercase_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_lowercase_letter) {
+TEST(rfc9485_unicode_property_lowercase_letter) {
   const auto regex{sourcemeta::core::to_regex("\\p{Ll}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Ll}"));
@@ -351,7 +351,7 @@ TEST(Regex_matches, rfc9485_unicode_property_lowercase_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_titlecase_letter) {
+TEST(rfc9485_unicode_property_titlecase_letter) {
   const auto regex{sourcemeta::core::to_regex("\\p{Lt}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lt}"));
@@ -359,7 +359,7 @@ TEST(Regex_matches, rfc9485_unicode_property_titlecase_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_modifier_letter) {
+TEST(rfc9485_unicode_property_modifier_letter) {
   const auto regex{sourcemeta::core::to_regex("\\p{Lm}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lm}"));
@@ -367,7 +367,7 @@ TEST(Regex_matches, rfc9485_unicode_property_modifier_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_other_letter) {
+TEST(rfc9485_unicode_property_other_letter) {
   const auto regex{sourcemeta::core::to_regex("\\p{Lo}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lo}"));
@@ -375,7 +375,7 @@ TEST(Regex_matches, rfc9485_unicode_property_other_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_mark) {
+TEST(rfc9485_unicode_property_mark) {
   const auto regex{sourcemeta::core::to_regex("\\p{M}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{M}"));
@@ -383,7 +383,7 @@ TEST(Regex_matches, rfc9485_unicode_property_mark) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_nonspacing_mark) {
+TEST(rfc9485_unicode_property_nonspacing_mark) {
   const auto regex{sourcemeta::core::to_regex("\\p{Mn}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Mn}"));
@@ -391,7 +391,7 @@ TEST(Regex_matches, rfc9485_unicode_property_nonspacing_mark) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_spacing_mark) {
+TEST(rfc9485_unicode_property_spacing_mark) {
   const auto regex{sourcemeta::core::to_regex("\\p{Mc}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Mc}"));
@@ -399,7 +399,7 @@ TEST(Regex_matches, rfc9485_unicode_property_spacing_mark) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_enclosing_mark) {
+TEST(rfc9485_unicode_property_enclosing_mark) {
   const auto regex{sourcemeta::core::to_regex("\\p{Me}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Me}"));
@@ -407,7 +407,7 @@ TEST(Regex_matches, rfc9485_unicode_property_enclosing_mark) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_number) {
+TEST(rfc9485_unicode_property_number) {
   const auto regex{sourcemeta::core::to_regex("\\p{N}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{N}"));
@@ -417,7 +417,7 @@ TEST(Regex_matches, rfc9485_unicode_property_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_decimal_number) {
+TEST(rfc9485_unicode_property_decimal_number) {
   const auto regex{sourcemeta::core::to_regex("\\p{Nd}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Nd}"));
@@ -427,7 +427,7 @@ TEST(Regex_matches, rfc9485_unicode_property_decimal_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_letter_number) {
+TEST(rfc9485_unicode_property_letter_number) {
   const auto regex{sourcemeta::core::to_regex("\\p{Nl}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Nl}"));
@@ -435,7 +435,7 @@ TEST(Regex_matches, rfc9485_unicode_property_letter_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_other_number) {
+TEST(rfc9485_unicode_property_other_number) {
   const auto regex{sourcemeta::core::to_regex("\\p{No}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{No}"));
@@ -443,7 +443,7 @@ TEST(Regex_matches, rfc9485_unicode_property_other_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_punctuation) {
+TEST(rfc9485_unicode_property_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{P}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{P}"));
@@ -453,7 +453,7 @@ TEST(Regex_matches, rfc9485_unicode_property_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_connector_punctuation) {
+TEST(rfc9485_unicode_property_connector_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Pc}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pc}"));
@@ -461,7 +461,7 @@ TEST(Regex_matches, rfc9485_unicode_property_connector_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "."));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_dash_punctuation) {
+TEST(rfc9485_unicode_property_dash_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Pd}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pd}"));
@@ -469,7 +469,7 @@ TEST(Regex_matches, rfc9485_unicode_property_dash_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "."));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_open_punctuation) {
+TEST(rfc9485_unicode_property_open_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Ps}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Ps}"));
@@ -478,7 +478,7 @@ TEST(Regex_matches, rfc9485_unicode_property_open_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ")"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_close_punctuation) {
+TEST(rfc9485_unicode_property_close_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Pe}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pe}"));
@@ -487,7 +487,7 @@ TEST(Regex_matches, rfc9485_unicode_property_close_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "("));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_initial_punctuation) {
+TEST(rfc9485_unicode_property_initial_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Pi}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pi}"));
@@ -495,7 +495,7 @@ TEST(Regex_matches, rfc9485_unicode_property_initial_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "."));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_final_punctuation) {
+TEST(rfc9485_unicode_property_final_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Pf}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pf}"));
@@ -503,7 +503,7 @@ TEST(Regex_matches, rfc9485_unicode_property_final_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "."));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_other_punctuation) {
+TEST(rfc9485_unicode_property_other_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Po}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Po}"));
@@ -512,7 +512,7 @@ TEST(Regex_matches, rfc9485_unicode_property_other_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "("));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_separator) {
+TEST(rfc9485_unicode_property_separator) {
   const auto regex{sourcemeta::core::to_regex("\\p{Z}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Z}"));
@@ -521,7 +521,7 @@ TEST(Regex_matches, rfc9485_unicode_property_separator) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_space_separator) {
+TEST(rfc9485_unicode_property_space_separator) {
   const auto regex{sourcemeta::core::to_regex("\\p{Zs}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Zs}"));
@@ -530,7 +530,7 @@ TEST(Regex_matches, rfc9485_unicode_property_space_separator) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_line_separator) {
+TEST(rfc9485_unicode_property_line_separator) {
   const auto regex{sourcemeta::core::to_regex("\\p{Zl}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Zl}"));
@@ -538,7 +538,7 @@ TEST(Regex_matches, rfc9485_unicode_property_line_separator) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), " "));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_paragraph_separator) {
+TEST(rfc9485_unicode_property_paragraph_separator) {
   const auto regex{sourcemeta::core::to_regex("\\p{Zp}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Zp}"));
@@ -546,7 +546,7 @@ TEST(Regex_matches, rfc9485_unicode_property_paragraph_separator) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), " "));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_symbol) {
+TEST(rfc9485_unicode_property_symbol) {
   const auto regex{sourcemeta::core::to_regex("\\p{S}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{S}"));
@@ -556,7 +556,7 @@ TEST(Regex_matches, rfc9485_unicode_property_symbol) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_math_symbol) {
+TEST(rfc9485_unicode_property_math_symbol) {
   const auto regex{sourcemeta::core::to_regex("\\p{Sm}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Sm}"));
@@ -565,7 +565,7 @@ TEST(Regex_matches, rfc9485_unicode_property_math_symbol) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "$"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_currency_symbol) {
+TEST(rfc9485_unicode_property_currency_symbol) {
   const auto regex{sourcemeta::core::to_regex("\\p{Sc}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Sc}"));
@@ -574,7 +574,7 @@ TEST(Regex_matches, rfc9485_unicode_property_currency_symbol) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "+"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_modifier_symbol) {
+TEST(rfc9485_unicode_property_modifier_symbol) {
   const auto regex{sourcemeta::core::to_regex("\\p{Sk}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Sk}"));
@@ -582,7 +582,7 @@ TEST(Regex_matches, rfc9485_unicode_property_modifier_symbol) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "$"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_other_symbol) {
+TEST(rfc9485_unicode_property_other_symbol) {
   const auto regex{sourcemeta::core::to_regex("\\p{So}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{So}"));
@@ -590,7 +590,7 @@ TEST(Regex_matches, rfc9485_unicode_property_other_symbol) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "$"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_other) {
+TEST(rfc9485_unicode_property_other) {
   const auto regex{sourcemeta::core::to_regex("\\p{C}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{C}"));
@@ -598,7 +598,7 @@ TEST(Regex_matches, rfc9485_unicode_property_other) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_control) {
+TEST(rfc9485_unicode_property_control) {
   const auto regex{sourcemeta::core::to_regex("\\p{Cc}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Cc}"));
@@ -607,7 +607,7 @@ TEST(Regex_matches, rfc9485_unicode_property_control) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_format) {
+TEST(rfc9485_unicode_property_format) {
   const auto regex{sourcemeta::core::to_regex("\\p{Cf}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Cf}"));
@@ -615,13 +615,13 @@ TEST(Regex_matches, rfc9485_unicode_property_format) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_unassigned) {
+TEST(rfc9485_unicode_property_unassigned) {
   const auto regex{sourcemeta::core::to_regex("\\p{Cn}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Cn}"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_private_use) {
+TEST(rfc9485_unicode_property_private_use) {
   const auto regex{sourcemeta::core::to_regex("\\p{Co}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Co}"));
@@ -629,7 +629,7 @@ TEST(Regex_matches, rfc9485_unicode_property_private_use) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_complement_letter) {
+TEST(rfc9485_unicode_property_complement_letter) {
   const auto regex{sourcemeta::core::to_regex("\\P{L}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{L}"));
@@ -638,7 +638,7 @@ TEST(Regex_matches, rfc9485_unicode_property_complement_letter) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_complement_number) {
+TEST(rfc9485_unicode_property_complement_number) {
   const auto regex{sourcemeta::core::to_regex("\\P{N}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{N}"));
@@ -647,7 +647,7 @@ TEST(Regex_matches, rfc9485_unicode_property_complement_number) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_property_complement_punctuation) {
+TEST(rfc9485_unicode_property_complement_punctuation) {
   const auto regex{sourcemeta::core::to_regex("\\P{P}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{P}"));
@@ -656,7 +656,7 @@ TEST(Regex_matches, rfc9485_unicode_property_complement_punctuation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "!"));
 }
 
-TEST(Regex_matches, rfc9485_group_simple) {
+TEST(rfc9485_group_simple) {
   const auto regex{sourcemeta::core::to_regex("(ab)c")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(ab)c"));
@@ -664,7 +664,7 @@ TEST(Regex_matches, rfc9485_group_simple) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ac"));
 }
 
-TEST(Regex_matches, rfc9485_group_nested) {
+TEST(rfc9485_group_nested) {
   const auto regex{sourcemeta::core::to_regex("((ab)c)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((ab)c)"));
@@ -672,7 +672,7 @@ TEST(Regex_matches, rfc9485_group_nested) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ac"));
 }
 
-TEST(Regex_matches, rfc9485_group_with_quantifier) {
+TEST(rfc9485_group_with_quantifier) {
   const auto regex{sourcemeta::core::to_regex("(ab)+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(ab)+"));
@@ -682,7 +682,7 @@ TEST(Regex_matches, rfc9485_group_with_quantifier) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_group_with_alternation) {
+TEST(rfc9485_group_with_alternation) {
   const auto regex{sourcemeta::core::to_regex("(cat|dog)s")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(cat|dog)s"));
@@ -691,7 +691,7 @@ TEST(Regex_matches, rfc9485_group_with_alternation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "birds"));
 }
 
-TEST(Regex_matches, rfc9485_complex_email_like) {
+TEST(rfc9485_complex_email_like) {
   const auto regex{sourcemeta::core::to_regex("[a-z]+@[a-z]+\\.[a-z]+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]+@[a-z]+\\.[a-z]+"));
@@ -700,7 +700,7 @@ TEST(Regex_matches, rfc9485_complex_email_like) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "invalid"));
 }
 
-TEST(Regex_matches, rfc9485_complex_identifier) {
+TEST(rfc9485_complex_identifier) {
   const auto regex{sourcemeta::core::to_regex("[a-zA-Z_][a-zA-Z0-9_]*")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-zA-Z_][a-zA-Z0-9_]*"));
@@ -710,7 +710,7 @@ TEST(Regex_matches, rfc9485_complex_identifier) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123invalid"));
 }
 
-TEST(Regex_matches, rfc9485_complex_unicode_word) {
+TEST(rfc9485_complex_unicode_word) {
   const auto regex{sourcemeta::core::to_regex("\\p{L}+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{L}+"));
@@ -720,7 +720,7 @@ TEST(Regex_matches, rfc9485_complex_unicode_word) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "123"));
 }
 
-TEST(Regex_matches, rfc9485_complex_mixed_quantifiers) {
+TEST(rfc9485_complex_mixed_quantifiers) {
   const auto regex{sourcemeta::core::to_regex("a{2,3}b+c*")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,3}b+c*"));
@@ -731,7 +731,7 @@ TEST(Regex_matches, rfc9485_complex_mixed_quantifiers) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_complex_nested_groups_quantifiers) {
+TEST(rfc9485_complex_nested_groups_quantifiers) {
   const auto regex{sourcemeta::core::to_regex("((ab)+c)*")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((ab)+c)*"));
@@ -742,7 +742,7 @@ TEST(Regex_matches, rfc9485_complex_nested_groups_quantifiers) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_empty_pattern) {
+TEST(rfc9485_edge_empty_pattern) {
   const auto regex{sourcemeta::core::to_regex("")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(""));
@@ -750,7 +750,7 @@ TEST(Regex_matches, rfc9485_edge_empty_pattern) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "anything"));
 }
 
-TEST(Regex_matches, rfc9485_edge_alternation_empty_first) {
+TEST(rfc9485_edge_alternation_empty_first) {
   const auto regex{sourcemeta::core::to_regex("|abc")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("|abc"));
@@ -759,7 +759,7 @@ TEST(Regex_matches, rfc9485_edge_alternation_empty_first) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xyz"));
 }
 
-TEST(Regex_matches, rfc9485_edge_alternation_empty_middle) {
+TEST(rfc9485_edge_alternation_empty_middle) {
   const auto regex{sourcemeta::core::to_regex("a||b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a||b"));
@@ -769,7 +769,7 @@ TEST(Regex_matches, rfc9485_edge_alternation_empty_middle) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xyz"));
 }
 
-TEST(Regex_matches, rfc9485_edge_alternation_all_empty) {
+TEST(rfc9485_edge_alternation_all_empty) {
   const auto regex{sourcemeta::core::to_regex("||")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("||"));
@@ -777,7 +777,7 @@ TEST(Regex_matches, rfc9485_edge_alternation_all_empty) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "anything"));
 }
 
-TEST(Regex_matches, rfc9485_edge_escape_backslash) {
+TEST(rfc9485_edge_escape_backslash) {
   const auto regex{sourcemeta::core::to_regex("a\\\\b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\\\b"));
@@ -785,7 +785,7 @@ TEST(Regex_matches, rfc9485_edge_escape_backslash) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_escape_pipe) {
+TEST(rfc9485_edge_escape_pipe) {
   const auto regex{sourcemeta::core::to_regex("a\\|b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\|b"));
@@ -793,14 +793,14 @@ TEST(Regex_matches, rfc9485_edge_escape_pipe) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_caret_literal) {
+TEST(rfc9485_edge_caret_literal) {
   const auto regex{sourcemeta::core::to_regex("a\\^b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\^b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a^b"));
 }
 
-TEST(Regex_matches, rfc9485_edge_quantifier_zero_exact) {
+TEST(rfc9485_edge_quantifier_zero_exact) {
   const auto regex{sourcemeta::core::to_regex("a{0}b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0}b"));
@@ -808,7 +808,7 @@ TEST(Regex_matches, rfc9485_edge_quantifier_zero_exact) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_quantifier_zero_or_more) {
+TEST(rfc9485_edge_quantifier_zero_or_more) {
   const auto regex{sourcemeta::core::to_regex("a{0,}b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0,}b"));
@@ -817,7 +817,7 @@ TEST(Regex_matches, rfc9485_edge_quantifier_zero_or_more) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_quantifier_zero_to_n) {
+TEST(rfc9485_edge_quantifier_zero_to_n) {
   const auto regex{sourcemeta::core::to_regex("a{0,3}b")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0,3}b"));
@@ -828,7 +828,7 @@ TEST(Regex_matches, rfc9485_edge_quantifier_zero_to_n) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaaab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_nested_groups_deep) {
+TEST(rfc9485_edge_nested_groups_deep) {
   const auto regex{sourcemeta::core::to_regex("(((a)))")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(((a)))"));
@@ -836,7 +836,7 @@ TEST(Regex_matches, rfc9485_edge_nested_groups_deep) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_only_dash) {
+TEST(rfc9485_edge_charclass_only_dash) {
   const auto regex{sourcemeta::core::to_regex("[-]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-]"));
@@ -844,7 +844,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_only_dash) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_dash_both_ends) {
+TEST(rfc9485_edge_charclass_dash_both_ends) {
   const auto regex{sourcemeta::core::to_regex("[-a-]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-a-]"));
@@ -853,7 +853,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_dash_both_ends) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_mixed_content) {
+TEST(rfc9485_edge_charclass_mixed_content) {
   const auto regex{sourcemeta::core::to_regex("[a-z\\p{N}._-]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z\\p{N}._-]"));
@@ -866,7 +866,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_mixed_content) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_escaped_bracket) {
+TEST(rfc9485_edge_charclass_escaped_bracket) {
   const auto regex{sourcemeta::core::to_regex("[\\[\\]]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\[\\]]"));
@@ -875,7 +875,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_escaped_bracket) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_multiple_ranges) {
+TEST(rfc9485_edge_charclass_multiple_ranges) {
   const auto regex{sourcemeta::core::to_regex("[a-cA-C0-2]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-cA-C0-2]"));
@@ -893,7 +893,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_multiple_ranges) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "3"));
 }
 
-TEST(Regex_matches, rfc9485_edge_group_with_alternation_quantified) {
+TEST(rfc9485_edge_group_with_alternation_quantified) {
   const auto regex{sourcemeta::core::to_regex("(a|b){2}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(a|b){2}"));
@@ -904,7 +904,7 @@ TEST(Regex_matches, rfc9485_edge_group_with_alternation_quantified) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_edge_multiple_dots) {
+TEST(rfc9485_edge_multiple_dots) {
   const auto regex{sourcemeta::core::to_regex("...")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("..."));
@@ -914,7 +914,7 @@ TEST(Regex_matches, rfc9485_edge_multiple_dots) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
 }
 
-TEST(Regex_matches, rfc9485_edge_quantifier_large_range) {
+TEST(rfc9485_edge_quantifier_large_range) {
   const auto regex{sourcemeta::core::to_regex("a{100,200}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{100,200}"));
@@ -924,7 +924,7 @@ TEST(Regex_matches, rfc9485_edge_quantifier_large_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), std::string(99, 'a')));
 }
 
-TEST(Regex_matches, rfc9485_edge_alternation_with_groups) {
+TEST(rfc9485_edge_alternation_with_groups) {
   const auto regex{sourcemeta::core::to_regex("(abc)|(def)|(ghi)")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(abc)|(def)|(ghi)"));
@@ -934,7 +934,7 @@ TEST(Regex_matches, rfc9485_edge_alternation_with_groups) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "jkl"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_with_unicode_properties) {
+TEST(rfc9485_edge_charclass_with_unicode_properties) {
   const auto regex{sourcemeta::core::to_regex("[\\p{Lu}\\p{Nd}]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\p{Lu}\\p{Nd}]"));
@@ -944,7 +944,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_with_unicode_properties) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
 }
 
-TEST(Regex_matches, rfc9485_all_major_categories_combined) {
+TEST(rfc9485_all_major_categories_combined) {
   const auto regex{sourcemeta::core::to_regex(
       "[\\p{L}\\p{M}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{C}]")};
   EXPECT_TRUE(regex.has_value());
@@ -957,7 +957,7 @@ TEST(Regex_matches, rfc9485_all_major_categories_combined) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
 }
 
-TEST(Regex_matches, rfc9485_complement_all_major_categories) {
+TEST(rfc9485_complement_all_major_categories) {
   const auto regex{sourcemeta::core::to_regex("\\P{L}\\P{N}\\P{P}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{L}\\P{N}\\P{P}"));
@@ -965,7 +965,7 @@ TEST(Regex_matches, rfc9485_complement_all_major_categories) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a  "));
 }
 
-TEST(Regex_matches, rfc9485_edge_nested_quantifiers_group) {
+TEST(rfc9485_edge_nested_quantifiers_group) {
   const auto regex{sourcemeta::core::to_regex("((a+)+)+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((a+)+)+"));
@@ -975,7 +975,7 @@ TEST(Regex_matches, rfc9485_edge_nested_quantifiers_group) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_negated_with_range) {
+TEST(rfc9485_edge_charclass_negated_with_range) {
   const auto regex{sourcemeta::core::to_regex("[^a-z]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^a-z]"));
@@ -986,7 +986,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_negated_with_range) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "z"));
 }
 
-TEST(Regex_matches, rfc9485_edge_consecutive_alternations) {
+TEST(rfc9485_edge_consecutive_alternations) {
   const auto regex{sourcemeta::core::to_regex("a|b|c|d|e")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|b|c|d|e"));
@@ -998,7 +998,7 @@ TEST(Regex_matches, rfc9485_edge_consecutive_alternations) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "f"));
 }
 
-TEST(Regex_matches, rfc9485_edge_group_quantifier_zero_or_one) {
+TEST(rfc9485_edge_group_quantifier_zero_or_one) {
   const auto regex{sourcemeta::core::to_regex("(abc)?")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(abc)?"));
@@ -1007,7 +1007,7 @@ TEST(Regex_matches, rfc9485_edge_group_quantifier_zero_or_one) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xyz"));
 }
 
-TEST(Regex_matches, rfc9485_edge_mixed_quantifiers_sequence) {
+TEST(rfc9485_edge_mixed_quantifiers_sequence) {
   const auto regex{sourcemeta::core::to_regex("a?b+c*d{2}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a?b+c*d{2}"));
@@ -1018,7 +1018,7 @@ TEST(Regex_matches, rfc9485_edge_mixed_quantifiers_sequence) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ad"));
 }
 
-TEST(Regex_matches, rfc9485_edge_unicode_in_alternation) {
+TEST(rfc9485_edge_unicode_in_alternation) {
   const auto regex{sourcemeta::core::to_regex("\\p{Lu}|\\p{Ll}|\\p{Nd}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lu}|\\p{Ll}|\\p{Nd}"));
@@ -1028,7 +1028,7 @@ TEST(Regex_matches, rfc9485_edge_unicode_in_alternation) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "!"));
 }
 
-TEST(Regex_matches, rfc9485_edge_charclass_single_char) {
+TEST(rfc9485_edge_charclass_single_char) {
   const auto regex{sourcemeta::core::to_regex("[a]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a]"));
@@ -1036,7 +1036,7 @@ TEST(Regex_matches, rfc9485_edge_charclass_single_char) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "b"));
 }
 
-TEST(Regex_matches, rfc9485_edge_complex_real_world_email_subset) {
+TEST(rfc9485_edge_complex_real_world_email_subset) {
   const auto regex{sourcemeta::core::to_regex(
       "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-z]{2,}")};
   EXPECT_TRUE(regex.has_value());
@@ -1049,7 +1049,7 @@ TEST(Regex_matches, rfc9485_edge_complex_real_world_email_subset) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "test@"));
 }
 
-TEST(Regex_matches, rfc9485_edge_complex_real_world_hex_color) {
+TEST(rfc9485_edge_complex_real_world_hex_color) {
   const auto regex{sourcemeta::core::to_regex("#[0-9a-fA-F]{6}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("#[0-9a-fA-F]{6}"));
@@ -1059,7 +1059,7 @@ TEST(Regex_matches, rfc9485_edge_complex_real_world_hex_color) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "#GGG"));
 }
 
-TEST(Regex_matches, rfc9485_edge_complex_real_world_uuid_partial) {
+TEST(rfc9485_edge_complex_real_world_uuid_partial) {
   const auto regex{sourcemeta::core::to_regex(
       "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")};
   EXPECT_TRUE(regex.has_value());
@@ -1070,7 +1070,7 @@ TEST(Regex_matches, rfc9485_edge_complex_real_world_uuid_partial) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "invalid-uuid"));
 }
 
-TEST(Regex_matches, rfc9485_preprocessing_literal_backslash_p) {
+TEST(rfc9485_preprocessing_literal_backslash_p) {
   const auto regex{sourcemeta::core::to_regex("\\\\p\\{L\\}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\p\\{L\\}"));
@@ -1078,7 +1078,7 @@ TEST(Regex_matches, rfc9485_preprocessing_literal_backslash_p) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A"));
 }
 
-TEST(Regex_matches, rfc9485_preprocessing_literal_backslash_P) {
+TEST(rfc9485_preprocessing_literal_backslash_P) {
   const auto regex{sourcemeta::core::to_regex("\\\\P\\{N\\}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\P\\{N\\}"));
@@ -1086,7 +1086,7 @@ TEST(Regex_matches, rfc9485_preprocessing_literal_backslash_P) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "5"));
 }
 
-TEST(Regex_matches, rfc9485_preprocessing_mixed_escaped_and_unicode) {
+TEST(rfc9485_preprocessing_mixed_escaped_and_unicode) {
   const auto regex{sourcemeta::core::to_regex("\\\\p\\{L\\} \\p{L}")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\p\\{L\\} \\p{L}"));
@@ -1094,7 +1094,7 @@ TEST(Regex_matches, rfc9485_preprocessing_mixed_escaped_and_unicode) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "A A"));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_star_any_string) {
+TEST(rfc9485_quantifier_star_any_string) {
   const auto regex{sourcemeta::core::to_regex(".*")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*"));
@@ -1102,7 +1102,7 @@ TEST(Regex_matches, rfc9485_quantifier_star_any_string) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, rfc9485_quantifier_plus_non_empty) {
+TEST(rfc9485_quantifier_plus_non_empty) {
   const auto regex{sourcemeta::core::to_regex(".+")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".+"));
@@ -1110,21 +1110,21 @@ TEST(Regex_matches, rfc9485_quantifier_plus_non_empty) {
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
 }
 
-TEST(Regex_matches, rfc9485_dot_matches_newline) {
+TEST(rfc9485_dot_matches_newline) {
   const auto regex{sourcemeta::core::to_regex(".")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
-TEST(Regex_matches, rfc9485_dot_matches_carriage_return) {
+TEST(rfc9485_dot_matches_carriage_return) {
   const auto regex{sourcemeta::core::to_regex(".")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\r"));
 }
 
-TEST(Regex_matches, rfc9485_unicode_range_4byte_deseret) {
+TEST(rfc9485_unicode_range_4byte_deseret) {
   const auto regex{sourcemeta::core::to_regex("[\\u{10400}-\\u{1044F}]")};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\u{10400}-\\u{1044F}]"));

--- a/test/regex/regex_test.cc
+++ b/test/regex/regex_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/regex.h>
 
@@ -6,7 +6,7 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move
 
-TEST(Regex, copy_construct) {
+TEST(copy_construct) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   const sourcemeta::core::Regex copy{regex.value()};
@@ -14,7 +14,7 @@ TEST(Regex, copy_construct) {
   EXPECT_FALSE(sourcemeta::core::matches(copy, "bar foo"));
 }
 
-TEST(Regex, copy_assign) {
+TEST(copy_assign) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   sourcemeta::core::Regex copy{sourcemeta::core::RegexTypeNoop{}};
@@ -23,7 +23,7 @@ TEST(Regex, copy_assign) {
   EXPECT_FALSE(sourcemeta::core::matches(copy, "bar foo"));
 }
 
-TEST(Regex, move_construct) {
+TEST(move_construct) {
   auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   const sourcemeta::core::Regex moved{std::move(regex).value()};
@@ -31,7 +31,7 @@ TEST(Regex, move_construct) {
   EXPECT_FALSE(sourcemeta::core::matches(moved, "bar foo"));
 }
 
-TEST(Regex, move_assign) {
+TEST(move_assign) {
   auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   sourcemeta::core::Regex moved{sourcemeta::core::RegexTypeNoop{}};
@@ -40,14 +40,14 @@ TEST(Regex, move_assign) {
   EXPECT_FALSE(sourcemeta::core::matches(moved, "bar foo"));
 }
 
-TEST(Regex, to_regex_with_string_view) {
+TEST(to_regex_with_string_view) {
   const std::string_view pattern{"^foo"};
   const auto regex{sourcemeta::core::to_regex(pattern)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo bar"));
 }
 
-TEST(Regex, to_regex_with_string_view_subview) {
+TEST(to_regex_with_string_view_subview) {
   const std::string buffer{"prefix^foosuffix"};
   const std::string_view pattern{buffer.data() + 6, 4};
   const auto regex{sourcemeta::core::to_regex(pattern)};
@@ -55,14 +55,14 @@ TEST(Regex, to_regex_with_string_view_subview) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo bar"));
 }
 
-TEST(Regex, matches_with_string_view) {
+TEST(matches_with_string_view) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   const std::string_view value{"foo bar"};
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), value));
 }
 
-TEST(Regex, matches_with_string_view_subview) {
+TEST(matches_with_string_view_subview) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
   const std::string buffer{"xxxfoo barxxx"};
@@ -70,20 +70,20 @@ TEST(Regex, matches_with_string_view_subview) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), value));
 }
 
-TEST(Regex, matches_if_valid_with_string_view) {
+TEST(matches_if_valid_with_string_view) {
   const std::string_view pattern{"^foo"};
   const std::string_view value{"foo bar"};
   EXPECT_TRUE(sourcemeta::core::matches_if_valid(pattern, value));
 }
 
-TEST(Regex, to_regex_default_string_view_does_not_invoke_ub) {
+TEST(to_regex_default_string_view_does_not_invoke_ub) {
   const std::string_view pattern{};
   EXPECT_EQ(pattern.data(), nullptr);
   const auto regex{sourcemeta::core::to_regex(pattern)};
   EXPECT_TRUE(regex.has_value());
 }
 
-TEST(Regex, catastrophic_backtracking_terminates) {
+TEST(catastrophic_backtracking_terminates) {
   const auto regex{sourcemeta::core::to_regex("(a+)+$")};
   EXPECT_TRUE(regex.has_value());
   const std::string value{std::string(64, 'a') + "!"};

--- a/test/regex/regex_to_regex_test.cc
+++ b/test/regex/regex_to_regex_test.cc
@@ -1,65 +1,65 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/regex.h>
 
-TEST(Regex_to_regex, valid_1) {
+TEST(valid_1) {
   const auto regex{sourcemeta::core::to_regex("^foo")};
   EXPECT_TRUE(regex.has_value());
 }
 
-TEST(Regex_to_regex, invalid_1) {
+TEST(invalid_1) {
   const auto regex{sourcemeta::core::to_regex("(abc")};
   EXPECT_FALSE(regex.has_value());
 }
 
-TEST(Regex_to_regex, posix_character_class) {
+TEST(posix_character_class) {
   const auto regex{sourcemeta::core::to_regex("^[[:digit:]]+$")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "123"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "abc"));
 }
 
-TEST(Regex_to_regex, posix_alpha_character_class) {
+TEST(posix_alpha_character_class) {
   const auto regex{sourcemeta::core::to_regex("^[[:alpha:]]+$")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "abc"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "123"));
 }
 
-TEST(Regex_to_regex, posix_class_in_osv_style_pattern) {
+TEST(posix_class_in_osv_style_pattern) {
   const auto regex{
       sourcemeta::core::to_regex("^(AlmaLinux|Alpine)(:[[:digit:]]+)?")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "AlmaLinux:9"));
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "Alpine:3"));
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "AlmaLinux"));
 }
 
-TEST(Regex_to_regex, pcre_named_capture_group) {
+TEST(pcre_named_capture_group) {
   const auto regex{sourcemeta::core::to_regex("^(?P<year>[0-9]+)$")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "2026"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "abc"));
 }
 
-TEST(Regex_to_regex, pcre_possessive_quantifier) {
+TEST(pcre_possessive_quantifier) {
   const auto regex{sourcemeta::core::to_regex("^a*+b$")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "aaab"));
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "b"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "aaa"));
 }
 
-TEST(Regex_to_regex, pcre_backtracking_control_verb) {
+TEST(pcre_backtracking_control_verb) {
   const auto regex{sourcemeta::core::to_regex("^(*COMMIT)abc$")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "abc"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "xyz"));
 }
 
-TEST(Regex_to_regex, pcre_unknown_escape) {
+TEST(pcre_unknown_escape) {
   const auto regex{sourcemeta::core::to_regex("\\Aabc$")};
-  ASSERT_TRUE(regex.has_value());
+  EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "abc"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "xabc"));
 }

--- a/test/text/CMakeLists.txt
+++ b/test/text/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME text
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME text
   SOURCES text_to_title_case_test.cc text_to_lowercase_test.cc
           text_is_lowercase_test.cc
           text_is_alpha_test.cc text_is_digit_test.cc text_is_alphanum_test.cc

--- a/test/text/text_bytes_to_hex_test.cc
+++ b/test/text/text_bytes_to_hex_test.cc
@@ -1,41 +1,39 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string
 
-TEST(Text_bytes_to_hex, empty_input) {
-  EXPECT_EQ(sourcemeta::core::bytes_to_hex(""), "");
-}
+TEST(empty_input) { EXPECT_EQ(sourcemeta::core::bytes_to_hex(""), ""); }
 
-TEST(Text_bytes_to_hex, single_high_byte) {
+TEST(single_high_byte) {
   EXPECT_EQ(sourcemeta::core::bytes_to_hex("\xFF"), "ff");
 }
 
-TEST(Text_bytes_to_hex, ascii_word) {
+TEST(ascii_word) {
   EXPECT_EQ(sourcemeta::core::bytes_to_hex("foobar"), "666f6f626172");
 }
 
-TEST(Text_bytes_to_hex, nul_byte) {
+TEST(nul_byte) {
   const std::string input("\x00", 1);
   EXPECT_EQ(sourcemeta::core::bytes_to_hex(input), "00");
 }
 
-TEST(Text_bytes_to_hex, leading_zero_byte) {
+TEST(leading_zero_byte) {
   const std::string input("\x00\x01", 2);
   EXPECT_EQ(sourcemeta::core::bytes_to_hex(input), "0001");
 }
 
-TEST(Text_bytes_to_hex, all_byte_values_sample) {
+TEST(all_byte_values_sample) {
   EXPECT_EQ(sourcemeta::core::bytes_to_hex("\x01\x23\x45\x67\x89\xAB\xCD\xEF"),
             "0123456789abcdef");
 }
 
-TEST(Text_bytes_to_hex, lowercase_output) {
+TEST(lowercase_output) {
   EXPECT_EQ(sourcemeta::core::bytes_to_hex("\xDE\xAD\xBE\xEF"), "deadbeef");
 }
 
-TEST(Text_bytes_to_hex, roundtrip_with_hex_to_bytes) {
+TEST(roundtrip_with_hex_to_bytes) {
   const std::string input("\x00\x10\x20\xFF\x7F", 5);
   const auto encoded{sourcemeta::core::bytes_to_hex(input)};
   const auto decoded{sourcemeta::core::hex_to_bytes(encoded)};

--- a/test/text/text_equals_ignore_case_test.cc
+++ b/test/text/text_equals_ignore_case_test.cc
@@ -1,45 +1,41 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string_view> // std::string_view
 
-TEST(Text_equals_ignore_case, identical) {
+TEST(identical) {
   EXPECT_TRUE(sourcemeta::core::equals_ignore_case("hello", "hello"));
 }
 
-TEST(Text_equals_ignore_case, differing_case) {
+TEST(differing_case) {
   EXPECT_TRUE(sourcemeta::core::equals_ignore_case("Hello", "hELLO"));
 }
 
-TEST(Text_equals_ignore_case, all_uppercase_against_all_lowercase) {
+TEST(all_uppercase_against_all_lowercase) {
   EXPECT_TRUE(sourcemeta::core::equals_ignore_case("AT+JWT", "at+jwt"));
 }
 
-TEST(Text_equals_ignore_case, different_content) {
+TEST(different_content) {
   EXPECT_FALSE(sourcemeta::core::equals_ignore_case("foo", "bar"));
 }
 
-TEST(Text_equals_ignore_case, different_length) {
+TEST(different_length) {
   EXPECT_FALSE(sourcemeta::core::equals_ignore_case("hello", "hell"));
 }
 
-TEST(Text_equals_ignore_case, prefix_is_not_equal) {
+TEST(prefix_is_not_equal) {
   EXPECT_FALSE(sourcemeta::core::equals_ignore_case("hell", "hello"));
 }
 
-TEST(Text_equals_ignore_case, both_empty) {
-  EXPECT_TRUE(sourcemeta::core::equals_ignore_case("", ""));
-}
+TEST(both_empty) { EXPECT_TRUE(sourcemeta::core::equals_ignore_case("", "")); }
 
-TEST(Text_equals_ignore_case, one_empty) {
-  EXPECT_FALSE(sourcemeta::core::equals_ignore_case("", "x"));
-}
+TEST(one_empty) { EXPECT_FALSE(sourcemeta::core::equals_ignore_case("", "x")); }
 
-TEST(Text_equals_ignore_case, non_alphabetic_characters_match) {
+TEST(non_alphabetic_characters_match) {
   EXPECT_TRUE(sourcemeta::core::equals_ignore_case("a-1_2.3", "A-1_2.3"));
 }
 
-TEST(Text_equals_ignore_case, digits_are_not_case_folded) {
+TEST(digits_are_not_case_folded) {
   EXPECT_FALSE(sourcemeta::core::equals_ignore_case("123", "124"));
 }

--- a/test/text/text_hex_to_bytes_test.cc
+++ b/test/text/text_hex_to_bytes_test.cc
@@ -1,97 +1,97 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string
 
-TEST(Text_hex_to_bytes, empty_input) {
+TEST(empty_input) {
   const auto result{sourcemeta::core::hex_to_bytes("")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(Text_hex_to_bytes, single_byte_lowercase) {
+TEST(single_byte_lowercase) {
   const auto result{sourcemeta::core::hex_to_bytes("ff")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xFF");
 }
 
-TEST(Text_hex_to_bytes, single_byte_uppercase) {
+TEST(single_byte_uppercase) {
   const auto result{sourcemeta::core::hex_to_bytes("FF")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xFF");
 }
 
-TEST(Text_hex_to_bytes, mixed_case) {
+TEST(mixed_case) {
   const auto result{sourcemeta::core::hex_to_bytes("DeadBeef")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xDE\xAD\xBE\xEF");
 }
 
-TEST(Text_hex_to_bytes, ascii_word) {
+TEST(ascii_word) {
   const auto result{sourcemeta::core::hex_to_bytes("666f6f626172")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foobar");
 }
 
-TEST(Text_hex_to_bytes, nul_byte) {
+TEST(nul_byte) {
   const auto result{sourcemeta::core::hex_to_bytes("00")};
   EXPECT_TRUE(result.has_value());
   const std::string expected("\x00", 1);
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Text_hex_to_bytes, leading_zeros) {
+TEST(leading_zeros) {
   const auto result{sourcemeta::core::hex_to_bytes("0001")};
   EXPECT_TRUE(result.has_value());
   const std::string expected("\x00\x01", 2);
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Text_hex_to_bytes, all_digit_pairs) {
+TEST(all_digit_pairs) {
   const auto result{sourcemeta::core::hex_to_bytes("0123456789abcdef")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\x01\x23\x45\x67\x89\xAB\xCD\xEF");
 }
 
-TEST(Text_hex_to_bytes, rejects_odd_length) {
+TEST(rejects_odd_length) {
   EXPECT_FALSE(sourcemeta::core::hex_to_bytes("abc").has_value());
 }
 
-TEST(Text_hex_to_bytes, rejects_single_character) {
+TEST(rejects_single_character) {
   EXPECT_FALSE(sourcemeta::core::hex_to_bytes("a").has_value());
 }
 
-TEST(Text_hex_to_bytes, odd_length_allowed_single_character) {
+TEST(odd_length_allowed_single_character) {
   const auto result{sourcemeta::core::hex_to_bytes("a", true)};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\x0A");
 }
 
-TEST(Text_hex_to_bytes, odd_length_allowed_assumes_leading_zero) {
+TEST(odd_length_allowed_assumes_leading_zero) {
   const auto result{sourcemeta::core::hex_to_bytes("abc", true)};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\x0A\xBC");
 }
 
-TEST(Text_hex_to_bytes, even_length_allowed_is_unchanged) {
+TEST(even_length_allowed_is_unchanged) {
   const auto result{sourcemeta::core::hex_to_bytes("abcd", true)};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "\xAB\xCD");
 }
 
-TEST(Text_hex_to_bytes, odd_length_allowed_rejects_non_hexadecimal) {
+TEST(odd_length_allowed_rejects_non_hexadecimal) {
   EXPECT_FALSE(sourcemeta::core::hex_to_bytes("xbc", true).has_value());
 }
 
-TEST(Text_hex_to_bytes, rejects_non_hexadecimal_letter) {
+TEST(rejects_non_hexadecimal_letter) {
   EXPECT_FALSE(sourcemeta::core::hex_to_bytes("zz").has_value());
 }
 
-TEST(Text_hex_to_bytes, rejects_interior_space) {
+TEST(rejects_interior_space) {
   EXPECT_FALSE(sourcemeta::core::hex_to_bytes("ab c").has_value());
 }
 
-TEST(Text_hex_to_bytes, rejects_prefix_notation) {
+TEST(rejects_prefix_notation) {
   EXPECT_FALSE(sourcemeta::core::hex_to_bytes("0xff").has_value());
 }

--- a/test/text/text_is_alpha_test.cc
+++ b/test/text/text_is_alpha_test.cc
@@ -1,31 +1,31 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
-TEST(Text_is_alpha, lowercase_letters) {
+TEST(lowercase_letters) {
   EXPECT_TRUE(sourcemeta::core::is_alpha('a'));
   EXPECT_TRUE(sourcemeta::core::is_alpha('m'));
   EXPECT_TRUE(sourcemeta::core::is_alpha('z'));
 }
 
-TEST(Text_is_alpha, uppercase_letters) {
+TEST(uppercase_letters) {
   EXPECT_TRUE(sourcemeta::core::is_alpha('A'));
   EXPECT_TRUE(sourcemeta::core::is_alpha('M'));
   EXPECT_TRUE(sourcemeta::core::is_alpha('Z'));
 }
 
-TEST(Text_is_alpha, digits) {
+TEST(digits) {
   EXPECT_FALSE(sourcemeta::core::is_alpha('0'));
   EXPECT_FALSE(sourcemeta::core::is_alpha('9'));
 }
 
-TEST(Text_is_alpha, punctuation) {
+TEST(punctuation) {
   EXPECT_FALSE(sourcemeta::core::is_alpha('-'));
   EXPECT_FALSE(sourcemeta::core::is_alpha('_'));
   EXPECT_FALSE(sourcemeta::core::is_alpha(' '));
 }
 
-TEST(Text_is_alpha, ascii_boundaries) {
+TEST(ascii_boundaries) {
   // The ASCII characters immediately outside the two letter ranges
   EXPECT_FALSE(sourcemeta::core::is_alpha('@'));
   EXPECT_FALSE(sourcemeta::core::is_alpha('['));
@@ -33,18 +33,12 @@ TEST(Text_is_alpha, ascii_boundaries) {
   EXPECT_FALSE(sourcemeta::core::is_alpha('{'));
 }
 
-TEST(Text_is_alpha, string_all_letters) {
-  EXPECT_TRUE(sourcemeta::core::is_alpha("abcXYZ"));
-}
+TEST(string_all_letters) { EXPECT_TRUE(sourcemeta::core::is_alpha("abcXYZ")); }
 
-TEST(Text_is_alpha, string_with_digit) {
-  EXPECT_FALSE(sourcemeta::core::is_alpha("abc1"));
-}
+TEST(string_with_digit) { EXPECT_FALSE(sourcemeta::core::is_alpha("abc1")); }
 
-TEST(Text_is_alpha, string_with_punctuation) {
+TEST(string_with_punctuation) {
   EXPECT_FALSE(sourcemeta::core::is_alpha("ab-cd"));
 }
 
-TEST(Text_is_alpha, empty_string) {
-  EXPECT_FALSE(sourcemeta::core::is_alpha(""));
-}
+TEST(empty_string) { EXPECT_FALSE(sourcemeta::core::is_alpha("")); }

--- a/test/text/text_is_alphanum_test.cc
+++ b/test/text/text_is_alphanum_test.cc
@@ -1,32 +1,30 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
-TEST(Text_is_alphanum, letters) {
+TEST(letters) {
   EXPECT_TRUE(sourcemeta::core::is_alphanum('a'));
   EXPECT_TRUE(sourcemeta::core::is_alphanum('Z'));
 }
 
-TEST(Text_is_alphanum, digits) {
+TEST(digits) {
   EXPECT_TRUE(sourcemeta::core::is_alphanum('0'));
   EXPECT_TRUE(sourcemeta::core::is_alphanum('9'));
 }
 
-TEST(Text_is_alphanum, punctuation) {
+TEST(punctuation) {
   EXPECT_FALSE(sourcemeta::core::is_alphanum('-'));
   EXPECT_FALSE(sourcemeta::core::is_alphanum('_'));
   EXPECT_FALSE(sourcemeta::core::is_alphanum('.'));
   EXPECT_FALSE(sourcemeta::core::is_alphanum(' '));
 }
 
-TEST(Text_is_alphanum, string_letters_and_digits) {
+TEST(string_letters_and_digits) {
   EXPECT_TRUE(sourcemeta::core::is_alphanum("abc123XYZ"));
 }
 
-TEST(Text_is_alphanum, string_with_punctuation) {
+TEST(string_with_punctuation) {
   EXPECT_FALSE(sourcemeta::core::is_alphanum("abc-123"));
 }
 
-TEST(Text_is_alphanum, empty_string) {
-  EXPECT_FALSE(sourcemeta::core::is_alphanum(""));
-}
+TEST(empty_string) { EXPECT_FALSE(sourcemeta::core::is_alphanum("")); }

--- a/test/text/text_is_digit_test.cc
+++ b/test/text/text_is_digit_test.cc
@@ -1,37 +1,33 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
-TEST(Text_is_digit, digits) {
+TEST(digits) {
   EXPECT_TRUE(sourcemeta::core::is_digit('0'));
   EXPECT_TRUE(sourcemeta::core::is_digit('5'));
   EXPECT_TRUE(sourcemeta::core::is_digit('9'));
 }
 
-TEST(Text_is_digit, letters) {
+TEST(letters) {
   EXPECT_FALSE(sourcemeta::core::is_digit('a'));
   EXPECT_FALSE(sourcemeta::core::is_digit('Z'));
 }
 
-TEST(Text_is_digit, punctuation) {
+TEST(punctuation) {
   EXPECT_FALSE(sourcemeta::core::is_digit('-'));
   EXPECT_FALSE(sourcemeta::core::is_digit(' '));
 }
 
-TEST(Text_is_digit, ascii_boundaries) {
+TEST(ascii_boundaries) {
   // The ASCII characters immediately outside the digit range
   EXPECT_FALSE(sourcemeta::core::is_digit('/'));
   EXPECT_FALSE(sourcemeta::core::is_digit(':'));
 }
 
-TEST(Text_is_digit, string_all_digits) {
+TEST(string_all_digits) {
   EXPECT_TRUE(sourcemeta::core::is_digit("0123456789"));
 }
 
-TEST(Text_is_digit, string_with_letter) {
-  EXPECT_FALSE(sourcemeta::core::is_digit("12a"));
-}
+TEST(string_with_letter) { EXPECT_FALSE(sourcemeta::core::is_digit("12a")); }
 
-TEST(Text_is_digit, empty_string) {
-  EXPECT_FALSE(sourcemeta::core::is_digit(""));
-}
+TEST(empty_string) { EXPECT_FALSE(sourcemeta::core::is_digit("")); }

--- a/test/text/text_is_lowercase_test.cc
+++ b/test/text/text_is_lowercase_test.cc
@@ -1,427 +1,391 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <filesystem>
 #include <string>
 
-TEST(Text_is_lowercase, lowercase_a) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase('a'));
-}
+TEST(lowercase_a) { EXPECT_TRUE(sourcemeta::core::is_lowercase('a')); }
 
-TEST(Text_is_lowercase, lowercase_z) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase('z'));
-}
+TEST(lowercase_z) { EXPECT_TRUE(sourcemeta::core::is_lowercase('z')); }
 
-TEST(Text_is_lowercase, lowercase_middle) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase('m'));
-}
+TEST(lowercase_middle) { EXPECT_TRUE(sourcemeta::core::is_lowercase('m')); }
 
-TEST(Text_is_lowercase, uppercase_a) {
-  EXPECT_FALSE(sourcemeta::core::is_lowercase('A'));
-}
+TEST(uppercase_a) { EXPECT_FALSE(sourcemeta::core::is_lowercase('A')); }
 
-TEST(Text_is_lowercase, uppercase_z) {
-  EXPECT_FALSE(sourcemeta::core::is_lowercase('Z'));
-}
+TEST(uppercase_z) { EXPECT_FALSE(sourcemeta::core::is_lowercase('Z')); }
 
-TEST(Text_is_lowercase, uppercase_middle) {
-  EXPECT_FALSE(sourcemeta::core::is_lowercase('M'));
-}
+TEST(uppercase_middle) { EXPECT_FALSE(sourcemeta::core::is_lowercase('M')); }
 
-TEST(Text_is_lowercase, digit) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase('5'));
-}
+TEST(digit) { EXPECT_TRUE(sourcemeta::core::is_lowercase('5')); }
 
-TEST(Text_is_lowercase, punctuation) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase('!'));
-}
+TEST(punctuation) { EXPECT_TRUE(sourcemeta::core::is_lowercase('!')); }
 
-TEST(Text_is_lowercase, space) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(' '));
-}
+TEST(space) { EXPECT_TRUE(sourcemeta::core::is_lowercase(' ')); }
 
-TEST(Text_is_lowercase, null) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase('\0'));
-}
+TEST(null) { EXPECT_TRUE(sourcemeta::core::is_lowercase('\0')); }
 
-TEST(Text_is_lowercase, just_before_uppercase_range) {
+TEST(just_before_uppercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase('@'));
 }
 
-TEST(Text_is_lowercase, just_after_uppercase_range) {
+TEST(just_after_uppercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase('['));
 }
 
-TEST(Text_is_lowercase, just_before_lowercase_range) {
+TEST(just_before_lowercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase('`'));
 }
 
-TEST(Text_is_lowercase, just_after_lowercase_range) {
+TEST(just_after_lowercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase('{'));
 }
 
-TEST(Text_is_lowercase, non_ascii_byte) {
+TEST(non_ascii_byte) {
   const char character{static_cast<char>(0xC3)};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, high_bit_byte) {
+TEST(high_bit_byte) {
   const char character{static_cast<char>(0xFF)};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, signed_char_uppercase) {
+TEST(signed_char_uppercase) {
   const signed char character{'A'};
   EXPECT_FALSE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, signed_char_lowercase) {
+TEST(signed_char_lowercase) {
   const signed char character{'a'};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, signed_char_digit) {
+TEST(signed_char_digit) {
   const signed char character{'5'};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, signed_char_high_bit) {
+TEST(signed_char_high_bit) {
   const signed char character{static_cast<signed char>(-1)};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, unsigned_char_uppercase) {
+TEST(unsigned_char_uppercase) {
   const unsigned char character{'A'};
   EXPECT_FALSE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, unsigned_char_lowercase) {
+TEST(unsigned_char_lowercase) {
   const unsigned char character{'a'};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, unsigned_char_digit) {
+TEST(unsigned_char_digit) {
   const unsigned char character{'5'};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, unsigned_char_high_bit) {
+TEST(unsigned_char_high_bit) {
   const unsigned char character{0xFFu};
   EXPECT_TRUE(sourcemeta::core::is_lowercase(character));
 }
 
-TEST(Text_is_lowercase, wide_lowercase_a) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(L'a'));
-}
+TEST(wide_lowercase_a) { EXPECT_TRUE(sourcemeta::core::is_lowercase(L'a')); }
 
-TEST(Text_is_lowercase, wide_lowercase_z) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(L'z'));
-}
+TEST(wide_lowercase_z) { EXPECT_TRUE(sourcemeta::core::is_lowercase(L'z')); }
 
-TEST(Text_is_lowercase, wide_lowercase_middle) {
+TEST(wide_lowercase_middle) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'm'));
 }
 
-TEST(Text_is_lowercase, wide_uppercase_a) {
-  EXPECT_FALSE(sourcemeta::core::is_lowercase(L'A'));
-}
+TEST(wide_uppercase_a) { EXPECT_FALSE(sourcemeta::core::is_lowercase(L'A')); }
 
-TEST(Text_is_lowercase, wide_uppercase_z) {
-  EXPECT_FALSE(sourcemeta::core::is_lowercase(L'Z'));
-}
+TEST(wide_uppercase_z) { EXPECT_FALSE(sourcemeta::core::is_lowercase(L'Z')); }
 
-TEST(Text_is_lowercase, wide_uppercase_middle) {
+TEST(wide_uppercase_middle) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(L'M'));
 }
 
-TEST(Text_is_lowercase, wide_digit) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(L'5'));
-}
+TEST(wide_digit) { EXPECT_TRUE(sourcemeta::core::is_lowercase(L'5')); }
 
-TEST(Text_is_lowercase, wide_punctuation) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(L'!'));
-}
+TEST(wide_punctuation) { EXPECT_TRUE(sourcemeta::core::is_lowercase(L'!')); }
 
-TEST(Text_is_lowercase, wide_null) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(L'\0'));
-}
+TEST(wide_null) { EXPECT_TRUE(sourcemeta::core::is_lowercase(L'\0')); }
 
-TEST(Text_is_lowercase, wide_just_before_uppercase_range) {
+TEST(wide_just_before_uppercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'@'));
 }
 
-TEST(Text_is_lowercase, wide_just_after_uppercase_range) {
+TEST(wide_just_after_uppercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'['));
 }
 
-TEST(Text_is_lowercase, wide_just_before_lowercase_range) {
+TEST(wide_just_before_lowercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'`'));
 }
 
-TEST(Text_is_lowercase, wide_just_after_lowercase_range) {
+TEST(wide_just_after_lowercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'{'));
 }
 
-TEST(Text_is_lowercase, wide_above_ascii) {
+TEST(wide_above_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'\u00C0'));
 }
 
-TEST(Text_is_lowercase, wide_far_above_ascii) {
+TEST(wide_far_above_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(L'\u2603'));
 }
 
-TEST(Text_is_lowercase_string, empty) {
-  EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{""}));
-}
+TEST(empty) { EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{""})); }
 
-TEST(Text_is_lowercase_string, single_lowercase) {
+TEST(single_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"a"}));
 }
 
-TEST(Text_is_lowercase_string, single_uppercase) {
+TEST(single_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"A"}));
 }
 
-TEST(Text_is_lowercase_string, single_digit) {
+TEST(single_digit) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"5"}));
 }
 
-TEST(Text_is_lowercase_string, all_lowercase) {
+TEST(all_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"hello"}));
 }
 
-TEST(Text_is_lowercase_string, all_uppercase) {
+TEST(all_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"HELLO"}));
 }
 
-TEST(Text_is_lowercase_string, leading_uppercase) {
+TEST(leading_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"Hello"}));
 }
 
-TEST(Text_is_lowercase_string, trailing_uppercase) {
+TEST(trailing_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"hellO"}));
 }
 
-TEST(Text_is_lowercase_string, middle_uppercase) {
+TEST(middle_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"heLlo"}));
 }
 
-TEST(Text_is_lowercase_string, mixed_case) {
+TEST(mixed_case) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"Hello WORLD"}));
 }
 
-TEST(Text_is_lowercase_string, digits_and_lowercase) {
+TEST(digits_and_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"abc123xyz"}));
 }
 
-TEST(Text_is_lowercase_string, digits_and_uppercase) {
+TEST(digits_and_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"ABC123xyz"}));
 }
 
-TEST(Text_is_lowercase_string, punctuation_only) {
+TEST(punctuation_only) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"!?,.:;"}));
 }
 
-TEST(Text_is_lowercase_string, whitespace_only) {
+TEST(whitespace_only) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"\t\n\r "}));
 }
 
-TEST(Text_is_lowercase_string, lowercase_with_punctuation) {
+TEST(lowercase_with_punctuation) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"foo, bar!"}));
 }
 
-TEST(Text_is_lowercase_string, uppercase_with_punctuation) {
+TEST(uppercase_with_punctuation) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"Foo, BAR!"}));
 }
 
-TEST(Text_is_lowercase_string, embedded_null_lowercase) {
+TEST(embedded_null_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"ab\0cd", 5}));
 }
 
-TEST(Text_is_lowercase_string, embedded_null_uppercase) {
+TEST(embedded_null_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"ab\0CD", 5}));
 }
 
-TEST(Text_is_lowercase_string, non_ascii_bytes) {
+TEST(non_ascii_bytes) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"\xC3"
                                                          "\x84"
                                                          "\xC3"
                                                          "\x96"}));
 }
 
-TEST(Text_is_lowercase_string, mixed_ascii_lowercase_and_non_ascii) {
+TEST(mixed_ascii_lowercase_and_non_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"foo"
                                                          "\xC3"
                                                          "\x84"
                                                          "bar"}));
 }
 
-TEST(Text_is_lowercase_string, mixed_ascii_uppercase_and_non_ascii) {
+TEST(mixed_ascii_uppercase_and_non_ascii) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"FOO"
                                                           "\xC3"
                                                           "\x84"
                                                           "bar"}));
 }
 
-TEST(Text_is_lowercase_string, just_before_uppercase_range) {
+TEST(string_just_before_uppercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"@@@"}));
 }
 
-TEST(Text_is_lowercase_string, just_after_uppercase_range) {
+TEST(string_just_after_uppercase_range) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string{"[[["}));
 }
 
-TEST(Text_is_lowercase_string, short_circuits_on_first_uppercase) {
+TEST(short_circuits_on_first_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string{"Aaaaaaaaaa"}));
 }
 
-TEST(Text_is_lowercase_string_view, empty) {
+TEST(string_view_empty) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string_view{""}));
 }
 
-TEST(Text_is_lowercase_string_view, all_lowercase) {
+TEST(string_view_all_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::string_view{"hello"}));
 }
 
-TEST(Text_is_lowercase_string_view, all_uppercase) {
+TEST(string_view_all_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string_view{"HELLO"}));
 }
 
-TEST(Text_is_lowercase_string_view, mixed_case) {
+TEST(string_view_mixed_case) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::string_view{"Hello"}));
 }
 
-TEST(Text_is_lowercase_wstring, empty) {
+TEST(wstring_empty) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::wstring{L""}));
 }
 
-TEST(Text_is_lowercase_wstring, single_lowercase) {
+TEST(wstring_single_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::wstring{L"a"}));
 }
 
-TEST(Text_is_lowercase_wstring, single_uppercase) {
+TEST(wstring_single_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::wstring{L"A"}));
 }
 
-TEST(Text_is_lowercase_wstring, all_lowercase) {
+TEST(wstring_all_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::wstring{L"hello"}));
 }
 
-TEST(Text_is_lowercase_wstring, all_uppercase) {
+TEST(wstring_all_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::wstring{L"HELLO"}));
 }
 
-TEST(Text_is_lowercase_wstring, mixed_case) {
+TEST(wstring_mixed_case) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::wstring{L"Hello"}));
 }
 
-TEST(Text_is_lowercase_wstring, digits_and_lowercase) {
+TEST(wstring_digits_and_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::wstring{L"abc123xyz"}));
 }
 
-TEST(Text_is_lowercase_wstring, digits_and_uppercase) {
+TEST(wstring_digits_and_uppercase) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::wstring{L"ABC123xyz"}));
 }
 
-TEST(Text_is_lowercase_wstring, above_ascii) {
+TEST(above_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::wstring{L"\u00C0\u00C9"}));
 }
 
-TEST(Text_is_lowercase_wstring, mixed_lowercase_and_above_ascii) {
+TEST(mixed_lowercase_and_above_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::wstring{L"foo\u00C0bar"}));
 }
 
-TEST(Text_is_lowercase_wstring, mixed_uppercase_and_above_ascii) {
+TEST(mixed_uppercase_and_above_ascii) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::wstring{L"FOO\u00C0bar"}));
 }
 
-TEST(Text_is_lowercase_path, empty) {
+TEST(path_empty) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::filesystem::path{""}));
 }
 
-TEST(Text_is_lowercase_path, single_lowercase_filename) {
+TEST(single_lowercase_filename) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::filesystem::path{"foo"}));
 }
 
-TEST(Text_is_lowercase_path, single_uppercase_filename) {
+TEST(single_uppercase_filename) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::filesystem::path{"FOO"}));
 }
 
-TEST(Text_is_lowercase_path, mixed_case_filename) {
+TEST(mixed_case_filename) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(std::filesystem::path{"FooBar"}));
 }
 
-TEST(Text_is_lowercase_path, lowercase_extension) {
+TEST(lowercase_extension) {
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"schema.json"}));
 }
 
-TEST(Text_is_lowercase_path, uppercase_extension) {
+TEST(uppercase_extension) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"schema.JSON"}));
 }
 
-TEST(Text_is_lowercase_path, mixed_case_extension) {
+TEST(mixed_case_extension) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"Schema.Json"}));
 }
 
-TEST(Text_is_lowercase_path, lowercase_absolute_path) {
+TEST(lowercase_absolute_path) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       std::filesystem::path{"/foo/bar/baz.json"}));
 }
 
-TEST(Text_is_lowercase_path, uppercase_in_absolute_path) {
+TEST(uppercase_in_absolute_path) {
   EXPECT_FALSE(sourcemeta::core::is_lowercase(
       std::filesystem::path{"/Foo/BAR/Baz.JSON"}));
 }
 
-TEST(Text_is_lowercase_path, lowercase_relative_path) {
+TEST(lowercase_relative_path) {
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"foo/bar/baz"}));
 }
 
-TEST(Text_is_lowercase_path, uppercase_in_relative_path) {
+TEST(uppercase_in_relative_path) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"Foo/BAR/baz"}));
 }
 
-TEST(Text_is_lowercase_path, digits_only) {
+TEST(digits_only) {
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"file123.txt"}));
 }
 
-TEST(Text_is_lowercase_path, digits_with_uppercase) {
+TEST(digits_with_uppercase) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"FILE123.TXT"}));
 }
 
-TEST(Text_is_lowercase_path, dot_segments_lowercase) {
+TEST(dot_segments_lowercase) {
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"./foo/../bar"}));
 }
 
-TEST(Text_is_lowercase_path, dot_segments_uppercase) {
+TEST(dot_segments_uppercase) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"./FOO/../BAR"}));
 }
 
-TEST(Text_is_lowercase_path, hidden_file_lowercase) {
+TEST(hidden_file_lowercase) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(std::filesystem::path{".config"}));
 }
 
-TEST(Text_is_lowercase_path, hidden_file_uppercase) {
+TEST(hidden_file_uppercase) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{".CONFIG"}));
 }
 
-TEST(Text_is_lowercase_path, multiple_extensions_lowercase) {
+TEST(multiple_extensions_lowercase) {
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"archive.tar.gz"}));
 }
 
-TEST(Text_is_lowercase_path, multiple_extensions_uppercase) {
+TEST(multiple_extensions_uppercase) {
   EXPECT_FALSE(
       sourcemeta::core::is_lowercase(std::filesystem::path{"Archive.TAR.GZ"}));
 }

--- a/test/text/text_join_to_test.cc
+++ b/test/text/text_join_to_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
@@ -9,42 +9,42 @@
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
-TEST(Text_join_to, multiple_integers) {
+TEST(multiple_integers) {
   std::ostringstream stream;
   const std::array<int, 3> values{{1, 2, 3}};
   sourcemeta::core::join_to(stream, values, ", ");
   EXPECT_EQ(stream.str(), "1, 2, 3");
 }
 
-TEST(Text_join_to, single_element_no_separator_written) {
+TEST(single_element_no_separator_written) {
   std::ostringstream stream;
   const std::array<int, 1> values{{42}};
   sourcemeta::core::join_to(stream, values, ", ");
   EXPECT_EQ(stream.str(), "42");
 }
 
-TEST(Text_join_to, empty_range_writes_nothing) {
+TEST(empty_range_writes_nothing) {
   std::ostringstream stream;
   const std::vector<int> values;
   sourcemeta::core::join_to(stream, values, ", ");
   EXPECT_EQ(stream.str(), "");
 }
 
-TEST(Text_join_to, empty_separator) {
+TEST(empty_separator) {
   std::ostringstream stream;
   const std::array<int, 3> values{{1, 2, 3}};
   sourcemeta::core::join_to(stream, values, "");
   EXPECT_EQ(stream.str(), "123");
 }
 
-TEST(Text_join_to, string_views) {
+TEST(string_views) {
   std::ostringstream stream;
   const std::array<std::string_view, 3> values{{"foo", "bar", "baz"}};
   sourcemeta::core::join_to(stream, values, " | ");
   EXPECT_EQ(stream.str(), "foo | bar | baz");
 }
 
-TEST(Text_join_to, transformed_range) {
+TEST(transformed_range) {
   std::ostringstream stream;
   const std::array<int, 3> values{{1, 2, 3}};
   const auto doubled{values | std::views::transform(
@@ -53,7 +53,7 @@ TEST(Text_join_to, transformed_range) {
   EXPECT_EQ(stream.str(), "2, 4, 6");
 }
 
-TEST(Text_join_to, widened_byte_values) {
+TEST(widened_byte_values) {
   std::ostringstream stream;
   const std::array<std::uint8_t, 3> values{{1, 2, 3}};
   const auto widened{values |

--- a/test/text/text_pad_left_test.cc
+++ b/test/text/text_pad_left_test.cc
@@ -1,34 +1,32 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string
 
-TEST(Text_pad_left, pads_to_width) {
+TEST(pads_to_width) {
   EXPECT_EQ(sourcemeta::core::pad_left("42", 5, '0'), "00042");
 }
 
-TEST(Text_pad_left, already_at_width) {
+TEST(already_at_width) {
   EXPECT_EQ(sourcemeta::core::pad_left("hello", 5, '0'), "hello");
 }
 
-TEST(Text_pad_left, longer_than_width) {
+TEST(longer_than_width) {
   EXPECT_EQ(sourcemeta::core::pad_left("hello", 3, '0'), "hello");
 }
 
-TEST(Text_pad_left, single_character_pad) {
+TEST(single_character_pad) {
   EXPECT_EQ(sourcemeta::core::pad_left("x", 4, ' '), "   x");
 }
 
-TEST(Text_pad_left, empty_input) {
-  EXPECT_EQ(sourcemeta::core::pad_left("", 3, '0'), "000");
-}
+TEST(empty_input) { EXPECT_EQ(sourcemeta::core::pad_left("", 3, '0'), "000"); }
 
-TEST(Text_pad_left, zero_width) {
+TEST(zero_width) {
   EXPECT_EQ(sourcemeta::core::pad_left("abc", 0, '0'), "abc");
 }
 
-TEST(Text_pad_left, pads_with_nul_bytes) {
+TEST(pads_with_nul_bytes) {
   const std::string expected("\x00\x00\x2a", 3);
   EXPECT_EQ(sourcemeta::core::pad_left("\x2a", 3, '\x00'), expected);
 }

--- a/test/text/text_remove_suffix_ignore_case_test.cc
+++ b/test/text/text_remove_suffix_ignore_case_test.cc
@@ -1,74 +1,74 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string_view> // std::string_view
 
-TEST(Text_remove_suffix_ignore_case, matches_lowercase) {
+TEST(matches_lowercase) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("schema.json", ".json"),
             "schema");
 }
 
-TEST(Text_remove_suffix_ignore_case, matches_uppercase) {
+TEST(matches_uppercase) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("schema.JSON", ".json"),
             "schema");
 }
 
-TEST(Text_remove_suffix_ignore_case, matches_mixed_case) {
+TEST(matches_mixed_case) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("schema.JsOn", ".json"),
             "schema");
 }
 
-TEST(Text_remove_suffix_ignore_case, matches_uppercase_suffix_argument) {
+TEST(matches_uppercase_suffix_argument) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("schema.json", ".JSON"),
             "schema");
 }
 
-TEST(Text_remove_suffix_ignore_case, exact_case_match) {
+TEST(exact_case_match) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("Schema.json", ".json"),
             "Schema");
 }
 
-TEST(Text_remove_suffix_ignore_case, no_match_returns_input_unchanged) {
+TEST(no_match_returns_input_unchanged) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("schema.txt", ".json"),
             "schema.txt");
 }
 
-TEST(Text_remove_suffix_ignore_case, suffix_longer_than_input) {
+TEST(suffix_longer_than_input) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("x", ".json"), "x");
 }
 
-TEST(Text_remove_suffix_ignore_case, empty_suffix) {
+TEST(empty_suffix) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("file.json", ""),
             "file.json");
 }
 
-TEST(Text_remove_suffix_ignore_case, empty_input) {
+TEST(empty_input) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("", ".json"), "");
 }
 
-TEST(Text_remove_suffix_ignore_case, empty_input_and_empty_suffix) {
+TEST(empty_input_and_empty_suffix) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("", ""), "");
 }
 
-TEST(Text_remove_suffix_ignore_case, suffix_equals_input) {
+TEST(suffix_equals_input) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case(".json", ".json"), "");
 }
 
-TEST(Text_remove_suffix_ignore_case, suffix_equals_input_different_case) {
+TEST(suffix_equals_input_different_case) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case(".JSON", ".json"), "");
 }
 
-TEST(Text_remove_suffix_ignore_case, partial_overlap_does_not_match) {
+TEST(partial_overlap_does_not_match) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("son", ".json"), "son");
 }
 
-TEST(Text_remove_suffix_ignore_case, multiple_extensions_only_last_removed) {
+TEST(multiple_extensions_only_last_removed) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("file.tar.gz", ".gz"),
             "file.tar");
 }
 
-TEST(Text_remove_suffix_ignore_case, non_alphabetic_suffix_chars) {
+TEST(non_alphabetic_suffix_chars) {
   EXPECT_EQ(sourcemeta::core::remove_suffix_ignore_case("data-123", "-123"),
             "data");
 }

--- a/test/text/text_split_once_test.cc
+++ b/test/text/text_split_once_test.cc
@@ -1,98 +1,98 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
-TEST(Text_split_once, char_delimiter_in_middle) {
+TEST(char_delimiter_in_middle) {
   const auto parts{sourcemeta::core::split_once("key=value", '=')};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "key");
   EXPECT_EQ(parts->second, "value");
 }
 
-TEST(Text_split_once, char_delimiter_at_start) {
+TEST(char_delimiter_at_start) {
   const auto parts{sourcemeta::core::split_once("=value", '=')};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "");
   EXPECT_EQ(parts->second, "value");
 }
 
-TEST(Text_split_once, char_delimiter_at_end) {
+TEST(char_delimiter_at_end) {
   const auto parts{sourcemeta::core::split_once("key=", '=')};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "key");
   EXPECT_EQ(parts->second, "");
 }
 
-TEST(Text_split_once, char_delimiter_absent) {
+TEST(char_delimiter_absent) {
   EXPECT_FALSE(sourcemeta::core::split_once("no separator", '=').has_value());
 }
 
-TEST(Text_split_once, char_delimiter_only_first_occurrence) {
+TEST(char_delimiter_only_first_occurrence) {
   const auto parts{sourcemeta::core::split_once("a=b=c", '=')};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "a");
   EXPECT_EQ(parts->second, "b=c");
 }
 
-TEST(Text_split_once, char_delimiter_empty_input) {
+TEST(char_delimiter_empty_input) {
   EXPECT_FALSE(sourcemeta::core::split_once("", '=').has_value());
 }
 
-TEST(Text_split_once, char_delimiter_only_delimiter) {
+TEST(char_delimiter_only_delimiter) {
   const auto parts{sourcemeta::core::split_once("=", '=')};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "");
   EXPECT_EQ(parts->second, "");
 }
 
-TEST(Text_split_once, string_delimiter_in_middle) {
+TEST(string_delimiter_in_middle) {
   const auto parts{sourcemeta::core::split_once("1..5", "..")};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "1");
   EXPECT_EQ(parts->second, "5");
 }
 
-TEST(Text_split_once, string_delimiter_at_start) {
+TEST(string_delimiter_at_start) {
   const auto parts{sourcemeta::core::split_once("..suffix", "..")};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "");
   EXPECT_EQ(parts->second, "suffix");
 }
 
-TEST(Text_split_once, string_delimiter_at_end) {
+TEST(string_delimiter_at_end) {
   const auto parts{sourcemeta::core::split_once("prefix..", "..")};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "prefix");
   EXPECT_EQ(parts->second, "");
 }
 
-TEST(Text_split_once, string_delimiter_absent) {
+TEST(string_delimiter_absent) {
   EXPECT_FALSE(
       sourcemeta::core::split_once("no double dots", "..").has_value());
 }
 
-TEST(Text_split_once, string_delimiter_only_first_occurrence) {
+TEST(string_delimiter_only_first_occurrence) {
   const auto parts{sourcemeta::core::split_once("a..b..c", "..")};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "a");
   EXPECT_EQ(parts->second, "b..c");
 }
 
-TEST(Text_split_once, string_delimiter_partial_match_not_treated_as_split) {
+TEST(string_delimiter_partial_match_not_treated_as_split) {
   EXPECT_FALSE(sourcemeta::core::split_once("a.b.c", "..").has_value());
 }
 
-TEST(Text_split_once, string_delimiter_empty_returns_nullopt) {
+TEST(string_delimiter_empty_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::split_once("anything", "").has_value());
 }
 
-TEST(Text_split_once, string_delimiter_longer_than_input) {
+TEST(string_delimiter_longer_than_input) {
   EXPECT_FALSE(sourcemeta::core::split_once("ab", "abc").has_value());
 }
 
-TEST(Text_split_once, string_delimiter_equals_input) {
+TEST(string_delimiter_equals_input) {
   const auto parts{sourcemeta::core::split_once("XYZ", "XYZ")};
-  ASSERT_TRUE(parts.has_value());
+  EXPECT_TRUE(parts.has_value());
   EXPECT_EQ(parts->first, "");
   EXPECT_EQ(parts->second, "");
 }

--- a/test/text/text_split_test.cc
+++ b/test/text/text_split_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
@@ -7,98 +7,98 @@
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
-TEST(Text_split, multiple_parts) {
+TEST(multiple_parts) {
   std::vector<std::string> parts;
   sourcemeta::core::split(
       "alpha;beta;gamma", ';',
       [&](const std::string_view part) { parts.emplace_back(part); });
-  ASSERT_EQ(parts.size(), 3);
+  EXPECT_EQ(parts.size(), 3);
   EXPECT_EQ(parts.at(0), "alpha");
   EXPECT_EQ(parts.at(1), "beta");
   EXPECT_EQ(parts.at(2), "gamma");
 }
 
-TEST(Text_split, no_delimiter_yields_full_input) {
+TEST(no_delimiter_yields_full_input) {
   std::vector<std::string> parts;
   sourcemeta::core::split("solo", ';', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 1);
+  EXPECT_EQ(parts.size(), 1);
   EXPECT_EQ(parts.at(0), "solo");
 }
 
-TEST(Text_split, empty_input_yields_single_empty_part) {
+TEST(empty_input_yields_single_empty_part) {
   std::vector<std::string> parts;
   sourcemeta::core::split(
       "", ';', [&](const std::string_view part) { parts.emplace_back(part); });
-  ASSERT_EQ(parts.size(), 1);
+  EXPECT_EQ(parts.size(), 1);
   EXPECT_EQ(parts.at(0), "");
 }
 
-TEST(Text_split, leading_delimiter_yields_empty_first_part) {
+TEST(leading_delimiter_yields_empty_first_part) {
   std::vector<std::string> parts;
   sourcemeta::core::split(";beta", ';', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 2);
+  EXPECT_EQ(parts.size(), 2);
   EXPECT_EQ(parts.at(0), "");
   EXPECT_EQ(parts.at(1), "beta");
 }
 
-TEST(Text_split, trailing_delimiter_yields_empty_last_part) {
+TEST(trailing_delimiter_yields_empty_last_part) {
   std::vector<std::string> parts;
   sourcemeta::core::split("alpha;", ';', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 2);
+  EXPECT_EQ(parts.size(), 2);
   EXPECT_EQ(parts.at(0), "alpha");
   EXPECT_EQ(parts.at(1), "");
 }
 
-TEST(Text_split, consecutive_delimiters_yield_empty_parts) {
+TEST(consecutive_delimiters_yield_empty_parts) {
   std::vector<std::string> parts;
   sourcemeta::core::split("a;;c", ';', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 3);
+  EXPECT_EQ(parts.size(), 3);
   EXPECT_EQ(parts.at(0), "a");
   EXPECT_EQ(parts.at(1), "");
   EXPECT_EQ(parts.at(2), "c");
 }
 
-TEST(Text_split, only_delimiters) {
+TEST(only_delimiters) {
   std::vector<std::string> parts;
   sourcemeta::core::split(";;", ';', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 3);
+  EXPECT_EQ(parts.size(), 3);
   EXPECT_EQ(parts.at(0), "");
   EXPECT_EQ(parts.at(1), "");
   EXPECT_EQ(parts.at(2), "");
 }
 
-TEST(Text_split, comma_delimiter) {
+TEST(comma_delimiter) {
   std::vector<std::string> parts;
   sourcemeta::core::split("1,2,3,4", ',', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 4);
+  EXPECT_EQ(parts.size(), 4);
   EXPECT_EQ(parts.at(0), "1");
   EXPECT_EQ(parts.at(3), "4");
 }
 
-TEST(Text_split, newline_delimiter) {
+TEST(newline_delimiter) {
   std::vector<std::string> parts;
   sourcemeta::core::split("a\nb\nc", '\n', [&](const std::string_view part) {
     parts.emplace_back(part);
   });
-  ASSERT_EQ(parts.size(), 3);
+  EXPECT_EQ(parts.size(), 3);
   EXPECT_EQ(parts.at(0), "a");
   EXPECT_EQ(parts.at(1), "b");
   EXPECT_EQ(parts.at(2), "c");
 }
 
-TEST(Text_split, parts_reference_input_buffer) {
+TEST(parts_reference_input_buffer) {
   const std::string input{"alpha;beta"};
   std::vector<std::size_t> sizes;
   sourcemeta::core::split(input, ';', [&](const std::string_view part) {
@@ -106,7 +106,7 @@ TEST(Text_split, parts_reference_input_buffer) {
     EXPECT_GE(part.data(), input.data());
     EXPECT_LE(part.data() + part.size(), input.data() + input.size());
   });
-  ASSERT_EQ(sizes.size(), 2);
+  EXPECT_EQ(sizes.size(), 2);
   EXPECT_EQ(sizes.at(0), 5);
   EXPECT_EQ(sizes.at(1), 4);
 }

--- a/test/text/text_strip_left_test.cc
+++ b/test/text/text_strip_left_test.cc
@@ -1,38 +1,36 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string
 
-TEST(Text_strip_left, no_leading_character) {
+TEST(no_leading_character) {
   EXPECT_EQ(sourcemeta::core::strip_left("abc", '0'), "abc");
 }
 
-TEST(Text_strip_left, single_leading_character) {
+TEST(single_leading_character) {
   EXPECT_EQ(sourcemeta::core::strip_left("0abc", '0'), "abc");
 }
 
-TEST(Text_strip_left, multiple_leading_characters) {
+TEST(multiple_leading_characters) {
   EXPECT_EQ(sourcemeta::core::strip_left("000123", '0'), "123");
 }
 
-TEST(Text_strip_left, only_leading_stripped) {
+TEST(only_leading_stripped) {
   EXPECT_EQ(sourcemeta::core::strip_left("00a0b0", '0'), "a0b0");
 }
 
-TEST(Text_strip_left, all_characters_stripped) {
+TEST(all_characters_stripped) {
   EXPECT_EQ(sourcemeta::core::strip_left("0000", '0'), "");
 }
 
-TEST(Text_strip_left, empty_input) {
-  EXPECT_EQ(sourcemeta::core::strip_left("", '0'), "");
-}
+TEST(empty_input) { EXPECT_EQ(sourcemeta::core::strip_left("", '0'), ""); }
 
-TEST(Text_strip_left, strips_nul_bytes) {
+TEST(strips_nul_bytes) {
   const std::string input("\x00\x00\x2a", 3);
   EXPECT_EQ(sourcemeta::core::strip_left(input, '\x00'), "\x2a");
 }
 
-TEST(Text_strip_left, strips_spaces) {
+TEST(strips_spaces) {
   EXPECT_EQ(sourcemeta::core::strip_left("   value", ' '), "value");
 }

--- a/test/text/text_strip_right_test.cc
+++ b/test/text/text_strip_right_test.cc
@@ -1,35 +1,33 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
-TEST(Text_strip_right, no_trailing_character) {
+TEST(no_trailing_character) {
   EXPECT_EQ(sourcemeta::core::strip_right("abc", '0'), "abc");
 }
 
-TEST(Text_strip_right, single_trailing_character) {
+TEST(single_trailing_character) {
   EXPECT_EQ(sourcemeta::core::strip_right("abc0", '0'), "abc");
 }
 
-TEST(Text_strip_right, multiple_trailing_characters) {
+TEST(multiple_trailing_characters) {
   EXPECT_EQ(sourcemeta::core::strip_right("123000", '0'), "123");
 }
 
-TEST(Text_strip_right, only_trailing_stripped) {
+TEST(only_trailing_stripped) {
   EXPECT_EQ(sourcemeta::core::strip_right("0a0b00", '0'), "0a0b");
 }
 
-TEST(Text_strip_right, all_characters_stripped) {
+TEST(all_characters_stripped) {
   EXPECT_EQ(sourcemeta::core::strip_right("0000", '0'), "");
 }
 
-TEST(Text_strip_right, empty_input) {
-  EXPECT_EQ(sourcemeta::core::strip_right("", '0'), "");
-}
+TEST(empty_input) { EXPECT_EQ(sourcemeta::core::strip_right("", '0'), ""); }
 
-TEST(Text_strip_right, strips_carriage_return) {
+TEST(strips_carriage_return) {
   EXPECT_EQ(sourcemeta::core::strip_right("line\r", '\r'), "line");
 }
 
-TEST(Text_strip_right, strips_trailing_spaces) {
+TEST(strips_trailing_spaces) {
   EXPECT_EQ(sourcemeta::core::strip_right("value   ", ' '), "value");
 }

--- a/test/text/text_take_until_test.cc
+++ b/test/text/text_take_until_test.cc
@@ -1,42 +1,38 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
-TEST(Text_take_until, marker_in_middle) {
+TEST(marker_in_middle) {
   EXPECT_EQ(sourcemeta::core::take_until("foo # bar", '#'), "foo ");
 }
 
-TEST(Text_take_until, marker_absent_returns_input) {
+TEST(marker_absent_returns_input) {
   EXPECT_EQ(sourcemeta::core::take_until("no marker here", '#'),
             "no marker here");
 }
 
-TEST(Text_take_until, marker_at_start_returns_empty) {
+TEST(marker_at_start_returns_empty) {
   EXPECT_EQ(sourcemeta::core::take_until("#leading", '#'), "");
 }
 
-TEST(Text_take_until, marker_at_end) {
+TEST(marker_at_end) {
   EXPECT_EQ(sourcemeta::core::take_until("trailing#", '#'), "trailing");
 }
 
-TEST(Text_take_until, only_first_occurrence) {
+TEST(only_first_occurrence) {
   EXPECT_EQ(sourcemeta::core::take_until("a#b#c", '#'), "a");
 }
 
-TEST(Text_take_until, empty_input) {
-  EXPECT_EQ(sourcemeta::core::take_until("", '#'), "");
-}
+TEST(empty_input) { EXPECT_EQ(sourcemeta::core::take_until("", '#'), ""); }
 
-TEST(Text_take_until, marker_only) {
-  EXPECT_EQ(sourcemeta::core::take_until("#", '#'), "");
-}
+TEST(marker_only) { EXPECT_EQ(sourcemeta::core::take_until("#", '#'), ""); }
 
-TEST(Text_take_until, marker_null_byte) {
+TEST(marker_null_byte) {
   EXPECT_EQ(sourcemeta::core::take_until(std::string_view{"ab\0cd", 5}, '\0'),
             "ab");
 }
 
-TEST(Text_take_until, non_ascii_passthrough) {
+TEST(non_ascii_passthrough) {
   EXPECT_EQ(sourcemeta::core::take_until("caf\xC3\xA9 # x", '#'),
             "caf\xC3\xA9 ");
 }

--- a/test/text/text_to_lowercase_test.cc
+++ b/test/text/text_to_lowercase_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
@@ -6,99 +6,99 @@
 #include <memory>
 #include <string>
 
-TEST(Text_to_lowercase, uppercase_a) {
+TEST(uppercase_a) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('A'), 'a');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('A')));
 }
 
-TEST(Text_to_lowercase, uppercase_z) {
+TEST(uppercase_z) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('Z'), 'z');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('Z')));
 }
 
-TEST(Text_to_lowercase, uppercase_middle) {
+TEST(uppercase_middle) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('M'), 'm');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('M')));
 }
 
-TEST(Text_to_lowercase, lowercase_a_unchanged) {
+TEST(lowercase_a_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('a'), 'a');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('a')));
 }
 
-TEST(Text_to_lowercase, lowercase_z_unchanged) {
+TEST(lowercase_z_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('z'), 'z');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('z')));
 }
 
-TEST(Text_to_lowercase, digit_unchanged) {
+TEST(digit_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('5'), '5');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('5')));
 }
 
-TEST(Text_to_lowercase, punctuation_unchanged) {
+TEST(punctuation_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('!'), '!');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('!')));
 }
 
-TEST(Text_to_lowercase, space_unchanged) {
+TEST(space_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(' '), ' ');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(' ')));
 }
 
-TEST(Text_to_lowercase, null_unchanged) {
+TEST(null_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('\0'), '\0');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('\0')));
 }
 
-TEST(Text_to_lowercase, just_before_uppercase_range_unchanged) {
+TEST(just_before_uppercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('@'), '@');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('@')));
 }
 
-TEST(Text_to_lowercase, just_after_uppercase_range_unchanged) {
+TEST(just_after_uppercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('['), '[');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('[')));
 }
 
-TEST(Text_to_lowercase, just_before_lowercase_range_unchanged) {
+TEST(just_before_lowercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('`'), '`');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('`')));
 }
 
-TEST(Text_to_lowercase, just_after_lowercase_range_unchanged) {
+TEST(just_after_lowercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase('{'), '{');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase('{')));
 }
 
-TEST(Text_to_lowercase, non_ascii_byte_unchanged) {
+TEST(non_ascii_byte_unchanged) {
   const char character{static_cast<char>(0xC3)};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character), character);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, high_bit_byte_unchanged) {
+TEST(high_bit_byte_unchanged) {
   const char character{static_cast<char>(0xFF)};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character), character);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, signed_char_uppercase) {
+TEST(signed_char_uppercase) {
   const signed char character{'A'};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character),
             static_cast<signed char>('a'));
@@ -106,21 +106,21 @@ TEST(Text_to_lowercase, signed_char_uppercase) {
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, signed_char_digit_unchanged) {
+TEST(signed_char_digit_unchanged) {
   const signed char character{'5'};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character), character);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, signed_char_high_bit_unchanged) {
+TEST(signed_char_high_bit_unchanged) {
   const signed char character{static_cast<signed char>(-1)};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character), character);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, unsigned_char_uppercase) {
+TEST(unsigned_char_uppercase) {
   const unsigned char character{'A'};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character),
             static_cast<unsigned char>('a'));
@@ -128,182 +128,182 @@ TEST(Text_to_lowercase, unsigned_char_uppercase) {
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, unsigned_char_digit_unchanged) {
+TEST(unsigned_char_digit_unchanged) {
   const unsigned char character{'5'};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character), character);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, unsigned_char_high_bit_unchanged) {
+TEST(unsigned_char_high_bit_unchanged) {
   const unsigned char character{0xFFu};
   EXPECT_EQ(sourcemeta::core::to_lowercase(character), character);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(character)));
 }
 
-TEST(Text_to_lowercase, wide_uppercase_a) {
+TEST(wide_uppercase_a) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'A'), L'a');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'A')));
 }
 
-TEST(Text_to_lowercase, wide_uppercase_z) {
+TEST(wide_uppercase_z) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'Z'), L'z');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'Z')));
 }
 
-TEST(Text_to_lowercase, wide_uppercase_middle) {
+TEST(wide_uppercase_middle) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'M'), L'm');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'M')));
 }
 
-TEST(Text_to_lowercase, wide_lowercase_a_unchanged) {
+TEST(wide_lowercase_a_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'a'), L'a');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'a')));
 }
 
-TEST(Text_to_lowercase, wide_lowercase_z_unchanged) {
+TEST(wide_lowercase_z_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'z'), L'z');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'z')));
 }
 
-TEST(Text_to_lowercase, wide_digit_unchanged) {
+TEST(wide_digit_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'5'), L'5');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'5')));
 }
 
-TEST(Text_to_lowercase, wide_punctuation_unchanged) {
+TEST(wide_punctuation_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'!'), L'!');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'!')));
 }
 
-TEST(Text_to_lowercase, wide_null_unchanged) {
+TEST(wide_null_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'\0'), L'\0');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'\0')));
 }
 
-TEST(Text_to_lowercase, wide_just_before_uppercase_range_unchanged) {
+TEST(wide_just_before_uppercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'@'), L'@');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'@')));
 }
 
-TEST(Text_to_lowercase, wide_just_after_uppercase_range_unchanged) {
+TEST(wide_just_after_uppercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'['), L'[');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'[')));
 }
 
-TEST(Text_to_lowercase, wide_just_before_lowercase_range_unchanged) {
+TEST(wide_just_before_lowercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'`'), L'`');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'`')));
 }
 
-TEST(Text_to_lowercase, wide_just_after_lowercase_range_unchanged) {
+TEST(wide_just_after_lowercase_range_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'{'), L'{');
   EXPECT_TRUE(
       sourcemeta::core::is_lowercase(sourcemeta::core::to_lowercase(L'{')));
 }
 
-TEST(Text_to_lowercase, wide_above_ascii_unchanged) {
+TEST(wide_above_ascii_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'\u00C0'), L'\u00C0');
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(L'\u00C0')));
 }
 
-TEST(Text_to_lowercase, wide_far_above_ascii_unchanged) {
+TEST(wide_far_above_ascii_unchanged) {
   EXPECT_EQ(sourcemeta::core::to_lowercase(L'\u2603'), L'\u2603');
   EXPECT_TRUE(sourcemeta::core::is_lowercase(
       sourcemeta::core::to_lowercase(L'\u2603')));
 }
 
-TEST(Text_to_lowercase_string, empty) {
+TEST(empty) {
   std::string value{""};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, single_uppercase) {
+TEST(single_uppercase) {
   std::string value{"A"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "a");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, single_lowercase_unchanged) {
+TEST(single_lowercase_unchanged) {
   std::string value{"a"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "a");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, single_digit_unchanged) {
+TEST(single_digit_unchanged) {
   std::string value{"5"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "5");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, all_uppercase) {
+TEST(all_uppercase) {
   std::string value{"HELLO"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "hello");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, all_lowercase_unchanged) {
+TEST(all_lowercase_unchanged) {
   std::string value{"hello"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "hello");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, mixed_case) {
+TEST(mixed_case) {
   std::string value{"Hello WORLD"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "hello world");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, digits_and_letters) {
+TEST(digits_and_letters) {
   std::string value{"ABC123xyz"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "abc123xyz");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, punctuation_preserved) {
+TEST(punctuation_preserved) {
   std::string value{"Foo, BAR!"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "foo, bar!");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, whitespace_preserved) {
+TEST(whitespace_preserved) {
   std::string value{"\tFOO\nBAR\r"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, "\tfoo\nbar\r");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, embedded_null_preserved) {
+TEST(embedded_null_preserved) {
   std::string value{"AB\0CD", 5};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::string("ab\0cd", 5));
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, non_ascii_bytes_unchanged) {
+TEST(non_ascii_bytes_unchanged) {
   std::string value{"\xC3"
                     "\x84"
                     "\xC3"
@@ -316,7 +316,7 @@ TEST(Text_to_lowercase_string, non_ascii_bytes_unchanged) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, mixed_ascii_and_non_ascii) {
+TEST(mixed_ascii_and_non_ascii) {
   std::string value{"FOO"
                     "\xC3"
                     "\x84"
@@ -329,112 +329,112 @@ TEST(Text_to_lowercase_string, mixed_ascii_and_non_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_string, size_unchanged) {
+TEST(size_unchanged) {
   std::string value{"HELLO_WORLD"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value.size(), 11);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, empty) {
+TEST(wstring_empty) {
   std::wstring value{L""};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, single_uppercase) {
+TEST(wstring_single_uppercase) {
   std::wstring value{L"A"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"a");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, single_lowercase_unchanged) {
+TEST(wstring_single_lowercase_unchanged) {
   std::wstring value{L"a"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"a");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, single_digit_unchanged) {
+TEST(wstring_single_digit_unchanged) {
   std::wstring value{L"5"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"5");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, all_uppercase) {
+TEST(wstring_all_uppercase) {
   std::wstring value{L"HELLO"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"hello");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, all_lowercase_unchanged) {
+TEST(wstring_all_lowercase_unchanged) {
   std::wstring value{L"hello"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"hello");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, mixed_case) {
+TEST(wstring_mixed_case) {
   std::wstring value{L"Hello WORLD"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"hello world");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, digits_and_letters) {
+TEST(wstring_digits_and_letters) {
   std::wstring value{L"ABC123xyz"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"abc123xyz");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, punctuation_preserved) {
+TEST(wstring_punctuation_preserved) {
   std::wstring value{L"Foo, BAR!"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"foo, bar!");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, whitespace_preserved) {
+TEST(wstring_whitespace_preserved) {
   std::wstring value{L"\tFOO\nBAR\r"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"\tfoo\nbar\r");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, embedded_null_preserved) {
+TEST(wstring_embedded_null_preserved) {
   std::wstring value{L"AB\0CD", 5};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::wstring(L"ab\0cd", 5));
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, above_ascii_unchanged) {
+TEST(above_ascii_unchanged) {
   std::wstring value{L"\u00C0\u00C9\u00CE"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"\u00C0\u00C9\u00CE");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, mixed_ascii_and_above_ascii) {
+TEST(mixed_ascii_and_above_ascii) {
   std::wstring value{L"FOO\u00C0BAR"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, L"foo\u00C0bar");
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_wstring, size_unchanged) {
+TEST(wstring_size_unchanged) {
   std::wstring value{L"HELLO_WORLD"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value.size(), 11);
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_basic_string, custom_allocator_char) {
+TEST(custom_allocator_char) {
   std::basic_string<char, std::char_traits<char>, std::allocator<char>> value{
       "Hello WORLD"};
   sourcemeta::core::to_lowercase(value);
@@ -442,7 +442,7 @@ TEST(Text_to_lowercase_basic_string, custom_allocator_char) {
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_basic_string, custom_allocator_wchar_t) {
+TEST(custom_allocator_wchar_t) {
   std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t>>
       value{L"Hello WORLD"};
   sourcemeta::core::to_lowercase(value);
@@ -456,7 +456,7 @@ TEST(Text_to_lowercase_basic_string, custom_allocator_wchar_t) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-TEST(Text_to_lowercase_basic_string, unsigned_char_string) {
+TEST(unsigned_char_string) {
   std::basic_string<unsigned char> value{
       reinterpret_cast<const unsigned char *>("Hello WORLD")};
   sourcemeta::core::to_lowercase(value);
@@ -467,98 +467,98 @@ TEST(Text_to_lowercase_basic_string, unsigned_char_string) {
 #pragma GCC diagnostic pop
 #endif
 
-TEST(Text_to_lowercase_path, empty) {
+TEST(path_empty) {
   std::filesystem::path value{""};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{""});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, single_uppercase_filename) {
+TEST(single_uppercase_filename) {
   std::filesystem::path value{"FOO"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"foo"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, single_lowercase_filename_unchanged) {
+TEST(single_lowercase_filename_unchanged) {
   std::filesystem::path value{"foo"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"foo"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, mixed_case_filename) {
+TEST(mixed_case_filename) {
   std::filesystem::path value{"FooBar"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"foobar"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, uppercase_extension) {
+TEST(uppercase_extension) {
   std::filesystem::path value{"schema.JSON"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"schema.json"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, mixed_case_extension) {
+TEST(mixed_case_extension) {
   std::filesystem::path value{"Schema.Json"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"schema.json"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, absolute_path_with_directories) {
+TEST(absolute_path_with_directories) {
   std::filesystem::path value{"/Foo/BAR/Baz.JSON"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"/foo/bar/baz.json"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, relative_path_with_directories) {
+TEST(relative_path_with_directories) {
   std::filesystem::path value{"Foo/BAR/baz"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"foo/bar/baz"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, separators_preserved) {
+TEST(separators_preserved) {
   std::filesystem::path value{"/A/B/C"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"/a/b/c"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, digits_preserved) {
+TEST(digits_preserved) {
   std::filesystem::path value{"FILE123.TXT"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"file123.txt"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, dot_segments_preserved) {
+TEST(dot_segments_preserved) {
   std::filesystem::path value{"./FOO/../BAR"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"./foo/../bar"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, hidden_file_uppercase) {
+TEST(hidden_file_uppercase) {
   std::filesystem::path value{".CONFIG"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{".config"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, multiple_extensions) {
+TEST(multiple_extensions) {
   std::filesystem::path value{"Archive.TAR.GZ"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"archive.tar.gz"});
   EXPECT_TRUE(sourcemeta::core::is_lowercase(value));
 }
 
-TEST(Text_to_lowercase_path, already_lowercase_unchanged) {
+TEST(already_lowercase_unchanged) {
   std::filesystem::path value{"/foo/bar/baz.json"};
   sourcemeta::core::to_lowercase(value);
   EXPECT_EQ(value, std::filesystem::path{"/foo/bar/baz.json"});

--- a/test/text/text_to_title_case_test.cc
+++ b/test/text/text_to_title_case_test.cc
@@ -1,184 +1,184 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string
 
-TEST(Text_to_title_case, empty_string) {
+TEST(empty_string) {
   std::string value{""};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "");
 }
 
-TEST(Text_to_title_case, single_lowercase_character) {
+TEST(single_lowercase_character) {
   std::string value{"a"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "A");
 }
 
-TEST(Text_to_title_case, single_uppercase_character) {
+TEST(single_uppercase_character) {
   std::string value{"A"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "A");
 }
 
-TEST(Text_to_title_case, single_underscore_is_empty) {
+TEST(single_underscore_is_empty) {
   std::string value{"_"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "");
 }
 
-TEST(Text_to_title_case, single_dash_is_empty) {
+TEST(single_dash_is_empty) {
   std::string value{"-"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "");
 }
 
-TEST(Text_to_title_case, only_separators_is_empty) {
+TEST(only_separators_is_empty) {
   std::string value{"___"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "");
 }
 
-TEST(Text_to_title_case, single_lowercase_word) {
+TEST(single_lowercase_word) {
   std::string value{"hello"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, already_title_cased_word) {
+TEST(already_title_cased_word) {
   std::string value{"Hello"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, all_uppercase_word) {
+TEST(all_uppercase_word) {
   std::string value{"HELLO"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "HELLO");
 }
 
-TEST(Text_to_title_case, snake_case_two_words) {
+TEST(snake_case_two_words) {
   std::string value{"hello_world"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello World");
 }
 
-TEST(Text_to_title_case, kebab_case_two_words) {
+TEST(kebab_case_two_words) {
   std::string value{"hello-world"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello World");
 }
 
-TEST(Text_to_title_case, mixed_snake_and_kebab_separators) {
+TEST(mixed_snake_and_kebab_separators) {
   std::string value{"hello_world-test"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello World Test");
 }
 
-TEST(Text_to_title_case, snake_case_three_words) {
+TEST(snake_case_three_words) {
   std::string value{"abc_def_ghi"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Abc Def Ghi");
 }
 
-TEST(Text_to_title_case, preserves_existing_uppercase_after_separator) {
+TEST(preserves_existing_uppercase_after_separator) {
   std::string value{"Hello_World"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello World");
 }
 
-TEST(Text_to_title_case, leading_underscore_is_stripped) {
+TEST(leading_underscore_is_stripped) {
   std::string value{"_hello"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, leading_dash_is_stripped) {
+TEST(leading_dash_is_stripped) {
   std::string value{"-hello"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, trailing_underscore_is_stripped) {
+TEST(trailing_underscore_is_stripped) {
   std::string value{"hello_"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, trailing_dash_is_stripped) {
+TEST(trailing_dash_is_stripped) {
   std::string value{"hello-"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, separators_around_word_are_stripped) {
+TEST(separators_around_word_are_stripped) {
   std::string value{"_hello_"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, multiple_leading_separators_are_stripped) {
+TEST(multiple_leading_separators_are_stripped) {
   std::string value{"__hello"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, multiple_trailing_separators_are_stripped) {
+TEST(multiple_trailing_separators_are_stripped) {
   std::string value{"hello__"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello");
 }
 
-TEST(Text_to_title_case, consecutive_separators_collapse_to_single_space) {
+TEST(consecutive_separators_collapse_to_single_space) {
   std::string value{"hello__world"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello World");
 }
 
-TEST(Text_to_title_case, mixed_consecutive_separators_collapse) {
+TEST(mixed_consecutive_separators_collapse) {
   std::string value{"hello_-world"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello World");
 }
 
-TEST(Text_to_title_case, single_letter_words) {
+TEST(single_letter_words) {
   std::string value{"a_b_c"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "A B C");
 }
 
-TEST(Text_to_title_case, digits_pass_through) {
+TEST(digits_pass_through) {
   std::string value{"abc123def"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Abc123def");
 }
 
-TEST(Text_to_title_case, digit_after_separator) {
+TEST(digit_after_separator) {
   std::string value{"abc_123"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Abc 123");
 }
 
-TEST(Text_to_title_case, letter_after_leading_digits_in_segment) {
+TEST(letter_after_leading_digits_in_segment) {
   std::string value{"abc_123def"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Abc 123Def");
 }
 
-TEST(Text_to_title_case, leading_digits_then_letter_at_start) {
+TEST(leading_digits_then_letter_at_start) {
   std::string value{"123abc"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "123Abc");
 }
 
-TEST(Text_to_title_case, space_in_input_is_not_a_separator) {
+TEST(space_in_input_is_not_a_separator) {
   std::string value{"hello world"};
   sourcemeta::core::to_title_case(value);
   EXPECT_EQ(value, "Hello world");
 }
 
-TEST(Text_to_title_case, non_ascii_byte_is_not_uppercased) {
+TEST(non_ascii_byte_is_not_uppercased) {
   std::string value{};
   value.push_back(static_cast<char>(0xE9));
   value.append("hello");

--- a/test/text/text_trim_test.cc
+++ b/test/text/text_trim_test.cc
@@ -1,79 +1,67 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string_view> // std::string_view
 
-TEST(Text_trim, no_whitespace_returns_input_unchanged) {
+TEST(no_whitespace_returns_input_unchanged) {
   EXPECT_EQ(sourcemeta::core::trim("hello"), "hello");
 }
 
-TEST(Text_trim, leading_spaces) {
-  EXPECT_EQ(sourcemeta::core::trim("   hello"), "hello");
-}
+TEST(leading_spaces) { EXPECT_EQ(sourcemeta::core::trim("   hello"), "hello"); }
 
-TEST(Text_trim, trailing_spaces) {
+TEST(trailing_spaces) {
   EXPECT_EQ(sourcemeta::core::trim("hello   "), "hello");
 }
 
-TEST(Text_trim, both_ends_spaces) {
+TEST(both_ends_spaces) {
   EXPECT_EQ(sourcemeta::core::trim("  hello  "), "hello");
 }
 
-TEST(Text_trim, preserves_internal_whitespace) {
+TEST(preserves_internal_whitespace) {
   EXPECT_EQ(sourcemeta::core::trim("  hello world  "), "hello world");
 }
 
-TEST(Text_trim, tabs) {
-  EXPECT_EQ(sourcemeta::core::trim("\thello\t"), "hello");
-}
+TEST(tabs) { EXPECT_EQ(sourcemeta::core::trim("\thello\t"), "hello"); }
 
-TEST(Text_trim, line_feed) {
-  EXPECT_EQ(sourcemeta::core::trim("\nhello\n"), "hello");
-}
+TEST(line_feed) { EXPECT_EQ(sourcemeta::core::trim("\nhello\n"), "hello"); }
 
-TEST(Text_trim, carriage_return) {
+TEST(carriage_return) {
   EXPECT_EQ(sourcemeta::core::trim("\rhello\r"), "hello");
 }
 
-TEST(Text_trim, vertical_tab) {
-  EXPECT_EQ(sourcemeta::core::trim("\vhello\v"), "hello");
-}
+TEST(vertical_tab) { EXPECT_EQ(sourcemeta::core::trim("\vhello\v"), "hello"); }
 
-TEST(Text_trim, form_feed) {
-  EXPECT_EQ(sourcemeta::core::trim("\fhello\f"), "hello");
-}
+TEST(form_feed) { EXPECT_EQ(sourcemeta::core::trim("\fhello\f"), "hello"); }
 
-TEST(Text_trim, mixed_whitespace_characters) {
+TEST(mixed_whitespace_characters) {
   EXPECT_EQ(sourcemeta::core::trim("\t\n\r\v\f hello \f\v\r\n\t"), "hello");
 }
 
-TEST(Text_trim, all_whitespace_returns_empty) {
+TEST(all_whitespace_returns_empty) {
   EXPECT_EQ(sourcemeta::core::trim("    "), "");
 }
 
-TEST(Text_trim, all_whitespace_mixed_returns_empty) {
+TEST(all_whitespace_mixed_returns_empty) {
   EXPECT_EQ(sourcemeta::core::trim("\t\n \r"), "");
 }
 
-TEST(Text_trim, empty_input_returns_empty) {
-  EXPECT_EQ(sourcemeta::core::trim(""), "");
-}
+TEST(empty_input_returns_empty) { EXPECT_EQ(sourcemeta::core::trim(""), ""); }
 
-TEST(Text_trim, single_non_whitespace_character) {
+TEST(single_non_whitespace_character) {
   EXPECT_EQ(sourcemeta::core::trim("a"), "a");
 }
 
-TEST(Text_trim, single_whitespace_character) {
+TEST(single_whitespace_character) {
   EXPECT_EQ(sourcemeta::core::trim(" "), "");
 }
 
-TEST(Text_trim, non_ascii_bytes_pass_through) {
+TEST(non_ascii_bytes_pass_through) {
   const std::string_view input{"\xC3\xA9 caf\xC3\xA9 "};
   EXPECT_EQ(sourcemeta::core::trim(input), "\xC3\xA9 caf\xC3\xA9");
 }
 
-TEST(Text_trim, null_byte_is_not_whitespace) {
+TEST(null_byte_is_not_whitespace) {
   const std::string_view input{"\0hello\0", 7};
   EXPECT_EQ(sourcemeta::core::trim(input), input);
 }

--- a/test/text/text_truncate_test.cc
+++ b/test/text/text_truncate_test.cc
@@ -1,102 +1,102 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string
 
-TEST(Text_truncate, no_op_when_within_limit) {
+TEST(no_op_when_within_limit) {
   std::string value{"hello"};
   sourcemeta::core::truncate(value, 10, "...");
   EXPECT_EQ(value, "hello");
 }
 
-TEST(Text_truncate, no_op_when_equal_to_limit) {
+TEST(no_op_when_equal_to_limit) {
   std::string value{"hello"};
   sourcemeta::core::truncate(value, 5, "...");
   EXPECT_EQ(value, "hello");
 }
 
-TEST(Text_truncate, truncates_and_appends_marker) {
+TEST(truncates_and_appends_marker) {
   std::string value{"abcdef"};
   sourcemeta::core::truncate(value, 5, "...");
   EXPECT_EQ(value, "abcde...");
 }
 
-TEST(Text_truncate, truncates_to_single_byte) {
+TEST(truncates_to_single_byte) {
   std::string value{"hello"};
   sourcemeta::core::truncate(value, 1, "...");
   EXPECT_EQ(value, "h...");
 }
 
-TEST(Text_truncate, truncates_with_zero_limit) {
+TEST(truncates_with_zero_limit) {
   std::string value{"hello"};
   sourcemeta::core::truncate(value, 0, "...");
   EXPECT_EQ(value, "...");
 }
 
-TEST(Text_truncate, empty_input_within_limit) {
+TEST(empty_input_within_limit) {
   std::string value;
   sourcemeta::core::truncate(value, 10, "...");
   EXPECT_EQ(value, "");
 }
 
-TEST(Text_truncate, empty_input_zero_limit) {
+TEST(empty_input_zero_limit) {
   std::string value;
   sourcemeta::core::truncate(value, 0, "...");
   EXPECT_EQ(value, "");
 }
 
-TEST(Text_truncate, empty_marker_just_truncates) {
+TEST(empty_marker_just_truncates) {
   std::string value{"hello"};
   sourcemeta::core::truncate(value, 2, "");
   EXPECT_EQ(value, "he");
 }
 
-TEST(Text_truncate, custom_marker) {
+TEST(custom_marker) {
   std::string value{"hello world"};
   sourcemeta::core::truncate(value, 5, " [more]");
   EXPECT_EQ(value, "hello [more]");
 }
 
-TEST(Text_truncate, unicode_marker) {
+TEST(unicode_marker) {
   std::string value{"abcdef"};
   sourcemeta::core::truncate(value, 3, "\xe2\x80\xa6");
   EXPECT_EQ(value, "abc\xe2\x80\xa6");
 }
 
-TEST(Text_truncate, utf8_two_byte_boundary_aware) {
+TEST(utf8_two_byte_boundary_aware) {
   std::string value{"caf\xc3\xa9"};
   sourcemeta::core::truncate(value, 4, "...");
   EXPECT_EQ(value, "caf...");
 }
 
-TEST(Text_truncate, utf8_two_byte_no_split_at_exact_boundary) {
+TEST(utf8_two_byte_no_split_at_exact_boundary) {
   std::string value{"caf\xc3\xa9"};
   sourcemeta::core::truncate(value, 5, "...");
   EXPECT_EQ(value, "caf\xc3\xa9");
 }
 
-TEST(Text_truncate, utf8_four_byte_emoji_split_inside_rewinds) {
+TEST(utf8_four_byte_emoji_split_inside_rewinds) {
   std::string value{"ab\xf0\x9f\x98\x80"
                     "c"};
   sourcemeta::core::truncate(value, 4, "...");
   EXPECT_EQ(value, "ab...");
 }
 
-TEST(Text_truncate, utf8_four_byte_emoji_kept_when_boundary_lands_after) {
+TEST(utf8_four_byte_emoji_kept_when_boundary_lands_after) {
   std::string value{"ab\xf0\x9f\x98\x80"
                     "c"};
   sourcemeta::core::truncate(value, 6, "...");
   EXPECT_EQ(value, "ab\xf0\x9f\x98\x80...");
 }
 
-TEST(Text_truncate, utf8_no_split_when_no_truncation) {
+TEST(utf8_no_split_when_no_truncation) {
   std::string value{"\xc3\xa9\xc3\xa9"};
   sourcemeta::core::truncate(value, 4, "...");
   EXPECT_EQ(value, "\xc3\xa9\xc3\xa9");
 }
 
-TEST(Text_truncate, ascii_truncation_at_exact_boundary) {
+TEST(ascii_truncation_at_exact_boundary) {
   std::string value{"abcdefghij"};
   sourcemeta::core::truncate(value, 6, "...");
   EXPECT_EQ(value, "abcdef...");

--- a/test/time/CMakeLists.txt
+++ b/test/time/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME time
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME time
   SOURCES imf_fixdate_test.cc rfc850_date_test.cc asctime_test.cc
           unix_timestamp_test.cc
           rfc3339_datetime_test.cc rfc3339_fulldate_test.cc

--- a/test/time/asctime_test.cc
+++ b/test/time/asctime_test.cc
@@ -1,13 +1,13 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>
 #include <ctime>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_asctime, parse_rfc_example) {
+TEST(parse_rfc_example) {
   const auto point{sourcemeta::core::from_asctime("Sun Nov  6 08:49:37 1994")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 94;
@@ -26,9 +26,9 @@ TEST(Time_asctime, parse_rfc_example) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_asctime, parse_two_digit_day) {
+TEST(parse_two_digit_day) {
   const auto point{sourcemeta::core::from_asctime("Wed Oct 21 11:28:00 2015")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 115;
@@ -47,30 +47,30 @@ TEST(Time_asctime, parse_two_digit_day) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_asctime, parse_empty_returns_nullopt) {
+TEST(parse_empty_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_asctime("").has_value());
 }
 
-TEST(Time_asctime, parse_wrong_length_returns_nullopt) {
+TEST(parse_wrong_length_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_asctime("Sun Nov  6 08:49:37 1994 GMT")
                    .has_value());
 }
 
-TEST(Time_asctime, parse_imf_fixdate_form_returns_nullopt) {
+TEST(parse_imf_fixdate_form_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_asctime("Sun, 06 Nov 1994 08:49:37 GMT")
                    .has_value());
 }
 
-TEST(Time_asctime, parse_rfc850_form_returns_nullopt) {
+TEST(parse_rfc850_form_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_asctime("Sunday, 06-Nov-94 08:49:37 GMT")
                    .has_value());
 }
 
-TEST(Time_asctime, parse_garbage_returns_nullopt) {
+TEST(parse_garbage_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_asctime("FOO").has_value());
 }
 
-TEST(Time_asctime, format_round_trip) {
+TEST(format_round_trip) {
   std::tm parts = {};
   parts.tm_year = 70;
   parts.tm_mon = 0;
@@ -87,68 +87,68 @@ TEST(Time_asctime, format_round_trip) {
   EXPECT_EQ(sourcemeta::core::to_asctime(point), "Thu Jan  1 00:00:00 1970");
 }
 
-TEST(Time_asctime, parse_accepts_zero_padded_single_digit_day) {
+TEST(parse_accepts_zero_padded_single_digit_day) {
   EXPECT_TRUE(
       sourcemeta::core::from_asctime("Sun Nov 06 08:49:37 1994").has_value());
 }
 
-TEST(Time_asctime, parse_rejects_trailing_newline) {
+TEST(parse_rejects_trailing_newline) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Nov  6 08:49:37 1994\n").has_value());
 }
 
-TEST(Time_asctime, parse_rejects_sign_prefix_in_day) {
+TEST(parse_rejects_sign_prefix_in_day) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Nov +6 08:49:37 1994").has_value());
 }
 
 // RFC 9110 §5.6.7: the day-of-month must be valid for the given month and year
-TEST(Time_asctime, parse_rejects_february_thirtieth) {
+TEST(parse_rejects_february_thirtieth) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Feb 30 08:49:37 2015").has_value());
 }
 
 // RFC 9110 §5.6.7: 2015 is not a leap year so February has only 28 days
-TEST(Time_asctime, parse_rejects_february_twenty_ninth_non_leap) {
+TEST(parse_rejects_february_twenty_ninth_non_leap) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Feb 29 08:49:37 2015").has_value());
 }
 
 // RFC 9110 §5.6.7: the day-of-month must be at least one
-TEST(Time_asctime, parse_rejects_zero_day) {
+TEST(parse_rejects_zero_day) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Nov 00 08:49:37 1994").has_value());
 }
 
 // RFC 9110 §5.6.7: the hour must be in the range 00-23
-TEST(Time_asctime, parse_rejects_hour_twenty_four) {
+TEST(parse_rejects_hour_twenty_four) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Nov  6 24:49:37 1994").has_value());
 }
 
 // RFC 9110 §5.6.7: the minute must be in the range 00-59
-TEST(Time_asctime, parse_rejects_minute_sixty) {
+TEST(parse_rejects_minute_sixty) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Nov  6 08:60:37 1994").has_value());
 }
 
 // RFC 9110 §5.6.7: the second must not exceed a leap second
-TEST(Time_asctime, parse_rejects_second_sixty_one) {
+TEST(parse_rejects_second_sixty_one) {
   EXPECT_FALSE(
       sourcemeta::core::from_asctime("Sun Nov  6 08:49:61 1994").has_value());
 }
 
-TEST(Time_asctime, format_output_length_is_24) {
+TEST(format_output_length_is_24) {
   const auto point{std::chrono::system_clock::from_time_t(0)};
   EXPECT_EQ(sourcemeta::core::to_asctime(point).size(), 24u);
 }
 
-TEST(Time_asctime, format_output_has_no_trailing_newline) {
+TEST(format_output_has_no_trailing_newline) {
   const auto point{std::chrono::system_clock::from_time_t(0)};
   EXPECT_NE(sourcemeta::core::to_asctime(point).back(), '\n');
 }
 
-TEST(Time_asctime, format_two_digit_day) {
+TEST(format_two_digit_day) {
   std::tm parts = {};
   parts.tm_year = 115;
   parts.tm_mon = 9;

--- a/test/time/imf_fixdate_test.cc
+++ b/test/time/imf_fixdate_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>
 #include <ctime>
@@ -7,7 +7,7 @@
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_imf_fixdate, format_round_trip) {
+TEST(format_round_trip) {
   std::tm parts = {};
   parts.tm_year = 115;
   parts.tm_mon = 9;
@@ -27,10 +27,10 @@ TEST(Time_imf_fixdate, format_round_trip) {
             "Wed, 21 Oct 2015 11:28:00 GMT");
 }
 
-TEST(Time_imf_fixdate, parse_valid) {
+TEST(parse_valid) {
   const auto point{
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 115;
@@ -51,185 +51,185 @@ TEST(Time_imf_fixdate, parse_valid) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_imf_fixdate, parse_then_format) {
+TEST(parse_then_format) {
   const auto point{
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point.value()),
             "Wed, 21 Oct 2015 11:28:00 GMT");
 }
 
-TEST(Time_imf_fixdate, parse_invalid_returns_nullopt) {
+TEST(parse_invalid_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("FOO").has_value());
 }
 
-TEST(Time_imf_fixdate, parse_empty_returns_nullopt) {
+TEST(parse_empty_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("").has_value());
 }
 
-TEST(Time_imf_fixdate, parse_comparison_equal_1) {
+TEST(parse_comparison_equal_1) {
   EXPECT_EQ(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT"),
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT"));
 }
 
-TEST(Time_imf_fixdate, parse_comparison_equal_2) {
+TEST(parse_comparison_equal_2) {
   EXPECT_EQ(
       sourcemeta::core::from_imf_fixdate("Mon, 29 Jul 2024 16:30:29 GMT"),
       sourcemeta::core::from_imf_fixdate("Mon, 29 Jul 2024 16:30:29 GMT"));
 }
 
-TEST(Time_imf_fixdate, parse_comparison_less_than) {
+TEST(parse_comparison_less_than) {
   const auto earlier{
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:27:00 GMT")};
   const auto later{
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT")};
-  ASSERT_TRUE(earlier.has_value());
-  ASSERT_TRUE(later.has_value());
+  EXPECT_TRUE(earlier.has_value());
+  EXPECT_TRUE(later.has_value());
   EXPECT_TRUE(earlier.value() < later.value());
 }
 
-TEST(Time_imf_fixdate, parse_comparison_greater_than) {
+TEST(parse_comparison_greater_than) {
   const auto future{
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2100 11:28:00 GMT")};
   const auto past{
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT")};
-  ASSERT_TRUE(future.has_value());
-  ASSERT_TRUE(past.has_value());
+  EXPECT_TRUE(future.has_value());
+  EXPECT_TRUE(past.has_value());
   EXPECT_TRUE(future.value() > past.value());
 }
 
-TEST(Time_imf_fixdate, parse_with_string_view) {
+TEST(parse_with_string_view) {
   const std::string_view input{"Wed, 21 Oct 2015 11:28:00 GMT"};
   const auto point{sourcemeta::core::from_imf_fixdate(input)};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point.value()),
             "Wed, 21 Oct 2015 11:28:00 GMT");
 }
 
-TEST(Time_imf_fixdate, parse_with_string_view_subview) {
+TEST(parse_with_string_view_subview) {
   const std::string buffer{"prefix:Wed, 21 Oct 2015 11:28:00 GMT:suffix"};
   const std::string_view input{buffer.data() + 7, 29};
   const auto point{sourcemeta::core::from_imf_fixdate(input)};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point.value()),
             "Wed, 21 Oct 2015 11:28:00 GMT");
 }
 
-TEST(Time_imf_fixdate, parse_rejects_lowercase_gmt) {
+TEST(parse_rejects_lowercase_gmt) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 gmt")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_wrong_zone) {
+TEST(parse_rejects_wrong_zone) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 UTC")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_missing_zone) {
+TEST(parse_rejects_missing_zone) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00")
                    .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_single_digit_day) {
+TEST(parse_rejects_single_digit_day) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 1 Oct 2015 11:28:00 GMT")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_double_space_after_comma) {
+TEST(parse_rejects_double_space_after_comma) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed,  21 Oct 2015 11:28:00 GMT")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_missing_space_after_comma) {
+TEST(parse_rejects_missing_space_after_comma) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed,21 Oct 2015 11:28:00 GMT")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_two_digit_year) {
+TEST(parse_rejects_two_digit_year) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 15 11:28:00 GMT")
                    .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_trailing_garbage) {
+TEST(parse_rejects_trailing_garbage) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:00 GMT extra")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_rfc850_shape) {
+TEST(parse_rejects_rfc850_shape) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Sunday, 06-Nov-94 08:49:37 GMT")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, parse_rejects_asctime_shape) {
+TEST(parse_rejects_asctime_shape) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("Sun Nov  6 08:49:37 1994")
                    .has_value());
 }
 
 // RFC 9110 §5.6.7: the day-of-month must be valid for the given month and year
-TEST(Time_imf_fixdate, parse_rejects_february_thirtieth) {
+TEST(parse_rejects_february_thirtieth) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Mon, 30 Feb 2015 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: April has only 30 days
-TEST(Time_imf_fixdate, parse_rejects_april_thirty_first) {
+TEST(parse_rejects_april_thirty_first) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 31 Apr 2015 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: 2015 is not a leap year so February has only 28 days
-TEST(Time_imf_fixdate, parse_rejects_february_twenty_ninth_non_leap) {
+TEST(parse_rejects_february_twenty_ninth_non_leap) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Sun, 29 Feb 2015 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: 2020 is a leap year so February has 29 days
-TEST(Time_imf_fixdate, parse_accepts_february_twenty_ninth_leap) {
+TEST(parse_accepts_february_twenty_ninth_leap) {
   EXPECT_TRUE(
       sourcemeta::core::from_imf_fixdate("Sat, 29 Feb 2020 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the day-of-month must be at least one
-TEST(Time_imf_fixdate, parse_rejects_zero_day) {
+TEST(parse_rejects_zero_day) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 00 Oct 2015 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the hour must be in the range 00-23
-TEST(Time_imf_fixdate, parse_rejects_hour_twenty_four) {
+TEST(parse_rejects_hour_twenty_four) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 24:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the minute must be in the range 00-59
-TEST(Time_imf_fixdate, parse_rejects_minute_sixty) {
+TEST(parse_rejects_minute_sixty) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:60:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the second must not exceed a leap second
-TEST(Time_imf_fixdate, parse_rejects_second_sixty_one) {
+TEST(parse_rejects_second_sixty_one) {
   EXPECT_FALSE(
       sourcemeta::core::from_imf_fixdate("Wed, 21 Oct 2015 11:28:61 GMT")
           .has_value());
 }
 
-TEST(Time_imf_fixdate, format_epoch) {
+TEST(format_epoch) {
   const auto point{std::chrono::system_clock::from_time_t(0)};
   EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point),
             "Thu, 01 Jan 1970 00:00:00 GMT");

--- a/test/time/is_leap_year_test.cc
+++ b/test/time/is_leap_year_test.cc
@@ -1,47 +1,25 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_is_leap_year, year_zero) {
-  EXPECT_TRUE(sourcemeta::core::is_leap_year(0));
-}
+TEST(year_zero) { EXPECT_TRUE(sourcemeta::core::is_leap_year(0)); }
 
-TEST(Time_is_leap_year, year_one) {
-  EXPECT_FALSE(sourcemeta::core::is_leap_year(1));
-}
+TEST(year_one) { EXPECT_FALSE(sourcemeta::core::is_leap_year(1)); }
 
-TEST(Time_is_leap_year, year_4) {
-  EXPECT_TRUE(sourcemeta::core::is_leap_year(4));
-}
+TEST(year_4) { EXPECT_TRUE(sourcemeta::core::is_leap_year(4)); }
 
-TEST(Time_is_leap_year, year_100) {
-  EXPECT_FALSE(sourcemeta::core::is_leap_year(100));
-}
+TEST(year_100) { EXPECT_FALSE(sourcemeta::core::is_leap_year(100)); }
 
-TEST(Time_is_leap_year, year_400) {
-  EXPECT_TRUE(sourcemeta::core::is_leap_year(400));
-}
+TEST(year_400) { EXPECT_TRUE(sourcemeta::core::is_leap_year(400)); }
 
-TEST(Time_is_leap_year, year_1900) {
-  EXPECT_FALSE(sourcemeta::core::is_leap_year(1900));
-}
+TEST(year_1900) { EXPECT_FALSE(sourcemeta::core::is_leap_year(1900)); }
 
-TEST(Time_is_leap_year, year_2000) {
-  EXPECT_TRUE(sourcemeta::core::is_leap_year(2000));
-}
+TEST(year_2000) { EXPECT_TRUE(sourcemeta::core::is_leap_year(2000)); }
 
-TEST(Time_is_leap_year, year_2020) {
-  EXPECT_TRUE(sourcemeta::core::is_leap_year(2020));
-}
+TEST(year_2020) { EXPECT_TRUE(sourcemeta::core::is_leap_year(2020)); }
 
-TEST(Time_is_leap_year, year_2021) {
-  EXPECT_FALSE(sourcemeta::core::is_leap_year(2021));
-}
+TEST(year_2021) { EXPECT_FALSE(sourcemeta::core::is_leap_year(2021)); }
 
-TEST(Time_is_leap_year, year_2100) {
-  EXPECT_FALSE(sourcemeta::core::is_leap_year(2100));
-}
+TEST(year_2100) { EXPECT_FALSE(sourcemeta::core::is_leap_year(2100)); }
 
-TEST(Time_is_leap_year, year_9999) {
-  EXPECT_FALSE(sourcemeta::core::is_leap_year(9999));
-}
+TEST(year_9999) { EXPECT_FALSE(sourcemeta::core::is_leap_year(9999)); }

--- a/test/time/max_day_in_month_test.cc
+++ b/test/time/max_day_in_month_test.cc
@@ -1,67 +1,57 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_max_day_in_month, january_2024) {
+TEST(january_2024) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(1, 2024), 31);
 }
 
-TEST(Time_max_day_in_month, february_2020_leap) {
+TEST(february_2020_leap) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(2, 2020), 29);
 }
 
-TEST(Time_max_day_in_month, february_2021_non_leap) {
+TEST(february_2021_non_leap) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(2, 2021), 28);
 }
 
-TEST(Time_max_day_in_month, february_2000_leap) {
+TEST(february_2000_leap) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(2, 2000), 29);
 }
 
-TEST(Time_max_day_in_month, february_1900_non_leap) {
+TEST(february_1900_non_leap) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(2, 1900), 28);
 }
 
-TEST(Time_max_day_in_month, february_year_zero_leap) {
+TEST(february_year_zero_leap) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(2, 0), 29);
 }
 
-TEST(Time_max_day_in_month, march_2024) {
-  EXPECT_EQ(sourcemeta::core::max_day_in_month(3, 2024), 31);
-}
+TEST(march_2024) { EXPECT_EQ(sourcemeta::core::max_day_in_month(3, 2024), 31); }
 
-TEST(Time_max_day_in_month, april_2024) {
-  EXPECT_EQ(sourcemeta::core::max_day_in_month(4, 2024), 30);
-}
+TEST(april_2024) { EXPECT_EQ(sourcemeta::core::max_day_in_month(4, 2024), 30); }
 
-TEST(Time_max_day_in_month, may_2024) {
-  EXPECT_EQ(sourcemeta::core::max_day_in_month(5, 2024), 31);
-}
+TEST(may_2024) { EXPECT_EQ(sourcemeta::core::max_day_in_month(5, 2024), 31); }
 
-TEST(Time_max_day_in_month, june_2024) {
-  EXPECT_EQ(sourcemeta::core::max_day_in_month(6, 2024), 30);
-}
+TEST(june_2024) { EXPECT_EQ(sourcemeta::core::max_day_in_month(6, 2024), 30); }
 
-TEST(Time_max_day_in_month, july_2024) {
-  EXPECT_EQ(sourcemeta::core::max_day_in_month(7, 2024), 31);
-}
+TEST(july_2024) { EXPECT_EQ(sourcemeta::core::max_day_in_month(7, 2024), 31); }
 
-TEST(Time_max_day_in_month, august_2024) {
+TEST(august_2024) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(8, 2024), 31);
 }
 
-TEST(Time_max_day_in_month, september_2024) {
+TEST(september_2024) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(9, 2024), 30);
 }
 
-TEST(Time_max_day_in_month, october_2024) {
+TEST(october_2024) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(10, 2024), 31);
 }
 
-TEST(Time_max_day_in_month, november_2024) {
+TEST(november_2024) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(11, 2024), 30);
 }
 
-TEST(Time_max_day_in_month, december_2024) {
+TEST(december_2024) {
   EXPECT_EQ(sourcemeta::core::max_day_in_month(12, 2024), 31);
 }

--- a/test/time/rfc3339_datetime_test.cc
+++ b/test/time/rfc3339_datetime_test.cc
@@ -1,259 +1,256 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_rfc3339_datetime, valid_rfc_example_1) {
+TEST(valid_rfc_example_1) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("1985-04-12T23:20:50.52Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_rfc_example_negative) {
+TEST(valid_rfc_example_negative) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("1996-12-19T16:39:57-08:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_rfc_leap_second_1) {
+TEST(valid_rfc_leap_second_1) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("1990-12-31T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_rfc_leap_second_2) {
+TEST(valid_rfc_leap_second_2) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("1990-12-31T15:59:60-08:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_rfc_historical) {
+TEST(valid_rfc_historical) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("1937-01-01T12:00:27.87+00:20"));
 }
 
-TEST(Time_rfc3339_datetime, valid_basic_utc) {
+TEST(valid_basic_utc) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_long_secfrac) {
+TEST(valid_long_secfrac) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00.123456Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_historical_leap_sec) {
+TEST(valid_historical_leap_sec) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_year_zero) {
+TEST(valid_year_zero) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("0000-01-01T00:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_year_zero_leap_day) {
+TEST(valid_year_zero_leap_day) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("0000-02-29T00:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_max_year) {
+TEST(valid_max_year) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("9999-12-31T23:59:59Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_lowercase_t_z) {
+TEST(valid_lowercase_t_z) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2024-01-15t14:30:00z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_utc_offset_zero) {
+TEST(valid_utc_offset_zero) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-15T00:00:00+00:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_unknown_offset) {
+TEST(valid_unknown_offset) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-15T00:00:00-00:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_year_2000_leap) {
+TEST(valid_year_2000_leap) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2000-02-29T12:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_normal_leap_year) {
+TEST(valid_normal_leap_year) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2004-02-29T12:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_secfrac_with_offset) {
+TEST(valid_secfrac_with_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime(
       "1963-06-19T08:30:06.283185+01:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_no_timezone) {
+TEST(invalid_no_timezone) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_colonless_offset) {
+TEST(invalid_colonless_offset) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00+0530"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_non_leap_feb29) {
+TEST(invalid_non_leap_feb29) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2023-02-29T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_century_non_leap) {
+TEST(invalid_century_non_leap) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2100-02-29T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_1900_non_leap) {
+TEST(invalid_1900_non_leap) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1900-02-29T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_space_separator) {
+TEST(invalid_space_separator) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15 14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_tab_separator) {
+TEST(invalid_tab_separator) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15\t14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_five_digit_year) {
+TEST(invalid_five_digit_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("10000-01-01T00:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_month_13) {
+TEST(invalid_month_13) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-13-01T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_month_00) {
+TEST(invalid_month_00) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-00-01T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_day_00) {
+TEST(invalid_day_00) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-00T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_day_32) {
+TEST(invalid_day_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-32T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_hour_24) {
+TEST(invalid_hour_24) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T24:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_minute_60) {
+TEST(invalid_minute_60) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:60:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_second_61) {
+TEST(invalid_second_61) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:61Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00Z "));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime(" 2024-01-15T14:30:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("")); }
 
-TEST(Time_rfc3339_datetime, invalid_not_a_date) {
+TEST(invalid_not_a_date) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("not-a-date"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_offset_hour_25) {
+TEST(invalid_offset_hour_25) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00+25:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_offset_minute_60) {
+TEST(invalid_offset_minute_60) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00+00:60"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_empty_secfrac) {
+TEST(invalid_empty_secfrac) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-01-15T14:30:00.Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_feb29_year_2300) {
+TEST(invalid_feb29_year_2300) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2300-02-29T00:00:00Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_minute_utc) {
+TEST(invalid_leap_second_wrong_minute_utc) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T23:58:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_hour_utc) {
+TEST(invalid_leap_second_wrong_hour_utc) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T22:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_local_negative_offset) {
+TEST(invalid_leap_second_wrong_local_negative_offset) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("1998-12-31T22:59:60-08:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_wrong_local_positive_offset) {
+TEST(invalid_leap_second_wrong_local_positive_offset) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("1998-12-31T04:59:60+04:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_leap_second_positive_offset_rollover) {
+TEST(valid_leap_second_positive_offset_rollover) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("1999-01-01T03:59:60+04:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_leap_second_negative_offset_rollover) {
+TEST(valid_leap_second_negative_offset_rollover) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("1998-12-31T07:59:60-16:00"));
 }
 
-TEST(Time_rfc3339_datetime, valid_leap_second_unknown_offset) {
+TEST(valid_leap_second_unknown_offset) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("1998-12-31T23:59:60-00:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_zero_hour_utc) {
+TEST(invalid_leap_second_zero_hour_utc) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-31T00:00:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_leap_second_june_30) {
+TEST(valid_leap_second_june_30) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2012-06-30T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_leap_second_december_31) {
+TEST(valid_leap_second_december_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2008-12-31T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, valid_leap_second_june_30_negative_offset) {
+TEST(valid_leap_second_june_30_negative_offset) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("2012-06-30T15:59:60-08:00"));
 }
 
-TEST(Time_rfc3339_datetime,
-     valid_leap_second_june_30_positive_offset_rollover) {
+TEST(valid_leap_second_june_30_positive_offset_rollover) {
   EXPECT_TRUE(
       sourcemeta::core::is_rfc3339_datetime("2012-07-01T03:59:60+04:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_december_30) {
+TEST(invalid_leap_second_december_30) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("1998-12-30T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_march_31) {
+TEST(invalid_leap_second_march_31) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-03-31T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_september_30) {
+TEST(invalid_leap_second_september_30) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-09-30T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_june_29) {
+TEST(invalid_leap_second_june_29) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-06-29T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_july_1) {
+TEST(invalid_leap_second_july_1) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2024-07-01T23:59:60Z"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_january_1_utc_shifts_to_jan_1) {
+TEST(invalid_leap_second_january_1_utc_shifts_to_jan_1) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("2024-01-01T23:59:60-00:00"));
 }
 
-TEST(Time_rfc3339_datetime, invalid_leap_second_year_zero_jan_1_underflow) {
+TEST(invalid_leap_second_year_zero_jan_1_underflow) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("0000-01-01T00:59:60+01:00"));
 }

--- a/test/time/rfc3339_duration_test.cc
+++ b/test/time/rfc3339_duration_test.cc
@@ -1,245 +1,243 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_rfc3339_duration, valid_year_only) {
+TEST(valid_year_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1Y"));
 }
 
-TEST(Time_rfc3339_duration, valid_month_only) {
+TEST(valid_month_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1M"));
 }
 
-TEST(Time_rfc3339_duration, valid_day_only) {
+TEST(valid_day_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1D"));
 }
 
-TEST(Time_rfc3339_duration, valid_week_only) {
+TEST(valid_week_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1W"));
 }
 
-TEST(Time_rfc3339_duration, valid_year_month) {
+TEST(valid_year_month) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1Y2M"));
 }
 
-TEST(Time_rfc3339_duration, valid_year_month_day) {
+TEST(valid_year_month_day) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1Y2M3D"));
 }
 
-TEST(Time_rfc3339_duration, valid_month_day) {
+TEST(valid_month_day) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1M2D"));
 }
 
-TEST(Time_rfc3339_duration, valid_zero_day) {
+TEST(valid_zero_day) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P0D"));
 }
 
-TEST(Time_rfc3339_duration, valid_multi_digit_year) {
+TEST(valid_multi_digit_year) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P100Y"));
 }
 
-TEST(Time_rfc3339_duration, valid_leading_zero) {
+TEST(valid_leading_zero) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P01D"));
 }
 
-TEST(Time_rfc3339_duration, valid_hour_only) {
+TEST(valid_hour_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT1H"));
 }
 
-TEST(Time_rfc3339_duration, valid_minute_only) {
+TEST(valid_minute_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT1M"));
 }
 
-TEST(Time_rfc3339_duration, valid_second_only) {
+TEST(valid_second_only) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT1S"));
 }
 
-TEST(Time_rfc3339_duration, valid_zero_seconds) {
+TEST(valid_zero_seconds) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT0S"));
 }
 
-TEST(Time_rfc3339_duration, valid_hour_minute) {
+TEST(valid_hour_minute) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT1H30M"));
 }
 
-TEST(Time_rfc3339_duration, valid_hour_minute_second) {
+TEST(valid_hour_minute_second) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT1H30M45S"));
 }
 
-TEST(Time_rfc3339_duration, valid_minute_second) {
+TEST(valid_minute_second) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT1M30S"));
 }
 
-TEST(Time_rfc3339_duration, valid_large_hours) {
+TEST(valid_large_hours) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("PT36H"));
 }
 
-TEST(Time_rfc3339_duration, valid_day_with_time) {
+TEST(valid_day_with_time) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1DT12H"));
 }
 
-TEST(Time_rfc3339_duration, valid_year_with_time) {
+TEST(valid_year_with_time) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1YT1H"));
 }
 
-TEST(Time_rfc3339_duration, valid_all_components) {
+TEST(valid_all_components) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P1Y2M3DT4H5M6S"));
 }
 
-TEST(Time_rfc3339_duration, valid_multi_digit_all) {
+TEST(valid_multi_digit_all) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P10Y10M10DT10H10M10S"));
 }
 
-TEST(Time_rfc3339_duration, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("")); }
 
-TEST(Time_rfc3339_duration, invalid_only_p) {
+TEST(invalid_only_p) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P"));
 }
 
-TEST(Time_rfc3339_duration, invalid_only_pt) {
+TEST(invalid_only_pt) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PT"));
 }
 
-TEST(Time_rfc3339_duration, invalid_t_no_time_units) {
+TEST(invalid_t_no_time_units) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1YT"));
 }
 
-TEST(Time_rfc3339_duration, invalid_no_p_prefix) {
+TEST(invalid_no_p_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("1Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_lowercase_p) {
+TEST(invalid_lowercase_p) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("p1Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_digit_without_unit) {
+TEST(invalid_digit_without_unit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1"));
 }
 
-TEST(Time_rfc3339_duration, invalid_unit_without_digit) {
+TEST(invalid_unit_without_digit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PY"));
 }
 
-TEST(Time_rfc3339_duration, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration(" P1D"));
 }
 
-TEST(Time_rfc3339_duration, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1D "));
 }
 
-TEST(Time_rfc3339_duration, invalid_internal_space) {
+TEST(invalid_internal_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1Y 2M"));
 }
 
-TEST(Time_rfc3339_duration, invalid_year_after_day) {
+TEST(invalid_year_after_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1D2Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_month_after_day) {
+TEST(invalid_month_after_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1D2M"));
 }
 
-TEST(Time_rfc3339_duration, invalid_year_skip_to_day) {
+TEST(invalid_year_skip_to_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1Y2D"));
 }
 
-TEST(Time_rfc3339_duration, invalid_hour_skip_to_second) {
+TEST(invalid_hour_skip_to_second) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PT1H2S"));
 }
 
-TEST(Time_rfc3339_duration, invalid_duplicate_year) {
+TEST(invalid_duplicate_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1Y2Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_duplicate_minute_time) {
+TEST(invalid_duplicate_minute_time) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PT1M2M"));
 }
 
-TEST(Time_rfc3339_duration, invalid_day_in_time_section) {
+TEST(invalid_day_in_time_section) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PT1D"));
 }
 
-TEST(Time_rfc3339_duration, invalid_hour_in_date_section) {
+TEST(invalid_hour_in_date_section) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1H"));
 }
 
-TEST(Time_rfc3339_duration, invalid_second_in_date_section) {
+TEST(invalid_second_in_date_section) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1S"));
 }
 
-TEST(Time_rfc3339_duration, invalid_missing_t_with_hour) {
+TEST(invalid_missing_t_with_hour) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1D2H"));
 }
 
-TEST(Time_rfc3339_duration, invalid_year_then_week) {
+TEST(invalid_year_then_week) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1Y2W"));
 }
 
-TEST(Time_rfc3339_duration, invalid_week_then_day) {
+TEST(invalid_week_then_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1W2D"));
 }
 
-TEST(Time_rfc3339_duration, invalid_week_then_time) {
+TEST(invalid_week_then_time) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1WT1H"));
 }
 
-TEST(Time_rfc3339_duration, invalid_fractional_seconds) {
+TEST(invalid_fractional_seconds) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PT0.5S"));
 }
 
-TEST(Time_rfc3339_duration, invalid_fractional_years) {
+TEST(invalid_fractional_years) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1.5Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_negative_value) {
+TEST(invalid_negative_value) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P-1D"));
 }
 
-TEST(Time_rfc3339_duration, invalid_positive_sign) {
+TEST(invalid_positive_sign) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P+1D"));
 }
 
-TEST(Time_rfc3339_duration, invalid_bengali_digit) {
+TEST(invalid_bengali_digit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P\xe0\xa7\xa8"
                                                      "Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_arabic_indic_digit) {
+TEST(invalid_arabic_indic_digit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P\xd9\xa1"
                                                      "Y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_unknown_letter_date) {
+TEST(invalid_unknown_letter_date) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1X"));
 }
 
-TEST(Time_rfc3339_duration, invalid_unknown_letter_time) {
+TEST(invalid_unknown_letter_time) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("PT1X"));
 }
 
-TEST(Time_rfc3339_duration, invalid_lowercase_unit) {
+TEST(invalid_lowercase_unit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1y"));
 }
 
-TEST(Time_rfc3339_duration, invalid_lowercase_t) {
+TEST(invalid_lowercase_t) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("P1Dt1H"));
 }
 
-TEST(Time_rfc3339_duration, suite_valid_basic) {
+TEST(suite_valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P4DT12H30M5S"));
 }
 
-TEST(Time_rfc3339_duration, suite_invalid_no_p_prefix_full) {
+TEST(suite_invalid_no_p_prefix_full) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_duration("4DT12H30M5S"));
 }
 
-TEST(Time_rfc3339_duration, suite_valid_four_years) {
+TEST(suite_valid_four_years) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P4Y"));
 }
 
-TEST(Time_rfc3339_duration, suite_valid_two_weeks) {
+TEST(suite_valid_two_weeks) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_duration("P2W"));
 }

--- a/test/time/rfc3339_fulldate_test.cc
+++ b/test/time/rfc3339_fulldate_test.cc
@@ -1,271 +1,269 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_rfc3339_fulldate, valid_basic) {
+TEST(valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2024-01-15"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_year_zero) {
+TEST(valid_year_zero) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("0000-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_year_zero_leap_day) {
+TEST(valid_year_zero_leap_day) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("0000-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_min_non_zero_year) {
+TEST(valid_min_non_zero_year) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("0001-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_max_year) {
+TEST(valid_max_year) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("9999-12-31"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_year_2000_leap) {
+TEST(valid_year_2000_leap) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2000-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_normal_leap_year) {
+TEST(valid_normal_leap_year) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2020-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_february_28_non_leap) {
+TEST(valid_february_28_non_leap) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2021-02-28"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_april_30) {
+TEST(valid_april_30) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2024-04-30"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_january_31) {
+TEST(valid_january_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2024-01-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_non_leap_feb29) {
+TEST(invalid_non_leap_feb29) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2021-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_century_non_leap) {
+TEST(invalid_century_non_leap) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2100-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_1900_non_leap) {
+TEST(invalid_1900_non_leap) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("1900-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_feb_30) {
+TEST(invalid_feb_30) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-02-30"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_april_31) {
+TEST(invalid_april_31) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-04-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_june_31) {
+TEST(invalid_june_31) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-06-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_september_31) {
+TEST(invalid_september_31) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-09-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_november_31) {
+TEST(invalid_november_31) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-11-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_month_13) {
+TEST(invalid_month_13) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024-13-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_month_00) {
+TEST(invalid_month_00) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024-00-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_day_00) {
+TEST(invalid_day_00) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024-01-00"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_day_32) {
+TEST(invalid_day_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024-01-32"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_two_digit_year) {
+TEST(invalid_two_digit_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("20-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_three_digit_year) {
+TEST(invalid_three_digit_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("998-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_five_digit_year) {
+TEST(invalid_five_digit_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("12020-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_one_digit_month) {
+TEST(invalid_one_digit_month) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-1-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_three_digit_month) {
+TEST(invalid_three_digit_month) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-001-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_one_digit_day) {
+TEST(invalid_one_digit_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-1"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_three_digit_day) {
+TEST(invalid_three_digit_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-001"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_positive_sign_prefix) {
+TEST(invalid_positive_sign_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("+2020-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_negative_sign_prefix) {
+TEST(invalid_negative_sign_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("-2020-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_slash_separator) {
+TEST(invalid_slash_separator) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024/01/15"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_en_dash_separator) {
+TEST(invalid_en_dash_separator) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024\xe2\x80\x93"
                                                      "01\xe2\x80\x93"
                                                      "15"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_bengali_digit) {
+TEST(invalid_bengali_digit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-0\xe0\xa7\xaa-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_arabic_indic_digit) {
+TEST(invalid_arabic_indic_digit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-\xd9\xa0\xd9\xa1"
                                                      "-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_trailing_time) {
+TEST(invalid_trailing_time) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-01T00:00:00"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_trailing_t) {
+TEST(invalid_trailing_t) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-01T"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2024-01-15 "));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate(" 2024-01-15"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("")); }
 
-TEST(Time_rfc3339_fulldate, invalid_not_a_date) {
+TEST(invalid_not_a_date) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("not-a-date"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_march_31) {
+TEST(valid_march_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2020-03-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_march_32) {
+TEST(invalid_march_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-03-32"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_may_31) {
+TEST(valid_may_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2020-05-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_may_32) {
+TEST(invalid_may_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-05-32"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_july_31) {
+TEST(valid_july_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2020-07-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_july_32) {
+TEST(invalid_july_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-07-32"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_august_31) {
+TEST(valid_august_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2020-08-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_august_32) {
+TEST(invalid_august_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-08-32"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_october_31) {
+TEST(valid_october_31) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("2020-10-31"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_october_32) {
+TEST(invalid_october_32) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-10-32"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_century_0100_non_leap) {
+TEST(invalid_century_0100_non_leap) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("0100-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, valid_century_0400_leap) {
+TEST(valid_century_0400_leap) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulldate("0400-02-29"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_iso8601_ordinal_date) {
+TEST(invalid_iso8601_ordinal_date) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2013-350"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_iso8601_no_dashes) {
+TEST(invalid_iso8601_no_dashes) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("20230328"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_iso8601_week_number) {
+TEST(invalid_iso8601_week_number) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2023-W01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_iso8601_week_with_day) {
+TEST(invalid_iso8601_week_with_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2023-W13-2"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_iso8601_week_rollover) {
+TEST(invalid_iso8601_week_rollover) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2022W527"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_full_datetime) {
+TEST(invalid_full_datetime) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-11-28T23:55:45Z"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_trailing_x) {
+TEST(invalid_trailing_x) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-01X"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_trailing_z) {
+TEST(invalid_trailing_z) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-01Z"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_date_space_time) {
+TEST(invalid_date_space_time) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020-01-01 00:00:00Z"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_embedded_space) {
+TEST(invalid_embedded_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("2020 -01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_bengali_digit_in_day) {
+TEST(invalid_bengali_digit_in_day) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("1963-06-1\xe0\xa7\xaa"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_bengali_digit_in_year) {
+TEST(invalid_bengali_digit_in_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("\xe0\xa7\xa8"
                                                      "020-01-01"));
 }
 
-TEST(Time_rfc3339_fulldate, invalid_alpha_year) {
+TEST(invalid_alpha_year) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulldate("YYYY-01-01"));
 }

--- a/test/time/rfc3339_fulltime_test.cc
+++ b/test/time/rfc3339_fulltime_test.cc
@@ -1,232 +1,230 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_rfc3339_fulltime, valid_basic_zulu) {
+TEST(valid_basic_zulu) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_min_time) {
+TEST(valid_min_time) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("00:00:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_max_normal_time) {
+TEST(valid_max_normal_time) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:59Z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_lowercase_z) {
+TEST(valid_lowercase_z) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_positive_offset) {
+TEST(valid_positive_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00+05:30"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_negative_offset) {
+TEST(valid_negative_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00-08:00"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_zero_offset) {
+TEST(valid_zero_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00+00:00"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_unknown_offset) {
+TEST(valid_unknown_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00-00:00"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_short_secfrac) {
+TEST(valid_short_secfrac) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00.5Z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_long_secfrac) {
+TEST(valid_long_secfrac) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("14:30:00.123456789Z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_secfrac_with_offset) {
+TEST(valid_secfrac_with_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.283185+01:00"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_leap_second_zulu) {
+TEST(valid_leap_second_zulu) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:60Z"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_leap_second_negative_offset) {
+TEST(valid_leap_second_negative_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("15:59:60-08:00"));
 }
 
-TEST(Time_rfc3339_fulltime, valid_leap_second_positive_offset_wraparound) {
+TEST(valid_leap_second_positive_offset_wraparound) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("01:29:60+01:30"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_empty) {
-  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(""));
-}
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("")); }
 
-TEST(Time_rfc3339_fulltime, invalid_no_offset) {
+TEST(invalid_no_offset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_no_offset_with_secfrac) {
+TEST(invalid_no_offset_with_secfrac) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00.5"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_empty_secfrac) {
+TEST(invalid_empty_secfrac) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00.Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_one_digit_hour) {
+TEST(invalid_one_digit_hour) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("4:30:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_one_digit_minute) {
+TEST(invalid_one_digit_minute) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:3:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_one_digit_second) {
+TEST(invalid_one_digit_second) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:0Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_dot_separator) {
+TEST(invalid_dot_separator) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14.30.00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_colonless_offset) {
+TEST(invalid_colonless_offset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00+0530"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00Z "));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(" 14:30:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_hour_24) {
+TEST(invalid_hour_24) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("24:00:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_minute_60) {
+TEST(invalid_minute_60) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("00:60:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_second_61) {
+TEST(invalid_second_61) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("00:00:61Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_offset_hour_24) {
+TEST(invalid_offset_hour_24) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00+24:00"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_offset_minute_60) {
+TEST(invalid_offset_minute_60) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("14:30:00+00:60"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_leap_second_wrong_hour_zulu) {
+TEST(invalid_leap_second_wrong_hour_zulu) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("22:59:60Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_leap_second_wrong_minute_zulu) {
+TEST(invalid_leap_second_wrong_minute_zulu) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:58:60Z"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_leap_second_wrong_offset_hour) {
+TEST(invalid_leap_second_wrong_offset_hour) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:60+01:00"));
 }
 
-TEST(Time_rfc3339_fulltime, invalid_leap_second_wrong_offset_minute) {
+TEST(invalid_leap_second_wrong_offset_minute) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:60+00:30"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_basic) {
+TEST(suite_valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_extra_leading_zeros) {
+TEST(suite_invalid_extra_leading_zeros) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("008:030:006Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_no_leading_zero) {
+TEST(suite_invalid_no_leading_zero) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("8:3:6Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_mixed_field_widths) {
+TEST(suite_invalid_mixed_field_widths) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("8:0030:6Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_leap_second_zero_offset) {
+TEST(suite_valid_leap_second_zero_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:60+00:00"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_leap_wrong_hour_zero_offset) {
+TEST(suite_invalid_leap_wrong_hour_zero_offset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("22:59:60+00:00"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_leap_wrong_minute_zero_offset) {
+TEST(suite_invalid_leap_wrong_minute_zero_offset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:58:60+00:00"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_leap_large_positive_offset) {
+TEST(suite_valid_leap_large_positive_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:29:60+23:30"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_leap_large_negative_offset) {
+TEST(suite_valid_leap_large_negative_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("00:29:60-23:30"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_leap_wrong_hour_negative_offset) {
+TEST(suite_invalid_leap_wrong_hour_negative_offset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:60-01:00"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_leap_wrong_minute_negative_offset) {
+TEST(suite_invalid_leap_wrong_minute_negative_offset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:60-00:30"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_short_secfrac) {
+TEST(suite_valid_short_secfrac) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:20:50.52Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_precise_secfrac) {
+TEST(suite_valid_precise_secfrac) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.283185Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_plus_offset) {
+TEST(suite_valid_plus_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:20"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_valid_unknown_local_offset) {
+TEST(suite_valid_unknown_local_offset) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("12:34:56-00:00"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_offset_field_widths) {
+TEST(suite_invalid_offset_field_widths) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06-8:000"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_both_z_and_numoffset) {
+TEST(suite_invalid_both_z_and_numoffset) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("01:02:03Z+00:30"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_offset_indicator_pst) {
+TEST(suite_invalid_offset_indicator_pst) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06 PST"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_iso8601_comma_secfrac) {
+TEST(suite_invalid_iso8601_comma_secfrac) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("01:01:01,1111"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_bengali_digit) {
+TEST(suite_invalid_bengali_digit) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("1\xe0\xa7\xa8"
                                                      ":00:00Z"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_hash_offset_prefix) {
+TEST(suite_invalid_hash_offset_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06#00:20"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_letters) {
+TEST(suite_invalid_letters) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("ab:cd:ef"));
 }
 
-TEST(Time_rfc3339_fulltime, suite_invalid_datetime_passed_in) {
+TEST(suite_invalid_datetime_passed_in) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("2020-11-28T23:55:45Z"));
 }

--- a/test/time/rfc3339_partialtime_no_secfrac_test.cc
+++ b/test/time/rfc3339_partialtime_no_secfrac_test.cc
@@ -1,131 +1,131 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_rfc3339_partialtime_no_secfrac, valid_basic) {
+TEST(valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, valid_min_time) {
+TEST(valid_min_time) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("00:00:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, valid_max_normal_time) {
+TEST(valid_max_normal_time) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("23:59:59"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, valid_leap_second) {
+TEST(valid_leap_second) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("23:59:60"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_empty) {
+TEST(invalid_empty) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac(""));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_with_secfrac) {
+TEST(invalid_with_secfrac) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06.5"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_with_long_secfrac) {
+TEST(invalid_with_long_secfrac) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06.283185"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_with_zulu) {
+TEST(invalid_with_zulu) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06Z"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_with_lowercase_z) {
+TEST(invalid_with_lowercase_z) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06z"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_with_positive_offset) {
+TEST(invalid_with_positive_offset) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("14:30:00+05:30"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_with_negative_offset) {
+TEST(invalid_with_negative_offset) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("14:30:00-08:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_one_digit_hour) {
+TEST(invalid_one_digit_hour) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("4:30:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_one_digit_minute) {
+TEST(invalid_one_digit_minute) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("14:3:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_one_digit_second) {
+TEST(invalid_one_digit_second) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("14:30:0"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_dot_separator) {
+TEST(invalid_dot_separator) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("14.30.00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_hour_24) {
+TEST(invalid_hour_24) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("24:00:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_minute_60) {
+TEST(invalid_minute_60) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("00:60:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_second_61) {
+TEST(invalid_second_61) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("00:00:61"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_leap_second_wrong_hour) {
+TEST(invalid_leap_second_wrong_hour) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("22:59:60"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_leap_second_wrong_minute) {
+TEST(invalid_leap_second_wrong_minute) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("23:58:60"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_trailing_space) {
+TEST(invalid_trailing_space) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06 "));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_leading_space) {
+TEST(invalid_leading_space) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac(" 08:30:06"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_letters) {
+TEST(invalid_letters) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("ab:cd:ef"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_extra_leading_zeros) {
+TEST(invalid_extra_leading_zeros) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("008:030:06"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_no_leading_zero) {
+TEST(invalid_no_leading_zero) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("8:3:6"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, invalid_bengali_digit) {
+TEST(invalid_bengali_digit) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_partialtime_no_secfrac("1\xe0\xa7\xa8"
                                                           ":00:00"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, suite_valid_basic) {
+TEST(suite_valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("08:30:06"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, suite_invalid_am_pm) {
+TEST(suite_invalid_am_pm) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac("8:30 AM"));
 }
 
-TEST(Time_rfc3339_partialtime_no_secfrac, suite_invalid_datetime_passed_in) {
+TEST(suite_invalid_datetime_passed_in) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_partialtime_no_secfrac(
       "2020-11-28T23:55:45Z"));
 }

--- a/test/time/rfc850_date_test.cc
+++ b/test/time/rfc850_date_test.cc
@@ -1,14 +1,14 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>
 #include <ctime>
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_rfc850_date, parse_rfc_example) {
+TEST(parse_rfc_example) {
   const auto point{
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-94 08:49:37 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 94;
@@ -27,16 +27,16 @@ TEST(Time_rfc850_date, parse_rfc_example) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_rfc850_date, parse_full_weekday_name) {
+TEST(parse_full_weekday_name) {
   EXPECT_TRUE(
       sourcemeta::core::from_rfc850_date("Wednesday, 21-Oct-15 11:28:00 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_y2k_current_century) {
+TEST(parse_y2k_current_century) {
   const auto point{
       sourcemeta::core::from_rfc850_date("Friday, 01-Jan-21 00:00:00 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 121;
@@ -55,10 +55,10 @@ TEST(Time_rfc850_date, parse_y2k_current_century) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_rfc850_date, parse_y2k_previous_century) {
+TEST(parse_y2k_previous_century) {
   const auto point{
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-94 08:49:37 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 94;
@@ -77,105 +77,105 @@ TEST(Time_rfc850_date, parse_y2k_previous_century) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_rfc850_date, parse_empty_returns_nullopt) {
+TEST(parse_empty_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_rfc850_date("").has_value());
 }
 
-TEST(Time_rfc850_date, parse_missing_comma_returns_nullopt) {
+TEST(parse_missing_comma_returns_nullopt) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday 06-Nov-94 08:49:37 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_wrong_separator_returns_nullopt) {
+TEST(parse_wrong_separator_returns_nullopt) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 06 Nov 94 08:49:37 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_imf_fixdate_form_returns_nullopt) {
+TEST(parse_imf_fixdate_form_returns_nullopt) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sun, 06 Nov 1994 08:49:37 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_garbage_returns_nullopt) {
+TEST(parse_garbage_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_rfc850_date("FOO").has_value());
 }
 
-TEST(Time_rfc850_date, parse_rejects_abbreviated_weekday) {
+TEST(parse_rejects_abbreviated_weekday) {
   EXPECT_FALSE(sourcemeta::core::from_rfc850_date("Sun, 06-Nov-94 08:49:37 GMT")
                    .has_value());
 }
 
-TEST(Time_rfc850_date, parse_rejects_unknown_weekday) {
+TEST(parse_rejects_unknown_weekday) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Xyzzy, 06-Nov-94 08:49:37 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_rejects_empty_weekday) {
+TEST(parse_rejects_empty_weekday) {
   EXPECT_FALSE(sourcemeta::core::from_rfc850_date(", 06-Nov-94 08:49:37 GMT")
                    .has_value());
 }
 
-TEST(Time_rfc850_date, parse_rejects_leading_prefix) {
+TEST(parse_rejects_leading_prefix) {
   EXPECT_FALSE(sourcemeta::core::from_rfc850_date(
                    "prefix Sunday, 06-Nov-94 08:49:37 GMT")
                    .has_value());
 }
 
-TEST(Time_rfc850_date, parse_rejects_four_digit_year) {
+TEST(parse_rejects_four_digit_year) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-1994 08:49:37 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_rejects_lowercase_gmt) {
+TEST(parse_rejects_lowercase_gmt) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-94 08:49:37 gmt")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the day-of-month must be valid for the given month and year
-TEST(Time_rfc850_date, parse_rejects_february_thirtieth) {
+TEST(parse_rejects_february_thirtieth) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Monday, 30-Feb-15 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: 2015 is not a leap year so February has only 28 days
-TEST(Time_rfc850_date, parse_rejects_february_twenty_ninth_non_leap) {
+TEST(parse_rejects_february_twenty_ninth_non_leap) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 29-Feb-15 11:28:00 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the hour must be in the range 00-23
-TEST(Time_rfc850_date, parse_rejects_hour_twenty_four) {
+TEST(parse_rejects_hour_twenty_four) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-94 24:49:37 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the minute must be in the range 00-59
-TEST(Time_rfc850_date, parse_rejects_minute_sixty) {
+TEST(parse_rejects_minute_sixty) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-94 08:60:37 GMT")
           .has_value());
 }
 
 // RFC 9110 §5.6.7: the second must not exceed a leap second
-TEST(Time_rfc850_date, parse_rejects_second_sixty_one) {
+TEST(parse_rejects_second_sixty_one) {
   EXPECT_FALSE(
       sourcemeta::core::from_rfc850_date("Sunday, 06-Nov-94 08:49:61 GMT")
           .has_value());
 }
 
-TEST(Time_rfc850_date, parse_y2k_boundary_at_threshold) {
+TEST(parse_y2k_boundary_at_threshold) {
   const auto point{
       sourcemeta::core::from_rfc850_date("Friday, 01-Jan-76 00:00:00 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 176;
@@ -194,10 +194,10 @@ TEST(Time_rfc850_date, parse_y2k_boundary_at_threshold) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_rfc850_date, parse_y2k_boundary_just_over) {
+TEST(parse_y2k_boundary_just_over) {
   const auto point{
       sourcemeta::core::from_rfc850_date("Tuesday, 01-Jan-77 00:00:00 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 77;
@@ -216,10 +216,10 @@ TEST(Time_rfc850_date, parse_y2k_boundary_just_over) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_rfc850_date, parse_y2k_yy_zero) {
+TEST(parse_y2k_yy_zero) {
   const auto point{
       sourcemeta::core::from_rfc850_date("Saturday, 01-Jan-00 00:00:00 GMT")};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
 
   std::tm parts = {};
   parts.tm_year = 100;
@@ -238,7 +238,7 @@ TEST(Time_rfc850_date, parse_y2k_yy_zero) {
   EXPECT_EQ(point.value(), expected);
 }
 
-TEST(Time_rfc850_date, format_round_trip) {
+TEST(format_round_trip) {
   std::tm parts = {};
   parts.tm_year = 70;
   parts.tm_mon = 0;

--- a/test/time/unix_timestamp_test.cc
+++ b/test/time/unix_timestamp_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>
 #include <ctime>
@@ -6,87 +6,87 @@
 
 #include <sourcemeta/core/time.h>
 
-TEST(Time_unix_timestamp, from_epoch) {
+TEST(from_epoch) {
   const auto point{
       sourcemeta::core::from_unix_timestamp(std::chrono::duration<double>{0})};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   EXPECT_EQ(point.value(), std::chrono::system_clock::from_time_t(0));
 }
 
-TEST(Time_unix_timestamp, from_positive_integer) {
+TEST(from_positive_integer) {
   const auto point{sourcemeta::core::from_unix_timestamp(
       std::chrono::duration<double>{1700000000})};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   EXPECT_EQ(point.value(), std::chrono::system_clock::from_time_t(1700000000));
 }
 
-TEST(Time_unix_timestamp, from_negative_integer) {
+TEST(from_negative_integer) {
   const auto point{
       sourcemeta::core::from_unix_timestamp(std::chrono::duration<double>{-1})};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   // Expressed without `from_time_t(-1)`, as `time_t` is not guaranteed to be
   // signed
   EXPECT_EQ(point.value(), std::chrono::system_clock::from_time_t(0) -
                                std::chrono::seconds{1});
 }
 
-TEST(Time_unix_timestamp, from_fractional) {
+TEST(from_fractional) {
   const auto point{sourcemeta::core::from_unix_timestamp(
       std::chrono::duration<double>{1.5})};
-  ASSERT_TRUE(point.has_value());
+  EXPECT_TRUE(point.has_value());
   EXPECT_EQ(sourcemeta::core::to_unix_timestamp(point.value()),
             std::chrono::duration<double>{1.5});
 }
 
-TEST(Time_unix_timestamp, from_rejects_nan) {
+TEST(from_rejects_nan) {
   EXPECT_FALSE(sourcemeta::core::from_unix_timestamp(
                    std::chrono::duration<double>{
                        std::numeric_limits<double>::quiet_NaN()})
                    .has_value());
 }
 
-TEST(Time_unix_timestamp, from_rejects_positive_infinity) {
+TEST(from_rejects_positive_infinity) {
   EXPECT_FALSE(sourcemeta::core::from_unix_timestamp(
                    std::chrono::duration<double>{
                        std::numeric_limits<double>::infinity()})
                    .has_value());
 }
 
-TEST(Time_unix_timestamp, from_rejects_negative_infinity) {
+TEST(from_rejects_negative_infinity) {
   EXPECT_FALSE(sourcemeta::core::from_unix_timestamp(
                    std::chrono::duration<double>{
                        -std::numeric_limits<double>::infinity()})
                    .has_value());
 }
 
-TEST(Time_unix_timestamp, from_rejects_out_of_range_positive) {
+TEST(from_rejects_out_of_range_positive) {
   EXPECT_FALSE(sourcemeta::core::from_unix_timestamp(
                    std::chrono::duration<double>{1e300})
                    .has_value());
 }
 
-TEST(Time_unix_timestamp, from_rejects_out_of_range_negative) {
+TEST(from_rejects_out_of_range_negative) {
   EXPECT_FALSE(sourcemeta::core::from_unix_timestamp(
                    std::chrono::duration<double>{-1e300})
                    .has_value());
 }
 
-TEST(Time_unix_timestamp, to_epoch) {
+TEST(to_epoch) {
   EXPECT_EQ(sourcemeta::core::to_unix_timestamp(
                 std::chrono::system_clock::from_time_t(0)),
             std::chrono::duration<double>{0});
 }
 
-TEST(Time_unix_timestamp, to_positive_integer) {
+TEST(to_positive_integer) {
   EXPECT_EQ(sourcemeta::core::to_unix_timestamp(
                 std::chrono::system_clock::from_time_t(1700000000)),
             std::chrono::duration<double>{1700000000});
 }
 
-TEST(Time_unix_timestamp, round_trip_through_time_point) {
+TEST(round_trip_through_time_point) {
   const auto point{std::chrono::system_clock::from_time_t(1700000000)};
   const auto timestamp{sourcemeta::core::to_unix_timestamp(point)};
   const auto restored{sourcemeta::core::from_unix_timestamp(timestamp)};
-  ASSERT_TRUE(restored.has_value());
+  EXPECT_TRUE(restored.has_value());
   EXPECT_EQ(restored.value(), point);
 }

--- a/test/unicode/CMakeLists.txt
+++ b/test/unicode/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME unicode
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME unicode
   SOURCES
     unicode_codepoint_to_utf8_test.cc
     unicode_utf8_to_utf32_test.cc

--- a/test/unicode/unicode_bidi_class_test.cc
+++ b/test/unicode/unicode_bidi_class_test.cc
@@ -1,108 +1,108 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_bidi_class, null) {
+TEST(null) {
   EXPECT_EQ(sourcemeta::core::bidi_class(0x0000),
             sourcemeta::core::BidiClass::BoundaryNeutral);
 }
 
-TEST(Unicode_bidi_class, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'A'),
             sourcemeta::core::BidiClass::LeftToRight);
 }
 
-TEST(Unicode_bidi_class, ascii_digit) {
+TEST(ascii_digit) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'0'),
             sourcemeta::core::BidiClass::EuropeanNumber);
 }
 
-TEST(Unicode_bidi_class, tab) {
+TEST(tab) {
   EXPECT_EQ(sourcemeta::core::bidi_class(0x0009),
             sourcemeta::core::BidiClass::SegmentSeparator);
 }
 
-TEST(Unicode_bidi_class, space) {
+TEST(space) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U' '),
             sourcemeta::core::BidiClass::WhiteSpace);
 }
 
-TEST(Unicode_bidi_class, dollar_sign) {
+TEST(dollar_sign) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'$'),
             sourcemeta::core::BidiClass::EuropeanTerminator);
 }
 
-TEST(Unicode_bidi_class, plus_sign) {
+TEST(plus_sign) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'+'),
             sourcemeta::core::BidiClass::EuropeanSeparator);
 }
 
-TEST(Unicode_bidi_class, comma) {
+TEST(comma) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U','),
             sourcemeta::core::BidiClass::CommonSeparator);
 }
 
-TEST(Unicode_bidi_class, combining_acute_accent) {
+TEST(combining_acute_accent) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u0301'),
             sourcemeta::core::BidiClass::NonspacingMark);
 }
 
-TEST(Unicode_bidi_class, hebrew_letter_alef) {
+TEST(hebrew_letter_alef) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u05D0'),
             sourcemeta::core::BidiClass::RightToLeft);
 }
 
-TEST(Unicode_bidi_class, arabic_letter_alef) {
+TEST(arabic_letter_alef) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u0627'),
             sourcemeta::core::BidiClass::ArabicLetter);
 }
 
-TEST(Unicode_bidi_class, arabic_indic_digit_zero) {
+TEST(arabic_indic_digit_zero) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u0660'),
             sourcemeta::core::BidiClass::ArabicNumber);
 }
 
-TEST(Unicode_bidi_class, zero_width_joiner) {
+TEST(zero_width_joiner) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u200D'),
             sourcemeta::core::BidiClass::BoundaryNeutral);
 }
 
-TEST(Unicode_bidi_class, zero_width_non_joiner) {
+TEST(zero_width_non_joiner) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u200C'),
             sourcemeta::core::BidiClass::BoundaryNeutral);
 }
 
-TEST(Unicode_bidi_class, paragraph_separator) {
+TEST(paragraph_separator) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u2029'),
             sourcemeta::core::BidiClass::ParagraphSeparator);
 }
 
-TEST(Unicode_bidi_class, left_to_right_embedding) {
+TEST(left_to_right_embedding) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u202A'),
             sourcemeta::core::BidiClass::LeftToRightEmbedding);
 }
 
-TEST(Unicode_bidi_class, left_to_right_isolate) {
+TEST(left_to_right_isolate) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\u2066'),
             sourcemeta::core::BidiClass::LeftToRightIsolate);
 }
 
-TEST(Unicode_bidi_class, emoji_grinning_face) {
+TEST(emoji_grinning_face) {
   EXPECT_EQ(sourcemeta::core::bidi_class(U'\U0001F600'),
             sourcemeta::core::BidiClass::OtherNeutral);
 }
 
-TEST(Unicode_bidi_class, unassigned_in_hebrew_block) {
+TEST(unassigned_in_hebrew_block) {
   EXPECT_EQ(sourcemeta::core::bidi_class(0x05FF),
             sourcemeta::core::BidiClass::RightToLeft);
 }
 
-TEST(Unicode_bidi_class, unassigned_in_arabic_block) {
+TEST(unassigned_in_arabic_block) {
   EXPECT_EQ(sourcemeta::core::bidi_class(0x07BF),
             sourcemeta::core::BidiClass::ArabicLetter);
 }
 
-TEST(Unicode_bidi_class, above_max_codepoint) {
+TEST(above_max_codepoint) {
   EXPECT_EQ(sourcemeta::core::bidi_class(0x110000),
             sourcemeta::core::BidiClass::LeftToRight);
 }

--- a/test/unicode/unicode_canonical_composition_test.cc
+++ b/test/unicode/unicode_canonical_composition_test.cc
@@ -1,34 +1,34 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <optional>
 
 // U+0041 + U+0300 compose to U+00C0 LATIN CAPITAL LETTER A WITH GRAVE
-TEST(Unicode_canonical_composition, latin_a_grave) {
+TEST(latin_a_grave) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'A', U'\u0300'),
             U'\u00C0');
 }
 
 // U+0041 + U+0301 compose to U+00C1 LATIN CAPITAL LETTER A WITH ACUTE
-TEST(Unicode_canonical_composition, latin_a_acute) {
+TEST(latin_a_acute) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'A', U'\u0301'),
             U'\u00C1');
 }
 
 // U+0075 + U+0308 compose to U+00FC LATIN SMALL LETTER U WITH DIAERESIS
-TEST(Unicode_canonical_composition, latin_u_diaeresis) {
+TEST(latin_u_diaeresis) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'u', U'\u0308'),
             U'\u00FC');
 }
 
 // Two ASCII letters do not compose
-TEST(Unicode_canonical_composition, no_composition_ascii_pair) {
+TEST(no_composition_ascii_pair) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'A', U'B'), std::nullopt);
 }
 
 // Reverse order: combining mark on the left is never a starter
-TEST(Unicode_canonical_composition, no_composition_reversed_order) {
+TEST(no_composition_reversed_order) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'\u0300', U'A'),
             std::nullopt);
 }
@@ -36,61 +36,60 @@ TEST(Unicode_canonical_composition, no_composition_reversed_order) {
 // U+0F73 TIBETAN VOWEL SIGN II decomposes to U+0F71 U+0F72, but U+0F71 has
 // CCC=129 making this a non-starter decomposition. Excluded from the
 // composition table per UAX #15
-TEST(Unicode_canonical_composition, no_composition_non_starter_decomposition) {
+TEST(no_composition_non_starter_decomposition) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'\u0F71', U'\u0F72'),
             std::nullopt);
 }
 
 // U+0958 DEVANAGARI LETTER QA decomposes to U+0915 U+093C but is in the
 // composition exclusion list (script-specific exclusion)
-TEST(Unicode_canonical_composition, no_composition_script_exclusion_qa) {
+TEST(no_composition_script_exclusion_qa) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'\u0915', U'\u093C'),
             std::nullopt);
 }
 
 // U+09DC BENGALI LETTER RRA decomposes to U+09A1 U+09BC and is in the
 // composition exclusion list
-TEST(Unicode_canonical_composition,
-     no_composition_script_exclusion_bengali_rra) {
+TEST(no_composition_script_exclusion_bengali_rra) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'\u09A1', U'\u09BC'),
             std::nullopt);
 }
 
 // Hangul L + V composes algorithmically per UAX #15 §3.12, not via the
 // table. The function must return nullopt for these pairs
-TEST(Unicode_canonical_composition, no_composition_hangul_l_v) {
+TEST(no_composition_hangul_l_v) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'\u1100', U'\u1161'),
             std::nullopt);
 }
 
 // U+003C LESS-THAN SIGN + U+0338 COMBINING LONG SOLIDUS OVERLAY compose to
 // U+226E NOT LESS-THAN. First entry in the sorted composition table
-TEST(Unicode_canonical_composition, less_than_solidus_overlay) {
+TEST(less_than_solidus_overlay) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'<', U'\u0338'),
             U'\u226E');
 }
 
 // U+003D + U+0338 compose to U+2260 NOT EQUAL TO
-TEST(Unicode_canonical_composition, equals_solidus_overlay) {
+TEST(equals_solidus_overlay) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'=', U'\u0338'),
             U'\u2260');
 }
 
 // Out-of-range starter
-TEST(Unicode_canonical_composition, out_of_range_starter) {
+TEST(out_of_range_starter) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(0x110000, U'\u0300'),
             std::nullopt);
 }
 
 // Out-of-range combining
-TEST(Unicode_canonical_composition, out_of_range_combining) {
+TEST(out_of_range_combining) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'A', 0x110000),
             std::nullopt);
 }
 
 // A non-combining codepoint as the second argument exercises the
 // binary-search miss path near a real starter cluster
-TEST(Unicode_canonical_composition, near_match_does_not_compose) {
+TEST(near_match_does_not_compose) {
   EXPECT_EQ(sourcemeta::core::canonical_composition(U'A', U'\u0299'),
             std::nullopt);
 }

--- a/test/unicode/unicode_canonical_decomposition_test.cc
+++ b/test/unicode/unicode_canonical_decomposition_test.cc
@@ -1,112 +1,110 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <string_view>
 
-TEST(Unicode_canonical_decomposition, ascii_letter_has_no_decomposition) {
+TEST(ascii_letter_has_no_decomposition) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'A').empty());
 }
 
-TEST(Unicode_canonical_decomposition, ascii_digit_has_no_decomposition) {
+TEST(ascii_digit_has_no_decomposition) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'0').empty());
 }
 
-TEST(Unicode_canonical_decomposition, null_has_no_decomposition) {
+TEST(null_has_no_decomposition) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(0x0000).empty());
 }
 
 // U+00C0 LATIN CAPITAL LETTER A WITH GRAVE decomposes to U+0041 U+0300
-TEST(Unicode_canonical_decomposition, latin_a_with_grave) {
+TEST(latin_a_with_grave) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u00C0'),
             std::u32string_view{U"A\u0300"});
 }
 
 // U+00C1 LATIN CAPITAL LETTER A WITH ACUTE decomposes to U+0041 U+0301
-TEST(Unicode_canonical_decomposition, latin_a_with_acute) {
+TEST(latin_a_with_acute) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u00C1'),
             std::u32string_view{U"A\u0301"});
 }
 
 // U+00FC LATIN SMALL LETTER U WITH DIAERESIS decomposes to U+0075 U+0308
-TEST(Unicode_canonical_decomposition, latin_u_with_diaeresis) {
+TEST(latin_u_with_diaeresis) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u00FC'),
             std::u32string_view{U"u\u0308"});
 }
 
 // U+2126 OHM SIGN: singleton decomposition to U+03A9 GREEK CAPITAL OMEGA
-TEST(Unicode_canonical_decomposition, ohm_sign_singleton) {
+TEST(ohm_sign_singleton) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u2126'),
             std::u32string_view{U"\u03A9"});
 }
 
 // U+1E9B LATIN SMALL LETTER LONG S WITH DOT ABOVE: decomposes one step to
 // U+017F U+0307. Full recursive decomposition is the algorithm's job
-TEST(Unicode_canonical_decomposition, long_s_with_dot_above_non_recursive) {
+TEST(long_s_with_dot_above_non_recursive) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u1E9B'),
             std::u32string_view{U"\u017F\u0307"});
 }
 
 // Combining marks themselves have no decomposition
-TEST(Unicode_canonical_decomposition, combining_grave_no_decomposition) {
+TEST(combining_grave_no_decomposition) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'\u0300').empty());
 }
 
-TEST(Unicode_canonical_decomposition, combining_acute_no_decomposition) {
+TEST(combining_acute_no_decomposition) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'\u0301').empty());
 }
 
 // U+212B ANGSTROM SIGN: singleton decomposition to U+00C5 LATIN A WITH RING
-TEST(Unicode_canonical_decomposition, angstrom_sign_singleton) {
+TEST(angstrom_sign_singleton) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u212B'),
             std::u32string_view{U"\u00C5"});
 }
 
 // U+0958 DEVANAGARI LETTER QA decomposes to U+0915 U+093C
-TEST(Unicode_canonical_decomposition, devanagari_qa) {
+TEST(devanagari_qa) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u0958'),
             std::u32string_view{U"\u0915\u093C"});
 }
 
 // U+212C SCRIPT CAPITAL B has decomposition `<font> 0042` (compatibility)
-TEST(Unicode_canonical_decomposition,
-     compatibility_decomposition_font_excluded) {
+TEST(compatibility_decomposition_font_excluded) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'\u212C').empty());
 }
 
 // U+FF21 FULLWIDTH LATIN CAPITAL LETTER A has decomposition `<wide> 0041`
-TEST(Unicode_canonical_decomposition,
-     compatibility_decomposition_wide_excluded) {
+TEST(compatibility_decomposition_wide_excluded) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'\uFF21').empty());
 }
 
 // U+212A KELVIN SIGN, by contrast, has an untagged singleton canonical
 // decomposition to U+004B (ASCII K), so it must still be present
-TEST(Unicode_canonical_decomposition, kelvin_sign_canonical_singleton) {
+TEST(kelvin_sign_canonical_singleton) {
   EXPECT_EQ(sourcemeta::core::canonical_decomposition(U'\u212A'),
             std::u32string_view{U"K"});
 }
 
 // Hangul precomposed syllables have no entry in UnicodeData.txt. Their
 // algorithmic decomposition is the caller's job
-TEST(Unicode_canonical_decomposition, hangul_syllable_first) {
+TEST(hangul_syllable_first) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'\uAC00').empty());
 }
 
-TEST(Unicode_canonical_decomposition, hangul_syllable_last) {
+TEST(hangul_syllable_last) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(U'\uD7A3').empty());
 }
 
 // Past the Unicode maximum: empty by definition
-TEST(Unicode_canonical_decomposition, beyond_max_codepoint) {
+TEST(beyond_max_codepoint) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(0x110000).empty());
 }
 
-TEST(Unicode_canonical_decomposition, beyond_max_codepoint_high) {
+TEST(beyond_max_codepoint_high) {
   EXPECT_TRUE(sourcemeta::core::canonical_decomposition(0xFFFFFFFF).empty());
 }
 
-TEST(Unicode_canonical_decomposition, view_outlives_call) {
+TEST(view_outlives_call) {
   const auto first{sourcemeta::core::canonical_decomposition(U'\u00C0')};
   const auto second{sourcemeta::core::canonical_decomposition(U'\u00C0')};
   EXPECT_EQ(first.data(), second.data());

--- a/test/unicode/unicode_codepoint_to_utf8_test.cc
+++ b/test/unicode/unicode_codepoint_to_utf8_test.cc
@@ -1,84 +1,84 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <sstream> // std::ostringstream
 #include <string>  // std::string
 
-TEST(Unicode_codepoint_to_utf8, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x41), "A");
 }
 
-TEST(Unicode_codepoint_to_utf8, ascii_null) {
+TEST(ascii_null) {
   const std::string expected(1, '\0');
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x00), expected);
 }
 
-TEST(Unicode_codepoint_to_utf8, ascii_max) {
+TEST(ascii_max) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x7F), "\x7F");
 }
 
-TEST(Unicode_codepoint_to_utf8, two_byte_min) {
+TEST(two_byte_min) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x80), "\xC2\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, two_byte_latin_e_acute) {
+TEST(two_byte_latin_e_acute) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0xE9), "\xC3\xA9");
 }
 
-TEST(Unicode_codepoint_to_utf8, two_byte_max) {
+TEST(two_byte_max) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x7FF), "\xDF\xBF");
 }
 
-TEST(Unicode_codepoint_to_utf8, three_byte_min) {
+TEST(three_byte_min) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x800), "\xE0\xA0\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, three_byte_cjk) {
+TEST(three_byte_cjk) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x4E16), "\xE4\xB8\x96");
 }
 
-TEST(Unicode_codepoint_to_utf8, three_byte_max) {
+TEST(three_byte_max) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0xFFFF), "\xEF\xBF\xBF");
 }
 
-TEST(Unicode_codepoint_to_utf8, four_byte_min) {
+TEST(four_byte_min) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x10000), "\xF0\x90\x80\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, four_byte_emoji) {
+TEST(four_byte_emoji) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x1F600), "\xF0\x9F\x98\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, four_byte_max) {
+TEST(four_byte_max) {
   EXPECT_EQ(sourcemeta::core::codepoint_to_utf8(0x10FFFF), "\xF4\x8F\xBF\xBF");
 }
 
-TEST(Unicode_codepoint_to_utf8, stream_ascii_letter) {
+TEST(stream_ascii_letter) {
   std::ostringstream output;
   sourcemeta::core::codepoint_to_utf8(0x41, output);
   EXPECT_EQ(output.str(), "A");
 }
 
-TEST(Unicode_codepoint_to_utf8, stream_two_byte_latin_e_acute) {
+TEST(stream_two_byte_latin_e_acute) {
   std::ostringstream output;
   sourcemeta::core::codepoint_to_utf8(0xE9, output);
   EXPECT_EQ(output.str(), "\xC3\xA9");
 }
 
-TEST(Unicode_codepoint_to_utf8, stream_three_byte_cjk) {
+TEST(stream_three_byte_cjk) {
   std::ostringstream output;
   sourcemeta::core::codepoint_to_utf8(0x4E16, output);
   EXPECT_EQ(output.str(), "\xE4\xB8\x96");
 }
 
-TEST(Unicode_codepoint_to_utf8, stream_four_byte_emoji) {
+TEST(stream_four_byte_emoji) {
   std::ostringstream output;
   sourcemeta::core::codepoint_to_utf8(0x1F600, output);
   EXPECT_EQ(output.str(), "\xF0\x9F\x98\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, stream_multiple_codepoints) {
+TEST(stream_multiple_codepoints) {
   std::ostringstream output;
   sourcemeta::core::codepoint_to_utf8(0x48, output);
   sourcemeta::core::codepoint_to_utf8(0xE9, output);
@@ -86,31 +86,31 @@ TEST(Unicode_codepoint_to_utf8, stream_multiple_codepoints) {
   EXPECT_EQ(output.str(), "H\xC3\xA9\xF0\x9F\x98\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, string_ascii_letter) {
+TEST(string_ascii_letter) {
   std::string output;
   sourcemeta::core::codepoint_to_utf8(0x41, output);
   EXPECT_EQ(output, "A");
 }
 
-TEST(Unicode_codepoint_to_utf8, string_two_byte_latin_e_acute) {
+TEST(string_two_byte_latin_e_acute) {
   std::string output;
   sourcemeta::core::codepoint_to_utf8(0xE9, output);
   EXPECT_EQ(output, "\xC3\xA9");
 }
 
-TEST(Unicode_codepoint_to_utf8, string_three_byte_cjk) {
+TEST(string_three_byte_cjk) {
   std::string output;
   sourcemeta::core::codepoint_to_utf8(0x4E16, output);
   EXPECT_EQ(output, "\xE4\xB8\x96");
 }
 
-TEST(Unicode_codepoint_to_utf8, string_four_byte_emoji) {
+TEST(string_four_byte_emoji) {
   std::string output;
   sourcemeta::core::codepoint_to_utf8(0x1F600, output);
   EXPECT_EQ(output, "\xF0\x9F\x98\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, string_multiple_codepoints) {
+TEST(string_multiple_codepoints) {
   std::string output;
   sourcemeta::core::codepoint_to_utf8(0x48, output);
   sourcemeta::core::codepoint_to_utf8(0xE9, output);
@@ -118,7 +118,7 @@ TEST(Unicode_codepoint_to_utf8, string_multiple_codepoints) {
   EXPECT_EQ(output, "H\xC3\xA9\xF0\x9F\x98\x80");
 }
 
-TEST(Unicode_codepoint_to_utf8, string_four_byte_max) {
+TEST(string_four_byte_max) {
   std::string output;
   sourcemeta::core::codepoint_to_utf8(0x10FFFF, output);
   EXPECT_EQ(output, "\xF4\x8F\xBF\xBF");

--- a/test/unicode/unicode_combining_class_test.cc
+++ b/test/unicode/unicode_combining_class_test.cc
@@ -1,67 +1,59 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_combining_class, ascii_letter) {
-  EXPECT_EQ(sourcemeta::core::combining_class(U'A'), 0);
-}
+TEST(ascii_letter) { EXPECT_EQ(sourcemeta::core::combining_class(U'A'), 0); }
 
-TEST(Unicode_combining_class, ascii_digit) {
-  EXPECT_EQ(sourcemeta::core::combining_class(U'0'), 0);
-}
+TEST(ascii_digit) { EXPECT_EQ(sourcemeta::core::combining_class(U'0'), 0); }
 
-TEST(Unicode_combining_class, space) {
-  EXPECT_EQ(sourcemeta::core::combining_class(U' '), 0);
-}
+TEST(space) { EXPECT_EQ(sourcemeta::core::combining_class(U' '), 0); }
 
-TEST(Unicode_combining_class, null) {
-  EXPECT_EQ(sourcemeta::core::combining_class(0x0000), 0);
-}
+TEST(null) { EXPECT_EQ(sourcemeta::core::combining_class(0x0000), 0); }
 
-TEST(Unicode_combining_class, combining_acute_accent) {
+TEST(combining_acute_accent) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u0301'), 230);
 }
 
-TEST(Unicode_combining_class, combining_grave_accent_below) {
+TEST(combining_grave_accent_below) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u0316'), 220);
 }
 
-TEST(Unicode_combining_class, combining_cedilla) {
+TEST(combining_cedilla) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u0327'), 202);
 }
 
-TEST(Unicode_combining_class, devanagari_nukta) {
+TEST(devanagari_nukta) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u093C'), 7);
 }
 
-TEST(Unicode_combining_class, devanagari_virama) {
+TEST(devanagari_virama) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u094D'), 9);
 }
 
-TEST(Unicode_combining_class, bengali_virama) {
+TEST(bengali_virama) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u09CD'), 9);
 }
 
-TEST(Unicode_combining_class, gurmukhi_virama) {
+TEST(gurmukhi_virama) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u0A4D'), 9);
 }
 
-TEST(Unicode_combining_class, malayalam_vertical_bar_virama) {
+TEST(malayalam_vertical_bar_virama) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u0D3B'), 9);
 }
 
-TEST(Unicode_combining_class, malayalam_circular_virama) {
+TEST(malayalam_circular_virama) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u0D3C'), 9);
 }
 
-TEST(Unicode_combining_class, hiragana_voicing_mark) {
+TEST(hiragana_voicing_mark) {
   EXPECT_EQ(sourcemeta::core::combining_class(U'\u3099'), 8);
 }
 
-TEST(Unicode_combining_class, max_codepoint) {
+TEST(max_codepoint) {
   EXPECT_EQ(sourcemeta::core::combining_class(0x10FFFF), 0);
 }
 
-TEST(Unicode_combining_class, unassigned_high_codepoint) {
+TEST(unassigned_high_codepoint) {
   EXPECT_EQ(sourcemeta::core::combining_class(0x0E000), 0);
 }

--- a/test/unicode/unicode_is_combining_mark_test.cc
+++ b/test/unicode/unicode_is_combining_mark_test.cc
@@ -1,85 +1,79 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_is_combining_mark, ascii_letter) {
-  EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'A'));
-}
+TEST(ascii_letter) { EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'A')); }
 
-TEST(Unicode_is_combining_mark, ascii_digit) {
-  EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'0'));
-}
+TEST(ascii_digit) { EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'0')); }
 
-TEST(Unicode_is_combining_mark, null) {
-  EXPECT_FALSE(sourcemeta::core::is_combining_mark(0x0000));
-}
+TEST(null) { EXPECT_FALSE(sourcemeta::core::is_combining_mark(0x0000)); }
 
-TEST(Unicode_is_combining_mark, hebrew_letter_alef) {
+TEST(hebrew_letter_alef) {
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'\u05D0'));
 }
 
-TEST(Unicode_is_combining_mark, combining_acute_accent_nonspacing) {
+TEST(combining_acute_accent_nonspacing) {
   // U+0301 Mn (Nonspacing_Mark)
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u0301'));
 }
 
-TEST(Unicode_is_combining_mark, combining_grave_accent_below_nonspacing) {
+TEST(combining_grave_accent_below_nonspacing) {
   // U+0316 Mn
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u0316'));
 }
 
-TEST(Unicode_is_combining_mark, devanagari_virama_nonspacing) {
+TEST(devanagari_virama_nonspacing) {
   // U+094D Mn
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u094D'));
 }
 
-TEST(Unicode_is_combining_mark, devanagari_vowel_sign_aa_spacing) {
+TEST(devanagari_vowel_sign_aa_spacing) {
   // U+093E Mc (Spacing_Mark)
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u093E'));
 }
 
-TEST(Unicode_is_combining_mark, devanagari_sign_visarga_spacing) {
+TEST(devanagari_sign_visarga_spacing) {
   // U+0903 Mc
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u0903'));
 }
 
-TEST(Unicode_is_combining_mark, tamil_vowel_sign_e_spacing) {
+TEST(tamil_vowel_sign_e_spacing) {
   // U+0BC6 Mc
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u0BC6'));
 }
 
-TEST(Unicode_is_combining_mark, combining_enclosing_circle_enclosing) {
+TEST(combining_enclosing_circle_enclosing) {
   // U+20DD Me (Enclosing_Mark)
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u20DD'));
 }
 
-TEST(Unicode_is_combining_mark, combining_enclosing_square_enclosing) {
+TEST(combining_enclosing_square_enclosing) {
   // U+20DE Me
   EXPECT_TRUE(sourcemeta::core::is_combining_mark(U'\u20DE'));
 }
 
-TEST(Unicode_is_combining_mark, zero_width_joiner_not_mark) {
+TEST(zero_width_joiner_not_mark) {
   // U+200D is bidi class BN but general category Cf (Format), not a mark
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'\u200D'));
 }
 
-TEST(Unicode_is_combining_mark, hangul_letter_not_mark) {
+TEST(hangul_letter_not_mark) {
   // U+1100 is Lo (Other_Letter), not a mark
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'\u1100'));
 }
 
-TEST(Unicode_is_combining_mark, emoji_grinning_face_not_mark) {
+TEST(emoji_grinning_face_not_mark) {
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'\U0001F600'));
 }
 
-TEST(Unicode_is_combining_mark, unassigned_codepoint) {
+TEST(unassigned_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(0x0E80));
 }
 
-TEST(Unicode_is_combining_mark, max_codepoint) {
+TEST(max_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(0x10FFFF));
 }
 
-TEST(Unicode_is_combining_mark, above_max_codepoint) {
+TEST(above_max_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_combining_mark(0x110000));
 }

--- a/test/unicode/unicode_is_iprivate_test.cc
+++ b/test/unicode/unicode_is_iprivate_test.cc
@@ -1,84 +1,70 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_is_iprivate, ascii_letter_excluded) {
+TEST(ascii_letter_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(U'A'));
 }
 
-TEST(Unicode_is_iprivate, before_bmp_private_use_excluded) {
+TEST(before_bmp_private_use_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0xDFFF));
 }
 
 // BMP private use area: U+E000..U+F8FF
-TEST(Unicode_is_iprivate, bmp_lower_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xE000));
-}
+TEST(bmp_lower_bound) { EXPECT_TRUE(sourcemeta::core::is_iprivate(0xE000)); }
 
-TEST(Unicode_is_iprivate, bmp_middle) {
-  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xE800));
-}
+TEST(bmp_middle) { EXPECT_TRUE(sourcemeta::core::is_iprivate(0xE800)); }
 
-TEST(Unicode_is_iprivate, bmp_upper_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF8FF));
-}
+TEST(bmp_upper_bound) { EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF8FF)); }
 
-TEST(Unicode_is_iprivate, just_above_bmp_excluded) {
+TEST(just_above_bmp_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0xF900));
 }
 
 // Plane 15 supplementary private use: U+F0000..U+FFFFD
-TEST(Unicode_is_iprivate, plane15_lower_bound) {
+TEST(plane15_lower_bound) {
   EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF0000));
 }
 
-TEST(Unicode_is_iprivate, plane15_middle) {
-  EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF8000));
-}
+TEST(plane15_middle) { EXPECT_TRUE(sourcemeta::core::is_iprivate(0xF8000)); }
 
-TEST(Unicode_is_iprivate, plane15_upper_bound) {
+TEST(plane15_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::is_iprivate(0xFFFFD));
 }
 
-TEST(Unicode_is_iprivate, plane15_fffe_excluded) {
+TEST(plane15_fffe_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0xFFFFE));
 }
 
-TEST(Unicode_is_iprivate, plane15_ffff_excluded) {
+TEST(plane15_ffff_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0xFFFFF));
 }
 
 // Plane 16 supplementary private use: U+100000..U+10FFFD
-TEST(Unicode_is_iprivate, plane16_lower_bound) {
+TEST(plane16_lower_bound) {
   EXPECT_TRUE(sourcemeta::core::is_iprivate(0x100000));
 }
 
-TEST(Unicode_is_iprivate, plane16_middle) {
-  EXPECT_TRUE(sourcemeta::core::is_iprivate(0x108000));
-}
+TEST(plane16_middle) { EXPECT_TRUE(sourcemeta::core::is_iprivate(0x108000)); }
 
-TEST(Unicode_is_iprivate, plane16_upper_bound) {
+TEST(plane16_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::is_iprivate(0x10FFFD));
 }
 
-TEST(Unicode_is_iprivate, plane16_fffe_excluded) {
+TEST(plane16_fffe_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0x10FFFE));
 }
 
-TEST(Unicode_is_iprivate, beyond_max_codepoint) {
+TEST(beyond_max_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0x110000));
 }
 
 // Plane 14 (ucschar) is not iprivate
-TEST(Unicode_is_iprivate, plane14_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_iprivate(0xE1000));
-}
+TEST(plane14_excluded) { EXPECT_FALSE(sourcemeta::core::is_iprivate(0xE1000)); }
 
 // BMP non-ASCII letters are not iprivate
-TEST(Unicode_is_iprivate, latin_extended_excluded) {
+TEST(latin_extended_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_iprivate(0x00C0));
 }
 
-TEST(Unicode_is_iprivate, han_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_iprivate(0x4E2D));
-}
+TEST(han_excluded) { EXPECT_FALSE(sourcemeta::core::is_iprivate(0x4E2D)); }

--- a/test/unicode/unicode_is_nfc_test.cc
+++ b/test/unicode/unicode_is_nfc_test.cc
@@ -1,72 +1,66 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_is_nfc, empty) { EXPECT_TRUE(sourcemeta::core::is_nfc(U"")); }
+TEST(empty) { EXPECT_TRUE(sourcemeta::core::is_nfc(U"")); }
 
-TEST(Unicode_is_nfc, ascii_letter) {
-  EXPECT_TRUE(sourcemeta::core::is_nfc(U"hello"));
-}
+TEST(ascii_letter) { EXPECT_TRUE(sourcemeta::core::is_nfc(U"hello")); }
 
-TEST(Unicode_is_nfc, ascii_digits_and_punctuation) {
+TEST(ascii_digits_and_punctuation) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"abc-123_xyz."));
 }
 
 // Precomposed character is in NFC
-TEST(Unicode_is_nfc, precomposed_latin_a_grave) {
+TEST(precomposed_latin_a_grave) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"\u00C0"));
 }
 
-TEST(Unicode_is_nfc, precomposed_latin_u_diaeresis) {
+TEST(precomposed_latin_u_diaeresis) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"\u00FC"));
 }
 
-TEST(Unicode_is_nfc, precomposed_cafe_word) {
+TEST(precomposed_cafe_word) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"caf\u00E9"));
 }
 
 // Decomposed sequence is not in NFC (quick check returns Maybe for the
 // combining mark, slow path compares against the composed form)
-TEST(Unicode_is_nfc, decomposed_latin_a_grave) {
+TEST(decomposed_latin_a_grave) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"A\u0300"));
 }
 
-TEST(Unicode_is_nfc, decomposed_latin_u_diaeresis) {
+TEST(decomposed_latin_u_diaeresis) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"u\u0308"));
 }
 
-TEST(Unicode_is_nfc, decomposed_cafe_word) {
+TEST(decomposed_cafe_word) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"cafe\u0301"));
 }
 
 // U+2126 OHM SIGN has NFC_QC=No, so the quick check rejects immediately
-TEST(Unicode_is_nfc, ohm_sign_is_not_nfc) {
-  EXPECT_FALSE(sourcemeta::core::is_nfc(U"\u2126"));
-}
+TEST(ohm_sign_is_not_nfc) { EXPECT_FALSE(sourcemeta::core::is_nfc(U"\u2126")); }
 
 // U+03A9 GREEK CAPITAL OMEGA (the NFC form of OHM SIGN) IS in NFC
-TEST(Unicode_is_nfc, greek_omega_is_nfc) {
-  EXPECT_TRUE(sourcemeta::core::is_nfc(U"\u03A9"));
-}
+TEST(greek_omega_is_nfc) { EXPECT_TRUE(sourcemeta::core::is_nfc(U"\u03A9")); }
 
 // U+212B ANGSTROM SIGN has NFC_QC=No
-TEST(Unicode_is_nfc, angstrom_sign_is_not_nfc) {
+TEST(angstrom_sign_is_not_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"\u212B"));
 }
 
 // U+0958 DEVANAGARI LETTER QA has NFC_QC=No (decomposes in NFC)
-TEST(Unicode_is_nfc, devanagari_qa_precomposed_is_not_nfc) {
+TEST(devanagari_qa_precomposed_is_not_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"\u0958"));
 }
 
 // Decomposed [U+0915, U+093C] IS the NFC form of U+0958
-TEST(Unicode_is_nfc, devanagari_qa_decomposed_is_nfc) {
+TEST(devanagari_qa_decomposed_is_nfc) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"\u0915\u093C"));
 }
 
 // Out-of-order combining marks: quick check rejects on the CCC compare.
 // a + U+0301 (CCC=230) + U+0316 (CCC=220): 230 > 220 with ccc != 0
-TEST(Unicode_is_nfc, out_of_order_combining_marks) {
+TEST(out_of_order_combining_marks) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"a\u0301\u0316"));
 }
 
@@ -74,55 +68,55 @@ TEST(Unicode_is_nfc, out_of_order_combining_marks) {
 // slow path confirms the input is not in NFC. Input: a + U+0316 + U+0301.
 // NFC would compose a + U+0301 to á (the intervening U+0316 does not
 // block since 220 < 230), so the input is NOT in NFC
-TEST(Unicode_is_nfc, in_order_combining_marks_with_composition) {
+TEST(in_order_combining_marks_with_composition) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"a\u0316\u0301"));
 }
 
 // Hangul precomposed syllable is in NFC
-TEST(Unicode_is_nfc, hangul_precomposed_syllable) {
+TEST(hangul_precomposed_syllable) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"\uAC00"));
 }
 
 // Hangul L + V jamo decomposed: not in NFC
-TEST(Unicode_is_nfc, hangul_l_v_decomposed_is_not_nfc) {
+TEST(hangul_l_v_decomposed_is_not_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"\u1100\u1161"));
 }
 
 // Hangul L + V + T decomposed: not in NFC
-TEST(Unicode_is_nfc, hangul_l_v_t_decomposed_is_not_nfc) {
+TEST(hangul_l_v_t_decomposed_is_not_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"\u1100\u1161\u11A8"));
 }
 
 // Hangul LV syllable + T (precomposed LV plus T jamo) is not in NFC
-TEST(Unicode_is_nfc, hangul_precomposed_lv_plus_t_is_not_nfc) {
+TEST(hangul_precomposed_lv_plus_t_is_not_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(U"\uAC00\u11A8"));
 }
 
 // A leading combining mark with no preceding starter is in NFC.
 // nfc(input) leaves the combining mark in place
-TEST(Unicode_is_nfc, leading_combining_mark_is_nfc) {
+TEST(leading_combining_mark_is_nfc) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"\u0301abc"));
 }
 
 // Supplementary plane codepoint with no decomposition is in NFC
-TEST(Unicode_is_nfc, supplementary_plane_codepoint) {
+TEST(supplementary_plane_codepoint) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(U"\U00020000"));
 }
 
 // Greek precomposed text is in NFC
-TEST(Unicode_is_nfc, greek_precomposed) {
+TEST(greek_precomposed) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(
       U"\u03C0\u03B1\u03C1\u03AC\u03B4\u03B5\u03B9\u03B3\u03BC\u03B1"));
 }
 
 // Greek with ά decomposed to α + acute is not in NFC
-TEST(Unicode_is_nfc, greek_decomposed_is_not_nfc) {
+TEST(greek_decomposed_is_not_nfc) {
   EXPECT_FALSE(sourcemeta::core::is_nfc(
       U"\u03C0\u03B1\u03C1\u03B1\u0301\u03B4\u03B5\u03B9\u03B3\u03BC\u03B1"));
 }
 
 // is_nfc(nfc(x)) is always true (NFC is idempotent and a fixed point)
-TEST(Unicode_is_nfc, after_nfc_is_nfc) {
+TEST(after_nfc_is_nfc) {
   EXPECT_TRUE(sourcemeta::core::is_nfc(sourcemeta::core::nfc(U"A\u0300")));
   EXPECT_TRUE(sourcemeta::core::is_nfc(sourcemeta::core::nfc(U"\u1100\u1161")));
   EXPECT_TRUE(sourcemeta::core::is_nfc(sourcemeta::core::nfc(U"\u2126")));

--- a/test/unicode/unicode_is_surrogate_test.cc
+++ b/test/unicode/unicode_is_surrogate_test.cc
@@ -1,55 +1,45 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_is_surrogate, null) {
-  EXPECT_FALSE(sourcemeta::core::is_surrogate(0x0000));
-}
+TEST(null) { EXPECT_FALSE(sourcemeta::core::is_surrogate(0x0000)); }
 
-TEST(Unicode_is_surrogate, ascii_letter) {
-  EXPECT_FALSE(sourcemeta::core::is_surrogate(0x0041));
-}
+TEST(ascii_letter) { EXPECT_FALSE(sourcemeta::core::is_surrogate(0x0041)); }
 
-TEST(Unicode_is_surrogate, just_below_low_surrogate) {
+TEST(just_below_low_surrogate) {
   EXPECT_FALSE(sourcemeta::core::is_surrogate(0xD7FF));
 }
 
-TEST(Unicode_is_surrogate, low_surrogate_low_boundary) {
+TEST(low_surrogate_low_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_surrogate(0xD800));
 }
 
-TEST(Unicode_is_surrogate, low_surrogate_mid) {
-  EXPECT_TRUE(sourcemeta::core::is_surrogate(0xDA00));
-}
+TEST(low_surrogate_mid) { EXPECT_TRUE(sourcemeta::core::is_surrogate(0xDA00)); }
 
-TEST(Unicode_is_surrogate, low_surrogate_high_boundary) {
+TEST(low_surrogate_high_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_surrogate(0xDBFF));
 }
 
-TEST(Unicode_is_surrogate, high_surrogate_low_boundary) {
+TEST(high_surrogate_low_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_surrogate(0xDC00));
 }
 
-TEST(Unicode_is_surrogate, high_surrogate_mid) {
+TEST(high_surrogate_mid) {
   EXPECT_TRUE(sourcemeta::core::is_surrogate(0xDE00));
 }
 
-TEST(Unicode_is_surrogate, high_surrogate_high_boundary) {
+TEST(high_surrogate_high_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_surrogate(0xDFFF));
 }
 
-TEST(Unicode_is_surrogate, just_above_high_surrogate) {
+TEST(just_above_high_surrogate) {
   EXPECT_FALSE(sourcemeta::core::is_surrogate(0xE000));
 }
 
-TEST(Unicode_is_surrogate, max_bmp) {
-  EXPECT_FALSE(sourcemeta::core::is_surrogate(0xFFFF));
-}
+TEST(max_bmp) { EXPECT_FALSE(sourcemeta::core::is_surrogate(0xFFFF)); }
 
-TEST(Unicode_is_surrogate, emoji_grinning_face) {
+TEST(emoji_grinning_face) {
   EXPECT_FALSE(sourcemeta::core::is_surrogate(0x1F600));
 }
 
-TEST(Unicode_is_surrogate, max_codepoint) {
-  EXPECT_FALSE(sourcemeta::core::is_surrogate(0x10FFFF));
-}
+TEST(max_codepoint) { EXPECT_FALSE(sourcemeta::core::is_surrogate(0x10FFFF)); }

--- a/test/unicode/unicode_is_ucschar_test.cc
+++ b/test/unicode/unicode_is_ucschar_test.cc
@@ -1,167 +1,131 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 // ASCII range is excluded from ucschar (those are in the URI ASCII set)
-TEST(Unicode_is_ucschar, ascii_letter_excluded) {
+TEST(ascii_letter_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(U'A'));
 }
 
-TEST(Unicode_is_ucschar, ascii_digit_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(U'0'));
-}
+TEST(ascii_digit_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(U'0')); }
 
-TEST(Unicode_is_ucschar, null_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x0000));
-}
+TEST(null_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(0x0000)); }
 
-TEST(Unicode_is_ucschar, c0_control_excluded) {
+TEST(c0_control_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0x001F));
 }
 
-TEST(Unicode_is_ucschar, latin1_below_a0_excluded) {
+TEST(latin1_below_a0_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0x009F));
 }
 
 // BMP non-ASCII letters are in ucschar
-TEST(Unicode_is_ucschar, nbsp_lower_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x00A0));
-}
+TEST(nbsp_lower_bound) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x00A0)); }
 
-TEST(Unicode_is_ucschar, latin_extended) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x00C0));
-}
+TEST(latin_extended) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x00C0)); }
 
-TEST(Unicode_is_ucschar, greek_alpha) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x03B1));
-}
+TEST(greek_alpha) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x03B1)); }
 
-TEST(Unicode_is_ucschar, hebrew_alef) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x05D0));
-}
+TEST(hebrew_alef) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x05D0)); }
 
-TEST(Unicode_is_ucschar, han_zhong) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x4E2D));
-}
+TEST(han_zhong) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x4E2D)); }
 
-TEST(Unicode_is_ucschar, before_surrogates) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xD7FF));
-}
+TEST(before_surrogates) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0xD7FF)); }
 
 // Surrogates are excluded
-TEST(Unicode_is_ucschar, surrogate_high_excluded) {
+TEST(surrogate_high_excluded) {
   // U+D800 is a high (leading) surrogate
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xD800));
 }
 
-TEST(Unicode_is_ucschar, surrogate_low_excluded) {
+TEST(surrogate_low_excluded) {
   // U+DFFF is a low (trailing) surrogate
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xDFFF));
 }
 
 // BMP private use area is iprivate, not ucschar
-TEST(Unicode_is_ucschar, bmp_private_use_excluded) {
+TEST(bmp_private_use_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xE000));
 }
 
-TEST(Unicode_is_ucschar, bmp_private_use_top_excluded) {
+TEST(bmp_private_use_top_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF8FF));
 }
 
 // Compatibility ideographs gap
-TEST(Unicode_is_ucschar, before_compatibility_excluded) {
+TEST(before_compatibility_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF8FF));
 }
 
-TEST(Unicode_is_ucschar, compatibility_lower_bound) {
+TEST(compatibility_lower_bound) {
   EXPECT_TRUE(sourcemeta::core::is_ucschar(0xF900));
 }
 
-TEST(Unicode_is_ucschar, compatibility_upper_bound) {
+TEST(compatibility_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFDCF));
 }
 
 // Arabic presentation forms-A noncharacters gap
-TEST(Unicode_is_ucschar, fdd0_noncharacter_excluded) {
+TEST(fdd0_noncharacter_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFDD0));
 }
 
-TEST(Unicode_is_ucschar, fdef_noncharacter_excluded) {
+TEST(fdef_noncharacter_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFDEF));
 }
 
-TEST(Unicode_is_ucschar, after_fdef_gap) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFDF0));
-}
+TEST(after_fdef_gap) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFDF0)); }
 
-TEST(Unicode_is_ucschar, ffef_upper_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFFEF));
-}
+TEST(ffef_upper_bound) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0xFFEF)); }
 
 // End-of-plane-0 noncharacters
-TEST(Unicode_is_ucschar, fff0_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFF0));
-}
+TEST(fff0_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFF0)); }
 
-TEST(Unicode_is_ucschar, fffe_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFFE));
-}
+TEST(fffe_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFFE)); }
 
-TEST(Unicode_is_ucschar, ffff_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFFF));
-}
+TEST(ffff_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(0xFFFF)); }
 
 // Supplementary planes 1..13 each allow 0..FFFD
-TEST(Unicode_is_ucschar, plane1_lower_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x10000));
-}
+TEST(plane1_lower_bound) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x10000)); }
 
-TEST(Unicode_is_ucschar, plane1_upper_bound) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x1FFFD));
-}
+TEST(plane1_upper_bound) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x1FFFD)); }
 
-TEST(Unicode_is_ucschar, plane1_fffe_excluded) {
+TEST(plane1_fffe_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0x1FFFE));
 }
 
-TEST(Unicode_is_ucschar, plane1_ffff_excluded) {
+TEST(plane1_ffff_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0x1FFFF));
 }
 
-TEST(Unicode_is_ucschar, plane2) {
-  EXPECT_TRUE(sourcemeta::core::is_ucschar(0x20000));
-}
+TEST(plane2) { EXPECT_TRUE(sourcemeta::core::is_ucschar(0x20000)); }
 
-TEST(Unicode_is_ucschar, plane13_upper_bound) {
+TEST(plane13_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::is_ucschar(0xDFFFD));
 }
 
 // Plane 14 starts at offset 0x1000 (E1000), not E0000
-TEST(Unicode_is_ucschar, plane14_e0000_excluded) {
+TEST(plane14_e0000_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xE0000));
 }
 
-TEST(Unicode_is_ucschar, plane14_e0fff_excluded) {
+TEST(plane14_e0fff_excluded) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0xE0FFF));
 }
 
-TEST(Unicode_is_ucschar, plane14_lower_bound) {
+TEST(plane14_lower_bound) {
   EXPECT_TRUE(sourcemeta::core::is_ucschar(0xE1000));
 }
 
-TEST(Unicode_is_ucschar, plane14_upper_bound) {
+TEST(plane14_upper_bound) {
   EXPECT_TRUE(sourcemeta::core::is_ucschar(0xEFFFD));
 }
 
 // Planes 15 and 16 are iprivate, not ucschar
-TEST(Unicode_is_ucschar, plane15_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF0000));
-}
+TEST(plane15_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(0xF0000)); }
 
-TEST(Unicode_is_ucschar, plane16_excluded) {
-  EXPECT_FALSE(sourcemeta::core::is_ucschar(0x100000));
-}
+TEST(plane16_excluded) { EXPECT_FALSE(sourcemeta::core::is_ucschar(0x100000)); }
 
-TEST(Unicode_is_ucschar, beyond_max_codepoint) {
+TEST(beyond_max_codepoint) {
   EXPECT_FALSE(sourcemeta::core::is_ucschar(0x110000));
 }

--- a/test/unicode/unicode_is_utf8_continuation_test.cc
+++ b/test/unicode/unicode_is_utf8_continuation_test.cc
@@ -1,51 +1,51 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_is_utf8_continuation, ascii_null_rejected) {
+TEST(ascii_null_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0x00));
 }
 
-TEST(Unicode_is_utf8_continuation, ascii_letter_rejected) {
+TEST(ascii_letter_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0x41));
 }
 
-TEST(Unicode_is_utf8_continuation, ascii_high_boundary_rejected) {
+TEST(ascii_high_boundary_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0x7F));
 }
 
-TEST(Unicode_is_utf8_continuation, low_boundary) {
+TEST(low_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_utf8_continuation(0x80));
 }
 
-TEST(Unicode_is_utf8_continuation, just_above_ascii) {
+TEST(just_above_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_utf8_continuation(0x81));
 }
 
-TEST(Unicode_is_utf8_continuation, mid_range_a0) {
+TEST(mid_range_a0) {
   EXPECT_TRUE(sourcemeta::core::is_utf8_continuation(0xA0));
 }
 
-TEST(Unicode_is_utf8_continuation, mid_range_b0) {
+TEST(mid_range_b0) {
   EXPECT_TRUE(sourcemeta::core::is_utf8_continuation(0xB0));
 }
 
-TEST(Unicode_is_utf8_continuation, high_boundary) {
+TEST(high_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_utf8_continuation(0xBF));
 }
 
-TEST(Unicode_is_utf8_continuation, two_byte_lead_rejected) {
+TEST(two_byte_lead_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0xC0));
 }
 
-TEST(Unicode_is_utf8_continuation, three_byte_lead_rejected) {
+TEST(three_byte_lead_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0xE0));
 }
 
-TEST(Unicode_is_utf8_continuation, four_byte_lead_rejected) {
+TEST(four_byte_lead_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0xF0));
 }
 
-TEST(Unicode_is_utf8_continuation, max_byte_rejected) {
+TEST(max_byte_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_utf8_continuation(0xFF));
 }

--- a/test/unicode/unicode_is_valid_codepoint_test.cc
+++ b/test/unicode/unicode_is_valid_codepoint_test.cc
@@ -1,67 +1,63 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_is_valid_codepoint, null) {
-  EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x0000));
-}
+TEST(null) { EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x0000)); }
 
-TEST(Unicode_is_valid_codepoint, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x0041));
 }
 
-TEST(Unicode_is_valid_codepoint, ascii_high_boundary) {
+TEST(ascii_high_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x007F));
 }
 
-TEST(Unicode_is_valid_codepoint, latin_extended) {
+TEST(latin_extended) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x00E9));
 }
 
-TEST(Unicode_is_valid_codepoint, just_below_surrogate_range) {
+TEST(just_below_surrogate_range) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0xD7FF));
 }
 
-TEST(Unicode_is_valid_codepoint, low_surrogate_low_boundary_rejected) {
+TEST(low_surrogate_low_boundary_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_valid_codepoint(0xD800));
 }
 
-TEST(Unicode_is_valid_codepoint, low_surrogate_high_boundary_rejected) {
+TEST(low_surrogate_high_boundary_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_valid_codepoint(0xDBFF));
 }
 
-TEST(Unicode_is_valid_codepoint, high_surrogate_low_boundary_rejected) {
+TEST(high_surrogate_low_boundary_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_valid_codepoint(0xDC00));
 }
 
-TEST(Unicode_is_valid_codepoint, high_surrogate_high_boundary_rejected) {
+TEST(high_surrogate_high_boundary_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_valid_codepoint(0xDFFF));
 }
 
-TEST(Unicode_is_valid_codepoint, just_above_surrogate_range) {
+TEST(just_above_surrogate_range) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0xE000));
 }
 
-TEST(Unicode_is_valid_codepoint, max_bmp) {
-  EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0xFFFF));
-}
+TEST(max_bmp) { EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0xFFFF)); }
 
-TEST(Unicode_is_valid_codepoint, smp_low_boundary) {
+TEST(smp_low_boundary) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x10000));
 }
 
-TEST(Unicode_is_valid_codepoint, emoji_grinning_face) {
+TEST(emoji_grinning_face) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x1F600));
 }
 
-TEST(Unicode_is_valid_codepoint, max_codepoint) {
+TEST(max_codepoint) {
   EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x10FFFF));
 }
 
-TEST(Unicode_is_valid_codepoint, just_above_max_rejected) {
+TEST(just_above_max_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_valid_codepoint(0x110000));
 }
 
-TEST(Unicode_is_valid_codepoint, far_above_max_rejected) {
+TEST(far_above_max_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_valid_codepoint(0x1FFFFF));
 }

--- a/test/unicode/unicode_joining_type_test.cc
+++ b/test/unicode/unicode_joining_type_test.cc
@@ -1,78 +1,78 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_joining_type, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'A'),
             sourcemeta::core::JoiningType::NonJoining);
 }
 
-TEST(Unicode_joining_type, ascii_digit) {
+TEST(ascii_digit) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'0'),
             sourcemeta::core::JoiningType::NonJoining);
 }
 
-TEST(Unicode_joining_type, null) {
+TEST(null) {
   EXPECT_EQ(sourcemeta::core::joining_type(0x0000),
             sourcemeta::core::JoiningType::NonJoining);
 }
 
-TEST(Unicode_joining_type, arabic_tatweel) {
+TEST(arabic_tatweel) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u0640'),
             sourcemeta::core::JoiningType::JoinCausing);
 }
 
-TEST(Unicode_joining_type, zero_width_joiner) {
+TEST(zero_width_joiner) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u200D'),
             sourcemeta::core::JoiningType::JoinCausing);
 }
 
-TEST(Unicode_joining_type, zero_width_non_joiner) {
+TEST(zero_width_non_joiner) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u200C'),
             sourcemeta::core::JoiningType::NonJoining);
 }
 
-TEST(Unicode_joining_type, arabic_letter_beh) {
+TEST(arabic_letter_beh) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u0628'),
             sourcemeta::core::JoiningType::DualJoining);
 }
 
-TEST(Unicode_joining_type, arabic_letter_alef) {
+TEST(arabic_letter_alef) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u0627'),
             sourcemeta::core::JoiningType::RightJoining);
 }
 
-TEST(Unicode_joining_type, syriac_letter_alaph) {
+TEST(syriac_letter_alaph) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u0710'),
             sourcemeta::core::JoiningType::RightJoining);
 }
 
-TEST(Unicode_joining_type, mandaic_letter_az) {
+TEST(mandaic_letter_az) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u0846'),
             sourcemeta::core::JoiningType::RightJoining);
 }
 
-TEST(Unicode_joining_type, phags_pa_superfixed_letter_ra) {
+TEST(phags_pa_superfixed_letter_ra) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\uA872'),
             sourcemeta::core::JoiningType::LeftJoining);
 }
 
-TEST(Unicode_joining_type, manichaean_letter_aleph) {
+TEST(manichaean_letter_aleph) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\U00010AC0'),
             sourcemeta::core::JoiningType::DualJoining);
 }
 
-TEST(Unicode_joining_type, combining_acute_accent) {
+TEST(combining_acute_accent) {
   EXPECT_EQ(sourcemeta::core::joining_type(U'\u0301'),
             sourcemeta::core::JoiningType::Transparent);
 }
 
-TEST(Unicode_joining_type, max_codepoint) {
+TEST(max_codepoint) {
   EXPECT_EQ(sourcemeta::core::joining_type(0x10FFFF),
             sourcemeta::core::JoiningType::NonJoining);
 }
 
-TEST(Unicode_joining_type, above_max_codepoint) {
+TEST(above_max_codepoint) {
   EXPECT_EQ(sourcemeta::core::joining_type(0x110000),
             sourcemeta::core::JoiningType::NonJoining);
 }

--- a/test/unicode/unicode_nfc_quick_check_test.cc
+++ b/test/unicode/unicode_nfc_quick_check_test.cc
@@ -1,109 +1,109 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_nfc_quick_check, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'A'),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
-TEST(Unicode_nfc_quick_check, ascii_digit) {
+TEST(ascii_digit) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'0'),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
-TEST(Unicode_nfc_quick_check, ascii_space) {
+TEST(ascii_space) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U' '),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
-TEST(Unicode_nfc_quick_check, null) {
+TEST(null) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(0x0000),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
 // Latin-1 precomposed character that IS its own NFC form
-TEST(Unicode_nfc_quick_check, latin_a_with_grave) {
+TEST(latin_a_with_grave) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u00C0'),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
-TEST(Unicode_nfc_quick_check, latin_small_u_with_diaeresis) {
+TEST(latin_small_u_with_diaeresis) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u00FC'),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
 // U+0300 COMBINING GRAVE ACCENT may compose with a preceding starter
-TEST(Unicode_nfc_quick_check, combining_grave_accent_is_maybe) {
+TEST(combining_grave_accent_is_maybe) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u0300'),
             sourcemeta::core::NFCQuickCheck::Maybe);
 }
 
 // U+0301 COMBINING ACUTE ACCENT
-TEST(Unicode_nfc_quick_check, combining_acute_accent_is_maybe) {
+TEST(combining_acute_accent_is_maybe) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u0301'),
             sourcemeta::core::NFCQuickCheck::Maybe);
 }
 
 // U+2126 OHM SIGN is a singleton decomposition of U+03A9 GREEK CAPITAL
 // LETTER OMEGA, so it never appears in NFC output
-TEST(Unicode_nfc_quick_check, ohm_sign_is_no) {
+TEST(ohm_sign_is_no) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u2126'),
             sourcemeta::core::NFCQuickCheck::No);
 }
 
 // U+0958 DEVANAGARI LETTER QA decomposes to U+0915 U+093C in NFC
-TEST(Unicode_nfc_quick_check, devanagari_qa_is_no) {
+TEST(devanagari_qa_is_no) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u0958'),
             sourcemeta::core::NFCQuickCheck::No);
 }
 
 // U+FB1D HEBREW LETTER YOD WITH HIRIQ decomposes in NFC
-TEST(Unicode_nfc_quick_check, hebrew_yod_with_hiriq_is_no) {
+TEST(hebrew_yod_with_hiriq_is_no) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\uFB1D'),
             sourcemeta::core::NFCQuickCheck::No);
 }
 
 // U+2000 EN QUAD is a singleton decomposition of U+0020 SPACE
-TEST(Unicode_nfc_quick_check, en_quad_is_no) {
+TEST(en_quad_is_no) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u2000'),
             sourcemeta::core::NFCQuickCheck::No);
 }
 
 // Hangul precomposed syllable, allowed in NFC
-TEST(Unicode_nfc_quick_check, hangul_syllable_is_yes) {
+TEST(hangul_syllable_is_yes) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\uAC00'),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
 // Hangul L jamo (leading consonant): cannot start a precomposed syllable
 // alone, but composes only with following jamos so is Yes itself
-TEST(Unicode_nfc_quick_check, hangul_l_jamo_is_yes) {
+TEST(hangul_l_jamo_is_yes) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u1100'),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
 // Hangul V jamo (vowel): may compose with a preceding L jamo into a LV
 // syllable, so the quick check is Maybe
-TEST(Unicode_nfc_quick_check, hangul_v_jamo_is_maybe) {
+TEST(hangul_v_jamo_is_maybe) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u1161'),
             sourcemeta::core::NFCQuickCheck::Maybe);
 }
 
 // Hangul T jamo (trailing consonant): may compose with a preceding LV
 // syllable into an LVT syllable
-TEST(Unicode_nfc_quick_check, hangul_t_jamo_is_maybe) {
+TEST(hangul_t_jamo_is_maybe) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(U'\u11A8'),
             sourcemeta::core::NFCQuickCheck::Maybe);
 }
 
 // Past the Unicode maximum: default per @missing rule is Yes
-TEST(Unicode_nfc_quick_check, beyond_max_codepoint) {
+TEST(beyond_max_codepoint) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(0x110000),
             sourcemeta::core::NFCQuickCheck::Yes);
 }
 
-TEST(Unicode_nfc_quick_check, beyond_max_codepoint_high) {
+TEST(beyond_max_codepoint_high) {
   EXPECT_EQ(sourcemeta::core::nfc_quick_check(0xFFFFFFFF),
             sourcemeta::core::NFCQuickCheck::Yes);
 }

--- a/test/unicode/unicode_nfc_test.cc
+++ b/test/unicode/unicode_nfc_test.cc
@@ -1,36 +1,36 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <string>
 
-TEST(Unicode_nfc, empty_input) { EXPECT_EQ(sourcemeta::core::nfc(U""), U""); }
+TEST(empty_input) { EXPECT_EQ(sourcemeta::core::nfc(U""), U""); }
 
-TEST(Unicode_nfc, ascii_passthrough) {
+TEST(ascii_passthrough) {
   EXPECT_EQ(sourcemeta::core::nfc(U"hello world"), U"hello world");
 }
 
 // A precomposed character that IS its own NFC form stays unchanged
-TEST(Unicode_nfc, precomposed_a_grave_unchanged) {
+TEST(precomposed_a_grave_unchanged) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u00C0"), U"\u00C0");
 }
 
-TEST(Unicode_nfc, precomposed_u_diaeresis_unchanged) {
+TEST(precomposed_u_diaeresis_unchanged) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u00FC"), U"\u00FC");
 }
 
 // A decomposed sequence canonically composes into its precomposed form
-TEST(Unicode_nfc, decomposed_a_grave_composes) {
+TEST(decomposed_a_grave_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"A\u0300"), U"\u00C0");
 }
 
-TEST(Unicode_nfc, decomposed_u_diaeresis_composes) {
+TEST(decomposed_u_diaeresis_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"u\u0308"), U"\u00FC");
 }
 
 // "café" decomposes to "cafe" + combining acute, which composes
 // into "café"
-TEST(Unicode_nfc, multiple_composing_pairs) {
+TEST(multiple_composing_pairs) {
   EXPECT_EQ(sourcemeta::core::nfc(U"cafe\u0301"), U"caf\u00E9");
 }
 
@@ -39,101 +39,101 @@ TEST(Unicode_nfc, multiple_composing_pairs) {
 // After reorder: a + U+0316 + U+0301. After compose: a + U+0316 has no
 // composition so U+0316 stays, then a + U+0301 composes (220 < 230, the
 // intervening mark does not block). Result: á̖
-TEST(Unicode_nfc, combining_marks_reordered) {
+TEST(combining_marks_reordered) {
   EXPECT_EQ(sourcemeta::core::nfc(U"a\u0301\u0316"), U"\u00E1\u0316");
 }
 
 // U+1E9B LATIN SMALL LETTER LONG S WITH DOT ABOVE decomposes recursively
 // to [U+017F, U+0307] which then composes back to U+1E9B
-TEST(Unicode_nfc, recursive_decompose_then_compose) {
+TEST(recursive_decompose_then_compose) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u1E9B"), U"\u1E9B");
 }
 
 // U+212B ANGSTROM SIGN has a singleton canonical decomposition to U+00C5.
 // NFC discards the ANGSTROM SIGN form and produces U+00C5
-TEST(Unicode_nfc, singleton_angstrom_to_latin_a_with_ring) {
+TEST(singleton_angstrom_to_latin_a_with_ring) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u212B"), U"\u00C5");
 }
 
 // U+2126 OHM SIGN has a singleton canonical decomposition to U+03A9
 // GREEK CAPITAL LETTER OMEGA. NFC produces U+03A9
-TEST(Unicode_nfc, singleton_ohm_to_greek_omega) {
+TEST(singleton_ohm_to_greek_omega) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u2126"), U"\u03A9");
 }
 
 // U+0958 DEVANAGARI LETTER QA decomposes to [U+0915, U+093C] but is in the
 // composition exclusion list, so it does not recompose
-TEST(Unicode_nfc, composition_exclusion_devanagari_qa_decomposes) {
+TEST(composition_exclusion_devanagari_qa_decomposes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u0958"), U"\u0915\u093C");
 }
 
 // Decomposed [U+0915, U+093C] also stays decomposed for the same reason
-TEST(Unicode_nfc, composition_exclusion_devanagari_qa_stays_decomposed) {
+TEST(composition_exclusion_devanagari_qa_stays_decomposed) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u0915\u093C"), U"\u0915\u093C");
 }
 
 // U+09DC BENGALI LETTER RRA: same exclusion pattern
-TEST(Unicode_nfc, composition_exclusion_bengali_rra) {
+TEST(composition_exclusion_bengali_rra) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u09DC"), U"\u09A1\u09BC");
 }
 
 // Hangul precomposed syllable stays precomposed
-TEST(Unicode_nfc, hangul_precomposed_unchanged) {
+TEST(hangul_precomposed_unchanged) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\uAC00"), U"\uAC00");
 }
 
 // Hangul L jamo + V jamo composes algorithmically to an LV syllable
-TEST(Unicode_nfc, hangul_l_v_composes) {
+TEST(hangul_l_v_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u1100\u1161"), U"\uAC00");
 }
 
 // Hangul L + V + T composes algorithmically to an LVT syllable
-TEST(Unicode_nfc, hangul_l_v_t_composes) {
+TEST(hangul_l_v_t_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u1100\u1161\u11A8"), U"\uAC01");
 }
 
 // Multi-syllable decomposed Hangul
-TEST(Unicode_nfc, hangul_word_composes) {
+TEST(hangul_word_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u1100\u1161\u11AB\u1100\u1175\u11AF"),
             U"\uAC04\uAE38");
 }
 
 // A precomposed LV syllable plus a separate T jamo composes into an LVT
-TEST(Unicode_nfc, hangul_precomposed_lv_plus_t_composes) {
+TEST(hangul_precomposed_lv_plus_t_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\uAC00\u11A8"), U"\uAC01");
 }
 
 // A combining mark with no preceding starter is left in place
-TEST(Unicode_nfc, leading_combining_mark) {
+TEST(leading_combining_mark) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u0301abc"), U"\u0301abc");
 }
 
 // Input: A + U+0308 (diaeresis, CCC=230) + U+0301 (acute, CCC=230). After
 // reorder (stable, same CCC): unchanged. A + U+0308 composes to Ä.
 // Ä + U+0301 has no precomposed form, so the acute stays separate
-TEST(Unicode_nfc, two_same_class_marks_first_composes) {
+TEST(two_same_class_marks_first_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"A\u0308\u0301"), U"\u00C4\u0301");
 }
 
 // NFC is idempotent: applying it twice yields the same result
-TEST(Unicode_nfc, idempotent_on_already_composed) {
+TEST(idempotent_on_already_composed) {
   const std::u32string input{U"caf\u00E9\u00C0"};
   EXPECT_EQ(sourcemeta::core::nfc(input), input);
 }
 
-TEST(Unicode_nfc, idempotent_on_complex_input) {
+TEST(idempotent_on_complex_input) {
   const auto once{sourcemeta::core::nfc(U"A\u0301\u0316\u00C0\u1100\u1161")};
   EXPECT_EQ(sourcemeta::core::nfc(once), once);
 }
 
 // Codepoints above U+FFFF (supplementary plane) with no decomposition pass
 // through unchanged
-TEST(Unicode_nfc, supplementary_plane_passthrough) {
+TEST(supplementary_plane_passthrough) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\U00020000"), U"\U00020000");
 }
 
 // Greek text in precomposed form is unchanged
-TEST(Unicode_nfc, greek_precomposed_unchanged) {
+TEST(greek_precomposed_unchanged) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u03C0\u03B1\u03C1\u03AC\u03B4"
                                   U"\u03B5\u03B9\u03B3\u03BC\u03B1"),
             U"\u03C0\u03B1\u03C1\u03AC\u03B4"
@@ -142,7 +142,7 @@ TEST(Unicode_nfc, greek_precomposed_unchanged) {
 
 // Decomposed Greek "παράδειγμα" (with U+03AC replaced by alpha + acute)
 // composes back to the precomposed form
-TEST(Unicode_nfc, greek_decomposed_composes) {
+TEST(greek_decomposed_composes) {
   EXPECT_EQ(sourcemeta::core::nfc(U"\u03C0\u03B1\u03C1\u03B1\u0301\u03B4"
                                   U"\u03B5\u03B9\u03B3\u03BC\u03B1"),
             U"\u03C0\u03B1\u03C1\u03AC\u03B4"

--- a/test/unicode/unicode_script_test.cc
+++ b/test/unicode/unicode_script_test.cc
@@ -1,98 +1,98 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_script, null) {
+TEST(null) {
   EXPECT_EQ(sourcemeta::core::script(0x0000),
             sourcemeta::core::UnicodeScript::Common);
 }
 
-TEST(Unicode_script, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::script(U'A'),
             sourcemeta::core::UnicodeScript::Latin);
 }
 
-TEST(Unicode_script, ascii_digit) {
+TEST(ascii_digit) {
   EXPECT_EQ(sourcemeta::core::script(U'0'),
             sourcemeta::core::UnicodeScript::Common);
 }
 
-TEST(Unicode_script, space) {
+TEST(space) {
   EXPECT_EQ(sourcemeta::core::script(U' '),
             sourcemeta::core::UnicodeScript::Common);
 }
 
-TEST(Unicode_script, greek_capital_alpha) {
+TEST(greek_capital_alpha) {
   EXPECT_EQ(sourcemeta::core::script(U'\u0391'),
             sourcemeta::core::UnicodeScript::Greek);
 }
 
-TEST(Unicode_script, greek_lower_numeral_sign) {
+TEST(greek_lower_numeral_sign) {
   EXPECT_EQ(sourcemeta::core::script(U'\u0375'),
             sourcemeta::core::UnicodeScript::Greek);
 }
 
-TEST(Unicode_script, hebrew_letter_alef) {
+TEST(hebrew_letter_alef) {
   EXPECT_EQ(sourcemeta::core::script(U'\u05D0'),
             sourcemeta::core::UnicodeScript::Hebrew);
 }
 
-TEST(Unicode_script, arabic_letter_alef) {
+TEST(arabic_letter_alef) {
   EXPECT_EQ(sourcemeta::core::script(U'\u0627'),
             sourcemeta::core::UnicodeScript::Arabic);
 }
 
-TEST(Unicode_script, hiragana_a) {
+TEST(hiragana_a) {
   EXPECT_EQ(sourcemeta::core::script(U'\u3042'),
             sourcemeta::core::UnicodeScript::Hiragana);
 }
 
-TEST(Unicode_script, katakana_a) {
+TEST(katakana_a) {
   EXPECT_EQ(sourcemeta::core::script(U'\u30A2'),
             sourcemeta::core::UnicodeScript::Katakana);
 }
 
-TEST(Unicode_script, katakana_middle_dot) {
+TEST(katakana_middle_dot) {
   EXPECT_EQ(sourcemeta::core::script(U'\u30FB'),
             sourcemeta::core::UnicodeScript::Common);
 }
 
-TEST(Unicode_script, han_ideograph) {
+TEST(han_ideograph) {
   EXPECT_EQ(sourcemeta::core::script(U'\u6F22'),
             sourcemeta::core::UnicodeScript::Han);
 }
 
-TEST(Unicode_script, devanagari_letter_a) {
+TEST(devanagari_letter_a) {
   EXPECT_EQ(sourcemeta::core::script(U'\u0905'),
             sourcemeta::core::UnicodeScript::Devanagari);
 }
 
-TEST(Unicode_script, cyrillic_letter_a) {
+TEST(cyrillic_letter_a) {
   EXPECT_EQ(sourcemeta::core::script(U'\u0410'),
             sourcemeta::core::UnicodeScript::Cyrillic);
 }
 
-TEST(Unicode_script, combining_acute_accent) {
+TEST(combining_acute_accent) {
   EXPECT_EQ(sourcemeta::core::script(U'\u0301'),
             sourcemeta::core::UnicodeScript::Inherited);
 }
 
-TEST(Unicode_script, emoji_grinning_face) {
+TEST(emoji_grinning_face) {
   EXPECT_EQ(sourcemeta::core::script(U'\U0001F600'),
             sourcemeta::core::UnicodeScript::Common);
 }
 
-TEST(Unicode_script, unassigned_codepoint) {
+TEST(unassigned_codepoint) {
   EXPECT_EQ(sourcemeta::core::script(0x0E80),
             sourcemeta::core::UnicodeScript::Unknown);
 }
 
-TEST(Unicode_script, max_codepoint) {
+TEST(max_codepoint) {
   EXPECT_EQ(sourcemeta::core::script(0x10FFFF),
             sourcemeta::core::UnicodeScript::Unknown);
 }
 
-TEST(Unicode_script, above_max_codepoint) {
+TEST(above_max_codepoint) {
   EXPECT_EQ(sourcemeta::core::script(0x110000),
             sourcemeta::core::UnicodeScript::Unknown);
 }

--- a/test/unicode/unicode_utf8_codepoint_byte_count_test.cc
+++ b/test/unicode/unicode_utf8_codepoint_byte_count_test.cc
@@ -1,63 +1,63 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_utf8_codepoint_byte_count, ascii_null) {
+TEST(ascii_null) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x0000), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x0041), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, ascii_high_boundary) {
+TEST(ascii_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x007F), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, two_byte_low_boundary) {
+TEST(two_byte_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x0080), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, two_byte_latin_e_acute) {
+TEST(two_byte_latin_e_acute) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x00E9), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, two_byte_greek_alpha) {
+TEST(two_byte_greek_alpha) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x03B1), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, two_byte_high_boundary) {
+TEST(two_byte_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x07FF), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, three_byte_low_boundary) {
+TEST(three_byte_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x0800), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, three_byte_cjk) {
+TEST(three_byte_cjk) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x4E2D), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, three_byte_korean_si) {
+TEST(three_byte_korean_si) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0xC2E4), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, three_byte_high_boundary) {
+TEST(three_byte_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0xFFFF), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, four_byte_low_boundary) {
+TEST(four_byte_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x10000), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, four_byte_emoji_grinning) {
+TEST(four_byte_emoji_grinning) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x1F600), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, four_byte_smp_mid) {
+TEST(four_byte_smp_mid) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x40000), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_byte_count, four_byte_high_boundary) {
+TEST(four_byte_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_byte_count(0x10FFFF), 4u);
 }

--- a/test/unicode/unicode_utf8_codepoint_length_test.cc
+++ b/test/unicode/unicode_utf8_codepoint_length_test.cc
@@ -1,300 +1,300 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <string> // std::string
 
-TEST(Unicode_utf8_codepoint_length, empty_input_returns_zero) {
+TEST(empty_input_returns_zero) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, position_at_size_returns_zero) {
+TEST(position_at_size_returns_zero) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("A", 1), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, position_past_size_returns_zero) {
+TEST(position_past_size_returns_zero) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("A", 5), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_letter_returns_one) {
+TEST(ascii_letter_returns_one) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("A", 0), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_null_returns_one) {
+TEST(ascii_null_returns_one) {
   const std::string null_byte(1, '\0');
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length(null_byte, 0), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_low_boundary_returns_one) {
+TEST(ascii_low_boundary_returns_one) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\x01", 0), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_high_boundary_returns_one) {
+TEST(ascii_high_boundary_returns_one) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\x7f", 0), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_digit_returns_one) {
+TEST(ascii_digit_returns_one) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("0", 0), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_space_returns_one) {
+TEST(ascii_space_returns_one) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length(" ", 0), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_lead_low_boundary) {
+TEST(two_byte_lead_low_boundary) {
   // U+0080: \xC2\x80 (smallest 2-byte codepoint)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xc2\x80", 0), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_lead_high_boundary) {
+TEST(two_byte_lead_high_boundary) {
   // U+07FF: \xDF\xBF (largest 2-byte codepoint)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xdf\xbf", 0), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_greek_alpha) {
+TEST(two_byte_greek_alpha) {
   // U+03B1 GREEK SMALL ALPHA: \xCE\xB1
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xce\xb1", 0), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_latin_e_acute) {
+TEST(two_byte_latin_e_acute) {
   // U+00E9 LATIN SMALL E ACUTE: \xC3\xA9
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xc3\xa9", 0), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_overlong_c0_zero) {
+TEST(two_byte_overlong_c0_zero) {
   // %xC0 is forbidden (overlong encoding of U+0000)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xc0\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_overlong_c1_max) {
+TEST(two_byte_overlong_c1_max) {
   // %xC1 is forbidden (overlong encoding of U+007F)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xc1\xbf", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_invalid_tail_below_range) {
+TEST(two_byte_invalid_tail_below_range) {
   // UTF8-tail = %x80-BF; \x7F is below range
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xce\x7f", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_invalid_tail_above_range) {
+TEST(two_byte_invalid_tail_above_range) {
   // UTF8-tail = %x80-BF; \xC0 is above range
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xce\xc0", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_truncated) {
+TEST(two_byte_truncated) {
   // Lead byte with no continuation
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xce", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_e0_low_boundary) {
+TEST(three_byte_e0_low_boundary) {
   // U+0800: \xE0\xA0\x80 (smallest 3-byte codepoint)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe0\xa0\x80", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_e0_high_boundary) {
+TEST(three_byte_e0_high_boundary) {
   // U+0FFF: \xE0\xBF\xBF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe0\xbf\xbf", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_e0_overlong_low) {
+TEST(three_byte_e0_overlong_low) {
   // %xE0 %x80-9F is overlong (codepoints < U+0800)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe0\x80\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_e0_overlong_boundary) {
+TEST(three_byte_e0_overlong_boundary) {
   // %xE0 %x9F is just below the valid %xA0
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe0\x9f\xbf", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_e1_letter) {
+TEST(three_byte_e1_letter) {
   // U+1000 MYANMAR: \xE1\x80\x80
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe1\x80\x80", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_e4_cjk) {
+TEST(three_byte_e4_cjk) {
   // U+4E2D CJK 中: \xE4\xB8\xAD
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe4\xb8\xad", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_ec_high_boundary) {
+TEST(three_byte_ec_high_boundary) {
   // %xEC range is fully open: \xEC\xBF\xBF (U+CFFF)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xec\xbf\xbf", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_ec_korean_si) {
+TEST(three_byte_ec_korean_si) {
   // U+C2E4 실 (Hangul SI): \xEC\x8B\xA4
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xec\x8b\xa4", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_ed_low_boundary) {
+TEST(three_byte_ed_low_boundary) {
   // U+D000: \xED\x80\x80 (just below surrogate range)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xed\x80\x80", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_ed_high_boundary) {
+TEST(three_byte_ed_high_boundary) {
   // U+D7FF: \xED\x9F\xBF (the last codepoint before the surrogate range)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xed\x9f\xbf", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_surrogate_low) {
+TEST(three_byte_surrogate_low) {
   // U+D800: \xED\xA0\x80 (forbidden surrogate range)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xed\xa0\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_surrogate_high) {
+TEST(three_byte_surrogate_high) {
   // U+DFFF: \xED\xBF\xBF (forbidden surrogate range)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xed\xbf\xbf", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_ee_low_boundary) {
+TEST(three_byte_ee_low_boundary) {
   // U+E000 (first codepoint after the surrogate range): \xEE\x80\x80
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xee\x80\x80", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_ef_high_boundary) {
+TEST(three_byte_ef_high_boundary) {
   // U+FFFF (largest 3-byte codepoint): \xEF\xBF\xBF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xef\xbf\xbf", 0), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_truncated_one_byte) {
+TEST(three_byte_truncated_one_byte) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe4", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_truncated_two_bytes) {
+TEST(three_byte_truncated_two_bytes) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe4\xb8", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_invalid_third_byte) {
+TEST(three_byte_invalid_third_byte) {
   // Third byte must be %x80-BF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xe4\xb8\x7f", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f0_low_boundary) {
+TEST(four_byte_f0_low_boundary) {
   // U+10000 (smallest 4-byte codepoint): \xF0\x90\x80\x80
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x90\x80\x80", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f0_high_boundary) {
+TEST(four_byte_f0_high_boundary) {
   // %xF0 %xBF\xBF\xBF (U+3FFFF)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\xbf\xbf\xbf", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f0_overlong_low) {
+TEST(four_byte_f0_overlong_low) {
   // %xF0 %x80-8F is overlong (codepoints < U+10000)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x80\x80\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f0_overlong_high_boundary) {
+TEST(four_byte_f0_overlong_high_boundary) {
   // %xF0 %x8F is just below the valid %x90
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x8f\xbf\xbf", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f1_low) {
+TEST(four_byte_f1_low) {
   // U+40000: \xF1\x80\x80\x80
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf1\x80\x80\x80", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f3_high) {
+TEST(four_byte_f3_high) {
   // U+FFFFF: \xF3\xBF\xBF\xBF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf3\xbf\xbf\xbf", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_emoji_grinning) {
+TEST(four_byte_emoji_grinning) {
   // U+1F600 😀: \xF0\x9F\x98\x80
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x9f\x98\x80", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f4_low_boundary) {
+TEST(four_byte_f4_low_boundary) {
   // U+100000: \xF4\x80\x80\x80
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf4\x80\x80\x80", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f4_high_boundary) {
+TEST(four_byte_f4_high_boundary) {
   // U+10FFFF (last valid Unicode codepoint): \xF4\x8F\xBF\xBF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf4\x8f\xbf\xbf", 0), 4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_above_max_codepoint) {
+TEST(four_byte_above_max_codepoint) {
   // %xF4 %x90+ would encode codepoints > U+10FFFF (forbidden)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf4\x90\x80\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_above_max_high) {
+TEST(four_byte_above_max_high) {
   // %xF4 %xBF\xBF\xBF would encode U+13FFFF (forbidden)
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf4\xbf\xbf\xbf", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_truncated_one_byte) {
+TEST(four_byte_truncated_one_byte) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_truncated_two_bytes) {
+TEST(four_byte_truncated_two_bytes) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x9f", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_truncated_three_bytes) {
+TEST(four_byte_truncated_three_bytes) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x9f\x98", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_invalid_third) {
+TEST(four_byte_invalid_third) {
   // Third byte must be %x80-BF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x9f\x7f\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_invalid_fourth) {
+TEST(four_byte_invalid_fourth) {
   // Fourth byte must be %x80-BF
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf0\x9f\x98\xc0", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_f5_forbidden_lead) {
+TEST(four_byte_f5_forbidden_lead) {
   // %xF5-FF are not valid lead bytes per RFC 6532 §3.1
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xf5\x80\x80\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, lead_byte_fe_forbidden) {
+TEST(lead_byte_fe_forbidden) {
   // %xFE is not a valid lead byte
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xfe\x80\x80\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, lead_byte_ff_forbidden) {
+TEST(lead_byte_ff_forbidden) {
   // %xFF is not a valid lead byte
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xff", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, lone_continuation_low) {
+TEST(lone_continuation_low) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\x80", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, lone_continuation_high) {
+TEST(lone_continuation_high) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xbf", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, lone_continuation_middle) {
+TEST(lone_continuation_middle) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("\xa0", 0), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, ascii_at_offset) {
+TEST(ascii_at_offset) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("ABC", 1), 1u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_at_offset) {
+TEST(two_byte_at_offset) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("xy\xce\xb1z", 2), 2u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_at_offset) {
+TEST(three_byte_at_offset) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("xy\xe4\xb8\xad", 2), 3u);
 }
 
-TEST(Unicode_utf8_codepoint_length, four_byte_at_offset) {
+TEST(four_byte_at_offset) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("xy\xf0\x9f\x98\x80", 2),
             4u);
 }
 
-TEST(Unicode_utf8_codepoint_length, two_byte_truncated_at_offset) {
+TEST(two_byte_truncated_at_offset) {
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("xy\xce", 2), 0u);
 }
 
-TEST(Unicode_utf8_codepoint_length, three_byte_truncated_at_offset) {
+TEST(three_byte_truncated_at_offset) {
   // Only one byte after the lead at position 2
   EXPECT_EQ(sourcemeta::core::utf8_codepoint_length("xy\xe4\xb8", 2), 0u);
 }

--- a/test/unicode/unicode_utf8_decode_test.cc
+++ b/test/unicode/unicode_utf8_decode_test.cc
@@ -1,74 +1,72 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_utf8_decode, ascii) {
+TEST(ascii) {
   const auto result{sourcemeta::core::utf8_decode("A", 0)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().first, 0x41U);
   EXPECT_EQ(result.value().second, 1U);
 }
 
-TEST(Unicode_utf8_decode, two_byte) {
+TEST(two_byte) {
   const auto result{sourcemeta::core::utf8_decode("\xCE\xB1", 0)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().first, 0x03B1U);
   EXPECT_EQ(result.value().second, 2U);
 }
 
-TEST(Unicode_utf8_decode, three_byte) {
+TEST(three_byte) {
   const auto result{sourcemeta::core::utf8_decode("\xE4\xB8\xAD", 0)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().first, 0x4E2DU);
   EXPECT_EQ(result.value().second, 3U);
 }
 
-TEST(Unicode_utf8_decode, four_byte) {
+TEST(four_byte) {
   const auto result{sourcemeta::core::utf8_decode("\xF0\x9F\x98\x80", 0)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().first, 0x1F600U);
   EXPECT_EQ(result.value().second, 4U);
 }
 
-TEST(Unicode_utf8_decode, at_offset) {
+TEST(at_offset) {
   const auto result{sourcemeta::core::utf8_decode("A\xCE\xB1", 1)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().first, 0x03B1U);
   EXPECT_EQ(result.value().second, 2U);
 }
 
-TEST(Unicode_utf8_decode, max_codepoint) {
+TEST(max_codepoint) {
   const auto result{sourcemeta::core::utf8_decode("\xF4\x8F\xBF\xBF", 0)};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value().first, 0x10FFFFU);
   EXPECT_EQ(result.value().second, 4U);
 }
 
-TEST(Unicode_utf8_decode, empty) {
-  EXPECT_FALSE(sourcemeta::core::utf8_decode("", 0).has_value());
-}
+TEST(empty) { EXPECT_FALSE(sourcemeta::core::utf8_decode("", 0).has_value()); }
 
-TEST(Unicode_utf8_decode, position_out_of_range) {
+TEST(position_out_of_range) {
   EXPECT_FALSE(sourcemeta::core::utf8_decode("A", 5).has_value());
 }
 
-TEST(Unicode_utf8_decode, truncated) {
+TEST(truncated) {
   EXPECT_FALSE(sourcemeta::core::utf8_decode("\xCE", 0).has_value());
 }
 
-TEST(Unicode_utf8_decode, lone_continuation) {
+TEST(lone_continuation) {
   EXPECT_FALSE(sourcemeta::core::utf8_decode("\x80", 0).has_value());
 }
 
-TEST(Unicode_utf8_decode, overlong) {
+TEST(overlong) {
   EXPECT_FALSE(sourcemeta::core::utf8_decode("\xC0\xAF", 0).has_value());
 }
 
-TEST(Unicode_utf8_decode, surrogate) {
+TEST(surrogate) {
   EXPECT_FALSE(sourcemeta::core::utf8_decode("\xED\xA0\x80", 0).has_value());
 }
 
-TEST(Unicode_utf8_decode, above_max) {
+TEST(above_max) {
   EXPECT_FALSE(
       sourcemeta::core::utf8_decode("\xF4\x90\x80\x80", 0).has_value());
 }

--- a/test/unicode/unicode_utf8_lead_byte_size_test.cc
+++ b/test/unicode/unicode_utf8_lead_byte_size_test.cc
@@ -1,87 +1,85 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
-TEST(Unicode_utf8_lead_byte_size, ascii_null) {
-  EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0x00), 1u);
-}
+TEST(ascii_null) { EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0x00), 1u); }
 
-TEST(Unicode_utf8_lead_byte_size, ascii_letter) {
+TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0x41), 1u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, ascii_high_boundary) {
+TEST(ascii_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0x7F), 1u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, continuation_low_boundary) {
+TEST(continuation_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0x80), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, continuation_mid) {
+TEST(continuation_mid) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xA0), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, continuation_high_boundary) {
+TEST(continuation_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xBF), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, overlong_c0) {
+TEST(overlong_c0) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xC0), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, overlong_c1) {
+TEST(overlong_c1) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xC1), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, two_byte_low_boundary) {
+TEST(two_byte_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xC2), 2u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, two_byte_mid) {
+TEST(two_byte_mid) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xCE), 2u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, two_byte_high_boundary) {
+TEST(two_byte_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xDF), 2u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, three_byte_low_boundary) {
+TEST(three_byte_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xE0), 3u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, three_byte_mid_e4) {
+TEST(three_byte_mid_e4) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xE4), 3u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, three_byte_ed) {
+TEST(three_byte_ed) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xED), 3u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, three_byte_high_boundary) {
+TEST(three_byte_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xEF), 3u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, four_byte_low_boundary) {
+TEST(four_byte_low_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xF0), 4u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, four_byte_mid_f2) {
+TEST(four_byte_mid_f2) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xF2), 4u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, four_byte_high_boundary) {
+TEST(four_byte_high_boundary) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xF4), 4u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, above_range_f5) {
+TEST(above_range_f5) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xF5), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, above_range_fe) {
+TEST(above_range_fe) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xFE), 0u);
 }
 
-TEST(Unicode_utf8_lead_byte_size, above_range_ff) {
+TEST(above_range_ff) {
   EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0xFF), 0u);
 }

--- a/test/unicode/unicode_utf8_to_utf32_test.cc
+++ b/test/unicode/unicode_utf8_to_utf32_test.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <sstream> // std::istringstream
 #include <string>  // std::u32string
 
-TEST(Unicode_utf8_to_utf32, ascii) {
+TEST(ascii) {
   std::istringstream input{"Hello"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_TRUE(result.has_value());
@@ -13,14 +13,14 @@ TEST(Unicode_utf8_to_utf32, ascii) {
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, empty) {
+TEST(empty) {
   std::istringstream input{""};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().empty());
 }
 
-TEST(Unicode_utf8_to_utf32, two_byte) {
+TEST(two_byte) {
   std::istringstream input{"\xC3\xA9"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_TRUE(result.has_value());
@@ -28,7 +28,7 @@ TEST(Unicode_utf8_to_utf32, two_byte) {
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, three_byte_cjk) {
+TEST(three_byte_cjk) {
   std::istringstream input{"\xE4\xB8\x96"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_TRUE(result.has_value());
@@ -36,7 +36,7 @@ TEST(Unicode_utf8_to_utf32, three_byte_cjk) {
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, four_byte_emoji) {
+TEST(four_byte_emoji) {
   std::istringstream input{"\xF0\x9F\x98\x80"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_TRUE(result.has_value());
@@ -44,7 +44,7 @@ TEST(Unicode_utf8_to_utf32, four_byte_emoji) {
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, mixed) {
+TEST(mixed) {
   std::istringstream input{"H\xC3\xA9\xE4\xB8\x96\xF0\x9F\x98\x80"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_TRUE(result.has_value());
@@ -52,50 +52,50 @@ TEST(Unicode_utf8_to_utf32, mixed) {
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, invalid_continuation) {
+TEST(invalid_continuation) {
   std::istringstream input{"\xC3\x28"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Unicode_utf8_to_utf32, truncated_sequence) {
+TEST(truncated_sequence) {
   std::istringstream input{"\xE4\xB8"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Unicode_utf8_to_utf32, overlong_encoding) {
+TEST(overlong_encoding) {
   std::istringstream input{"\xC0\x80"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Unicode_utf8_to_utf32, surrogate_codepoint) {
+TEST(surrogate_codepoint) {
   std::istringstream input{"\xED\xA0\x80"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Unicode_utf8_to_utf32, invalid_start_byte) {
+TEST(invalid_start_byte) {
   std::istringstream input{"\xFF"};
   const auto result{sourcemeta::core::utf8_to_utf32(input)};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(Unicode_utf8_to_utf32, string_view_ascii) {
+TEST(string_view_ascii) {
   const auto result{sourcemeta::core::utf8_to_utf32("Hello")};
   EXPECT_TRUE(result.has_value());
   const std::u32string expected{0x48, 0x65, 0x6C, 0x6C, 0x6F};
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, string_view_empty) {
+TEST(string_view_empty) {
   const auto result{sourcemeta::core::utf8_to_utf32("")};
   EXPECT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().empty());
 }
 
-TEST(Unicode_utf8_to_utf32, string_view_mixed) {
+TEST(string_view_mixed) {
   const auto result{
       sourcemeta::core::utf8_to_utf32("H\xC3\xA9\xE4\xB8\x96\xF0\x9F\x98\x80")};
   EXPECT_TRUE(result.has_value());
@@ -103,7 +103,7 @@ TEST(Unicode_utf8_to_utf32, string_view_mixed) {
   EXPECT_EQ(result.value(), expected);
 }
 
-TEST(Unicode_utf8_to_utf32, string_view_invalid) {
+TEST(string_view_invalid) {
   const auto result{sourcemeta::core::utf8_to_utf32("\xFF")};
   EXPECT_FALSE(result.has_value());
 }

--- a/test/unicode/unicode_utf8_to_wide_test.cc
+++ b/test/unicode/unicode_utf8_to_wide_test.cc
@@ -1,117 +1,115 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <string>      // std::wstring
 #include <string_view> // std::string_view
 
-TEST(Unicode_utf8_to_wide, empty_string) {
-  EXPECT_EQ(sourcemeta::core::utf8_to_wide(""), L"");
-}
+TEST(empty_string) { EXPECT_EQ(sourcemeta::core::utf8_to_wide(""), L""); }
 
-TEST(Unicode_utf8_to_wide, single_ascii_character) {
+TEST(single_ascii_character) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("a"), L"a");
 }
 
-TEST(Unicode_utf8_to_wide, ascii_word) {
+TEST(ascii_word) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("hello"), L"hello");
 }
 
-TEST(Unicode_utf8_to_wide, ascii_sentence_with_punctuation) {
+TEST(ascii_sentence_with_punctuation) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("Hello, World! 123"),
             L"Hello, World! 123");
 }
 
-TEST(Unicode_utf8_to_wide, ascii_url) {
+TEST(ascii_url) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("https://example.com/foo?bar=baz"),
             L"https://example.com/foo?bar=baz");
 }
 
-TEST(Unicode_utf8_to_wide, two_byte_latin_small_letter_e_with_acute) {
+TEST(two_byte_latin_small_letter_e_with_acute) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xc3\xa9"), L"\x00e9");
 }
 
-TEST(Unicode_utf8_to_wide, two_byte_word) {
+TEST(two_byte_word) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("caf\xc3\xa9"), L"caf\x00e9");
 }
 
-TEST(Unicode_utf8_to_wide, two_byte_greek_word) {
+TEST(two_byte_greek_word) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xce\xb1\xce\xb2\xce\xb3"),
             L"\x03b1\x03b2\x03b3");
 }
 
-TEST(Unicode_utf8_to_wide, two_byte_cyrillic_word) {
+TEST(two_byte_cyrillic_word) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide(
                 "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82"),
             L"\x041f\x0440\x0438\x0432\x0435\x0442");
 }
 
-TEST(Unicode_utf8_to_wide, three_byte_euro_sign) {
+TEST(three_byte_euro_sign) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xe2\x82\xac"), L"\x20ac");
 }
 
-TEST(Unicode_utf8_to_wide, three_byte_cjk_word) {
+TEST(three_byte_cjk_word) {
   EXPECT_EQ(
       sourcemeta::core::utf8_to_wide("\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"),
       L"\x65e5\x672c\x8a9e");
 }
 
-TEST(Unicode_utf8_to_wide, four_byte_grinning_face_emoji) {
+TEST(four_byte_grinning_face_emoji) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x9f\x98\x80"), L"\U0001f600");
 }
 
-TEST(Unicode_utf8_to_wide, four_byte_musical_symbol_g_clef) {
+TEST(four_byte_musical_symbol_g_clef) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x9d\x84\x9e"), L"\U0001d11e");
 }
 
-TEST(Unicode_utf8_to_wide, consecutive_four_byte_code_points) {
+TEST(consecutive_four_byte_code_points) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x9f\x98\x80\xf0\x9f\x98\x81"),
             L"\U0001f600\U0001f601");
 }
 
-TEST(Unicode_utf8_to_wide, mixed_sequence_lengths) {
+TEST(mixed_sequence_lengths) {
   EXPECT_EQ(
       sourcemeta::core::utf8_to_wide("a\xc3\xa9\xe2\x82\xac\xf0\x9f\x98\x80"),
       L"a\x00e9\x20ac\U0001f600");
 }
 
-TEST(Unicode_utf8_to_wide, multibyte_at_start) {
+TEST(multibyte_at_start) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xe2\x82\xacxyz"), L"\x20acxyz");
 }
 
-TEST(Unicode_utf8_to_wide, multibyte_at_end) {
+TEST(multibyte_at_end) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("xyz\xe2\x82\xac"), L"xyz\x20ac");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_last_one_byte_code_point) {
+TEST(boundary_last_one_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\x7f"), L"\x007f");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_first_two_byte_code_point) {
+TEST(boundary_first_two_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xc2\x80"), L"\x0080");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_last_two_byte_code_point) {
+TEST(boundary_last_two_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xdf\xbf"), L"\x07ff");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_first_three_byte_code_point) {
+TEST(boundary_first_three_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xe0\xa0\x80"), L"\x0800");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_last_three_byte_code_point) {
+TEST(boundary_last_three_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xef\xbf\xbf"), L"\xffff");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_first_four_byte_code_point) {
+TEST(boundary_first_four_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf0\x90\x80\x80"), L"\U00010000");
 }
 
-TEST(Unicode_utf8_to_wide, boundary_last_four_byte_code_point) {
+TEST(boundary_last_four_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide("\xf4\x8f\xbf\xbf"), L"\U0010ffff");
 }
 
-TEST(Unicode_utf8_to_wide, embedded_null_byte) {
+TEST(embedded_null_byte) {
   const std::string_view input{"a\0b", 3};
   const std::wstring expected{L"a\0b", 3};
   EXPECT_EQ(sourcemeta::core::utf8_to_wide(input), expected);

--- a/test/unicode/unicode_wide_to_utf8_test.cc
+++ b/test/unicode/unicode_wide_to_utf8_test.cc
@@ -1,127 +1,125 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/unicode.h>
 
 #include <string>      // std::string
 #include <string_view> // std::wstring_view
 
-TEST(Unicode_wide_to_utf8, empty_string) {
-  EXPECT_EQ(sourcemeta::core::wide_to_utf8(L""), "");
-}
+TEST(empty_string) { EXPECT_EQ(sourcemeta::core::wide_to_utf8(L""), ""); }
 
-TEST(Unicode_wide_to_utf8, single_ascii_character) {
+TEST(single_ascii_character) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"a"), "a");
 }
 
-TEST(Unicode_wide_to_utf8, ascii_word) {
+TEST(ascii_word) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"hello"), "hello");
 }
 
-TEST(Unicode_wide_to_utf8, ascii_sentence_with_punctuation) {
+TEST(ascii_sentence_with_punctuation) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"Hello, World! 123"),
             "Hello, World! 123");
 }
 
-TEST(Unicode_wide_to_utf8, ascii_url) {
+TEST(ascii_url) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"https://example.com/foo?bar=baz"),
             "https://example.com/foo?bar=baz");
 }
 
-TEST(Unicode_wide_to_utf8, two_byte_latin_small_letter_e_with_acute) {
+TEST(two_byte_latin_small_letter_e_with_acute) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x00e9"), "\xc3\xa9");
 }
 
-TEST(Unicode_wide_to_utf8, two_byte_word) {
+TEST(two_byte_word) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"caf\x00e9"), "caf\xc3\xa9");
 }
 
-TEST(Unicode_wide_to_utf8, two_byte_greek_word) {
+TEST(two_byte_greek_word) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x03b1\x03b2\x03b3"),
             "\xce\xb1\xce\xb2\xce\xb3");
 }
 
-TEST(Unicode_wide_to_utf8, two_byte_cyrillic_word) {
+TEST(two_byte_cyrillic_word) {
   EXPECT_EQ(
       sourcemeta::core::wide_to_utf8(L"\x041f\x0440\x0438\x0432\x0435\x0442"),
       "\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82");
 }
 
-TEST(Unicode_wide_to_utf8, three_byte_euro_sign) {
+TEST(three_byte_euro_sign) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x20ac"), "\xe2\x82\xac");
 }
 
-TEST(Unicode_wide_to_utf8, three_byte_cjk_word) {
+TEST(three_byte_cjk_word) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x65e5\x672c\x8a9e"),
             "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e");
 }
 
-TEST(Unicode_wide_to_utf8, four_byte_grinning_face_emoji) {
+TEST(four_byte_grinning_face_emoji) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0001f600"), "\xf0\x9f\x98\x80");
 }
 
-TEST(Unicode_wide_to_utf8, four_byte_musical_symbol_g_clef) {
+TEST(four_byte_musical_symbol_g_clef) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0001d11e"), "\xf0\x9d\x84\x9e");
 }
 
-TEST(Unicode_wide_to_utf8, consecutive_four_byte_code_points) {
+TEST(consecutive_four_byte_code_points) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0001f600\U0001f601"),
             "\xf0\x9f\x98\x80\xf0\x9f\x98\x81");
 }
 
-TEST(Unicode_wide_to_utf8, mixed_sequence_lengths) {
+TEST(mixed_sequence_lengths) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"a\x00e9\x20ac\U0001f600"),
             "a\xc3\xa9\xe2\x82\xac\xf0\x9f\x98\x80");
 }
 
-TEST(Unicode_wide_to_utf8, multibyte_at_start) {
+TEST(multibyte_at_start) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x20acxyz"), "\xe2\x82\xacxyz");
 }
 
-TEST(Unicode_wide_to_utf8, multibyte_at_end) {
+TEST(multibyte_at_end) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"xyz\x20ac"), "xyz\xe2\x82\xac");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_last_one_byte_code_point) {
+TEST(boundary_last_one_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x007f"), "\x7f");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_first_two_byte_code_point) {
+TEST(boundary_first_two_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x0080"), "\xc2\x80");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_last_two_byte_code_point) {
+TEST(boundary_last_two_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x07ff"), "\xdf\xbf");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_first_three_byte_code_point) {
+TEST(boundary_first_three_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\x0800"), "\xe0\xa0\x80");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_last_three_byte_code_point) {
+TEST(boundary_last_three_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\xffff"), "\xef\xbf\xbf");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_first_four_byte_code_point) {
+TEST(boundary_first_four_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U00010000"), "\xf0\x90\x80\x80");
 }
 
-TEST(Unicode_wide_to_utf8, boundary_last_four_byte_code_point) {
+TEST(boundary_last_four_byte_code_point) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(L"\U0010ffff"), "\xf4\x8f\xbf\xbf");
 }
 
-TEST(Unicode_wide_to_utf8, embedded_null_character) {
+TEST(embedded_null_character) {
   const std::wstring_view input{L"a\0b", 3};
   const std::string expected{"a\0b", 3};
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(input), expected);
 }
 
-TEST(Unicode_wide_to_utf8, round_trip_from_utf8) {
+TEST(round_trip_from_utf8) {
   EXPECT_EQ(sourcemeta::core::wide_to_utf8(sourcemeta::core::utf8_to_wide(
                 "caf\xc3\xa9 \xe2\x82\xac \xf0\x9f\x98\x80")),
             "caf\xc3\xa9 \xe2\x82\xac \xf0\x9f\x98\x80");
 }
 
-TEST(Unicode_wide_to_utf8, round_trip_from_wide) {
+TEST(round_trip_from_wide) {
   EXPECT_EQ(sourcemeta::core::utf8_to_wide(
                 sourcemeta::core::wide_to_utf8(L"caf\x00e9 \x20ac \U0001f600")),
             L"caf\x00e9 \x20ac \U0001f600");

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME uri
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
   SOURCES
     uri_test.cc
     uri_fragment_test.cc

--- a/test/uri/uri_canonicalize_test.cc
+++ b/test/uri/uri_canonicalize_test.cc
@@ -1,117 +1,117 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_canonicalize, example_1) {
+TEST(example_1) {
   sourcemeta::core::URI uri{"https://example.com/foo?bar=baz#test"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "https://example.com/foo?bar=baz#test");
 }
 
 // The empty fragment is optional
-TEST(URI_canonicalize, example_2) {
+TEST(example_2) {
   sourcemeta::core::URI uri{"http://example.com/foo#"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo");
 }
 
 // Explicit 80 port for http scheme
-TEST(URI_canonicalize, example_3) {
+TEST(example_3) {
   sourcemeta::core::URI uri{"http://example.com:80/default/port"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/default/port");
 }
 
 // Explicit 443 port for https scheme
-TEST(URI_canonicalize, example_4) {
+TEST(example_4) {
   sourcemeta::core::URI uri{"https://example.com:443/default/port"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "https://example.com/default/port");
 }
 
-TEST(URI_canonicalize, example_5) {
+TEST(example_5) {
   sourcemeta::core::URI uri{"https://example.com:80/default/port"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "https://example.com:80/default/port");
 }
 
-TEST(URI_canonicalize, example_6) {
+TEST(example_6) {
   sourcemeta::core::URI uri{"http://example.com:443/default/port"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com:443/default/port");
 }
 
 // Schemes are case insensitive
-TEST(URI_canonicalize, example_7) {
+TEST(example_7) {
   sourcemeta::core::URI uri{"hTtP://example.com/case-insensitive-scheme"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/case-insensitive-scheme");
 }
 
 // Hosts are case insensitive
-TEST(URI_canonicalize, example_8) {
+TEST(example_8) {
   sourcemeta::core::URI uri{"http://exAmpLe.com/case-insensitive-host"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/case-insensitive-host");
 }
 
 // A percent-encoded uppercase letter in the host folds to lowercase
-TEST(URI_canonicalize, percent_encoded_uppercase_host_letter) {
+TEST(percent_encoded_uppercase_host_letter) {
   sourcemeta::core::URI uri{"http://%41EXAMPLE.com/path"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://aexample.com/path");
 }
 
 // Paths are case sensitive
-TEST(URI_canonicalize, example_9) {
+TEST(example_9) {
   sourcemeta::core::URI uri{"hTtP://exAmpLe.com/case-SENSITIVE-path"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/case-SENSITIVE-path");
 }
 
-TEST(URI_canonicalize, example_10) {
+TEST(example_10) {
   sourcemeta::core::URI uri{"urn:example:schema"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "urn:example:schema");
 }
 
-TEST(URI_canonicalize, example_relative_1) {
+TEST(example_relative_1) {
   sourcemeta::core::URI uri{"../foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../foo");
 }
 
-TEST(URI_canonicalize, example_relative_2) {
+TEST(example_relative_2) {
   sourcemeta::core::URI uri{"./foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "foo");
 }
 
-TEST(URI_canonicalize, example_relative_3) {
+TEST(example_relative_3) {
   sourcemeta::core::URI uri{"foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "foo");
 }
 
-TEST(URI_canonicalize, example_relative_4) {
+TEST(example_relative_4) {
   sourcemeta::core::URI uri{"foo/bar"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "foo/bar");
 }
 
-TEST(URI_canonicalize, example_relative_6) {
+TEST(example_relative_6) {
   sourcemeta::core::URI uri{"/foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "/foo");
 }
 
-TEST(URI_canonicalize, example_12) {
+TEST(example_12) {
   sourcemeta::core::URI uri{"#foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "#foo");
 }
 
-TEST(URI_canonicalize, example_13) {
+TEST(example_13) {
   sourcemeta::core::URI uri{
       "tag:bowtie.report,2023-11:referencing-suite-tag-uris-id"};
   uri.canonicalize();
@@ -119,128 +119,128 @@ TEST(URI_canonicalize, example_13) {
             "tag:bowtie.report,2023-11:referencing-suite-tag-uris-id");
 }
 
-TEST(URI_canonicalize, example_14) {
+TEST(example_14) {
   sourcemeta::core::URI uri{"http://example.com/escapes/a%c2%b1b"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/escapes/a%C2%B1b");
 }
 
-TEST(URI_canonicalize, example_15) {
+TEST(example_15) {
   sourcemeta::core::URI uri{"http://example.com/unreserved/%7Efoo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/unreserved/~foo");
 }
 
-TEST(URI_canonicalize, example_16) {
+TEST(example_16) {
   sourcemeta::core::URI uri{"http://example.com/foo/"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo/");
 }
 
-TEST(URI_canonicalize, example_17) {
+TEST(example_17) {
   sourcemeta::core::URI uri{"http://example.com/"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/");
 }
 
-TEST(URI_canonicalize, empty_fragment) {
+TEST(empty_fragment) {
   sourcemeta::core::URI uri{"#"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_canonicalize, static_from_string) {
+TEST(static_from_string) {
   const std::string uri{"hTtP://exAmpLe.com:80/TEST"};
   const auto result{sourcemeta::core::URI::canonicalize(uri)};
   EXPECT_EQ(result, "http://example.com/TEST");
 }
 
-TEST(URI_canonicalize, path_with_dotdot_absolute) {
+TEST(path_with_dotdot_absolute) {
   sourcemeta::core::URI uri{"http://example.com/foo/bar/../baz"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo/baz");
 }
 
-TEST(URI_canonicalize, path_with_multiple_dotdot_absolute) {
+TEST(path_with_multiple_dotdot_absolute) {
   sourcemeta::core::URI uri{"http://example.com/foo/bar/qux/../../baz"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo/baz");
 }
 
-TEST(URI_canonicalize, path_with_dotdot_at_root) {
+TEST(path_with_dotdot_at_root) {
   sourcemeta::core::URI uri{"http://example.com/../foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo");
 }
 
-TEST(URI_canonicalize, path_with_dot_segments) {
+TEST(path_with_dot_segments) {
   sourcemeta::core::URI uri{"http://example.com/foo/./bar"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo/bar");
 }
 
-TEST(URI_canonicalize, path_with_mixed_dot_segments) {
+TEST(path_with_mixed_dot_segments) {
   sourcemeta::core::URI uri{"http://example.com/foo/./bar/../baz"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/foo/baz");
 }
 
-TEST(URI_canonicalize, relative_path_with_dotdot) {
+TEST(relative_path_with_dotdot) {
   sourcemeta::core::URI uri{"../foo/bar"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../foo/bar");
 }
 
-TEST(URI_canonicalize, relative_path_with_dotdot_middle) {
+TEST(relative_path_with_dotdot_middle) {
   sourcemeta::core::URI uri{"foo/../bar"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "bar");
 }
 
-TEST(URI_canonicalize, relative_path_multiple_dotdot) {
+TEST(relative_path_multiple_dotdot) {
   sourcemeta::core::URI uri{"../../foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../../foo");
 }
 
-TEST(URI_canonicalize, relative_path_only_dotdot) {
+TEST(relative_path_only_dotdot) {
   sourcemeta::core::URI uri{".."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../");
 }
 
-TEST(URI_canonicalize, relative_path_two_dotdot_no_segment) {
+TEST(relative_path_two_dotdot_no_segment) {
   sourcemeta::core::URI uri{"../.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../../");
 }
 
-TEST(URI_canonicalize, relative_path_three_dotdot_no_segment) {
+TEST(relative_path_three_dotdot_no_segment) {
   sourcemeta::core::URI uri{"../../.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../../../");
 }
 
-TEST(URI_canonicalize, absolute_path_with_dotdot) {
+TEST(absolute_path_with_dotdot) {
   sourcemeta::core::URI uri{"/foo/bar/../baz"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "/foo/baz");
 }
 
-TEST(URI_canonicalize, absolute_path_excess_dotdot) {
+TEST(absolute_path_excess_dotdot) {
   sourcemeta::core::URI uri{"/foo/../../bar"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "/bar");
 }
 
-TEST(URI_canonicalize, empty_uri_default_constructor) {
+TEST(empty_uri_default_constructor) {
   sourcemeta::core::URI uri;
   uri.canonicalize();
   EXPECT_TRUE(uri.empty());
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_canonicalize, empty_uri_string_constructor) {
+TEST(empty_uri_string_constructor) {
   sourcemeta::core::URI uri{""};
   uri.canonicalize();
   EXPECT_TRUE(uri.empty());
@@ -249,7 +249,7 @@ TEST(URI_canonicalize, empty_uri_string_constructor) {
 
 // Inspired from https://cr.openjdk.org/~dfuchs/writeups/updating-uri/
 
-TEST(URI_canonicalize, rfc3986_1) {
+TEST(rfc3986_1) {
   sourcemeta::core::URI uri{"s://h/a/../../b"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "s://h/b");
@@ -258,44 +258,44 @@ TEST(URI_canonicalize, rfc3986_1) {
 // Inspired from
 // https://github.com/uriparser/uriparser/blob/master/test/test.cpp#L1438
 
-TEST(URI_canonicalize, rfc3986_2) {
+TEST(rfc3986_2) {
   sourcemeta::core::URI uri{"eXAMPLE://a/./b/../b/%63/%7bfoo%7d"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "example://a/b/c/%7Bfoo%7D");
 }
 
-TEST(URI_canonicalize, percent_encoding) {
+TEST(percent_encoding) {
   sourcemeta::core::URI uri{"http://examp%4Ce.com/"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/");
 }
 
-TEST(URI_canonicalize, dot_segments_percent_encoded) {
+TEST(dot_segments_percent_encoded) {
   sourcemeta::core::URI uri{"http://example.com/a/b/%2E%2E/"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://example.com/a/");
 }
 
-TEST(URI_canonicalize, case_normalization) {
+TEST(case_normalization) {
   sourcemeta::core::URI uri{"http://user:pass@SOMEHOST.COM:123"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://user:pass@somehost.com:123");
 }
 
-TEST(URI_canonicalize, complex_case) {
+TEST(complex_case) {
   sourcemeta::core::URI uri{"HTTP://a:b@HOST:123/./1/2/../%41?abc#def"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://a:b@host:123/1/A?abc#def");
 }
 
-TEST(URI_canonicalize, component_aware_decode) {
+TEST(component_aware_decode) {
   sourcemeta::core::URI uri{"http://example.com/%3a%3b%2f?foo%3dbar#baz%2fqux"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(),
             "http://example.com/%3A%3B%2F?foo%3Dbar#baz%2Fqux");
 }
 
-TEST(URI_canonicalize, fragment_encoded_colon) {
+TEST(fragment_encoded_colon) {
   sourcemeta::core::URI uri{
       "https://www.example.com#/$defs/https%3A~1~1example.com~1schema/type"};
   uri.canonicalize();
@@ -304,54 +304,54 @@ TEST(URI_canonicalize, fragment_encoded_colon) {
       "https://www.example.com#/$defs/https%3A~1~1example.com~1schema/type");
 }
 
-TEST(URI_canonicalize, relative_path_no_canonicalize) {
+TEST(relative_path_no_canonicalize) {
   const sourcemeta::core::URI uri{"../../abc"};
   EXPECT_EQ(uri.recompose(), "../../abc");
 }
 
-TEST(URI_canonicalize, relative_path_dotdot_trailing) {
+TEST(relative_path_dotdot_trailing) {
   sourcemeta::core::URI uri{"../../abc/.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../../");
 }
 
-TEST(URI_canonicalize, relative_path_dotdot_middle_with_segment) {
+TEST(relative_path_dotdot_middle_with_segment) {
   sourcemeta::core::URI uri{"../../abc/../def"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../../def");
 }
 
-TEST(URI_canonicalize, relative_path_cancel_to_empty) {
+TEST(relative_path_cancel_to_empty) {
   sourcemeta::core::URI uri{"abc/.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_canonicalize, relative_path_cancel_to_empty_trailing_slash) {
+TEST(relative_path_cancel_to_empty_trailing_slash) {
   sourcemeta::core::URI uri{"abc/../"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_canonicalize, relative_path_multiple_dotdot_with_dot) {
+TEST(relative_path_multiple_dotdot_with_dot) {
   sourcemeta::core::URI uri{"../../abc/./def"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "../../abc/def");
 }
 
-TEST(URI_canonicalize, relative_path_leading_dot_removed) {
+TEST(relative_path_leading_dot_removed) {
   sourcemeta::core::URI uri{"./def"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "def");
 }
 
-TEST(URI_canonicalize, relative_path_trailing_dot) {
+TEST(relative_path_trailing_dot) {
   sourcemeta::core::URI uri{"def/."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "def/");
 }
 
-TEST(URI_canonicalize, relative_path_colon_ambiguity) {
+TEST(relative_path_colon_ambiguity) {
   const sourcemeta::core::URI uri{"./abc:def"};
   EXPECT_EQ(uri.recompose(), "./abc:def");
 }
@@ -359,78 +359,78 @@ TEST(URI_canonicalize, relative_path_colon_ambiguity) {
 // Inspired from
 // https://github.com/uriparser/uriparser/blob/master/test/test.cpp#L1531
 
-TEST(URI_canonicalize, path_multiple_dotdot_to_root) {
+TEST(path_multiple_dotdot_to_root) {
   sourcemeta::core::URI uri{"http://a/b/c/../../.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://a/");
 }
 
-TEST(URI_canonicalize, path_mixed_dotdot_to_root) {
+TEST(path_mixed_dotdot_to_root) {
   sourcemeta::core::URI uri{"http://a/b/../c/../.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://a/");
 }
 
-TEST(URI_canonicalize, path_single_dotdot_at_root) {
+TEST(path_single_dotdot_at_root) {
   sourcemeta::core::URI uri{"http://a/.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://a/");
 }
 
-TEST(URI_canonicalize, path_dotdot_only_no_canonicalize) {
+TEST(path_dotdot_only_no_canonicalize) {
   const sourcemeta::core::URI uri{"/.."};
   EXPECT_EQ(uri.recompose(), "/..");
 }
 
-TEST(URI_canonicalize, path_empty_segments_after_dotdot) {
+TEST(path_empty_segments_after_dotdot) {
   sourcemeta::core::URI uri{"http://a/..///"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://a///");
 }
 
-TEST(URI_canonicalize, path_empty_segments_with_trailing_dotdot) {
+TEST(path_empty_segments_with_trailing_dotdot) {
   sourcemeta::core::URI uri{"http://a/..///.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://a//");
 }
 
-TEST(URI_canonicalize, relative_path_collapse_completely) {
+TEST(relative_path_collapse_completely) {
   sourcemeta::core::URI uri{"a/b/c/../../.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_canonicalize, relative_path_nested_collapse) {
+TEST(relative_path_nested_collapse) {
   sourcemeta::core::URI uri{"a/b/../../c/.."};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_canonicalize, ipv6_uppercase_to_lowercase) {
+TEST(ipv6_uppercase_to_lowercase) {
   sourcemeta::core::URI uri{"http://[1080::8:800:200C:417A]/foo"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://[1080::8:800:200c:417a]/foo");
 }
 
-TEST(URI_canonicalize, ipv6_mixed_case_to_lowercase) {
+TEST(ipv6_mixed_case_to_lowercase) {
   sourcemeta::core::URI uri{"http://[::FFFF:129.144.52.38]:80/index.html"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://[::ffff:129.144.52.38]/index.html");
 }
 
-TEST(URI_canonicalize, ipv6_hex_uppercase_to_lowercase) {
+TEST(ipv6_hex_uppercase_to_lowercase) {
   sourcemeta::core::URI uri{"http://[2010:836B:4179::836B:4179]"};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "http://[2010:836b:4179::836b:4179]");
 }
 
-TEST(URI_canonicalize, iri_preserves_literal_ucschar) {
+TEST(iri_preserves_literal_ucschar) {
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "https://example.com/caf\xC3\xA9");
 }
 
-TEST(URI_canonicalize, iri_decodes_percent_encoded_ucschar) {
+TEST(iri_decodes_percent_encoded_ucschar) {
   // RFC 3987 Section 5.3.2.3: percent-encoded octets that form characters an
   // IRI may carry unencoded are decoded to their literal form
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/caf%C3%A9")};
@@ -438,14 +438,14 @@ TEST(URI_canonicalize, iri_decodes_percent_encoded_ucschar) {
   EXPECT_EQ(uri.recompose(), "https://example.com/caf\xC3\xA9");
 }
 
-TEST(URI_canonicalize, iri_removes_dot_segments_preserving_ucschar) {
+TEST(iri_removes_dot_segments_preserving_ucschar) {
   auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/a/../caf\xC3\xA9")};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "https://example.com/caf\xC3\xA9");
 }
 
-TEST(URI_canonicalize, iri_leaves_private_use_percent_encoded) {
+TEST(iri_leaves_private_use_percent_encoded) {
   // Private-use characters are not among those an IRI may carry unencoded, so
   // they must stay percent-encoded even though allowed literally in the query
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/?x=%EE%80%80")};
@@ -453,14 +453,14 @@ TEST(URI_canonicalize, iri_leaves_private_use_percent_encoded) {
   EXPECT_EQ(uri.recompose(), "https://example.com/?x=%EE%80%80");
 }
 
-TEST(URI_canonicalize, iri_removes_default_port_preserving_host_ucschar) {
+TEST(iri_removes_default_port_preserving_host_ucschar) {
   auto uri{sourcemeta::core::URI::from_iri(
       "https://\xE4\xBE\x8B\xE3\x81\x88.jp:443/")};
   uri.canonicalize();
   EXPECT_EQ(uri.recompose(), "https://\xE4\xBE\x8B\xE3\x81\x88.jp/");
 }
 
-TEST(URI_canonicalize, static_rejects_non_ascii) {
+TEST(static_rejects_non_ascii) {
   // The static entry point parses as a plain URI, so IRI input is rejected
   try {
     sourcemeta::core::URI::canonicalize("https://example.com/caf\xC3\xA9");
@@ -470,7 +470,7 @@ TEST(URI_canonicalize, static_rejects_non_ascii) {
   }
 }
 
-TEST(URI_canonicalize, iri_decodes_percent_encoded_lower_boundary) {
+TEST(iri_decodes_percent_encoded_lower_boundary) {
   // U+00A0 is the lowest non-ASCII character an IRI may carry unencoded; its
   // percent-encoded form must decode to its literal bytes
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/%C2%A0")};
@@ -478,7 +478,7 @@ TEST(URI_canonicalize, iri_decodes_percent_encoded_lower_boundary) {
   EXPECT_EQ(uri.recompose(), "https://example.com/\xC2\xA0");
 }
 
-TEST(URI_canonicalize, iri_leaves_noncharacter_percent_encoded) {
+TEST(iri_leaves_noncharacter_percent_encoded) {
   // U+FFFF is a valid codepoint but not one an IRI may carry unencoded, so it
   // must stay percent-encoded
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/%EF%BF%BF")};
@@ -486,7 +486,7 @@ TEST(URI_canonicalize, iri_leaves_noncharacter_percent_encoded) {
   EXPECT_EQ(uri.recompose(), "https://example.com/%EF%BF%BF");
 }
 
-TEST(URI_canonicalize, iri_leaves_incomplete_percent_sequence_encoded) {
+TEST(iri_leaves_incomplete_percent_sequence_encoded) {
   // A percent-encoded lead byte not followed by its continuation is not a valid
   // character and must remain encoded
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/%C3x")};

--- a/test/uri/uri_empty_test.cc
+++ b/test/uri/uri_empty_test.cc
@@ -1,48 +1,48 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_empty, empty_default_constructor) {
+TEST(empty_default_constructor) {
   const sourcemeta::core::URI uri;
   EXPECT_TRUE(uri.empty());
 }
 
-TEST(URI_empty, empty_string_constructor) {
+TEST(empty_string_constructor) {
   const sourcemeta::core::URI uri{""};
   EXPECT_TRUE(uri.empty());
 }
 
-TEST(URI_empty, hier_only) {
+TEST(hier_only) {
   const sourcemeta::core::URI uri{"example.com"};
   EXPECT_FALSE(uri.empty());
 }
 
-TEST(URI_empty, path_only) {
+TEST(path_only) {
   const sourcemeta::core::URI uri{"/foo/bar"};
   EXPECT_FALSE(uri.empty());
 }
 
-TEST(URI_empty, query_only) {
+TEST(query_only) {
   const sourcemeta::core::URI uri{"?foo=bar"};
   EXPECT_FALSE(uri.empty());
 }
 
-TEST(URI_empty, fragment_only) {
+TEST(fragment_only) {
   const sourcemeta::core::URI uri{"#foo"};
   EXPECT_FALSE(uri.empty());
 }
 
-TEST(URI_empty, fragment_empty_only) {
+TEST(fragment_empty_only) {
   const sourcemeta::core::URI uri{"#"};
   EXPECT_FALSE(uri.empty());
 }
 
-TEST(URI_empty, urn_path) {
+TEST(urn_path) {
   const sourcemeta::core::URI uri{"urn:example:animal:ferret:nose"};
   EXPECT_FALSE(uri.empty());
 }
 
-TEST(URI_empty, iri_not_empty) {
+TEST(iri_not_empty) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   EXPECT_FALSE(uri.empty());

--- a/test/uri/uri_extension_test.cc
+++ b/test/uri/uri_extension_test.cc
@@ -1,112 +1,112 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
 #include <sstream>
 
-TEST(URI_extension, absolute_single_component_path_without_period) {
+TEST(absolute_single_component_path_without_period) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json");
 }
 
-TEST(URI_extension, absolute_single_component_path_with_period) {
+TEST(absolute_single_component_path_with_period) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo"};
   uri.extension(".json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json");
 }
 
-TEST(URI_extension, absolute_single_component_path_with_extension) {
+TEST(absolute_single_component_path_with_extension) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo.xml"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json");
 }
 
-TEST(URI_extension, absolute_single_component_path_with_double_extension) {
+TEST(absolute_single_component_path_with_double_extension) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo.tar.gz"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.tar.json");
 }
 
-TEST(URI_extension, absolute_no_path) {
+TEST(absolute_no_path) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com");
 }
 
-TEST(URI_extension, absolute_trailing_slash) {
+TEST(absolute_trailing_slash) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/");
 }
 
-TEST(URI_extension, absolute_trailing_slashes) {
+TEST(absolute_trailing_slashes) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com////"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com////");
 }
 
-TEST(URI_extension, absolute_trailing_period) {
+TEST(absolute_trailing_period) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo."};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json");
 }
 
-TEST(URI_extension, empty_fragment) {
+TEST(empty_fragment) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo#"};
   uri.extension(".json");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com/foo.json#");
 }
 
-TEST(URI_extension, fragment_only) {
+TEST(fragment_only) {
   sourcemeta::core::URI uri{"#foo"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "#foo");
 }
 
-TEST(URI_extension, relative_multi_component_1) {
+TEST(relative_multi_component_1) {
   sourcemeta::core::URI uri{"/foo/bar"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "/foo/bar.json");
 }
 
-TEST(URI_extension, relative_multi_component_2) {
+TEST(relative_multi_component_2) {
   sourcemeta::core::URI uri{"foo/bar"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "foo/bar.json");
 }
 
-TEST(URI_extension, path_with_dot_in_directory) {
+TEST(path_with_dot_in_directory) {
   sourcemeta::core::URI uri{"https://example.com/foo.bar/baz"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://example.com/foo.bar/baz.json");
 }
 
-TEST(URI_extension, path_with_multiple_dots_in_filename) {
+TEST(path_with_multiple_dots_in_filename) {
   sourcemeta::core::URI uri{"https://example.com/foo.bar.baz.qux"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://example.com/foo.bar.baz.json");
 }
 
-TEST(URI_extension, empty_extension_removes_existing) {
+TEST(empty_extension_removes_existing) {
   sourcemeta::core::URI uri{"https://example.com/foo.json"};
   uri.extension("");
   EXPECT_EQ(uri.recompose(), "https://example.com/foo");
 }
 
-TEST(URI_extension, path_with_query_string) {
+TEST(path_with_query_string) {
   sourcemeta::core::URI uri{"https://example.com/foo?query=value"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://example.com/foo.json?query=value");
 }
 
-TEST(URI_extension, path_ending_with_dot_in_directory) {
+TEST(path_ending_with_dot_in_directory) {
   sourcemeta::core::URI uri{"https://example.com/foo./bar"};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://example.com/foo./bar.json");
 }
 
-TEST(URI_extension, iri_unicode_path) {
+TEST(iri_unicode_path) {
   auto uri{sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   uri.extension("json");
   EXPECT_EQ(uri.recompose(), "https://example.com/caf\xC3\xA9.json");

--- a/test/uri/uri_fragment_test.cc
+++ b/test/uri/uri_fragment_test.cc
@@ -1,50 +1,50 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_fragment, https_no_fragment) {
+TEST(https_no_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_FALSE(uri.fragment().has_value());
 }
 
-TEST(URI_fragment, https_with_fragment) {
+TEST(https_with_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/#foo"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "foo");
 }
 
-TEST(URI_fragment, https_with_empty_fragment) {
+TEST(https_with_empty_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo#"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "");
 }
 
-TEST(URI_fragment, https_with_escaped_jsonpointer) {
+TEST(https_with_escaped_jsonpointer) {
   const sourcemeta::core::URI uri{"https://example.com/#/c%25d"};
   EXPECT_TRUE(uri.fragment().has_value());
   // %25 encodes %, which is not unreserved, so must not be decoded
   EXPECT_EQ(uri.fragment().value(), "/c%25d");
 }
 
-TEST(URI_fragment, encoded_slash_preserved) {
+TEST(encoded_slash_preserved) {
   const sourcemeta::core::URI uri{"https://example.com#/foo%2Fbar"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "/foo%2Fbar");
 }
 
-TEST(URI_fragment, encoded_hash_preserved) {
+TEST(encoded_hash_preserved) {
   const sourcemeta::core::URI uri{"https://example.com#/foo%23bar"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "/foo%23bar");
 }
 
-TEST(URI_fragment, encoded_question_mark_preserved) {
+TEST(encoded_question_mark_preserved) {
   const sourcemeta::core::URI uri{"https://example.com#/foo%3Fbar"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "/foo%3Fbar");
 }
 
-TEST(URI_fragment, invalid_fragment_with_pointer) {
+TEST(invalid_fragment_with_pointer) {
   try {
     sourcemeta::core::URI{"#foo#/$defs/bar"};
     FAIL();
@@ -53,145 +53,145 @@ TEST(URI_fragment, invalid_fragment_with_pointer) {
   }
 }
 
-TEST(URI_fragment, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_FALSE(uri.fragment().has_value());
 }
 
-TEST(URI_fragment, urn_with_fragment) {
+TEST(urn_with_fragment) {
   const sourcemeta::core::URI uri{"urn:example:schema#foo"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "foo");
 }
 
-TEST(URI_fragment, is_fragment_only_true_1) {
+TEST(is_fragment_only_true_1) {
   const sourcemeta::core::URI uri{"#foo"};
   EXPECT_TRUE(uri.is_fragment_only());
 }
 
-TEST(URI_fragment, is_fragment_only_true_2) {
+TEST(is_fragment_only_true_2) {
   // In this case it is not really a query, but part of the fragment
   const sourcemeta::core::URI uri{"#foo?bar=baz"};
   EXPECT_TRUE(uri.is_fragment_only());
   EXPECT_EQ(uri.fragment().value(), "foo?bar=baz");
 }
 
-TEST(URI_fragment, is_fragment_only_true_3) {
+TEST(is_fragment_only_true_3) {
   const sourcemeta::core::URI uri{"#"};
   EXPECT_TRUE(uri.is_fragment_only());
 }
 
-TEST(URI_fragment, is_fragment_only_false_1) {
+TEST(is_fragment_only_false_1) {
   const sourcemeta::core::URI uri{"foo#bar"};
   EXPECT_FALSE(uri.is_fragment_only());
 }
 
-TEST(URI_fragment, is_fragment_only_false_2) {
+TEST(is_fragment_only_false_2) {
   const sourcemeta::core::URI uri{"example.com/#bar"};
   EXPECT_FALSE(uri.is_fragment_only());
 }
 
-TEST(URI_fragment, is_fragment_only_false_3) {
+TEST(is_fragment_only_false_3) {
   const sourcemeta::core::URI uri{"urn:example:schema#foo"};
   EXPECT_FALSE(uri.is_fragment_only());
 }
 
-TEST(URI_fragment, set_uri_absolute_non_empty_with_hash_prefix) {
+TEST(set_uri_absolute_non_empty_with_hash_prefix) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("#foo");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#foo");
 }
 
-TEST(URI_fragment, set_uri_absolute_non_empty) {
+TEST(set_uri_absolute_non_empty) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("foo");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#foo");
 }
 
-TEST(URI_fragment, set_uri_absolute_empty) {
+TEST(set_uri_absolute_empty) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#");
 }
 
-TEST(URI_fragment, set_uri_absolute_replace) {
+TEST(set_uri_absolute_replace) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com#bar"};
   uri.fragment("foo");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#foo");
 }
 
-TEST(URI_fragment, set_urn_non_empty) {
+TEST(set_urn_non_empty) {
   sourcemeta::core::URI uri{"urn:example:schema"};
   uri.fragment("foo");
   EXPECT_EQ(uri.recompose(), "urn:example:schema#foo");
 }
 
-TEST(URI_fragment, set_urn_replace) {
+TEST(set_urn_replace) {
   sourcemeta::core::URI uri{"urn:example:schema#bar"};
   uri.fragment("foo");
   EXPECT_EQ(uri.recompose(), "urn:example:schema#foo");
 }
 
-TEST(URI_fragment, set_urn_empty) {
+TEST(set_urn_empty) {
   sourcemeta::core::URI uri{"urn:example:schema"};
   uri.fragment("");
   EXPECT_EQ(uri.recompose(), "urn:example:schema#");
 }
 
-TEST(URI_fragment, set_uri_relative_non_empty) {
+TEST(set_uri_relative_non_empty) {
   sourcemeta::core::URI uri{"foo/bar"};
   uri.fragment("baz");
   EXPECT_EQ(uri.recompose(), "foo/bar#baz");
 }
 
-TEST(URI_fragment, set_uri_empty_non_empty) {
+TEST(set_uri_empty_non_empty) {
   sourcemeta::core::URI uri{""};
   uri.fragment("baz");
   EXPECT_EQ(uri.recompose(), "#baz");
 }
 
-TEST(URI_fragment, set_uri_empty_empty) {
+TEST(set_uri_empty_empty) {
   sourcemeta::core::URI uri{""};
   uri.fragment("");
   EXPECT_EQ(uri.recompose(), "#");
 }
 
-TEST(URI_fragment, copy_semantics_1) {
+TEST(copy_semantics_1) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   const std::string fragment{"foo"};
   uri.fragment(fragment);
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#foo");
 }
 
-TEST(URI_fragment, copy_semantics_2) {
+TEST(copy_semantics_2) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   const std::string fragment{""};
   uri.fragment(fragment);
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#");
 }
 
-TEST(URI_fragment, copy_semantics_3) {
+TEST(copy_semantics_3) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   const std::string fragment{"#foo"};
   uri.fragment(fragment);
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#foo");
 }
 
-TEST(URI_fragment, set_pointer_at) {
+TEST(set_pointer_at) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/@foo/bar");
   EXPECT_EQ(uri.fragment(), "/@foo/bar");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/@foo/bar");
 }
 
-TEST(URI_fragment, set_pointer_bracket) {
+TEST(set_pointer_bracket) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/[foo/bar");
   EXPECT_EQ(uri.fragment(), "/[foo/bar");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/%5Bfoo/bar");
 }
 
-TEST(URI_fragment, set_pointer_percentage) {
+TEST(set_pointer_percentage) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo%bar");
   EXPECT_EQ(uri.fragment(), "/foo%bar");
@@ -199,21 +199,21 @@ TEST(URI_fragment, set_pointer_percentage) {
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%bar");
 }
 
-TEST(URI_fragment, set_percentage_at_end) {
+TEST(set_percentage_at_end) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo%");
   EXPECT_EQ(uri.fragment(), "/foo%");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%25");
 }
 
-TEST(URI_fragment, set_percentage_with_one_hex) {
+TEST(set_percentage_with_one_hex) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo%2");
   EXPECT_EQ(uri.fragment(), "/foo%2");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%252");
 }
 
-TEST(URI_fragment, set_multiple_percentages) {
+TEST(set_multiple_percentages) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo%%bar");
   EXPECT_EQ(uri.fragment(), "/foo%%bar");
@@ -222,7 +222,7 @@ TEST(URI_fragment, set_multiple_percentages) {
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%25%bar");
 }
 
-TEST(URI_fragment, set_percentage_followed_by_valid_hex_sequence) {
+TEST(set_percentage_followed_by_valid_hex_sequence) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo%2Fbar");
   EXPECT_EQ(uri.fragment(), "/foo%2Fbar");
@@ -230,21 +230,21 @@ TEST(URI_fragment, set_percentage_followed_by_valid_hex_sequence) {
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%2Fbar");
 }
 
-TEST(URI_fragment, set_space_character) {
+TEST(set_space_character) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo bar");
   EXPECT_EQ(uri.fragment(), "/foo bar");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%20bar");
 }
 
-TEST(URI_fragment, set_non_ascii_character) {
+TEST(set_non_ascii_character) {
   sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   uri.fragment("/foo\xC3\xA9");
   EXPECT_EQ(uri.fragment(), "/foo\xC3\xA9");
   EXPECT_EQ(uri.recompose(), "https://www.sourcemeta.com#/foo%C3%A9");
 }
 
-TEST(URI_fragment, getter_setter_invariant_simple) {
+TEST(getter_setter_invariant_simple) {
   sourcemeta::core::URI uri{"https://example.com/path#foo"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "foo");
@@ -257,7 +257,7 @@ TEST(URI_fragment, getter_setter_invariant_simple) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_fragment, getter_setter_invariant_with_pointer) {
+TEST(getter_setter_invariant_with_pointer) {
   sourcemeta::core::URI uri{"https://example.com#/foo/bar"};
   EXPECT_TRUE(uri.fragment().has_value());
 
@@ -269,7 +269,7 @@ TEST(URI_fragment, getter_setter_invariant_with_pointer) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_fragment, getter_setter_invariant_empty) {
+TEST(getter_setter_invariant_empty) {
   sourcemeta::core::URI uri{"https://example.com#"};
   EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "");
@@ -282,9 +282,9 @@ TEST(URI_fragment, getter_setter_invariant_empty) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_fragment, iri_unicode_fragment) {
+TEST(iri_unicode_fragment) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/#section-\xCE\xB1")};
-  ASSERT_TRUE(uri.fragment().has_value());
+  EXPECT_TRUE(uri.fragment().has_value());
   EXPECT_EQ(uri.fragment().value(), "section-\xCE\xB1");
 }

--- a/test/uri/uri_from_iri_test.cc
+++ b/test/uri/uri_from_iri_test.cc
@@ -1,19 +1,19 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_from_iri, parses_and_round_trips_unicode) {
+TEST(parses_and_round_trips_unicode) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   EXPECT_EQ(uri.recompose(), "https://example.com/caf\xC3\xA9");
 }
 
-TEST(URI_from_iri, accepts_ascii_like_uri) {
+TEST(accepts_ascii_like_uri) {
   const auto uri{sourcemeta::core::URI::from_iri("https://example.com/foo")};
   EXPECT_EQ(uri.recompose(), "https://example.com/foo");
 }
 
-TEST(URI_from_iri, rejects_private_use_in_path) {
+TEST(rejects_private_use_in_path) {
   // RFC 3987 allows private-use characters only in the query
   try {
     sourcemeta::core::URI::from_iri("https://example.com/\xEE\x80\x80");
@@ -23,7 +23,7 @@ TEST(URI_from_iri, rejects_private_use_in_path) {
   }
 }
 
-TEST(URI_from_iri, rejects_invalid_utf8) {
+TEST(rejects_invalid_utf8) {
   try {
     sourcemeta::core::URI::from_iri("https://example.com/\xC3");
     FAIL();
@@ -32,7 +32,7 @@ TEST(URI_from_iri, rejects_invalid_utf8) {
   }
 }
 
-TEST(URI_from_iri, equals_plain_uri_with_same_components) {
+TEST(equals_plain_uri_with_same_components) {
   // The parse mode is not part of a URI's value, so equality and ordering
   // ignore it and stay consistent with each other
   const sourcemeta::core::URI plain{"https://example.com/foo"};

--- a/test/uri/uri_from_path_test.cc
+++ b/test/uri/uri_from_path_test.cc
@@ -1,58 +1,58 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_from_path, unix_absolute) {
+TEST(unix_absolute) {
   const std::filesystem::path example{"/foo/bar/baz"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///foo/bar/baz");
 }
 
-TEST(URI_from_path, unix_with_space_and_reserved) {
+TEST(unix_with_space_and_reserved) {
   const std::filesystem::path example{"/foo/My Folder/has#hash?value%"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   // ? must be encoded as %3F in the path, not treated as a query delimiter
   EXPECT_EQ(uri.recompose(), "file:///foo/My%20Folder/has%23hash%3Fvalue%25");
 }
 
-TEST(URI_from_path, unix_trailing_slash) {
+TEST(unix_trailing_slash) {
   const std::filesystem::path example{"/foo/bar/"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///foo/bar/");
 }
 
-TEST(URI_from_path, windows_drive_absolute) {
+TEST(windows_drive_absolute) {
   const std::filesystem::path example{R"(C:\Program Files\Test)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///C:/Program%20Files/Test");
 }
 
-TEST(URI_from_path, windows_drive_lowercase) {
+TEST(windows_drive_lowercase) {
   const std::filesystem::path example{R"(c:\temp\logs)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///c:/temp/logs");
 }
 
-TEST(URI_from_path, windows_drive_root) {
+TEST(windows_drive_root) {
   const std::filesystem::path example{R"(D:\)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///D:/");
 }
 
-TEST(URI_from_path, windows_trailing_slash) {
+TEST(windows_trailing_slash) {
   const std::filesystem::path example{R"(C:\foo\bar\)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///C:/foo/bar/");
 }
 
-TEST(URI_from_path, windows_percent_and_plus) {
+TEST(windows_percent_and_plus) {
   // '%' → %25, '+' is allowed unencoded
   const std::filesystem::path example{R"(C:\path\50%+plus.txt)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///C:/path/50%25+plus.txt");
 }
 
-TEST(URI_from_path, windows_unc_simple) {
+TEST(windows_unc_simple) {
   const std::filesystem::path example{R"(\\server\share\file.txt)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(),
@@ -60,27 +60,27 @@ TEST(URI_from_path, windows_unc_simple) {
             "file://server/share/file.txt");
 }
 
-TEST(URI_from_path, windows_unc_with_space) {
+TEST(windows_unc_with_space) {
   const std::filesystem::path example{R"(\\srv\My Docs\a b.txt)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file://srv/My%20Docs/a%20b.txt");
 }
 
-TEST(URI_from_path, unicode_unix) {
+TEST(unicode_unix) {
   // U+00E9 (é) should be UTF-8 percent-encoded as %C3%A9
   const std::filesystem::path example{u8"/data/éclair.txt"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///data/%C3%A9clair.txt");
 }
 
-TEST(URI_from_path, unicode_windows) {
+TEST(unicode_windows) {
   // U+00E9 (é) should be UTF-8 percent-encoded as %C3%A9
   const std::filesystem::path example{u8R"(C:\data\résumé.doc)"};
   const auto uri{sourcemeta::core::URI::from_path(example)};
   EXPECT_EQ(uri.recompose(), "file:///C:/data/r%C3%A9sum%C3%A9.doc");
 }
 
-TEST(URI_from_path, unix_relative_simple) {
+TEST(unix_relative_simple) {
   const std::filesystem::path example{"foo/bar/baz"};
   try {
     sourcemeta::core::URI::from_path(example);
@@ -92,7 +92,7 @@ TEST(URI_from_path, unix_relative_simple) {
   }
 }
 
-TEST(URI_from_path, unix_relative_with_dot) {
+TEST(unix_relative_with_dot) {
   const std::filesystem::path example{"./foo/bar"};
   try {
     sourcemeta::core::URI::from_path(example);
@@ -104,7 +104,7 @@ TEST(URI_from_path, unix_relative_with_dot) {
   }
 }
 
-TEST(URI_from_path, unix_relative_with_dotdot) {
+TEST(unix_relative_with_dotdot) {
   const std::filesystem::path example{"../parent/dir"};
   try {
     sourcemeta::core::URI::from_path(example);
@@ -116,7 +116,7 @@ TEST(URI_from_path, unix_relative_with_dotdot) {
   }
 }
 
-TEST(URI_from_path, unix_empty_path) {
+TEST(unix_empty_path) {
   const std::filesystem::path example{""};
   try {
     sourcemeta::core::URI::from_path(example);
@@ -128,7 +128,7 @@ TEST(URI_from_path, unix_empty_path) {
   }
 }
 
-TEST(URI_from_path, windows_relative_simple) {
+TEST(windows_relative_simple) {
   const std::filesystem::path example{"folder\\file.txt"};
   try {
     sourcemeta::core::URI::from_path(example);
@@ -140,7 +140,7 @@ TEST(URI_from_path, windows_relative_simple) {
   }
 }
 
-TEST(URI_from_path, windows_relative_with_dot) {
+TEST(windows_relative_with_dot) {
   const std::filesystem::path example{".\\foo\\bar"};
   try {
     sourcemeta::core::URI::from_path(example);
@@ -152,7 +152,7 @@ TEST(URI_from_path, windows_relative_with_dot) {
   }
 }
 
-TEST(URI_from_path, windows_relative_with_dotdot) {
+TEST(windows_relative_with_dotdot) {
   const std::filesystem::path example{"..\\up\\one\\level"};
   try {
     sourcemeta::core::URI::from_path(example);

--- a/test/uri/uri_has_same_authority_test.cc
+++ b/test/uri/uri_has_same_authority_test.cc
@@ -1,38 +1,38 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_has_same_authority, same_host_same_port) {
+TEST(same_host_same_port) {
   const sourcemeta::core::URI left{"http://example.com:8080/foo"};
   const sourcemeta::core::URI right{"http://example.com:8080/bar"};
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, different_host) {
+TEST(different_host) {
   const sourcemeta::core::URI left{"http://example.com/foo"};
   const sourcemeta::core::URI right{"http://other.example.com/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, different_port) {
+TEST(different_port) {
   const sourcemeta::core::URI left{"http://example.com:8080/foo"};
   const sourcemeta::core::URI right{"http://example.com:9090/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, scheme_is_not_part_of_authority) {
+TEST(scheme_is_not_part_of_authority) {
   const sourcemeta::core::URI left{"https://example.com/foo"};
   const sourcemeta::core::URI right{"http://example.com/foo"};
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, host_case_sensitive_without_canonicalize) {
+TEST(host_case_sensitive_without_canonicalize) {
   const sourcemeta::core::URI left{"http://Example.COM/foo"};
   const sourcemeta::core::URI right{"http://example.com/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, host_case_insensitive_after_canonicalize) {
+TEST(host_case_insensitive_after_canonicalize) {
   sourcemeta::core::URI left{"http://Example.COM/foo"};
   sourcemeta::core::URI right{"http://EXAMPLE.com/bar"};
   left.canonicalize();
@@ -40,43 +40,43 @@ TEST(URI_has_same_authority, host_case_insensitive_after_canonicalize) {
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, same_userinfo) {
+TEST(same_userinfo) {
   const sourcemeta::core::URI left{"http://alice@example.com/foo"};
   const sourcemeta::core::URI right{"http://alice@example.com/bar"};
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, different_userinfo) {
+TEST(different_userinfo) {
   const sourcemeta::core::URI left{"http://alice@example.com/foo"};
   const sourcemeta::core::URI right{"http://bob@example.com/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, userinfo_vs_none) {
+TEST(userinfo_vs_none) {
   const sourcemeta::core::URI left{"http://alice@example.com/foo"};
   const sourcemeta::core::URI right{"http://example.com/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, both_relative_no_authority) {
+TEST(both_relative_no_authority) {
   const sourcemeta::core::URI left{"foo/bar"};
   const sourcemeta::core::URI right{"baz/qux"};
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, urn_vs_urn) {
+TEST(urn_vs_urn) {
   const sourcemeta::core::URI left{"urn:example:one"};
   const sourcemeta::core::URI right{"urn:example:two"};
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, default_port_vs_explicit) {
+TEST(default_port_vs_explicit) {
   const sourcemeta::core::URI left{"http://example.com:80/foo"};
   const sourcemeta::core::URI right{"http://example.com/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, default_port_vs_explicit_after_canonicalize) {
+TEST(default_port_vs_explicit_after_canonicalize) {
   sourcemeta::core::URI left{"http://example.com:80/foo"};
   sourcemeta::core::URI right{"http://example.com/foo"};
   left.canonicalize();
@@ -84,19 +84,19 @@ TEST(URI_has_same_authority, default_port_vs_explicit_after_canonicalize) {
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, ipv6_short_form_vs_long_form) {
+TEST(ipv6_short_form_vs_long_form) {
   const sourcemeta::core::URI left{"http://[::1]/foo"};
   const sourcemeta::core::URI right{"http://[0:0:0:0:0:0:0:1]/foo"};
   EXPECT_FALSE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, ipv6_same_literal) {
+TEST(ipv6_same_literal) {
   const sourcemeta::core::URI left{"http://[::1]/foo"};
   const sourcemeta::core::URI right{"http://[::1]/bar"};
   EXPECT_TRUE(left.has_same_authority(right));
 }
 
-TEST(URI_has_same_authority, iri_same_unicode_host) {
+TEST(iri_same_unicode_host) {
   const auto left{sourcemeta::core::URI::from_iri(
       "https://\xE4\xBE\x8B\xE3\x81\x88.jp/foo")};
   const auto right{sourcemeta::core::URI::from_iri(

--- a/test/uri/uri_host_test.cc
+++ b/test/uri/uri_host_test.cc
@@ -1,66 +1,66 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_host, https_example_url) {
+TEST(https_example_url) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "example.com");
 }
 
-TEST(URI_host, https_example_url_slash) {
+TEST(https_example_url_slash) {
   const sourcemeta::core::URI uri{"https://example.com/"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "example.com");
 }
 
-TEST(URI_host, https_example_url_with_port) {
+TEST(https_example_url_with_port) {
   const sourcemeta::core::URI uri{"https://example.com:8000/foo"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "example.com");
 }
 
-TEST(URI_host, relative_url) {
+TEST(relative_url) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.host().has_value());
 }
 
-TEST(URI_host, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_FALSE(uri.host().has_value());
 }
 
-TEST(URI_host, rfc3986_ipv4_address) {
+TEST(rfc3986_ipv4_address) {
   const sourcemeta::core::URI uri{"http://192.168.1.1/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "192.168.1.1");
 }
 
-TEST(URI_host, rfc3986_ipv4_address_with_port) {
+TEST(rfc3986_ipv4_address_with_port) {
   const sourcemeta::core::URI uri{"http://192.168.1.1:8080/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "192.168.1.1");
 }
 
-TEST(URI_host, rfc3986_ipv6_address) {
+TEST(rfc3986_ipv6_address) {
   const sourcemeta::core::URI uri{"http://[2001:db8::1]/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "2001:db8::1");
 }
 
-TEST(URI_host, rfc3986_ipv6_address_with_port) {
+TEST(rfc3986_ipv6_address_with_port) {
   const sourcemeta::core::URI uri{"http://[2001:db8::1]:8080/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "2001:db8::1");
 }
 
-TEST(URI_host, rfc3986_ipv6_localhost) {
+TEST(rfc3986_ipv6_localhost) {
   const sourcemeta::core::URI uri{"http://[::1]/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "::1");
 }
 
-TEST(URI_host, rfc3986_host_case_insensitive) {
+TEST(rfc3986_host_case_insensitive) {
   sourcemeta::core::URI uri1{"http://EXAMPLE.COM/path"};
   sourcemeta::core::URI uri2{"http://example.com/path"};
   // Without canonicalization, case is preserved
@@ -75,45 +75,45 @@ TEST(URI_host, rfc3986_host_case_insensitive) {
   EXPECT_EQ(uri1.host().value(), uri2.host().value());
 }
 
-TEST(URI_host, rfc3986_host_with_hyphen) {
+TEST(rfc3986_host_with_hyphen) {
   const sourcemeta::core::URI uri{"http://my-example-host.com/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "my-example-host.com");
 }
 
-TEST(URI_host, rfc3986_host_with_numbers) {
+TEST(rfc3986_host_with_numbers) {
   const sourcemeta::core::URI uri{"http://example123.com/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "example123.com");
 }
 
-TEST(URI_host, rfc3986_subdomain) {
+TEST(rfc3986_subdomain) {
   const sourcemeta::core::URI uri{"http://www.sub.example.com/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "www.sub.example.com");
 }
 
-TEST(URI_host, rfc3986_localhost) {
+TEST(rfc3986_localhost) {
   const sourcemeta::core::URI uri{"http://localhost/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "localhost");
 }
 
-TEST(URI_host, rfc3986_empty_host_with_authority) {
+TEST(rfc3986_empty_host_with_authority) {
   const sourcemeta::core::URI uri{"file:///path/to/file"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "");
 }
 
-TEST(URI_host, rfc3986_percent_encoded_host) {
+TEST(rfc3986_percent_encoded_host) {
   const sourcemeta::core::URI uri{"http://example%2Ecom/path"};
   EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "example.com");
 }
 
-TEST(URI_host, iri_unicode_host) {
+TEST(iri_unicode_host) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://\xE4\xBE\x8B\xE3\x81\x88.jp/")};
-  ASSERT_TRUE(uri.host().has_value());
+  EXPECT_TRUE(uri.host().has_value());
   EXPECT_EQ(uri.host().value(), "\xE4\xBE\x8B\xE3\x81\x88.jp");
 }

--- a/test/uri/uri_is_absolute_test.cc
+++ b/test/uri/uri_is_absolute_test.cc
@@ -1,109 +1,109 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_absolute, example_url) {
+TEST(example_url) {
   const sourcemeta::core::URI uri{"https://example.com"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, relative_url) {
+TEST(relative_url) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, slash) {
+TEST(slash) {
   // The is a relative URI, even if the path is absolute.
   const sourcemeta::core::URI uri{"/foo"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_http_scheme) {
+TEST(rfc3986_http_scheme) {
   const sourcemeta::core::URI uri{"http://example.com/path"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_https_scheme) {
+TEST(rfc3986_https_scheme) {
   const sourcemeta::core::URI uri{"https://example.com/path"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_ftp_scheme) {
+TEST(rfc3986_ftp_scheme) {
   const sourcemeta::core::URI uri{"ftp://ftp.example.com/file"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_file_scheme) {
+TEST(rfc3986_file_scheme) {
   const sourcemeta::core::URI uri{"file:///path/to/file"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_mailto_scheme) {
+TEST(rfc3986_mailto_scheme) {
   const sourcemeta::core::URI uri{"mailto:user@example.com"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_tel_scheme) {
+TEST(rfc3986_tel_scheme) {
   const sourcemeta::core::URI uri{"tel:+1-555-1212"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_data_scheme) {
+TEST(rfc3986_data_scheme) {
   const sourcemeta::core::URI uri{"data:text/plain;base64,SGVsbG8="};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_relative_path) {
+TEST(rfc3986_relative_path) {
   const sourcemeta::core::URI uri{"relative/path"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_absolute_path) {
+TEST(rfc3986_absolute_path) {
   const sourcemeta::core::URI uri{"/absolute/path"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_network_path) {
+TEST(rfc3986_network_path) {
   const sourcemeta::core::URI uri{"//example.com/path"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_query_only) {
+TEST(rfc3986_query_only) {
   const sourcemeta::core::URI uri{"?query=value"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_fragment_only) {
+TEST(rfc3986_fragment_only) {
   const sourcemeta::core::URI uri{"#fragment"};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_empty_uri) {
+TEST(rfc3986_empty_uri) {
   const sourcemeta::core::URI uri{""};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_dot_relative) {
+TEST(rfc3986_dot_relative) {
   const sourcemeta::core::URI uri{"."};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_dotdot_relative) {
+TEST(rfc3986_dotdot_relative) {
   const sourcemeta::core::URI uri{".."};
   EXPECT_FALSE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, rfc3986_scheme_with_fragment) {
+TEST(rfc3986_scheme_with_fragment) {
   const sourcemeta::core::URI uri{"http://example.com/path#fragment"};
   EXPECT_TRUE(uri.is_absolute());
 }
 
-TEST(URI_is_absolute, iri_absolute) {
+TEST(iri_absolute) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://\xE4\xBE\x8B\xE3\x81\x88.jp/")};
   EXPECT_TRUE(uri.is_absolute());

--- a/test/uri/uri_is_file_test.cc
+++ b/test/uri/uri_is_file_test.cc
@@ -1,38 +1,38 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_file, mailto) {
+TEST(mailto) {
   const sourcemeta::core::URI uri{"mailto:jdoe@mail.com"};
   EXPECT_FALSE(uri.is_file());
 }
 
-TEST(URI_is_file, https_url) {
+TEST(https_url) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   EXPECT_FALSE(uri.is_file());
 }
 
-TEST(URI_is_file, relative) {
+TEST(relative) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.is_file());
 }
 
-TEST(URI_is_file, tag) {
+TEST(tag) {
   const sourcemeta::core::URI uri{"tag:yaml.org,2002:int"};
   EXPECT_FALSE(uri.is_file());
 }
 
-TEST(URI_is_file, unix_absolute) {
+TEST(unix_absolute) {
   const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
   EXPECT_TRUE(uri.is_file());
 }
 
-TEST(URI_is_file, windows_drive_absolute) {
+TEST(windows_drive_absolute) {
   const sourcemeta::core::URI uri{"file:///C:/Program%20Files/Test"};
   EXPECT_TRUE(uri.is_file());
 }
 
-TEST(URI_is_file, iri_file) {
+TEST(iri_file) {
   const auto uri{sourcemeta::core::URI::from_iri("file:///caf\xC3\xA9.txt")};
   EXPECT_TRUE(uri.is_file());
 }

--- a/test/uri/uri_is_gen_delim_test.cc
+++ b/test/uri/uri_is_gen_delim_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_gen_delim, all_generic_delimiters) {
+TEST(all_generic_delimiters) {
   EXPECT_TRUE(sourcemeta::core::URI::is_gen_delim(':'));
   EXPECT_TRUE(sourcemeta::core::URI::is_gen_delim('/'));
   EXPECT_TRUE(sourcemeta::core::URI::is_gen_delim('?'));
@@ -12,7 +12,7 @@ TEST(URI_is_gen_delim, all_generic_delimiters) {
   EXPECT_TRUE(sourcemeta::core::URI::is_gen_delim('@'));
 }
 
-TEST(URI_is_gen_delim, sub_delimiters_are_not_generic) {
+TEST(sub_delimiters_are_not_generic) {
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('!'));
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('$'));
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('&'));
@@ -20,7 +20,7 @@ TEST(URI_is_gen_delim, sub_delimiters_are_not_generic) {
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('='));
 }
 
-TEST(URI_is_gen_delim, unreserved_are_not_generic) {
+TEST(unreserved_are_not_generic) {
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('a'));
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('Z'));
   EXPECT_FALSE(sourcemeta::core::URI::is_gen_delim('0'));

--- a/test/uri/uri_is_internationalized_test.cc
+++ b/test/uri/uri_is_internationalized_test.cc
@@ -1,71 +1,71 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
 #include <sstream> // std::istringstream
 
-TEST(URI_is_internationalized, from_iri_non_ascii) {
+TEST(from_iri_non_ascii) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   EXPECT_TRUE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, from_iri_ascii) {
+TEST(from_iri_ascii) {
   const auto uri{sourcemeta::core::URI::from_iri("https://example.com/foo")};
   EXPECT_TRUE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, default_constructor) {
+TEST(default_constructor) {
   const sourcemeta::core::URI uri;
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, string_constructor) {
+TEST(string_constructor) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, empty_string_constructor) {
+TEST(empty_string_constructor) {
   const sourcemeta::core::URI uri{""};
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, stream_constructor) {
+TEST(stream_constructor) {
   std::istringstream input{"https://example.com/foo"};
   const sourcemeta::core::URI uri{input};
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, from_fragment) {
+TEST(from_fragment) {
   const auto uri{sourcemeta::core::URI::from_fragment("foo")};
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, from_path) {
+TEST(from_path) {
   const auto uri{sourcemeta::core::URI::from_path("/foo/bar")};
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, survives_copy) {
+TEST(survives_copy) {
   const auto original{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   const sourcemeta::core::URI copy{original};
   EXPECT_TRUE(copy.is_internationalized());
 }
 
-TEST(URI_is_internationalized, plain_uri_survives_copy) {
+TEST(plain_uri_survives_copy) {
   const sourcemeta::core::URI original{"https://example.com/foo"};
   const sourcemeta::core::URI copy{original};
   EXPECT_FALSE(copy.is_internationalized());
 }
 
-TEST(URI_is_internationalized, plain_uri_stays_false_after_canonicalize) {
+TEST(plain_uri_stays_false_after_canonicalize) {
   sourcemeta::core::URI uri{"https://example.com/foo"};
   uri.canonicalize();
   EXPECT_FALSE(uri.is_internationalized());
 }
 
-TEST(URI_is_internationalized, plain_uri_stays_false_after_resolve) {
+TEST(plain_uri_stays_false_after_resolve) {
   const sourcemeta::core::URI base{"https://example.com/dir/"};
   sourcemeta::core::URI reference{"file"};
   reference.resolve_from(base);

--- a/test/uri/uri_is_ipv4_test.cc
+++ b/test/uri/uri_is_ipv4_test.cc
@@ -1,90 +1,90 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_ipv4, ipv4_simple) {
+TEST(ipv4_simple) {
   const sourcemeta::core::URI uri{"http://192.168.1.1/index.html"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "192.168.1.1");
 }
 
-TEST(URI_is_ipv4, ipv4_loopback) {
+TEST(ipv4_loopback) {
   const sourcemeta::core::URI uri{"http://127.0.0.1/"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "127.0.0.1");
 }
 
-TEST(URI_is_ipv4, ipv4_with_port) {
+TEST(ipv4_with_port) {
   const sourcemeta::core::URI uri{"http://10.0.0.1:8080/api"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "10.0.0.1");
   EXPECT_EQ(uri.port().value(), 8080);
 }
 
-TEST(URI_is_ipv4, ipv4_with_query) {
+TEST(ipv4_with_query) {
   const sourcemeta::core::URI uri{"http://1.2.3.4/search?q=test"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "1.2.3.4");
 }
 
-TEST(URI_is_ipv4, ipv4_with_fragment) {
+TEST(ipv4_with_fragment) {
   const sourcemeta::core::URI uri{"http://0.0.0.0/doc#top"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "0.0.0.0");
 }
 
-TEST(URI_is_ipv4, ipv4_with_userinfo) {
+TEST(ipv4_with_userinfo) {
   const sourcemeta::core::URI uri{"http://user:pass@255.255.255.255/"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "255.255.255.255");
 }
 
-TEST(URI_is_ipv4, ipv4_recompose) {
+TEST(ipv4_recompose) {
   const sourcemeta::core::URI uri{"http://192.168.1.1:80/path"};
   EXPECT_TRUE(uri.is_ipv4());
   EXPECT_EQ(uri.recompose(), "http://192.168.1.1:80/path");
 }
 
-TEST(URI_is_ipv4, not_ipv4_hostname) {
+TEST(not_ipv4_hostname) {
   const sourcemeta::core::URI uri{"http://example.com/"};
   EXPECT_FALSE(uri.is_ipv4());
 }
 
-TEST(URI_is_ipv4, not_ipv4_hostname_with_numbers) {
+TEST(not_ipv4_hostname_with_numbers) {
   const sourcemeta::core::URI uri{"http://host123.example.com/"};
   EXPECT_FALSE(uri.is_ipv4());
 }
 
-TEST(URI_is_ipv4, not_ipv4_ipv4_like_hostname) {
+TEST(not_ipv4_ipv4_like_hostname) {
   const sourcemeta::core::URI uri{
       "http://server.198.51.100.1.example.com/page"};
   EXPECT_FALSE(uri.is_ipv4());
 }
 
-TEST(URI_is_ipv4, not_ipv4_ipv6) {
+TEST(not_ipv4_ipv6) {
   const sourcemeta::core::URI uri{"http://[::1]/"};
   EXPECT_FALSE(uri.is_ipv4());
   EXPECT_TRUE(uri.is_ipv6());
 }
 
-TEST(URI_is_ipv4, not_ipv4_ipvfuture) {
+TEST(not_ipv4_ipvfuture) {
   const sourcemeta::core::URI uri{"http://[v1.test]/"};
   EXPECT_FALSE(uri.is_ipv4());
   EXPECT_FALSE(uri.is_ipv6());
 }
 
-TEST(URI_is_ipv4, not_ipv4_no_host) {
+TEST(not_ipv4_no_host) {
   const sourcemeta::core::URI uri{"file:///path"};
   EXPECT_FALSE(uri.is_ipv4());
 }
 
-TEST(URI_is_ipv4, not_ipv4_invalid_octet_in_hostname) {
+TEST(not_ipv4_invalid_octet_in_hostname) {
   const sourcemeta::core::URI uri{"http://999.999.999.999/"};
   EXPECT_FALSE(uri.is_ipv4());
 }
 
-TEST(URI_is_ipv4, iri_unicode_host_not_ipv4) {
+TEST(iri_unicode_host_not_ipv4) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://\xE4\xBE\x8B\xE3\x81\x88.jp/")};
   EXPECT_FALSE(uri.is_ipv4());

--- a/test/uri/uri_is_ipv6_test.cc
+++ b/test/uri/uri_is_ipv6_test.cc
@@ -1,10 +1,10 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
 // Insipred from https://datatracker.ietf.org/doc/html/rfc2732#section-2
 
-TEST(URI_is_ipv6, ipv6_1) {
+TEST(ipv6_1) {
   const sourcemeta::core::URI uri{
       "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html"};
   EXPECT_TRUE(uri.is_ipv6());
@@ -13,7 +13,7 @@ TEST(URI_is_ipv6, ipv6_1) {
             "http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html");
 }
 
-TEST(URI_is_ipv6, ipv6_2) {
+TEST(ipv6_2) {
   const sourcemeta::core::URI uri{
       "http://[1080:0:0:0:8:800:200C:417A]/index.html"};
   EXPECT_TRUE(uri.is_ipv6());
@@ -21,28 +21,28 @@ TEST(URI_is_ipv6, ipv6_2) {
   EXPECT_EQ(uri.recompose(), "http://[1080:0:0:0:8:800:200C:417A]/index.html");
 }
 
-TEST(URI_is_ipv6, ipv6_3) {
+TEST(ipv6_3) {
   const sourcemeta::core::URI uri{"http://[3ffe:2a00:100:7031::1]"};
   EXPECT_TRUE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "3ffe:2a00:100:7031::1");
   EXPECT_EQ(uri.recompose(), "http://[3ffe:2a00:100:7031::1]");
 }
 
-TEST(URI_is_ipv6, ipv6_4) {
+TEST(ipv6_4) {
   const sourcemeta::core::URI uri{"http://[1080::8:800:200C:417A]/foo"};
   EXPECT_TRUE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "1080::8:800:200C:417A");
   EXPECT_EQ(uri.recompose(), "http://[1080::8:800:200C:417A]/foo");
 }
 
-TEST(URI_is_ipv6, ipv6_5) {
+TEST(ipv6_5) {
   const sourcemeta::core::URI uri{"http://[::192.9.5.5]/ipng"};
   EXPECT_TRUE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "::192.9.5.5");
   EXPECT_EQ(uri.recompose(), "http://[::192.9.5.5]/ipng");
 }
 
-TEST(URI_is_ipv6, ipv6_6) {
+TEST(ipv6_6) {
   const sourcemeta::core::URI uri{
       "http://[::FFFF:129.144.52.38]:80/index.html"};
   EXPECT_TRUE(uri.is_ipv6());
@@ -50,28 +50,28 @@ TEST(URI_is_ipv6, ipv6_6) {
   EXPECT_EQ(uri.recompose(), "http://[::FFFF:129.144.52.38]:80/index.html");
 }
 
-TEST(URI_is_ipv6, ipv6_7) {
+TEST(ipv6_7) {
   const sourcemeta::core::URI uri{"http://[2010:836B:4179::836B:4179]"};
   EXPECT_TRUE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "2010:836B:4179::836B:4179");
   EXPECT_EQ(uri.recompose(), "http://[2010:836B:4179::836B:4179]");
 }
 
-TEST(URI_is_ipv6, ipv4) {
+TEST(ipv4) {
   const sourcemeta::core::URI uri{"http://192.168.1.1/index.html"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "192.168.1.1");
   EXPECT_EQ(uri.recompose(), "http://192.168.1.1/index.html");
 }
 
-TEST(URI_is_ipv6, ipv4_with_port) {
+TEST(ipv4_with_port) {
   const sourcemeta::core::URI uri{"http://203.0.113.1:8080/api/data"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "203.0.113.1");
   EXPECT_EQ(uri.recompose(), "http://203.0.113.1:8080/api/data");
 }
 
-TEST(URI_is_ipv6, ipv4_one_subdomain) {
+TEST(ipv4_one_subdomain) {
   const sourcemeta::core::URI uri{
       "http://server.198.51.100.1.example.com/page"};
   EXPECT_FALSE(uri.is_ipv6());
@@ -79,28 +79,28 @@ TEST(URI_is_ipv6, ipv4_one_subdomain) {
   EXPECT_EQ(uri.recompose(), "http://server.198.51.100.1.example.com/page");
 }
 
-TEST(URI_is_ipv6, ipv4_with_userinfo) {
+TEST(ipv4_with_userinfo) {
   const sourcemeta::core::URI uri{"http://user:pass@192.0.2.1/secure"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "192.0.2.1");
   EXPECT_EQ(uri.recompose(), "http://user:pass@192.0.2.1/secure");
 }
 
-TEST(URI_is_ipv6, ipv4_with_query) {
+TEST(ipv4_with_query) {
   const sourcemeta::core::URI uri{"http://198.51.100.42/search?q=test&page=1"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "198.51.100.42");
   EXPECT_EQ(uri.recompose(), "http://198.51.100.42/search?q=test&page=1");
 }
 
-TEST(URI_is_ipv6, ipv4_with_fragment) {
+TEST(ipv4_with_fragment) {
   const sourcemeta::core::URI uri{"http://203.0.113.53/document#section-2"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_EQ(uri.host().value(), "203.0.113.53");
   EXPECT_EQ(uri.recompose(), "http://203.0.113.53/document#section-2");
 }
 
-TEST(URI_is_ipv6, ipv4_multiple_subdomains) {
+TEST(ipv4_multiple_subdomains) {
   const sourcemeta::core::URI uri{
       "http://api.v1.198.51.100.5.example.com/endpoint"};
   EXPECT_FALSE(uri.is_ipv6());
@@ -108,21 +108,21 @@ TEST(URI_is_ipv6, ipv4_multiple_subdomains) {
   EXPECT_EQ(uri.recompose(), "http://api.v1.198.51.100.5.example.com/endpoint");
 }
 
-TEST(URI_is_ipv6, ipvfuture_no_colon) {
+TEST(ipvfuture_no_colon) {
   const sourcemeta::core::URI uri{"http://[v1.test]/"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_FALSE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "v1.test");
 }
 
-TEST(URI_is_ipv6, ipvfuture_with_colon) {
+TEST(ipvfuture_with_colon) {
   const sourcemeta::core::URI uri{"http://[vFF.a:b]/"};
   EXPECT_FALSE(uri.is_ipv6());
   EXPECT_FALSE(uri.is_ipv4());
   EXPECT_EQ(uri.host().value(), "vFF.a:b");
 }
 
-TEST(URI_is_ipv6, iri_unicode_host_not_ipv6) {
+TEST(iri_unicode_host_not_ipv6) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://\xE4\xBE\x8B\xE3\x81\x88.jp/")};
   EXPECT_FALSE(uri.is_ipv6());

--- a/test/uri/uri_is_iri_test.cc
+++ b/test/uri/uri_is_iri_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_iri, ascii_https_absolute) {
+TEST(ascii_https_absolute) {
   EXPECT_TRUE(sourcemeta::core::URI::is_iri("https://example.com/path"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_iri_reference("https://example.com/path"));
@@ -11,7 +11,7 @@ TEST(URI_is_iri, ascii_https_absolute) {
       sourcemeta::core::URI::is_uri_reference("https://example.com/path"));
 }
 
-TEST(URI_is_iri, fragment_with_ucschar) {
+TEST(fragment_with_ucschar) {
   const std::string input{"https://example.com/#section-\xCE\xB1"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -19,7 +19,7 @@ TEST(URI_is_iri, fragment_with_ucschar) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, fragment_with_iprivate_rejected) {
+TEST(fragment_with_iprivate_rejected) {
   const std::string input{"https://example.com/#\xEE\x80\x80"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -27,7 +27,7 @@ TEST(URI_is_iri, fragment_with_iprivate_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, fragment_with_invalid_utf8) {
+TEST(fragment_with_invalid_utf8) {
   const std::string input{"https://example.com/#\xC3"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -35,7 +35,7 @@ TEST(URI_is_iri, fragment_with_invalid_utf8) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, query_with_ucschar) {
+TEST(query_with_ucschar) {
   const std::string input{"https://example.com/?key=caf\xC3\xA9"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -43,7 +43,7 @@ TEST(URI_is_iri, query_with_ucschar) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, query_with_iprivate) {
+TEST(query_with_iprivate) {
   const std::string input{"https://example.com/?\xEE\x80\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -51,7 +51,7 @@ TEST(URI_is_iri, query_with_iprivate) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, query_with_invalid_utf8) {
+TEST(query_with_invalid_utf8) {
   const std::string input{"https://example.com/?\xC0"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -59,7 +59,7 @@ TEST(URI_is_iri, query_with_invalid_utf8) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, path_with_ucschar) {
+TEST(path_with_ucschar) {
   const std::string input{"https://example.com/\xE8\xB7\xAF\xE5\xBE\x84"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -67,7 +67,7 @@ TEST(URI_is_iri, path_with_ucschar) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, path_with_iprivate_rejected) {
+TEST(path_with_iprivate_rejected) {
   const std::string input{"https://example.com/\xEE\x80\x80"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -75,7 +75,7 @@ TEST(URI_is_iri, path_with_iprivate_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, relative_path_with_ucschar) {
+TEST(relative_path_with_ucschar) {
   const std::string input{"\xE8\xB7\xAF\xE5\xBE\x84/sub"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -83,7 +83,7 @@ TEST(URI_is_iri, relative_path_with_ucschar) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, host_with_ucschar) {
+TEST(host_with_ucschar) {
   const std::string input{"https://\xE4\xBE\x8B\xE3\x81\x88.jp/"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -91,7 +91,7 @@ TEST(URI_is_iri, host_with_ucschar) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, userinfo_with_ucschar) {
+TEST(userinfo_with_ucschar) {
   const std::string input{"https://user\xE5\x90\x8D@example.com/"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -99,7 +99,7 @@ TEST(URI_is_iri, userinfo_with_ucschar) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, host_with_iprivate_rejected) {
+TEST(host_with_iprivate_rejected) {
   const std::string input{"https://\xEE\x80\x80.example/"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -107,7 +107,7 @@ TEST(URI_is_iri, host_with_iprivate_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucschar_lower_bound_in_path) {
+TEST(ucschar_lower_bound_in_path) {
   const std::string input{"https://example.com/\xC2\xA0"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -115,7 +115,7 @@ TEST(URI_is_iri, ucschar_lower_bound_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, control_below_ucschar_in_path_rejected) {
+TEST(control_below_ucschar_in_path_rejected) {
   const std::string input{"https://example.com/\xC2\x9F"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -123,7 +123,7 @@ TEST(URI_is_iri, control_below_ucschar_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, surrogate_encoded_as_utf8_rejected) {
+TEST(surrogate_encoded_as_utf8_rejected) {
   const std::string input{"https://example.com/\xED\xA0\x80"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -131,7 +131,7 @@ TEST(URI_is_iri, surrogate_encoded_as_utf8_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, overlong_two_byte_rejected) {
+TEST(overlong_two_byte_rejected) {
   const std::string input{"https://example.com/\xC0\xAF"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -139,7 +139,7 @@ TEST(URI_is_iri, overlong_two_byte_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, overlong_three_byte_for_ucschar_rejected) {
+TEST(overlong_three_byte_for_ucschar_rejected) {
   const std::string input{"https://example.com/\xE0\x82\xAF"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -147,7 +147,7 @@ TEST(URI_is_iri, overlong_three_byte_for_ucschar_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, overlong_four_byte_for_ucschar_rejected) {
+TEST(overlong_four_byte_for_ucschar_rejected) {
   const std::string input{"https://example.com/\xF0\x80\x82\xAF"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -155,7 +155,7 @@ TEST(URI_is_iri, overlong_four_byte_for_ucschar_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, full_internationalised_iri) {
+TEST(full_internationalised_iri) {
   const std::string input{
       "https://user\xE5\x90\x8D@\xE4\xBE\x8B\xE3\x81\x88.jp/"
       "\xE8\xB7\xAF\xE5\xBE\x84?q=caf\xC3\xA9#section-\xCE\xB1"};
@@ -165,7 +165,7 @@ TEST(URI_is_iri, full_internationalised_iri) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, percent_encoded_non_ascii_is_also_valid_uri) {
+TEST(percent_encoded_non_ascii_is_also_valid_uri) {
   const std::string input{"https://example.com/caf%C3%A9"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -173,7 +173,7 @@ TEST(URI_is_iri, percent_encoded_non_ascii_is_also_valid_uri) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, scheme_with_non_ascii_rejected) {
+TEST(scheme_with_non_ascii_rejected) {
   const std::string input{"h\xC3\xA9ttp://example.com/"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -181,7 +181,7 @@ TEST(URI_is_iri, scheme_with_non_ascii_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucs_in_host_query_and_fragment) {
+TEST(ucs_in_host_query_and_fragment) {
   const std::string input{"http://\xC6\x92\xC3\xB8\xC3\xB8.\xC3\x9F\xC3\xA5r/?"
                           "\xE2\x88\x82\xC3\xA9\xC5\x93=\xCF\x80\xC3\xAEx#"
                           "\xCF\x80\xC3\xAE\xC3\xBCx"};
@@ -191,7 +191,7 @@ TEST(URI_is_iri, ucs_in_host_query_and_fragment) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, parens_and_ucs_in_path_and_fragment) {
+TEST(parens_and_ucs_in_path_and_fragment) {
   const std::string input{
       "http://\xC6\x92\xC3\xB8\xC3\xB8.com/blah_(w\xC3\xAEk\xC3\xAFp\xC3\xA9"
       "di\xC3\xA5)_blah#\xC3\x9Fit\xC3\xA9-1"};
@@ -201,7 +201,7 @@ TEST(URI_is_iri, parens_and_ucs_in_path_and_fragment) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucs_host_with_percent_encoded_query) {
+TEST(ucs_host_with_percent_encoded_query) {
   const std::string input{"http://\xC6\x92\xC3\xB8\xC3\xB8.\xC3\x9F\xC3\xA5r/"
                           "?q=Test%20URL-encoded%20stuff"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
@@ -210,7 +210,7 @@ TEST(URI_is_iri, ucs_host_with_percent_encoded_query) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, heavy_subdelims_and_colons_in_userinfo) {
+TEST(heavy_subdelims_and_colons_in_userinfo) {
   const std::string input{"http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -218,7 +218,7 @@ TEST(URI_is_iri, heavy_subdelims_and_colons_in_userinfo) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ipv6_host_in_brackets) {
+TEST(ipv6_host_in_brackets) {
   const std::string input{"http://[2001:0db8:85a3:0000:0000:8a2e:0370:7334]"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -226,7 +226,7 @@ TEST(URI_is_iri, ipv6_host_in_brackets) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ipv6_host_without_brackets_rejected) {
+TEST(ipv6_host_without_brackets_rejected) {
   const std::string input{"http://2001:0db8:85a3:0000:0000:8a2e:0370:7334"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -234,7 +234,7 @@ TEST(URI_is_iri, ipv6_host_without_brackets_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, backslashes_with_ucs_rejected) {
+TEST(backslashes_with_ucs_rejected) {
   const std::string input{"\\\\WINDOWS\\fil\xC3\xAB\xC3\x9F\xC3\xA5r\xC3\xA9"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -242,7 +242,7 @@ TEST(URI_is_iri, backslashes_with_ucs_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, only_ucs_chars_is_relative_iri_reference) {
+TEST(only_ucs_chars_is_relative_iri_reference) {
   const std::string input{"\xC3\xA2\xCF\x80\xCF\x80"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -250,7 +250,7 @@ TEST(URI_is_iri, only_ucs_chars_is_relative_iri_reference) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, protocol_relative_with_ucs_is_iri_reference) {
+TEST(protocol_relative_with_ucs_is_iri_reference) {
   const std::string input{"//\xC6\x92\xC3\xB8\xC3\xB8.\xC3\x9F\xC3\xA5r/?"
                           "\xE2\x88\x82\xC3\xA9\xC5\x93=\xCF\x80\xC3\xAEx#"
                           "\xCF\x80\xC3\xAE\xC3\xBCx"};
@@ -260,7 +260,7 @@ TEST(URI_is_iri, protocol_relative_with_ucs_is_iri_reference) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, absolute_path_with_ucs_is_iri_reference) {
+TEST(absolute_path_with_ucs_is_iri_reference) {
   const std::string input{"/\xC3\xA2\xCF\x80\xCF\x80"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -268,7 +268,7 @@ TEST(URI_is_iri, absolute_path_with_ucs_is_iri_reference) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, fragment_only_with_ucs_is_iri_reference) {
+TEST(fragment_only_with_ucs_is_iri_reference) {
   const std::string input{"#\xC6\x92r\xC3\xA4gm\xC3\xAAnt"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -276,7 +276,7 @@ TEST(URI_is_iri, fragment_only_with_ucs_is_iri_reference) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, fragment_with_backslash_rejected) {
+TEST(fragment_with_backslash_rejected) {
   const std::string input{"#\xC6\x92r\xC3\xA4g\\m\xC3\xAAnt"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -284,7 +284,7 @@ TEST(URI_is_iri, fragment_with_backslash_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucschar_before_surrogate_gap_in_path) {
+TEST(ucschar_before_surrogate_gap_in_path) {
   const std::string input{"https://example.com/\xED\x9F\xBF"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -292,7 +292,7 @@ TEST(URI_is_iri, ucschar_before_surrogate_gap_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucschar_after_private_use_gap_in_path) {
+TEST(ucschar_after_private_use_gap_in_path) {
   const std::string input{"https://example.com/\xEF\xA4\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -300,7 +300,7 @@ TEST(URI_is_iri, ucschar_after_private_use_gap_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucschar_before_noncharacter_block_in_path) {
+TEST(ucschar_before_noncharacter_block_in_path) {
   const std::string input{"https://example.com/\xEF\xB7\x8F"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -308,7 +308,7 @@ TEST(URI_is_iri, ucschar_before_noncharacter_block_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, noncharacter_fdd0_in_path_rejected) {
+TEST(noncharacter_fdd0_in_path_rejected) {
   const std::string input{"https://example.com/\xEF\xB7\x90"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -316,7 +316,7 @@ TEST(URI_is_iri, noncharacter_fdd0_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, noncharacter_fdef_in_path_rejected) {
+TEST(noncharacter_fdef_in_path_rejected) {
   const std::string input{"https://example.com/\xEF\xB7\xAF"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -324,7 +324,7 @@ TEST(URI_is_iri, noncharacter_fdef_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucschar_after_noncharacter_block_in_path) {
+TEST(ucschar_after_noncharacter_block_in_path) {
   const std::string input{"https://example.com/\xEF\xB7\xB0"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -332,7 +332,7 @@ TEST(URI_is_iri, ucschar_after_noncharacter_block_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ucschar_upper_bmp_bound_in_path) {
+TEST(ucschar_upper_bmp_bound_in_path) {
   const std::string input{"https://example.com/\xEF\xBF\xAF"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -340,7 +340,7 @@ TEST(URI_is_iri, ucschar_upper_bmp_bound_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, replacement_character_in_path_rejected) {
+TEST(replacement_character_in_path_rejected) {
   const std::string input{"https://example.com/\xEF\xBF\xBD"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -348,7 +348,7 @@ TEST(URI_is_iri, replacement_character_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, noncharacter_fffe_in_path_rejected) {
+TEST(noncharacter_fffe_in_path_rejected) {
   const std::string input{"https://example.com/\xEF\xBF\xBE"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -356,7 +356,7 @@ TEST(URI_is_iri, noncharacter_fffe_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, noncharacter_ffff_in_path_rejected) {
+TEST(noncharacter_ffff_in_path_rejected) {
   const std::string input{"https://example.com/\xEF\xBF\xBF"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -364,7 +364,7 @@ TEST(URI_is_iri, noncharacter_ffff_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, plane_fourteen_below_ucschar_in_path_rejected) {
+TEST(plane_fourteen_below_ucschar_in_path_rejected) {
   const std::string input{"https://example.com/\xF3\xA0\xBF\xBF"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -372,7 +372,7 @@ TEST(URI_is_iri, plane_fourteen_below_ucschar_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, plane_fourteen_ucschar_in_path) {
+TEST(plane_fourteen_ucschar_in_path) {
   const std::string input{"https://example.com/\xF3\xA1\x80\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -380,7 +380,7 @@ TEST(URI_is_iri, plane_fourteen_ucschar_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, astral_ucschar_in_path) {
+TEST(astral_ucschar_in_path) {
   const std::string input{"https://example.com/\xF0\x90\x80\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -388,7 +388,7 @@ TEST(URI_is_iri, astral_ucschar_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, astral_ucschar_upper_bound_in_path) {
+TEST(astral_ucschar_upper_bound_in_path) {
   const std::string input{"https://example.com/\xF0\x9F\xBF\xBD"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -396,7 +396,7 @@ TEST(URI_is_iri, astral_ucschar_upper_bound_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, astral_noncharacter_in_path_rejected) {
+TEST(astral_noncharacter_in_path_rejected) {
   const std::string input{"https://example.com/\xF0\x9F\xBF\xBE"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -404,7 +404,7 @@ TEST(URI_is_iri, astral_noncharacter_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, astral_plane_two_ucschar_in_path) {
+TEST(astral_plane_two_ucschar_in_path) {
   const std::string input{"https://example.com/\xF0\xA0\x80\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -412,7 +412,7 @@ TEST(URI_is_iri, astral_plane_two_ucschar_in_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, userinfo_with_iprivate_rejected) {
+TEST(userinfo_with_iprivate_rejected) {
   const std::string input{"https://u\xEE\x80\x80@example.com/"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -420,7 +420,7 @@ TEST(URI_is_iri, userinfo_with_iprivate_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, port_with_iprivate_rejected) {
+TEST(port_with_iprivate_rejected) {
   const std::string input{"https://example.com:\xEE\x80\x80/"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -428,7 +428,7 @@ TEST(URI_is_iri, port_with_iprivate_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, supplementary_iprivate_in_query) {
+TEST(supplementary_iprivate_in_query) {
   const std::string input{"https://example.com/?q=\xF3\xB0\x80\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -436,7 +436,7 @@ TEST(URI_is_iri, supplementary_iprivate_in_query) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, supplementary_iprivate_in_path_rejected) {
+TEST(supplementary_iprivate_in_path_rejected) {
   const std::string input{"https://example.com/\xF3\xB0\x80\x80"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -444,7 +444,7 @@ TEST(URI_is_iri, supplementary_iprivate_in_path_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, plane_sixteen_iprivate_in_query) {
+TEST(plane_sixteen_iprivate_in_query) {
   const std::string input{"https://example.com/?q=\xF4\x80\x80\x80"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -452,7 +452,7 @@ TEST(URI_is_iri, plane_sixteen_iprivate_in_query) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, iprivate_upper_bound_in_query) {
+TEST(iprivate_upper_bound_in_query) {
   const std::string input{"https://example.com/?q=\xF4\x8F\xBF\xBD"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -460,7 +460,7 @@ TEST(URI_is_iri, iprivate_upper_bound_in_query) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ipv4_host) {
+TEST(ipv4_host) {
   const std::string input{"http://192.168.0.1/p"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -468,7 +468,7 @@ TEST(URI_is_iri, ipv4_host) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ipvfuture_host_lowercase) {
+TEST(ipvfuture_host_lowercase) {
   const std::string input{"http://[v1.fe]/"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -476,7 +476,7 @@ TEST(URI_is_iri, ipvfuture_host_lowercase) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ipvfuture_host_uppercase) {
+TEST(ipvfuture_host_uppercase) {
   const std::string input{"http://[V1.fe]/"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -484,7 +484,7 @@ TEST(URI_is_iri, ipvfuture_host_uppercase) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, ipvfuture_host_non_hex_version_rejected) {
+TEST(ipvfuture_host_non_hex_version_rejected) {
   const std::string input{"http://[vG.fe]/"};
   EXPECT_FALSE(sourcemeta::core::URI::is_iri(input));
   EXPECT_FALSE(sourcemeta::core::URI::is_iri_reference(input));
@@ -492,7 +492,7 @@ TEST(URI_is_iri, ipvfuture_host_non_hex_version_rejected) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, opaque_path_with_scheme) {
+TEST(opaque_path_with_scheme) {
   const std::string input{"urn:example:resource"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -500,7 +500,7 @@ TEST(URI_is_iri, opaque_path_with_scheme) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, absolute_path_with_scheme) {
+TEST(absolute_path_with_scheme) {
   const std::string input{"file:/etc/hosts"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -508,7 +508,7 @@ TEST(URI_is_iri, absolute_path_with_scheme) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, explicit_port) {
+TEST(explicit_port) {
   const std::string input{"http://example.com:8080/p"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -516,7 +516,7 @@ TEST(URI_is_iri, explicit_port) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, scheme_with_empty_path) {
+TEST(scheme_with_empty_path) {
   const std::string input{"http:"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));
@@ -524,7 +524,7 @@ TEST(URI_is_iri, scheme_with_empty_path) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(input));
 }
 
-TEST(URI_is_iri, scheme_with_empty_authority) {
+TEST(scheme_with_empty_authority) {
   const std::string input{"http://"};
   EXPECT_TRUE(sourcemeta::core::URI::is_iri(input));
   EXPECT_TRUE(sourcemeta::core::URI::is_iri_reference(input));

--- a/test/uri/uri_is_mailto_test.cc
+++ b/test/uri/uri_is_mailto_test.cc
@@ -1,28 +1,28 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_mailto, success) {
+TEST(success) {
   const sourcemeta::core::URI uri{"mailto:jdoe@mail.com"};
   EXPECT_TRUE(uri.is_mailto());
 }
 
-TEST(URI_is_mailto, https_url) {
+TEST(https_url) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   EXPECT_FALSE(uri.is_mailto());
 }
 
-TEST(URI_is_mailto, relative) {
+TEST(relative) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.is_mailto());
 }
 
-TEST(URI_is_mailto, tag) {
+TEST(tag) {
   const sourcemeta::core::URI uri{"tag:yaml.org,2002:int"};
   EXPECT_FALSE(uri.is_mailto());
 }
 
-TEST(URI_is_mailto, iri_mailto) {
+TEST(iri_mailto) {
   const auto uri{sourcemeta::core::URI::from_iri(
       "mailto:user@\xE4\xBE\x8B\xE3\x81\x88.jp")};
   EXPECT_TRUE(uri.is_mailto());

--- a/test/uri/uri_is_relative_test.cc
+++ b/test/uri/uri_is_relative_test.cc
@@ -1,23 +1,23 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_relative, dot_slash) {
+TEST(dot_slash) {
   const sourcemeta::core::URI uri{"./foo"};
   EXPECT_TRUE(uri.is_relative());
 }
 
-TEST(URI_is_relative, dot_dot_slash) {
+TEST(dot_dot_slash) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_TRUE(uri.is_relative());
 }
 
-TEST(URI_is_relative, without_dot_and_slash) {
+TEST(without_dot_and_slash) {
   const sourcemeta::core::URI uri{"foo"};
   EXPECT_TRUE(uri.is_relative());
 }
 
-TEST(URI_is_relative, unique_slash) {
+TEST(unique_slash) {
   // The is a relative URI, even if the path is absolute.
   const sourcemeta::core::URI uri{"/foo"};
   EXPECT_TRUE(uri.is_relative());
@@ -25,25 +25,25 @@ TEST(URI_is_relative, unique_slash) {
 
 // RFC 3986 Section 4: a URI with a scheme is never a relative reference,
 // regardless of path content
-TEST(URI_is_relative, scheme_with_dot_path_is_not_relative) {
+TEST(scheme_with_dot_path_is_not_relative) {
   const sourcemeta::core::URI uri{"a:./foo"};
   EXPECT_TRUE(uri.is_absolute());
   EXPECT_FALSE(uri.is_relative());
 }
 
-TEST(URI_is_relative, scheme_with_dotdot_path_is_not_relative) {
+TEST(scheme_with_dotdot_path_is_not_relative) {
   const sourcemeta::core::URI uri{"a:../foo"};
   EXPECT_TRUE(uri.is_absolute());
   EXPECT_FALSE(uri.is_relative());
 }
 
-TEST(URI_is_relative, scheme_with_dot_only_is_not_relative) {
+TEST(scheme_with_dot_only_is_not_relative) {
   const sourcemeta::core::URI uri{"a:."};
   EXPECT_TRUE(uri.is_absolute());
   EXPECT_FALSE(uri.is_relative());
 }
 
-TEST(URI_is_relative, iri_relative_reference) {
+TEST(iri_relative_reference) {
   const auto uri{sourcemeta::core::URI::from_iri("caf\xC3\xA9/page")};
   EXPECT_TRUE(uri.is_relative());
 }

--- a/test/uri/uri_is_scheme_test.cc
+++ b/test/uri/uri_is_scheme_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_scheme, common_schemes) {
+TEST(common_schemes) {
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("http"));
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("https"));
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("urn"));
@@ -10,12 +10,12 @@ TEST(URI_is_scheme, common_schemes) {
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("mailto"));
 }
 
-TEST(URI_is_scheme, single_letter) {
+TEST(single_letter) {
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("a"));
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("Z"));
 }
 
-TEST(URI_is_scheme, allowed_non_alpha_after_first) {
+TEST(allowed_non_alpha_after_first) {
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("h123"));
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("foo+bar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("foo-bar"));
@@ -23,18 +23,18 @@ TEST(URI_is_scheme, allowed_non_alpha_after_first) {
   EXPECT_TRUE(sourcemeta::core::URI::is_scheme("a1+2-3.4"));
 }
 
-TEST(URI_is_scheme, empty_is_not_a_scheme) {
+TEST(empty_is_not_a_scheme) {
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme(""));
 }
 
-TEST(URI_is_scheme, must_start_with_alpha) {
+TEST(must_start_with_alpha) {
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme("1http"));
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme("+http"));
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme("-http"));
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme(".http"));
 }
 
-TEST(URI_is_scheme, rejects_disallowed_characters) {
+TEST(rejects_disallowed_characters) {
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme("http:"));
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme("ht tp"));
   EXPECT_FALSE(sourcemeta::core::URI::is_scheme("foo/bar"));

--- a/test/uri/uri_is_tag_test.cc
+++ b/test/uri/uri_is_tag_test.cc
@@ -1,28 +1,28 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_tag, tag) {
+TEST(tag) {
   const sourcemeta::core::URI uri{"tag:yaml.org,2002:int"};
   EXPECT_TRUE(uri.is_tag());
 }
 
-TEST(URI_is_tag, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_FALSE(uri.is_tag());
 }
 
-TEST(URI_is_tag, https_url) {
+TEST(https_url) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   EXPECT_FALSE(uri.is_tag());
 }
 
-TEST(URI_is_tag, relative) {
+TEST(relative) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.is_tag());
 }
 
-TEST(URI_is_tag, iri_tag) {
+TEST(iri_tag) {
   const auto uri{
       sourcemeta::core::URI::from_iri("tag:example.com,2024:caf\xC3\xA9")};
   EXPECT_TRUE(uri.is_tag());

--- a/test/uri/uri_is_urn_test.cc
+++ b/test/uri/uri_is_urn_test.cc
@@ -1,28 +1,28 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_is_urn, urn_1) {
+TEST(urn_1) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_TRUE(uri.is_urn());
 }
 
-TEST(URI_is_urn, https_url) {
+TEST(https_url) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   EXPECT_FALSE(uri.is_urn());
 }
 
-TEST(URI_is_urn, relative) {
+TEST(relative) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.is_urn());
 }
 
-TEST(URI_is_urn, tag) {
+TEST(tag) {
   const sourcemeta::core::URI uri{"tag:yaml.org,2002:int"};
   EXPECT_FALSE(uri.is_urn());
 }
 
-TEST(URI_is_urn, iri_urn) {
+TEST(iri_urn) {
   const auto uri{sourcemeta::core::URI::from_iri("urn:example:caf\xC3\xA9")};
   EXPECT_TRUE(uri.is_urn());
 }

--- a/test/uri/uri_parse_test.cc
+++ b/test/uri/uri_parse_test.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
 // Inspired from
 // https://github.com/uriparser/uriparser/blob/bf0174e83164a4659c51c135399478bec389eafa/test/test.cpp#L302
 
-TEST(URI_parse, syntax_error_1) {
+TEST(syntax_error_1) {
   try {
     sourcemeta::core::URI uri{"//[::44.1"};
     FAIL();
@@ -19,7 +19,7 @@ TEST(URI_parse, syntax_error_1) {
 // Inspired from
 // https://github.com/uriparser/uriparser/blob/bf0174e83164a4659c51c135399478bec389eafa/test/test.cpp#L510-L516
 
-TEST(URI_parse, syntax_error_2) {
+TEST(syntax_error_2) {
   try {
     sourcemeta::core::URI uri{"http://moo:21@moo:21@moo/"};
     FAIL();
@@ -31,7 +31,7 @@ TEST(URI_parse, syntax_error_2) {
       sourcemeta::core::URI::is_uri_reference("http://moo:21@moo:21@moo/"));
 }
 
-TEST(URI_parse, syntax_error_3) {
+TEST(syntax_error_3) {
   try {
     sourcemeta::core::URI uri{"http://moo:21@moo:21@moo:21/"};
     FAIL();
@@ -46,7 +46,7 @@ TEST(URI_parse, syntax_error_3) {
 // Inspired from
 // https://github.com/uriparser/uriparser/blob/bf0174e83164a4659c51c135399478bec389eafa/test/test.cpp#L2180
 
-TEST(URI_parse, syntax_error_4) {
+TEST(syntax_error_4) {
   try {
     // missing "]"
     sourcemeta::core::URI uri{"http://[vA.123456"};
@@ -58,7 +58,7 @@ TEST(URI_parse, syntax_error_4) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("http://[vA.123456"));
 }
 
-TEST(URI_parse, syntax_error_5) {
+TEST(syntax_error_5) {
   try {
     sourcemeta::core::URI uri{"https://www.example.com#/foo%6G"};
     FAIL();
@@ -71,7 +71,7 @@ TEST(URI_parse, syntax_error_5) {
       "https://www.example.com#/foo%6G"));
 }
 
-TEST(URI_parse, urn_with_slash) {
+TEST(urn_with_slash) {
   // RFC 8141 explicitly allows "/" in URN NSS
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("urn:example:foo/bar/baz"));
   EXPECT_TRUE(
@@ -82,7 +82,7 @@ TEST(URI_parse, urn_with_slash) {
   EXPECT_EQ(uri.recompose(), "urn:example:foo/bar/baz");
 }
 
-TEST(URI_parse, urn_with_numeric_path) {
+TEST(urn_with_numeric_path) {
   // Example from RFC 8141
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("urn:example:1/406/47452/2"));
   EXPECT_TRUE(
@@ -93,7 +93,7 @@ TEST(URI_parse, urn_with_numeric_path) {
   EXPECT_EQ(uri.recompose(), "urn:example:1/406/47452/2");
 }
 
-TEST(URI_parse, urn_with_query) {
+TEST(urn_with_query) {
   // RFC 8141 allows query components in URNs
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("urn:example:foo?+bar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("urn:example:foo?+bar"));
@@ -104,7 +104,7 @@ TEST(URI_parse, urn_with_query) {
   EXPECT_EQ(uri.recompose(), "urn:example:foo?+bar");
 }
 
-TEST(URI_parse, urn_with_fragment) {
+TEST(urn_with_fragment) {
   // RFC 8141 allows fragments in URNs
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("urn:example:foo#bar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("urn:example:foo#bar"));
@@ -115,7 +115,7 @@ TEST(URI_parse, urn_with_fragment) {
   EXPECT_EQ(uri.recompose(), "urn:example:foo#bar");
 }
 
-TEST(URI_parse, syntax_error_percent_at_end) {
+TEST(syntax_error_percent_at_end) {
   try {
     sourcemeta::core::URI uri{"https://www.example.com#/foo%"};
     FAIL();
@@ -127,7 +127,7 @@ TEST(URI_parse, syntax_error_percent_at_end) {
       sourcemeta::core::URI::is_uri_reference("https://www.example.com#/foo%"));
 }
 
-TEST(URI_parse, syntax_error_percent_one_hex) {
+TEST(syntax_error_percent_one_hex) {
   try {
     sourcemeta::core::URI uri{"https://www.example.com#/foo%2"};
     FAIL();
@@ -139,7 +139,7 @@ TEST(URI_parse, syntax_error_percent_one_hex) {
       "https://www.example.com#/foo%2"));
 }
 
-TEST(URI_parse, syntax_error_percent_non_hex) {
+TEST(syntax_error_percent_non_hex) {
   try {
     sourcemeta::core::URI uri{"https://www.example.com#/foo%ZZ"};
     FAIL();
@@ -152,7 +152,7 @@ TEST(URI_parse, syntax_error_percent_non_hex) {
       "https://www.example.com#/foo%ZZ"));
 }
 
-TEST(URI_parse, syntax_error_percent_in_path) {
+TEST(syntax_error_percent_in_path) {
   try {
     sourcemeta::core::URI uri{"https://www.example.com/foo%6G"};
     FAIL();
@@ -164,7 +164,7 @@ TEST(URI_parse, syntax_error_percent_in_path) {
       "https://www.example.com/foo%6G"));
 }
 
-TEST(URI_parse, syntax_error_percent_in_query) {
+TEST(syntax_error_percent_in_query) {
   try {
     sourcemeta::core::URI uri{"https://www.example.com?foo%6G"};
     FAIL();
@@ -176,7 +176,7 @@ TEST(URI_parse, syntax_error_percent_in_query) {
       "https://www.example.com?foo%6G"));
 }
 
-TEST(URI_parse, syntax_error_percent_in_host) {
+TEST(syntax_error_percent_in_host) {
   try {
     sourcemeta::core::URI uri{"https://www.exam%ple.com"};
     FAIL();
@@ -188,7 +188,7 @@ TEST(URI_parse, syntax_error_percent_in_host) {
       sourcemeta::core::URI::is_uri_reference("https://www.exam%ple.com"));
 }
 
-TEST(URI_parse, rfc3986_mixed_case_percent_encoding_lower_upper) {
+TEST(rfc3986_mixed_case_percent_encoding_lower_upper) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://a.com/%aF"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("http://a.com/%aF"));
   sourcemeta::core::URI uri{"http://a.com/%aF"};
@@ -196,7 +196,7 @@ TEST(URI_parse, rfc3986_mixed_case_percent_encoding_lower_upper) {
 }
 
 // RFC 3986: fragment = *( pchar / "/" / "?" )
-TEST(URI_parse, syntax_error_double_fragment_delimiter) {
+TEST(syntax_error_double_fragment_delimiter) {
   try {
     sourcemeta::core::URI uri{"http://example.com/#frag#ment"};
     FAIL();
@@ -210,7 +210,7 @@ TEST(URI_parse, syntax_error_double_fragment_delimiter) {
 
 // RFC 3986: "[" and "]" are gen-delims only allowed in IP-literal within
 // host.
-TEST(URI_parse, syntax_error_brackets_in_query) {
+TEST(syntax_error_brackets_in_query) {
   try {
     sourcemeta::core::URI uri{"http://example.com/?q=[value]"};
     FAIL();
@@ -224,7 +224,7 @@ TEST(URI_parse, syntax_error_brackets_in_query) {
 
 // RFC 3986: relative-ref path-noscheme means the first segment of a
 // schemeless, authorityless path must not contain a colon
-TEST(URI_parse, syntax_error_digit_prefix_scheme_like) {
+TEST(syntax_error_digit_prefix_scheme_like) {
   try {
     sourcemeta::core::URI uri{"2http://example.com"};
     FAIL();
@@ -235,7 +235,7 @@ TEST(URI_parse, syntax_error_digit_prefix_scheme_like) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("2http://example.com"));
 }
 
-TEST(URI_parse, syntax_error_underscore_scheme_like) {
+TEST(syntax_error_underscore_scheme_like) {
   try {
     sourcemeta::core::URI uri{"my_scheme://example.com"};
     FAIL();
@@ -247,7 +247,7 @@ TEST(URI_parse, syntax_error_underscore_scheme_like) {
       sourcemeta::core::URI::is_uri_reference("my_scheme://example.com"));
 }
 
-TEST(URI_parse, syntax_error_colon_slash_slash) {
+TEST(syntax_error_colon_slash_slash) {
   try {
     sourcemeta::core::URI uri{"://example.com"};
     FAIL();
@@ -258,7 +258,7 @@ TEST(URI_parse, syntax_error_colon_slash_slash) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("://example.com"));
 }
 
-TEST(URI_parse, syntax_error_hyphen_prefix_scheme_like) {
+TEST(syntax_error_hyphen_prefix_scheme_like) {
   try {
     sourcemeta::core::URI uri{"-http://example.com"};
     FAIL();
@@ -270,7 +270,7 @@ TEST(URI_parse, syntax_error_hyphen_prefix_scheme_like) {
 }
 
 // RFC 3986: path-abempty after authority must start with "/" or be empty
-TEST(URI_parse, syntax_error_port_trailing_alpha) {
+TEST(syntax_error_port_trailing_alpha) {
   try {
     sourcemeta::core::URI uri{"http://example.com:80a"};
     FAIL();
@@ -282,7 +282,7 @@ TEST(URI_parse, syntax_error_port_trailing_alpha) {
       sourcemeta::core::URI::is_uri_reference("http://example.com:80a"));
 }
 
-TEST(URI_parse, syntax_error_port_trailing_range) {
+TEST(syntax_error_port_trailing_range) {
   try {
     sourcemeta::core::URI uri{"http://example.com:80-90"};
     FAIL();
@@ -294,7 +294,7 @@ TEST(URI_parse, syntax_error_port_trailing_range) {
       sourcemeta::core::URI::is_uri_reference("http://example.com:80-90"));
 }
 
-TEST(URI_parse, syntax_error_port_exceeds_uint32) {
+TEST(syntax_error_port_exceeds_uint32) {
   try {
     sourcemeta::core::URI uri{"http://example.com:4294967296"};
     FAIL();
@@ -307,7 +307,7 @@ TEST(URI_parse, syntax_error_port_exceeds_uint32) {
       sourcemeta::core::URI::is_uri_reference("http://example.com:4294967296"));
 }
 
-TEST(URI_parse, syntax_error_port_overflow_unsigned_long) {
+TEST(syntax_error_port_overflow_unsigned_long) {
   try {
     sourcemeta::core::URI uri{
         "http://example.com:999999999999999999999999999999"};
@@ -322,7 +322,7 @@ TEST(URI_parse, syntax_error_port_overflow_unsigned_long) {
       "http://example.com:999999999999999999999999999999"));
 }
 
-TEST(URI_parse, rfc3986_port_max_uint32) {
+TEST(rfc3986_port_max_uint32) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com:4294967295"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://example.com:4294967295"));
@@ -330,7 +330,7 @@ TEST(URI_parse, rfc3986_port_max_uint32) {
   EXPECT_EQ(uri.port().value(), 4294967295U);
 }
 
-TEST(URI_parse, syntax_error_bare_ipv6_no_brackets) {
+TEST(syntax_error_bare_ipv6_no_brackets) {
   try {
     sourcemeta::core::URI uri{"http://2001:db8::1"};
     FAIL();
@@ -342,7 +342,7 @@ TEST(URI_parse, syntax_error_bare_ipv6_no_brackets) {
 }
 
 // RFC 3986: IPv6 brackets must contain valid hex digits, colons, and dots
-TEST(URI_parse, syntax_error_ipv6_invalid_hex) {
+TEST(syntax_error_ipv6_invalid_hex) {
   try {
     sourcemeta::core::URI uri{"http://[2001:db8::gggg]"};
     FAIL();
@@ -356,7 +356,7 @@ TEST(URI_parse, syntax_error_ipv6_invalid_hex) {
 
 // RFC 3986: IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
 // Must have version hex digits and dot separator
-TEST(URI_parse, syntax_error_ipvfuture_bare_v) {
+TEST(syntax_error_ipvfuture_bare_v) {
   try {
     sourcemeta::core::URI uri{"http://[v]"};
     FAIL();
@@ -367,7 +367,7 @@ TEST(URI_parse, syntax_error_ipvfuture_bare_v) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("http://[v]"));
 }
 
-TEST(URI_parse, syntax_error_ipvfuture_missing_dot) {
+TEST(syntax_error_ipvfuture_missing_dot) {
   try {
     sourcemeta::core::URI uri{"http://[vabc]"};
     FAIL();
@@ -378,7 +378,7 @@ TEST(URI_parse, syntax_error_ipvfuture_missing_dot) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("http://[vabc]"));
 }
 
-TEST(URI_parse, syntax_error_ipvfuture_non_hex_version) {
+TEST(syntax_error_ipvfuture_non_hex_version) {
   try {
     sourcemeta::core::URI uri{"http://[vZ.foo]"};
     FAIL();
@@ -389,7 +389,7 @@ TEST(URI_parse, syntax_error_ipvfuture_non_hex_version) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("http://[vZ.foo]"));
 }
 
-TEST(URI_parse, syntax_error_ipv6_empty_brackets) {
+TEST(syntax_error_ipv6_empty_brackets) {
   try {
     sourcemeta::core::URI uri{"http://[]"};
     FAIL();
@@ -400,7 +400,7 @@ TEST(URI_parse, syntax_error_ipv6_empty_brackets) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri_reference("http://[]"));
 }
 
-TEST(URI_parse, syntax_error_ipv6_h16_too_long) {
+TEST(syntax_error_ipv6_h16_too_long) {
   try {
     sourcemeta::core::URI uri{"http://[2001:db8::00000]"};
     FAIL();
@@ -412,7 +412,7 @@ TEST(URI_parse, syntax_error_ipv6_h16_too_long) {
       sourcemeta::core::URI::is_uri_reference("http://[2001:db8::00000]"));
 }
 
-TEST(URI_parse, syntax_error_ipv6_double_compression) {
+TEST(syntax_error_ipv6_double_compression) {
   try {
     sourcemeta::core::URI uri{"http://[2001::db8::1]"};
     FAIL();
@@ -424,7 +424,7 @@ TEST(URI_parse, syntax_error_ipv6_double_compression) {
       sourcemeta::core::URI::is_uri_reference("http://[2001::db8::1]"));
 }
 
-TEST(URI_parse, syntax_error_ipv6_too_few_groups_without_compression) {
+TEST(syntax_error_ipv6_too_few_groups_without_compression) {
   try {
     sourcemeta::core::URI uri{"http://[1:2:3:4:5:6:7]"};
     FAIL();
@@ -436,7 +436,7 @@ TEST(URI_parse, syntax_error_ipv6_too_few_groups_without_compression) {
       sourcemeta::core::URI::is_uri_reference("http://[1:2:3:4:5:6:7]"));
 }
 
-TEST(URI_parse, syntax_error_ipv6_too_many_groups) {
+TEST(syntax_error_ipv6_too_many_groups) {
   try {
     sourcemeta::core::URI uri{"http://[1:2:3:4:5:6:7:8:9]"};
     FAIL();
@@ -448,7 +448,7 @@ TEST(URI_parse, syntax_error_ipv6_too_many_groups) {
       sourcemeta::core::URI::is_uri_reference("http://[1:2:3:4:5:6:7:8:9]"));
 }
 
-TEST(URI_parse, syntax_error_ipv6_embedded_ipv4_out_of_range) {
+TEST(syntax_error_ipv6_embedded_ipv4_out_of_range) {
   try {
     sourcemeta::core::URI uri{"http://[::ffff:1.2.3.256]"};
     FAIL();
@@ -460,7 +460,7 @@ TEST(URI_parse, syntax_error_ipv6_embedded_ipv4_out_of_range) {
       sourcemeta::core::URI::is_uri_reference("http://[::ffff:1.2.3.256]"));
 }
 
-TEST(URI_parse, success_ipvfuture_valid) {
+TEST(success_ipvfuture_valid) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://[vFF.a:b]"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("http://[vFF.a:b]"));
   sourcemeta::core::URI uri{"http://[vFF.a:b]"};
@@ -469,7 +469,7 @@ TEST(URI_parse, success_ipvfuture_valid) {
 }
 
 // RFC 3986: port = *DIGIT (empty port after colon is valid)
-TEST(URI_parse, rfc3986_empty_port) {
+TEST(rfc3986_empty_port) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com:"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("http://example.com:"));
   sourcemeta::core::URI uri{"http://example.com:"};
@@ -477,7 +477,7 @@ TEST(URI_parse, rfc3986_empty_port) {
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_parse, rfc3986_empty_port_with_path) {
+TEST(rfc3986_empty_port_with_path) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com:/path"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://example.com:/path"));
@@ -490,7 +490,7 @@ TEST(URI_parse, rfc3986_empty_port_with_path) {
 // Inspired from
 // https://github.com/uriparser/uriparser/blob/bf0174e83164a4659c51c135399478bec389eafa/test/test.cpp#L315
 
-TEST(URI_parse, success_1) {
+TEST(success_1) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri(
       "//user:pass@[::1]:80/segment/index.html?query#frag"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -501,7 +501,7 @@ TEST(URI_parse, success_1) {
             "//user:pass@[::1]:80/segment/index.html?query#frag");
 }
 
-TEST(URI_parse, success_2) {
+TEST(success_2) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://[::1]:80/segment/index.html?query#frag"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -510,7 +510,7 @@ TEST(URI_parse, success_2) {
   EXPECT_EQ(uri.recompose(), "http://[::1]:80/segment/index.html?query#frag");
 }
 
-TEST(URI_parse, success_3) {
+TEST(success_3) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://user:pass@[::1]/segment/index.html?query#frag"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -521,7 +521,7 @@ TEST(URI_parse, success_3) {
             "http://user:pass@[::1]/segment/index.html?query#frag");
 }
 
-TEST(URI_parse, success_4) {
+TEST(success_4) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("http://user:pass@[::1]:80?query#frag"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -530,7 +530,7 @@ TEST(URI_parse, success_4) {
   EXPECT_EQ(uri.recompose(), "http://user:pass@[::1]:80?query#frag");
 }
 
-TEST(URI_parse, success_5) {
+TEST(success_5) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://user:pass@[::1]:80/segment/index.html#frag"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -541,7 +541,7 @@ TEST(URI_parse, success_5) {
             "http://user:pass@[::1]:80/segment/index.html#frag");
 }
 
-TEST(URI_parse, success_6) {
+TEST(success_6) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://user:pass@[::1]:80/segment/index.html?query"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -552,14 +552,14 @@ TEST(URI_parse, success_6) {
             "http://user:pass@[::1]:80/segment/index.html?query");
 }
 
-TEST(URI_parse, success_7) {
+TEST(success_7) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("ftp://host:21/gnu/"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("ftp://host:21/gnu/"));
   sourcemeta::core::URI uri{"ftp://host:21/gnu/"};
   EXPECT_EQ(uri.recompose(), "ftp://host:21/gnu/");
 }
 
-TEST(URI_parse, success_with_percent_25_stays_encoded) {
+TEST(success_with_percent_25_stays_encoded) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%25bar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -570,7 +570,7 @@ TEST(URI_parse, success_with_percent_25_stays_encoded) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/foo%25bar");
 }
 
-TEST(URI_parse, success_with_space_percent_20_stays_encoded) {
+TEST(success_with_space_percent_20_stays_encoded) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com/foo%20bar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -581,7 +581,7 @@ TEST(URI_parse, success_with_space_percent_20_stays_encoded) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com/foo%20bar");
 }
 
-TEST(URI_parse, success_with_equals_percent_3D_stays_encoded) {
+TEST(success_with_equals_percent_3D_stays_encoded) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com?foo%3Dbar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -593,7 +593,7 @@ TEST(URI_parse, success_with_equals_percent_3D_stays_encoded) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com?foo%3Dbar");
 }
 
-TEST(URI_parse, success_with_slash_percent_2F_stays_encoded) {
+TEST(success_with_slash_percent_2F_stays_encoded) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%2Fbar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -605,7 +605,7 @@ TEST(URI_parse, success_with_slash_percent_2F_stays_encoded) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/foo%2Fbar");
 }
 
-TEST(URI_parse, success_with_lowercase_normalized_to_uppercase) {
+TEST(success_with_lowercase_normalized_to_uppercase) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%2fbar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -617,7 +617,7 @@ TEST(URI_parse, success_with_lowercase_normalized_to_uppercase) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/foo%2fbar");
 }
 
-TEST(URI_parse, success_unreserved_char_decoded_hyphen) {
+TEST(success_unreserved_char_decoded_hyphen) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%2Dbar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -627,7 +627,7 @@ TEST(URI_parse, success_unreserved_char_decoded_hyphen) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/foo-bar");
 }
 
-TEST(URI_parse, success_unreserved_char_decoded_tilde) {
+TEST(success_unreserved_char_decoded_tilde) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%7Ebar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -637,7 +637,7 @@ TEST(URI_parse, success_unreserved_char_decoded_tilde) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/foo~bar");
 }
 
-TEST(URI_parse, success_unreserved_char_decoded_underscore) {
+TEST(success_unreserved_char_decoded_underscore) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%5Fbar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -647,7 +647,7 @@ TEST(URI_parse, success_unreserved_char_decoded_underscore) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/foo_bar");
 }
 
-TEST(URI_parse, success_unreserved_char_decoded_letter) {
+TEST(success_unreserved_char_decoded_letter) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("https://www.example.com#/foo%41bar"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -657,21 +657,21 @@ TEST(URI_parse, success_unreserved_char_decoded_letter) {
   EXPECT_EQ(uri.recompose(), "https://www.example.com#/fooAbar");
 }
 
-TEST(URI_parse, relative_1) {
+TEST(relative_1) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("one/two/three"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("one/two/three"));
   sourcemeta::core::URI uri{"one/two/three"};
   EXPECT_EQ(uri.recompose(), "one/two/three");
 }
 
-TEST(URI_parse, relative_2) {
+TEST(relative_2) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("/one/two/three"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("/one/two/three"));
   sourcemeta::core::URI uri{"/one/two/three"};
   EXPECT_EQ(uri.recompose(), "/one/two/three");
 }
 
-TEST(URI_parse, relative_3) {
+TEST(relative_3) {
   EXPECT_FALSE(
       sourcemeta::core::URI::is_uri("//user:pass@localhost/one/two/three"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -680,7 +680,7 @@ TEST(URI_parse, relative_3) {
   EXPECT_EQ(uri.recompose(), "//user:pass@localhost/one/two/three");
 }
 
-TEST(URI_parse, real_life_1) {
+TEST(real_life_1) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://sourceforge.net/projects/uriparser/"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -689,7 +689,7 @@ TEST(URI_parse, real_life_1) {
   EXPECT_EQ(uri.recompose(), "http://sourceforge.net/projects/uriparser/");
 }
 
-TEST(URI_parse, real_life_2) {
+TEST(real_life_2) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://sourceforge.net/project/platformdownload.php?group_id=182840"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -701,7 +701,7 @@ TEST(URI_parse, real_life_2) {
       "http://sourceforge.net/project/platformdownload.php?group_id=182840");
 }
 
-TEST(URI_parse, mailto) {
+TEST(mailto) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("mailto:test@example.com"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("mailto:test@example.com"));
@@ -709,35 +709,35 @@ TEST(URI_parse, mailto) {
   EXPECT_EQ(uri.recompose(), "mailto:test@example.com");
 }
 
-TEST(URI_parse, relative_4) {
+TEST(relative_4) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("../../"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("../../"));
   sourcemeta::core::URI uri{"../../"};
   EXPECT_EQ(uri.recompose(), "../../");
 }
 
-TEST(URI_parse, root_path) {
+TEST(root_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("/"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("/"));
   sourcemeta::core::URI uri{"/"};
   EXPECT_EQ(uri.recompose(), "/");
 }
 
-TEST(URI_parse, empty_uri) {
+TEST(empty_uri) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri(""));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(""));
   sourcemeta::core::URI uri{""};
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_parse, file_uri) {
+TEST(file_uri) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("file:///bin/bash"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("file:///bin/bash"));
   sourcemeta::core::URI uri{"file:///bin/bash"};
   EXPECT_EQ(uri.recompose(), "file:///bin/bash");
 }
 
-TEST(URI_parse, percent_encoding) {
+TEST(percent_encoding) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://www.example.com/name%20with%20spaces/"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -746,7 +746,7 @@ TEST(URI_parse, percent_encoding) {
   EXPECT_EQ(uri.recompose(), "http://www.example.com/name%20with%20spaces/");
 }
 
-TEST(URI_parse, rfc3986_complete_uri) {
+TEST(rfc3986_complete_uri) {
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri("http://user:pass@example.com:8080/path/to/"
                                     "resource?query=value&key=data#section"));
@@ -764,7 +764,7 @@ TEST(URI_parse, rfc3986_complete_uri) {
   EXPECT_EQ(uri.fragment().value(), "section");
 }
 
-TEST(URI_parse, rfc3986_minimal_uri) {
+TEST(rfc3986_minimal_uri) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("s:p"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("s:p"));
   sourcemeta::core::URI uri{"s:p"};
@@ -773,7 +773,7 @@ TEST(URI_parse, rfc3986_minimal_uri) {
   EXPECT_EQ(uri.recompose(), "s:p");
 }
 
-TEST(URI_parse, rfc3986_authority_without_userinfo) {
+TEST(rfc3986_authority_without_userinfo) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com/path"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://example.com/path"));
@@ -782,7 +782,7 @@ TEST(URI_parse, rfc3986_authority_without_userinfo) {
   EXPECT_EQ(uri.host().value(), "example.com");
 }
 
-TEST(URI_parse, rfc3986_authority_with_empty_userinfo) {
+TEST(rfc3986_authority_with_empty_userinfo) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://@example.com/path"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://@example.com/path"));
@@ -791,7 +791,7 @@ TEST(URI_parse, rfc3986_authority_with_empty_userinfo) {
   EXPECT_EQ(uri.userinfo().value(), "");
 }
 
-TEST(URI_parse, rfc3986_authority_with_userinfo_no_password) {
+TEST(rfc3986_authority_with_userinfo_no_password) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://user@example.com/path"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://user@example.com/path"));
@@ -800,7 +800,7 @@ TEST(URI_parse, rfc3986_authority_with_userinfo_no_password) {
   EXPECT_EQ(uri.userinfo().value(), "user");
 }
 
-TEST(URI_parse, rfc3986_path_absolute_no_authority) {
+TEST(rfc3986_path_absolute_no_authority) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("/absolute/path"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("/absolute/path"));
   sourcemeta::core::URI uri{"/absolute/path"};
@@ -810,7 +810,7 @@ TEST(URI_parse, rfc3986_path_absolute_no_authority) {
   EXPECT_EQ(uri.recompose(), "/absolute/path");
 }
 
-TEST(URI_parse, rfc3986_path_relative_simple) {
+TEST(rfc3986_path_relative_simple) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("relative/path"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("relative/path"));
   sourcemeta::core::URI uri{"relative/path"};
@@ -820,7 +820,7 @@ TEST(URI_parse, rfc3986_path_relative_simple) {
   EXPECT_EQ(uri.recompose(), "relative/path");
 }
 
-TEST(URI_parse, rfc3986_query_only) {
+TEST(rfc3986_query_only) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("?query=value"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("?query=value"));
   sourcemeta::core::URI uri{"?query=value"};
@@ -830,7 +830,7 @@ TEST(URI_parse, rfc3986_query_only) {
   EXPECT_EQ(uri.recompose(), "?query=value");
 }
 
-TEST(URI_parse, rfc3986_fragment_only) {
+TEST(rfc3986_fragment_only) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("#fragment"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("#fragment"));
   sourcemeta::core::URI uri{"#fragment"};
@@ -840,7 +840,7 @@ TEST(URI_parse, rfc3986_fragment_only) {
   EXPECT_EQ(uri.recompose(), "#fragment");
 }
 
-TEST(URI_parse, rfc3986_percent_encoded_unreserved) {
+TEST(rfc3986_percent_encoded_unreserved) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com/%7Euser/path"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
       "http://example.com/%7Euser/path"));
@@ -848,7 +848,7 @@ TEST(URI_parse, rfc3986_percent_encoded_unreserved) {
   EXPECT_EQ(uri.recompose(), "http://example.com/~user/path");
 }
 
-TEST(URI_parse, rfc3986_percent_encoded_reserved) {
+TEST(rfc3986_percent_encoded_reserved) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://example.com/path%2Fwith%2Fslashes"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -859,7 +859,7 @@ TEST(URI_parse, rfc3986_percent_encoded_reserved) {
   EXPECT_EQ(uri.recompose(), "http://example.com/path%2Fwith%2Fslashes");
 }
 
-TEST(URI_parse, rfc3986_mixed_case_percent_encoding) {
+TEST(rfc3986_mixed_case_percent_encoding) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com/%3a%3A%3b%3B"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
       "http://example.com/%3a%3A%3b%3B"));
@@ -869,7 +869,7 @@ TEST(URI_parse, rfc3986_mixed_case_percent_encoding) {
   EXPECT_EQ(uri.recompose(), "http://example.com/%3a%3A%3b%3B");
 }
 
-TEST(URI_parse, rfc3986_authority_only) {
+TEST(rfc3986_authority_only) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("//example.com"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("//example.com"));
   sourcemeta::core::URI uri{"//example.com"};
@@ -878,7 +878,7 @@ TEST(URI_parse, rfc3986_authority_only) {
   EXPECT_EQ(uri.recompose(), "//example.com");
 }
 
-TEST(URI_parse, rfc3986_authority_with_port_no_path) {
+TEST(rfc3986_authority_with_port_no_path) {
   EXPECT_FALSE(sourcemeta::core::URI::is_uri("//example.com:8080"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("//example.com:8080"));
   sourcemeta::core::URI uri{"//example.com:8080"};
@@ -888,7 +888,7 @@ TEST(URI_parse, rfc3986_authority_with_port_no_path) {
   EXPECT_EQ(uri.recompose(), "//example.com:8080");
 }
 
-TEST(URI_parse, rfc3986_ipv4_dotted_decimal) {
+TEST(rfc3986_ipv4_dotted_decimal) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://127.0.0.1/path"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("http://127.0.0.1/path"));
   sourcemeta::core::URI uri{"http://127.0.0.1/path"};
@@ -896,7 +896,7 @@ TEST(URI_parse, rfc3986_ipv4_dotted_decimal) {
   EXPECT_EQ(uri.recompose(), "http://127.0.0.1/path");
 }
 
-TEST(URI_parse, rfc3986_ipv6_full_form) {
+TEST(rfc3986_ipv6_full_form) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri(
       "http://[2001:0db8:0000:0000:0000:0000:0000:0001]/path"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference(
@@ -912,7 +912,7 @@ TEST(URI_parse, rfc3986_ipv6_full_form) {
               host.find("2001:") == 0);
 }
 
-TEST(URI_parse, rfc3986_ipv6_compressed) {
+TEST(rfc3986_ipv6_compressed) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://[::1]/path"));
   EXPECT_TRUE(sourcemeta::core::URI::is_uri_reference("http://[::1]/path"));
   sourcemeta::core::URI uri{"http://[::1]/path"};
@@ -920,7 +920,7 @@ TEST(URI_parse, rfc3986_ipv6_compressed) {
   EXPECT_EQ(uri.recompose(), "http://[::1]/path");
 }
 
-TEST(URI_parse, rfc3986_empty_path_with_query) {
+TEST(rfc3986_empty_path_with_query) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com?query"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://example.com?query"));
@@ -929,7 +929,7 @@ TEST(URI_parse, rfc3986_empty_path_with_query) {
   EXPECT_EQ(uri.query().value().raw(), "query");
 }
 
-TEST(URI_parse, rfc3986_empty_path_with_fragment) {
+TEST(rfc3986_empty_path_with_fragment) {
   EXPECT_TRUE(sourcemeta::core::URI::is_uri("http://example.com#fragment"));
   EXPECT_TRUE(
       sourcemeta::core::URI::is_uri_reference("http://example.com#fragment"));
@@ -938,7 +938,7 @@ TEST(URI_parse, rfc3986_empty_path_with_fragment) {
   EXPECT_EQ(uri.fragment().value(), "fragment");
 }
 
-TEST(URI_parse, uri_constructor_rejects_non_ascii) {
+TEST(uri_constructor_rejects_non_ascii) {
   // The plain URI constructor does not accept IRI characters
   try {
     sourcemeta::core::URI{"https://example.com/caf\xC3\xA9"};

--- a/test/uri/uri_path_test.cc
+++ b/test/uri/uri_path_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
@@ -7,48 +7,48 @@
 
 // Getter
 
-TEST(URI_path_getter, https_example_url_no_path) {
+TEST(https_example_url_no_path) {
   const sourcemeta::core::URI uri{"https://example.com"};
   EXPECT_FALSE(uri.path().has_value());
 }
 
-TEST(URI_path_getter, https_example_url_slash) {
+TEST(https_example_url_slash) {
   const sourcemeta::core::URI uri{"https://example.com/"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/");
 }
 
-TEST(URI_path_getter, https_example_url_single) {
+TEST(https_example_url_single) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/foo");
 }
 
-TEST(URI_path_getter, https_example_url_multi) {
+TEST(https_example_url_multi) {
   const sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/foo/bar/baz");
 }
 
-TEST(URI_path_getter, relative_multi) {
+TEST(relative_multi) {
   const sourcemeta::core::URI uri{"../foo/bar"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "../foo/bar");
 }
 
-TEST(URI_path_getter, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "example:schema");
 }
 
-TEST(URI_path_getter, urn_with_fragment) {
+TEST(urn_with_fragment) {
   const sourcemeta::core::URI uri{"urn:example:schema#foo"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "example:schema");
 }
 
-TEST(URI_path_getter, tag) {
+TEST(tag) {
   const sourcemeta::core::URI uri{
       "tag:bowtie.report,2023-11:referencing-suite-tag-uris-id"};
   EXPECT_TRUE(uri.path().has_value());
@@ -56,7 +56,7 @@ TEST(URI_path_getter, tag) {
             "bowtie.report,2023-11:referencing-suite-tag-uris-id");
 }
 
-TEST(URI_path_getter, tag_with_fragment) {
+TEST(tag_with_fragment) {
   const sourcemeta::core::URI uri{
       "tag:bowtie.report,2023-11:referencing-suite-tag-uris-id#foo"};
   EXPECT_TRUE(uri.path().has_value());
@@ -64,19 +64,19 @@ TEST(URI_path_getter, tag_with_fragment) {
             "bowtie.report,2023-11:referencing-suite-tag-uris-id");
 }
 
-TEST(URI_path_getter, without_scheme) {
+TEST(without_scheme) {
   const sourcemeta::core::URI uri{"example.com/foo"};
   EXPECT_EQ(uri.path().value(), "example.com/foo");
 }
 
-TEST(URI_path_getter, mailto) {
+TEST(mailto) {
   const sourcemeta::core::URI uri{"mailto:jdoe@woo.com"};
   EXPECT_EQ(uri.path().value(), "jdoe@woo.com");
 }
 
 // Setter
 
-TEST(URI_path_setter, no_path) {
+TEST(no_path) {
   sourcemeta::core::URI uri{"https://example.com"};
 
   uri.path(std::string{"/foo"});
@@ -89,7 +89,7 @@ TEST(URI_path_setter, no_path) {
   EXPECT_EQ(uri.recompose(), "https://example.com/bar");
 }
 
-TEST(URI_path_setter, url_slash) {
+TEST(url_slash) {
   sourcemeta::core::URI uri{"https://example.com/"};
 
   uri.path(std::string{"/foo"});
@@ -102,7 +102,7 @@ TEST(URI_path_setter, url_slash) {
   EXPECT_EQ(uri.recompose(), "https://example.com/bar");
 }
 
-TEST(URI_path_setter, url_path) {
+TEST(url_path) {
   sourcemeta::core::URI uri{"https://example.com/foo"};
 
   uri.path(std::string{"/bar"});
@@ -115,7 +115,7 @@ TEST(URI_path_setter, url_path) {
   EXPECT_EQ(uri.recompose(), "https://example.com/baz");
 }
 
-TEST(URI_path_setter, set_empty) {
+TEST(set_empty) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
 
   uri.path(std::string{""});
@@ -128,7 +128,7 @@ TEST(URI_path_setter, set_empty) {
   EXPECT_EQ(uri.recompose(), "https://example.com");
 }
 
-TEST(URI_path_setter, set_path_without_leading_slash) {
+TEST(set_path_without_leading_slash) {
   sourcemeta::core::URI uri{"https://example.com"};
 
   uri.path(std::string{"foo"});
@@ -141,7 +141,7 @@ TEST(URI_path_setter, set_path_without_leading_slash) {
   EXPECT_EQ(uri.recompose(), "https://example.com/bar");
 }
 
-TEST(URI_path_setter, set_path_with_trailing_slash) {
+TEST(set_path_with_trailing_slash) {
   sourcemeta::core::URI uri{"https://example.com"};
 
   uri.path(std::string{"/foo/"});
@@ -154,7 +154,7 @@ TEST(URI_path_setter, set_path_with_trailing_slash) {
   EXPECT_EQ(uri.recompose(), "https://example.com/foo2/");
 }
 
-TEST(URI_path_setter, set_relative_path) {
+TEST(set_relative_path) {
   sourcemeta::core::URI uri{"https://example.com"};
 
   try {
@@ -193,7 +193,7 @@ TEST(URI_path_setter, set_relative_path) {
   EXPECT_EQ(path, "./foo");
 }
 
-TEST(URI_path_setter, set_path_with_query) {
+TEST(set_path_with_query) {
   sourcemeta::core::URI uri{"https://example.com"};
 
   try {
@@ -212,7 +212,7 @@ TEST(URI_path_setter, set_path_with_query) {
   }
 }
 
-TEST(URI_path_setter, set_path_with_fragment) {
+TEST(set_path_with_fragment) {
   sourcemeta::core::URI uri{"https://example.com"};
 
   try {
@@ -233,7 +233,7 @@ TEST(URI_path_setter, set_path_with_fragment) {
   }
 }
 
-TEST(URI_path_setter, set_path_with_query_and_fragment) {
+TEST(set_path_with_query_and_fragment) {
   sourcemeta::core::URI uri{"https://example.com/old?query=value#fragment"};
 
   try {
@@ -252,7 +252,7 @@ TEST(URI_path_setter, set_path_with_query_and_fragment) {
   }
 }
 
-TEST(URI_path_setter_no_scheme, set_path_on_host_only) {
+TEST(set_path_on_host_only) {
   sourcemeta::core::URI uri{"example.com"};
 
   uri.path("/foo");
@@ -265,7 +265,7 @@ TEST(URI_path_setter_no_scheme, set_path_on_host_only) {
   EXPECT_EQ(uri.recompose(), "/bar");
 }
 
-TEST(URI_path_setter_no_scheme, replace_existing_path) {
+TEST(replace_existing_path) {
   sourcemeta::core::URI uri{"example.com/old"};
 
   uri.path("/new");
@@ -278,7 +278,7 @@ TEST(URI_path_setter_no_scheme, replace_existing_path) {
   EXPECT_EQ(uri.recompose(), "/newer");
 }
 
-TEST(URI_path_setter_no_scheme, set_empty_path) {
+TEST(set_empty_path) {
   sourcemeta::core::URI uri{"example.com/foo"};
 
   uri.path("");
@@ -291,7 +291,7 @@ TEST(URI_path_setter_no_scheme, set_empty_path) {
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_path_setter_no_scheme, set_path_on_ip_address) {
+TEST(set_path_on_ip_address) {
   sourcemeta::core::URI uri{"192.168.0.1"};
 
   uri.path("/admin");
@@ -304,7 +304,7 @@ TEST(URI_path_setter_no_scheme, set_path_on_ip_address) {
   EXPECT_EQ(uri.recompose(), "/admin2");
 }
 
-TEST(URI_path_setter, set_path_with_port) {
+TEST(set_path_with_port) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
 
   uri.path("/test");
@@ -317,7 +317,7 @@ TEST(URI_path_setter, set_path_with_port) {
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/test2");
 }
 
-TEST(URI_path_setter, lowercase_relative_path) {
+TEST(lowercase_relative_path) {
   sourcemeta::core::URI uri{"../SERVER.JSON"};
   EXPECT_EQ(uri.recompose(), "../SERVER.JSON");
   uri.path("../server.json");
@@ -327,73 +327,73 @@ TEST(URI_path_setter, lowercase_relative_path) {
   EXPECT_EQ(uri.recompose(), "../foo.json");
 }
 
-TEST(URI_path, append_path_without_path_from_root) {
+TEST(append_path_without_path_from_root) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("/test");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/test");
 }
 
-TEST(URI_path, append_path_without_path) {
+TEST(append_path_without_path) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("test/bar");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/test/bar");
 }
 
-TEST(URI_path, append_path_without_path_empty) {
+TEST(append_path_without_path_empty) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080");
 }
 
-TEST(URI_path, append_path_without_path_slash_only) {
+TEST(append_path_without_path_slash_only) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("/");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/");
 }
 
-TEST(URI_path, append_path_with_path_with_slash_prefix) {
+TEST(append_path_with_path_with_slash_prefix) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("/bar");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar");
 }
 
-TEST(URI_path, append_path_with_path_with_slash_only) {
+TEST(append_path_with_path_with_slash_only) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("/");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/");
 }
 
-TEST(URI_path, append_path_with_path_trailing_slash_clash) {
+TEST(append_path_with_path_trailing_slash_clash) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("/bar");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar");
 }
 
-TEST(URI_path, append_path_with_path_trailing_slash_in_argument) {
+TEST(append_path_with_path_trailing_slash_in_argument) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("/bar//baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar//baz");
 }
 
-TEST(URI_path, append_path_with_path_trailing_slash) {
+TEST(append_path_with_path_trailing_slash) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("bar/baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path, append_path_with_path_no_slash_delimiters) {
+TEST(append_path_with_path_no_slash_delimiters) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("bar/baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path, append_path_chain) {
+TEST(append_path_chain) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("bar").append_path("baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path, append_path_rejects_scheme) {
+TEST(append_path_rejects_scheme) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   try {
     uri.append_path("https://other.example.com/foo");
@@ -405,7 +405,7 @@ TEST(URI_path, append_path_rejects_scheme) {
   }
 }
 
-TEST(URI_path, append_path_rejects_authority_only) {
+TEST(append_path_rejects_authority_only) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   try {
     uri.append_path("//other.example.com/foo");
@@ -416,49 +416,49 @@ TEST(URI_path, append_path_rejects_authority_only) {
   }
 }
 
-TEST(URI_path, append_path_colon_in_first_segment_accepted) {
+TEST(append_path_colon_in_first_segment_accepted) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("bar:baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar:baz");
 }
 
-TEST(URI_path, append_path_urn_like_input_treated_as_path) {
+TEST(append_path_urn_like_input_treated_as_path) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("urn:example:foo");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/urn:example:foo");
 }
 
-TEST(URI_path, append_path_colon_in_non_first_segment_accepted) {
+TEST(append_path_colon_in_non_first_segment_accepted) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("foo/bar:baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar:baz");
 }
 
-TEST(URI_path, append_path_dot_dot_collapses) {
+TEST(append_path_dot_dot_collapses) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("../bar");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/bar");
 }
 
-TEST(URI_path, append_path_dot_dot_multiple) {
+TEST(append_path_dot_dot_multiple) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/bar/"};
   uri.append_path("../../baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/baz");
 }
 
-TEST(URI_path, append_path_dot_collapses) {
+TEST(append_path_dot_collapses) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("./bar");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar");
 }
 
-TEST(URI_path, append_path_dot_dot_empty_base) {
+TEST(append_path_dot_dot_empty_base) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   uri.append_path("../meta/custom.json");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/meta/custom.json");
 }
 
-TEST(URI_path, append_path_rejects_fragment) {
+TEST(append_path_rejects_fragment) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar#baz");
@@ -469,7 +469,7 @@ TEST(URI_path, append_path_rejects_fragment) {
   }
 }
 
-TEST(URI_path, append_path_rejects_query) {
+TEST(append_path_rejects_query) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar?x=1");
@@ -480,7 +480,7 @@ TEST(URI_path, append_path_rejects_query) {
   }
 }
 
-TEST(URI_path, append_path_rejects_fragment_only) {
+TEST(append_path_rejects_fragment_only) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("#bar");
@@ -491,7 +491,7 @@ TEST(URI_path, append_path_rejects_fragment_only) {
   }
 }
 
-TEST(URI_path, append_path_rejects_query_only) {
+TEST(append_path_rejects_query_only) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("?x=1");
@@ -502,37 +502,37 @@ TEST(URI_path, append_path_rejects_query_only) {
   }
 }
 
-TEST(URI_path, append_path_double_slash_in_argument_preserved) {
+TEST(append_path_double_slash_in_argument_preserved) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   uri.append_path("..//bar");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080//bar");
 }
 
-TEST(URI_path, append_path_deep_dot_dot_chain) {
+TEST(append_path_deep_dot_dot_chain) {
   sourcemeta::core::URI uri{"http://example.com:8080/a/b/c/"};
   uri.append_path("../../../d");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/d");
 }
 
-TEST(URI_path, append_path_dot_dot_past_root) {
+TEST(append_path_dot_dot_past_root) {
   sourcemeta::core::URI uri{"http://example.com:8080/a"};
   uri.append_path("../../b");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/b");
 }
 
-TEST(URI_path, append_path_at_sign_in_segment_accepted) {
+TEST(append_path_at_sign_in_segment_accepted) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("user@host");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/user@host");
 }
 
-TEST(URI_path, append_path_trailing_slash_on_segment_input) {
+TEST(append_path_trailing_slash_on_segment_input) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("/");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/");
 }
 
-TEST(URI_path, append_path_rejects_space) {
+TEST(append_path_rejects_space) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar baz");
@@ -544,7 +544,7 @@ TEST(URI_path, append_path_rejects_space) {
   }
 }
 
-TEST(URI_path, append_path_rejects_control_character) {
+TEST(append_path_rejects_control_character) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar\nbaz");
@@ -556,7 +556,7 @@ TEST(URI_path, append_path_rejects_control_character) {
   }
 }
 
-TEST(URI_path, append_path_rejects_square_brackets) {
+TEST(append_path_rejects_square_brackets) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar[1]");
@@ -568,7 +568,7 @@ TEST(URI_path, append_path_rejects_square_brackets) {
   }
 }
 
-TEST(URI_path, append_path_rejects_non_ascii) {
+TEST(append_path_rejects_non_ascii) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar\xE2\x86\x92");
@@ -580,7 +580,7 @@ TEST(URI_path, append_path_rejects_non_ascii) {
   }
 }
 
-TEST(URI_path, append_path_rejects_truncated_percent) {
+TEST(append_path_rejects_truncated_percent) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar%");
@@ -591,7 +591,7 @@ TEST(URI_path, append_path_rejects_truncated_percent) {
   }
 }
 
-TEST(URI_path, append_path_rejects_partial_percent) {
+TEST(append_path_rejects_partial_percent) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar%2");
@@ -602,7 +602,7 @@ TEST(URI_path, append_path_rejects_partial_percent) {
   }
 }
 
-TEST(URI_path, append_path_rejects_invalid_percent_digits) {
+TEST(append_path_rejects_invalid_percent_digits) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   try {
     uri.append_path("bar%GZ");
@@ -613,40 +613,40 @@ TEST(URI_path, append_path_rejects_invalid_percent_digits) {
   }
 }
 
-TEST(URI_path, append_path_accepts_valid_percent_encoding) {
+TEST(append_path_accepts_valid_percent_encoding) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("bar%20baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar%20baz");
 }
 
-TEST(URI_path, append_path_accepts_sub_delims) {
+TEST(append_path_accepts_sub_delims) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path("bar!$&'()*+,;=baz");
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar!$&'()*+,;=baz");
 }
 
-TEST(URI_path, append_path_uri_overload_relative_reference) {
+TEST(append_path_uri_overload_relative_reference) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   const sourcemeta::core::URI reference{"bar/baz"};
   uri.append_path(reference);
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path, append_path_uri_overload_with_leading_slash) {
+TEST(append_path_uri_overload_with_leading_slash) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   const sourcemeta::core::URI reference{"/bar"};
   uri.append_path(reference);
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar");
 }
 
-TEST(URI_path, append_path_uri_overload_dot_dot_collapses) {
+TEST(append_path_uri_overload_dot_dot_collapses) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo/"};
   const sourcemeta::core::URI reference{"../bar"};
   uri.append_path(reference);
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/bar");
 }
 
-TEST(URI_path, append_path_uri_overload_rejects_scheme) {
+TEST(append_path_uri_overload_rejects_scheme) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   const sourcemeta::core::URI reference{"https://other.example.com/foo"};
   try {
@@ -659,7 +659,7 @@ TEST(URI_path, append_path_uri_overload_rejects_scheme) {
   }
 }
 
-TEST(URI_path, append_path_uri_overload_rejects_urn) {
+TEST(append_path_uri_overload_rejects_urn) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   const sourcemeta::core::URI reference{"urn:example:foo"};
   try {
@@ -672,7 +672,7 @@ TEST(URI_path, append_path_uri_overload_rejects_urn) {
   }
 }
 
-TEST(URI_path, append_path_uri_overload_rejects_query) {
+TEST(append_path_uri_overload_rejects_query) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   const sourcemeta::core::URI reference{"bar?x=1"};
   try {
@@ -685,7 +685,7 @@ TEST(URI_path, append_path_uri_overload_rejects_query) {
   }
 }
 
-TEST(URI_path, append_path_uri_overload_rejects_fragment) {
+TEST(append_path_uri_overload_rejects_fragment) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   const sourcemeta::core::URI reference{"bar#baz"};
   try {
@@ -698,7 +698,7 @@ TEST(URI_path, append_path_uri_overload_rejects_fragment) {
   }
 }
 
-TEST(URI_path, append_path_uri_overload_rejects_authority) {
+TEST(append_path_uri_overload_rejects_authority) {
   sourcemeta::core::URI uri{"http://example.com:8080"};
   const sourcemeta::core::URI reference{"//other.example.com/foo"};
   try {
@@ -711,7 +711,7 @@ TEST(URI_path, append_path_uri_overload_rejects_authority) {
   }
 }
 
-TEST(URI_path, append_path_uri_overload_chain) {
+TEST(append_path_uri_overload_chain) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   const sourcemeta::core::URI bar{"bar"};
   const sourcemeta::core::URI baz{"baz"};
@@ -719,62 +719,62 @@ TEST(URI_path, append_path_uri_overload_chain) {
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path, append_path_uri_overload_move) {
+TEST(append_path_uri_overload_move) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   sourcemeta::core::URI reference{"bar/baz"};
   uri.append_path(std::move(reference));
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path, append_path_uri_overload_move_temporary) {
+TEST(append_path_uri_overload_move_temporary) {
   sourcemeta::core::URI uri{"http://example.com:8080/foo"};
   uri.append_path(sourcemeta::core::URI{"bar/baz"});
   EXPECT_EQ(uri.recompose(), "http://example.com:8080/foo/bar/baz");
 }
 
-TEST(URI_path_getter, rfc3986_path_with_colon) {
+TEST(rfc3986_path_with_colon) {
   const sourcemeta::core::URI uri{"http://example.com/path:with:colons"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path:with:colons");
 }
 
-TEST(URI_path_getter, rfc3986_path_with_at_sign) {
+TEST(rfc3986_path_with_at_sign) {
   const sourcemeta::core::URI uri{"http://example.com/path@with@at"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path@with@at");
 }
 
-TEST(URI_path_getter, rfc3986_path_with_equals) {
+TEST(rfc3986_path_with_equals) {
   const sourcemeta::core::URI uri{"http://example.com/path=with=equals"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path=with=equals");
 }
 
-TEST(URI_path_getter, rfc3986_path_with_subdelims) {
+TEST(rfc3986_path_with_subdelims) {
   const sourcemeta::core::URI uri{"http://example.com/path!$&'()*+,;="};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path!$&'()*+,;=");
 }
 
-TEST(URI_path_getter, rfc3986_empty_path_segments) {
+TEST(rfc3986_empty_path_segments) {
   const sourcemeta::core::URI uri{"http://example.com/a//b///c"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/a//b///c");
 }
 
-TEST(URI_path_getter, rfc3986_path_only_slashes) {
+TEST(rfc3986_path_only_slashes) {
   const sourcemeta::core::URI uri{"http://example.com////"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "////");
 }
 
-TEST(URI_path_getter, rfc3986_percent_encoded_path) {
+TEST(rfc3986_percent_encoded_path) {
   const sourcemeta::core::URI uri{"http://example.com/path%20with%20spaces"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path%20with%20spaces");
 }
 
-TEST(URI_path_getter, rfc3986_percent_encoded_slash) {
+TEST(rfc3986_percent_encoded_slash) {
   const sourcemeta::core::URI uri{
       "http://example.com/path%2Fwith%2Fencoded%2Fslashes"};
   EXPECT_TRUE(uri.path().has_value());
@@ -782,70 +782,70 @@ TEST(URI_path_getter, rfc3986_percent_encoded_slash) {
   EXPECT_EQ(uri.path().value(), "/path%2Fwith%2Fencoded%2Fslashes");
 }
 
-TEST(URI_path_getter, encoded_question_mark_not_query_delimiter) {
+TEST(encoded_question_mark_not_query_delimiter) {
   const sourcemeta::core::URI uri{"http://example.com/foo%3Fbar"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/foo%3Fbar");
   EXPECT_FALSE(uri.query().has_value());
 }
 
-TEST(URI_path_getter, encoded_hash_not_fragment_delimiter) {
+TEST(encoded_hash_not_fragment_delimiter) {
   const sourcemeta::core::URI uri{"http://example.com/foo%23bar"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/foo%23bar");
   EXPECT_FALSE(uri.fragment().has_value());
 }
 
-TEST(URI_path_getter, mixed_encoded_and_literal_slashes) {
+TEST(mixed_encoded_and_literal_slashes) {
   const sourcemeta::core::URI uri{"http://example.com/a/b%2Fc/d"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/a/b%2Fc/d");
 }
 
-TEST(URI_path_getter, encoded_slash_vs_literal_slash_are_distinct) {
+TEST(encoded_slash_vs_literal_slash_are_distinct) {
   const sourcemeta::core::URI encoded{"http://example.com/v1%2F2.json"};
   const sourcemeta::core::URI literal{"http://example.com/v1/2.json"};
   EXPECT_NE(encoded.path().value(), literal.path().value());
 }
 
-TEST(URI_path_getter, rfc3986_path_with_unreserved) {
+TEST(rfc3986_path_with_unreserved) {
   const sourcemeta::core::URI uri{
       "http://example.com/path-with_unreserved.chars~123"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path-with_unreserved.chars~123");
 }
 
-TEST(URI_path_getter, rfc3986_relative_path_no_slash) {
+TEST(rfc3986_relative_path_no_slash) {
   const sourcemeta::core::URI uri{"path/to/resource"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "path/to/resource");
 }
 
-TEST(URI_path_getter, rfc3986_relative_path_with_slash) {
+TEST(rfc3986_relative_path_with_slash) {
   const sourcemeta::core::URI uri{"/path/to/resource"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path/to/resource");
 }
 
-TEST(URI_path_getter, rfc3986_path_single_segment) {
+TEST(rfc3986_path_single_segment) {
   const sourcemeta::core::URI uri{"http://example.com/segment"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/segment");
 }
 
-TEST(URI_path_getter, rfc3986_path_with_query_separator) {
+TEST(rfc3986_path_with_query_separator) {
   const sourcemeta::core::URI uri{"http://example.com/path?query=value"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path");
 }
 
-TEST(URI_path_getter, rfc3986_path_with_fragment_separator) {
+TEST(rfc3986_path_with_fragment_separator) {
   const sourcemeta::core::URI uri{"http://example.com/path#fragment"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/path");
 }
 
-TEST(URI_path_setter, getter_setter_invariant_relative_with_leading_slash) {
+TEST(getter_setter_invariant_relative_with_leading_slash) {
   sourcemeta::core::URI uri{"/test/no-serve/schema"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/test/no-serve/schema");
@@ -859,7 +859,7 @@ TEST(URI_path_setter, getter_setter_invariant_relative_with_leading_slash) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_path_setter, getter_setter_invariant_relative_without_leading_slash) {
+TEST(getter_setter_invariant_relative_without_leading_slash) {
   sourcemeta::core::URI uri{"test/no-serve/schema"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "test/no-serve/schema");
@@ -873,7 +873,7 @@ TEST(URI_path_setter, getter_setter_invariant_relative_without_leading_slash) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_path_setter, getter_setter_invariant_absolute_uri) {
+TEST(getter_setter_invariant_absolute_uri) {
   sourcemeta::core::URI uri{"http://example.com/foo/bar"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/foo/bar");
@@ -887,7 +887,7 @@ TEST(URI_path_setter, getter_setter_invariant_absolute_uri) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_path_setter, getter_setter_invariant_relative_dotdot) {
+TEST(getter_setter_invariant_relative_dotdot) {
   sourcemeta::core::URI uri{"../foo/bar"};
   EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "../foo/bar");
@@ -901,9 +901,9 @@ TEST(URI_path_setter, getter_setter_invariant_relative_dotdot) {
   EXPECT_EQ(uri.recompose(), original_recompose);
 }
 
-TEST(URI_path, iri_unicode_path) {
+TEST(iri_unicode_path) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
-  ASSERT_TRUE(uri.path().has_value());
+  EXPECT_TRUE(uri.path().has_value());
   EXPECT_EQ(uri.path().value(), "/caf\xC3\xA9");
 }

--- a/test/uri/uri_port_test.cc
+++ b/test/uri/uri_port_test.cc
@@ -1,94 +1,94 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_port, https_example_url_no_port) {
+TEST(https_example_url_no_port) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_port, https_example_url_443) {
+TEST(https_example_url_443) {
   const sourcemeta::core::URI uri{"https://example.com:443/foo"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 443);
 }
 
-TEST(URI_port, http_example_url_8000) {
+TEST(http_example_url_8000) {
   const sourcemeta::core::URI uri{"http://example.com:8000/foo"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 8000);
 }
 
-TEST(URI_port, relative_url) {
+TEST(relative_url) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_port, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_port, rfc3986_port_80) {
+TEST(rfc3986_port_80) {
   const sourcemeta::core::URI uri{"http://example.com:80/path"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 80);
 }
 
-TEST(URI_port, rfc3986_port_443) {
+TEST(rfc3986_port_443) {
   const sourcemeta::core::URI uri{"https://example.com:443/path"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 443);
 }
 
-TEST(URI_port, rfc3986_port_21) {
+TEST(rfc3986_port_21) {
   const sourcemeta::core::URI uri{"ftp://ftp.example.com:21/file.txt"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 21);
 }
 
-TEST(URI_port, rfc3986_high_port_number) {
+TEST(rfc3986_high_port_number) {
   const sourcemeta::core::URI uri{"http://example.com:65535/path"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 65535);
 }
 
-TEST(URI_port, rfc3986_port_with_ipv4) {
+TEST(rfc3986_port_with_ipv4) {
   const sourcemeta::core::URI uri{"http://192.168.1.1:3000/path"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 3000);
 }
 
-TEST(URI_port, rfc3986_port_with_ipv6) {
+TEST(rfc3986_port_with_ipv6) {
   const sourcemeta::core::URI uri{"http://[2001:db8::1]:9000/path"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 9000);
 }
 
-TEST(URI_port, rfc3986_port_single_digit) {
+TEST(rfc3986_port_single_digit) {
   const sourcemeta::core::URI uri{"http://example.com:8/path"};
   EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 8);
 }
 
-TEST(URI_port, rfc3986_no_port_http) {
+TEST(rfc3986_no_port_http) {
   const sourcemeta::core::URI uri{"http://example.com/path"};
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_port, rfc3986_no_port_https) {
+TEST(rfc3986_no_port_https) {
   const sourcemeta::core::URI uri{"https://example.com/path"};
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_port, rfc3986_no_port_ftp) {
+TEST(rfc3986_no_port_ftp) {
   const sourcemeta::core::URI uri{"ftp://ftp.example.com/file.txt"};
   EXPECT_FALSE(uri.port().has_value());
 }
 
-TEST(URI_port, iri_host_with_port) {
+TEST(iri_host_with_port) {
   const auto uri{sourcemeta::core::URI::from_iri(
       "https://\xE4\xBE\x8B\xE3\x81\x88.jp:8443/")};
-  ASSERT_TRUE(uri.port().has_value());
+  EXPECT_TRUE(uri.port().has_value());
   EXPECT_EQ(uri.port().value(), 8443U);
 }

--- a/test/uri/uri_query_test.cc
+++ b/test/uri/uri_query_test.cc
@@ -1,16 +1,16 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
 #include <utility> // std::pair
 #include <vector>  // std::vector
 
-TEST(URI_query, https_example_url_no_query) {
+TEST(https_example_url_no_query) {
   const sourcemeta::core::URI uri{"https://example.com/test"};
   EXPECT_FALSE(uri.query().has_value());
 }
 
-TEST(URI_query, https_example_with_query_single) {
+TEST(https_example_with_query_single) {
   const sourcemeta::core::URI uri{"https://example.com/test?foo=bar"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "foo=bar");
@@ -18,37 +18,37 @@ TEST(URI_query, https_example_with_query_single) {
 
 // RFC 3986 itself does not understand the query part of a URI as a list of
 // key/value pairs.
-TEST(URI_query, https_example_with_query_double) {
+TEST(https_example_with_query_double) {
   const sourcemeta::core::URI uri{"https://example.com/test?foo=bar&bar=baz"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "foo=bar&bar=baz");
 }
 
-TEST(URI_query, rfc3986_query_with_slash) {
+TEST(rfc3986_query_with_slash) {
   const sourcemeta::core::URI uri{"http://example.com/path?query/with/slashes"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "query/with/slashes");
 }
 
-TEST(URI_query, rfc3986_query_with_question_mark) {
+TEST(rfc3986_query_with_question_mark) {
   const sourcemeta::core::URI uri{"http://example.com/path?query=value?more"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "query=value?more");
 }
 
-TEST(URI_query, rfc3986_query_with_colon) {
+TEST(rfc3986_query_with_colon) {
   const sourcemeta::core::URI uri{"http://example.com/path?query:with:colons"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "query:with:colons");
 }
 
-TEST(URI_query, rfc3986_query_with_at_sign) {
+TEST(rfc3986_query_with_at_sign) {
   const sourcemeta::core::URI uri{"http://example.com/path?query@with@at"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "query@with@at");
 }
 
-TEST(URI_query, rfc3986_query_percent_encoded) {
+TEST(rfc3986_query_percent_encoded) {
   const sourcemeta::core::URI uri{
       "http://example.com/path?query%20with%20spaces"};
   EXPECT_TRUE(uri.query().has_value());
@@ -56,32 +56,32 @@ TEST(URI_query, rfc3986_query_percent_encoded) {
   EXPECT_EQ(uri.query().value().raw(), "query%20with%20spaces");
 }
 
-TEST(URI_query, rfc3986_query_with_fragment) {
+TEST(rfc3986_query_with_fragment) {
   const sourcemeta::core::URI uri{
       "http://example.com/path?query=value#fragment"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "query=value");
 }
 
-TEST(URI_query, rfc3986_empty_query) {
+TEST(rfc3986_empty_query) {
   const sourcemeta::core::URI uri{"http://example.com/path?"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "");
 }
 
-TEST(URI_query, rfc3986_query_only_ampersands) {
+TEST(rfc3986_query_only_ampersands) {
   const sourcemeta::core::URI uri{"http://example.com/path?&&&"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "&&&");
 }
 
-TEST(URI_query, rfc3986_query_with_subdelims) {
+TEST(rfc3986_query_with_subdelims) {
   const sourcemeta::core::URI uri{"http://example.com/path?!$&'()*+,;="};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "!$&'()*+,;=");
 }
 
-TEST(URI_query, rfc3986_query_percent_encoded_brackets) {
+TEST(rfc3986_query_percent_encoded_brackets) {
   const sourcemeta::core::URI uri{
       "http://example.com/path?items%5B0%5D=a&items%5B1%5D=b"};
   EXPECT_TRUE(uri.query().has_value());
@@ -89,38 +89,38 @@ TEST(URI_query, rfc3986_query_percent_encoded_brackets) {
   EXPECT_EQ(uri.query().value().raw(), "items%5B0%5D=a&items%5B1%5D=b");
 }
 
-TEST(URI_query, rfc3986_query_no_value) {
+TEST(rfc3986_query_no_value) {
   const sourcemeta::core::URI uri{"http://example.com/path?key"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "key");
 }
 
-TEST(URI_query, rfc3986_query_multiple_equals) {
+TEST(rfc3986_query_multiple_equals) {
   const sourcemeta::core::URI uri{"http://example.com/path?key=value=extra"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "key=value=extra");
 }
 
-TEST(URI_query, encoded_ampersand_preserved) {
+TEST(encoded_ampersand_preserved) {
   const sourcemeta::core::URI uri{"http://example.com/path?foo%26bar=baz"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "foo%26bar=baz");
 }
 
-TEST(URI_query, encoded_hash_not_fragment_delimiter) {
+TEST(encoded_hash_not_fragment_delimiter) {
   const sourcemeta::core::URI uri{"http://example.com/path?foo%23bar"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "foo%23bar");
   EXPECT_FALSE(uri.fragment().has_value());
 }
 
-TEST(URI_query, encoded_equals_preserved) {
+TEST(encoded_equals_preserved) {
   const sourcemeta::core::URI uri{"http://example.com/path?key%3Dvalue"};
   EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "key%3Dvalue");
 }
 
-TEST(URI_query, setter_on_uri_without_query) {
+TEST(setter_on_uri_without_query) {
   sourcemeta::core::URI uri{"https://example.com/path"};
   uri.query("foo=bar");
   EXPECT_TRUE(uri.query().has_value());
@@ -128,7 +128,7 @@ TEST(URI_query, setter_on_uri_without_query) {
   EXPECT_EQ(uri.recompose(), "https://example.com/path?foo=bar");
 }
 
-TEST(URI_query, setter_replace_existing_query) {
+TEST(setter_replace_existing_query) {
   sourcemeta::core::URI uri{"https://example.com/path?old=value"};
   uri.query("foo=bar");
   EXPECT_TRUE(uri.query().has_value());
@@ -136,21 +136,21 @@ TEST(URI_query, setter_replace_existing_query) {
   EXPECT_EQ(uri.recompose(), "https://example.com/path?foo=bar");
 }
 
-TEST(URI_query, setter_clear_with_empty_string) {
+TEST(setter_clear_with_empty_string) {
   sourcemeta::core::URI uri{"https://example.com/path?foo=bar"};
   uri.query("");
   EXPECT_FALSE(uri.query().has_value());
   EXPECT_EQ(uri.recompose(), "https://example.com/path");
 }
 
-TEST(URI_query, setter_clear_when_already_absent) {
+TEST(setter_clear_when_already_absent) {
   sourcemeta::core::URI uri{"https://example.com/path"};
   uri.query("");
   EXPECT_FALSE(uri.query().has_value());
   EXPECT_EQ(uri.recompose(), "https://example.com/path");
 }
 
-TEST(URI_query, setter_leading_question_mark_stripped) {
+TEST(setter_leading_question_mark_stripped) {
   sourcemeta::core::URI uri{"https://example.com/path"};
   uri.query("?foo=bar");
   EXPECT_TRUE(uri.query().has_value());
@@ -158,14 +158,14 @@ TEST(URI_query, setter_leading_question_mark_stripped) {
   EXPECT_EQ(uri.recompose(), "https://example.com/path?foo=bar");
 }
 
-TEST(URI_query, setter_clear_preserves_fragment) {
+TEST(setter_clear_preserves_fragment) {
   sourcemeta::core::URI uri{"https://example.com/path?foo=bar#section"};
   uri.query("");
   EXPECT_FALSE(uri.query().has_value());
   EXPECT_EQ(uri.recompose(), "https://example.com/path#section");
 }
 
-TEST(URI_query, setter_percent_encoding_applied_on_recompose) {
+TEST(setter_percent_encoding_applied_on_recompose) {
   sourcemeta::core::URI uri{"https://example.com/path"};
   uri.query("foo=hello world");
   EXPECT_TRUE(uri.query().has_value());
@@ -173,13 +173,13 @@ TEST(URI_query, setter_percent_encoding_applied_on_recompose) {
   EXPECT_EQ(uri.recompose(), "https://example.com/path?foo=hello%20world");
 }
 
-TEST(URI_query, setter_returns_reference_for_chaining) {
+TEST(setter_returns_reference_for_chaining) {
   sourcemeta::core::URI uri{"https://example.com"};
   uri.query("a=1").fragment("section");
   EXPECT_EQ(uri.recompose(), "https://example.com?a=1#section");
 }
 
-TEST(URI_query, setter_normalizes_unreserved_percent_encoding) {
+TEST(setter_normalizes_unreserved_percent_encoding) {
   sourcemeta::core::URI uri{"https://example.com"};
   uri.query("foo=%7Ebar");
   EXPECT_TRUE(uri.query().has_value());
@@ -187,7 +187,7 @@ TEST(URI_query, setter_normalizes_unreserved_percent_encoding) {
   EXPECT_EQ(uri.query().value().raw(), "foo=~bar");
 }
 
-TEST(URI_query, setter_preserves_reserved_percent_encoding) {
+TEST(setter_preserves_reserved_percent_encoding) {
   sourcemeta::core::URI uri{"https://example.com"};
   uri.query("foo=%23bar");
   EXPECT_TRUE(uri.query().has_value());
@@ -195,7 +195,7 @@ TEST(URI_query, setter_preserves_reserved_percent_encoding) {
   EXPECT_EQ(uri.query().value().raw(), "foo=%23bar");
 }
 
-TEST(URI_query, setter_matches_parsed_uri_for_unreserved_percent) {
+TEST(setter_matches_parsed_uri_for_unreserved_percent) {
   sourcemeta::core::URI built{"https://example.com"};
   built.query("foo=%7Ebar");
   const sourcemeta::core::URI parsed{"https://example.com?foo=%7Ebar"};
@@ -203,252 +203,252 @@ TEST(URI_query, setter_matches_parsed_uri_for_unreserved_percent) {
   EXPECT_EQ(built.recompose(), parsed.recompose());
 }
 
-TEST(URI_query, iterator_no_query_has_no_iterable) {
+TEST(iterator_no_query_has_no_iterable) {
   const sourcemeta::core::URI uri{"https://example.com/path"};
   EXPECT_FALSE(uri.query().has_value());
 }
 
-TEST(URI_query, iterator_empty_query_yields_no_pairs) {
+TEST(iterator_empty_query_yields_no_pairs) {
   const sourcemeta::core::URI uri{"https://example.com/path?"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   EXPECT_EQ(query.value().begin(), query.value().end());
 }
 
-TEST(URI_query, iterator_single_pair) {
+TEST(iterator_single_pair) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
 }
 
-TEST(URI_query, iterator_two_pairs_in_order) {
+TEST(iterator_two_pairs_in_order) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar&baz=qux"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 2);
+  EXPECT_EQ(pairs.size(), 2);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
   EXPECT_EQ(pairs[1].first, "baz");
   EXPECT_EQ(pairs[1].second, "qux");
 }
 
-TEST(URI_query, iterator_key_without_equals) {
+TEST(iterator_key_without_equals) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "");
 }
 
-TEST(URI_query, iterator_key_with_empty_value) {
+TEST(iterator_key_with_empty_value) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo="};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "");
 }
 
-TEST(URI_query, iterator_empty_key_with_value) {
+TEST(iterator_empty_key_with_value) {
   const sourcemeta::core::URI uri{"https://example.com/path?=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "");
   EXPECT_EQ(pairs[0].second, "bar");
 }
 
-TEST(URI_query, iterator_only_ampersands_yields_empty_pairs) {
+TEST(iterator_only_ampersands_yields_empty_pairs) {
   const sourcemeta::core::URI uri{"https://example.com/path?&&&"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 4);
+  EXPECT_EQ(pairs.size(), 4);
   for (const auto &pair : pairs) {
     EXPECT_EQ(pair.first, "");
     EXPECT_EQ(pair.second, "");
   }
 }
 
-TEST(URI_query, iterator_multiple_equals_only_first_splits) {
+TEST(iterator_multiple_equals_only_first_splits) {
   const sourcemeta::core::URI uri{"https://example.com/path?key=value=extra"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "key");
   EXPECT_EQ(pairs[0].second, "value=extra");
 }
 
-TEST(URI_query, iterator_percent_encoding_left_untouched) {
+TEST(iterator_percent_encoding_left_untouched) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=%20"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "%20");
 }
 
-TEST(URI_query, at_single_match) {
+TEST(at_single_match) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "bar");
 }
 
-TEST(URI_query, at_missing_key_returns_nullopt) {
+TEST(at_missing_key_returns_nullopt) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   EXPECT_FALSE(query.value().at("missing").has_value());
 }
 
-TEST(URI_query, at_first_wins_on_duplicates) {
+TEST(at_first_wins_on_duplicates) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=1&foo=2"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "1");
 }
 
-TEST(URI_query, at_second_among_distinct_keys) {
+TEST(at_second_among_distinct_keys) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar&baz=qux"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("baz")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "qux");
 }
 
-TEST(URI_query, at_key_with_empty_value_returns_empty_string) {
+TEST(at_key_with_empty_value_returns_empty_string) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo="};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "");
 }
 
-TEST(URI_query, at_key_without_equals_returns_empty_string) {
+TEST(at_key_without_equals_returns_empty_string) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "");
 }
 
-TEST(URI_query, at_empty_key_lookup) {
+TEST(at_empty_key_lookup) {
   const sourcemeta::core::URI uri{"https://example.com/path?=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "bar");
 }
 
-TEST(URI_query, at_percent_encoded_value_left_untouched) {
+TEST(at_percent_encoded_value_left_untouched) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=%20bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "%20bar");
 }
 
-TEST(URI_query, at_empty_query_returns_nullopt) {
+TEST(at_empty_query_returns_nullopt) {
   const sourcemeta::core::URI uri{"https://example.com/path?"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   EXPECT_FALSE(query.value().at("anything").has_value());
 }
 
-TEST(URI_query, at_value_view_points_into_uri_storage) {
+TEST(at_value_view_points_into_uri_storage) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar&baz=qux"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("baz")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value().data(),
             query.value().raw().data() + query.value().raw().find("qux"));
 }
 
-TEST(URI_query, iterator_trailing_ampersand) {
+TEST(iterator_trailing_ampersand) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar&"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 2);
+  EXPECT_EQ(pairs.size(), 2);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
   EXPECT_EQ(pairs[1].first, "");
   EXPECT_EQ(pairs[1].second, "");
 }
 
-TEST(URI_query, iterator_leading_ampersand) {
+TEST(iterator_leading_ampersand) {
   const sourcemeta::core::URI uri{"https://example.com/path?&foo=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 2);
+  EXPECT_EQ(pairs.size(), 2);
   EXPECT_EQ(pairs[0].first, "");
   EXPECT_EQ(pairs[0].second, "");
   EXPECT_EQ(pairs[1].first, "foo");
   EXPECT_EQ(pairs[1].second, "bar");
 }
 
-TEST(URI_query, iterator_consecutive_ampersands_between_pairs) {
+TEST(iterator_consecutive_ampersands_between_pairs) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar&&baz=qux"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 3);
+  EXPECT_EQ(pairs.size(), 3);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
   EXPECT_EQ(pairs[1].first, "");
@@ -457,23 +457,23 @@ TEST(URI_query, iterator_consecutive_ampersands_between_pairs) {
   EXPECT_EQ(pairs[2].second, "qux");
 }
 
-TEST(URI_query, iterator_only_equals_sign) {
+TEST(iterator_only_equals_sign) {
   const sourcemeta::core::URI uri{"https://example.com/path?="};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "");
   EXPECT_EQ(pairs[0].second, "");
 }
 
-TEST(URI_query, iterator_postfix_increment_returns_previous) {
+TEST(iterator_postfix_increment_returns_previous) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=1&bar=2"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   auto iterator{query.value().begin()};
   const auto previous{iterator++};
   EXPECT_EQ(previous->first, "foo");
@@ -482,19 +482,19 @@ TEST(URI_query, iterator_postfix_increment_returns_previous) {
   EXPECT_EQ(iterator->second, "2");
 }
 
-TEST(URI_query, iterator_arrow_operator) {
+TEST(iterator_arrow_operator) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto iterator{query.value().begin()};
   EXPECT_EQ(iterator->first, "foo");
   EXPECT_EQ(iterator->second, "bar");
 }
 
-TEST(URI_query, iterator_multipass_forward_guarantee) {
+TEST(iterator_multipass_forward_guarantee) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=1&bar=2&baz=3"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto saved{query.value().begin()};
   auto advanced{saved};
   ++advanced;
@@ -505,10 +505,10 @@ TEST(URI_query, iterator_multipass_forward_guarantee) {
   EXPECT_EQ(advanced->second, "3");
 }
 
-TEST(URI_query, iterator_pair_views_into_query_storage) {
+TEST(iterator_pair_views_into_query_storage) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar&baz=qux"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto raw{query.value().raw()};
   auto iterator{query.value().begin()};
   EXPECT_EQ(iterator->first.data(), raw.data() + raw.find("foo"));
@@ -518,147 +518,147 @@ TEST(URI_query, iterator_pair_views_into_query_storage) {
   EXPECT_EQ(iterator->second.data(), raw.data() + raw.find("qux"));
 }
 
-TEST(URI_query, iterator_subdelims_in_value) {
+TEST(iterator_subdelims_in_value) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=!$'()*+,;"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "!$'()*+,;");
 }
 
-TEST(URI_query, iterator_pchar_colon_at_in_value) {
+TEST(iterator_pchar_colon_at_in_value) {
   const sourcemeta::core::URI uri{
       "https://example.com/path?foo=user:pass@host"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query.value()) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "user:pass@host");
 }
 
-TEST(URI_query, at_case_sensitive_no_match) {
+TEST(at_case_sensitive_no_match) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   EXPECT_FALSE(query.value().at("Foo").has_value());
   EXPECT_FALSE(query.value().at("FOO").has_value());
   EXPECT_FALSE(query.value().at("fOo").has_value());
 }
 
-TEST(URI_query, at_three_duplicates_returns_first) {
+TEST(at_three_duplicates_returns_first) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=1&foo=2&foo=3"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "1");
 }
 
-TEST(URI_query, at_first_value_empty_among_duplicates) {
+TEST(at_first_value_empty_among_duplicates) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=&foo=2"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "");
 }
 
-TEST(URI_query, at_value_containing_equals_returned_intact) {
+TEST(at_value_containing_equals_returned_intact) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=bar=baz"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "bar=baz");
 }
 
-TEST(URI_query, at_plus_sign_not_decoded_as_space) {
+TEST(at_plus_sign_not_decoded_as_space) {
   const sourcemeta::core::URI uri{"https://example.com/path?foo=a+b"};
   const auto query{uri.query()};
-  ASSERT_TRUE(query.has_value());
+  EXPECT_TRUE(query.has_value());
   const auto value{query.value().at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "a+b");
 }
 
-TEST(URI_query, standalone_raw_preserves_input) {
+TEST(standalone_raw_preserves_input) {
   const sourcemeta::core::URI::Query query{"foo=bar&baz=qux"};
   EXPECT_EQ(query.raw(), "foo=bar&baz=qux");
 }
 
-TEST(URI_query, standalone_empty_input) {
+TEST(standalone_empty_input) {
   const sourcemeta::core::URI::Query query{""};
   EXPECT_EQ(query.raw(), "");
   EXPECT_EQ(query.begin(), query.end());
   EXPECT_FALSE(query.at("anything").has_value());
 }
 
-TEST(URI_query, standalone_at_single_match) {
+TEST(standalone_at_single_match) {
   const sourcemeta::core::URI::Query query{"foo=bar"};
   const auto value{query.at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "bar");
 }
 
-TEST(URI_query, standalone_at_missing_key_returns_nullopt) {
+TEST(standalone_at_missing_key_returns_nullopt) {
   const sourcemeta::core::URI::Query query{"foo=bar"};
   EXPECT_FALSE(query.at("missing").has_value());
 }
 
-TEST(URI_query, standalone_at_first_wins_on_duplicates) {
+TEST(standalone_at_first_wins_on_duplicates) {
   const sourcemeta::core::URI::Query query{"foo=1&foo=2&foo=3"};
   const auto value{query.at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "1");
 }
 
-TEST(URI_query, standalone_at_key_without_equals_returns_empty_string) {
+TEST(standalone_at_key_without_equals_returns_empty_string) {
   const sourcemeta::core::URI::Query query{"foo"};
   const auto value{query.at("foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "");
 }
 
-TEST(URI_query, standalone_iterator_single_pair) {
+TEST(standalone_iterator_single_pair) {
   const sourcemeta::core::URI::Query query{"foo=bar"};
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 1);
+  EXPECT_EQ(pairs.size(), 1);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
 }
 
-TEST(URI_query, standalone_iterator_two_pairs_in_order) {
+TEST(standalone_iterator_two_pairs_in_order) {
   const sourcemeta::core::URI::Query query{"foo=bar&baz=qux"};
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 2);
+  EXPECT_EQ(pairs.size(), 2);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
   EXPECT_EQ(pairs[1].first, "baz");
   EXPECT_EQ(pairs[1].second, "qux");
 }
 
-TEST(URI_query, standalone_iterator_consecutive_ampersands) {
+TEST(standalone_iterator_consecutive_ampersands) {
   const sourcemeta::core::URI::Query query{"foo=bar&&baz=qux"};
   std::vector<std::pair<std::string_view, std::string_view>> pairs;
   for (const auto &pair : query) {
     pairs.emplace_back(pair);
   }
-  ASSERT_EQ(pairs.size(), 3);
+  EXPECT_EQ(pairs.size(), 3);
   EXPECT_EQ(pairs[0].first, "foo");
   EXPECT_EQ(pairs[0].second, "bar");
   EXPECT_EQ(pairs[1].first, "");
@@ -667,27 +667,27 @@ TEST(URI_query, standalone_iterator_consecutive_ampersands) {
   EXPECT_EQ(pairs[2].second, "qux");
 }
 
-TEST(URI_query, standalone_view_points_into_input_storage) {
+TEST(standalone_view_points_into_input_storage) {
   const std::string_view raw{"foo=bar&baz=qux"};
   const sourcemeta::core::URI::Query query{raw};
   EXPECT_EQ(query.raw().data(), raw.data());
   const auto value{query.at("baz")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value().data(), raw.data() + raw.find("qux"));
 }
 
-TEST(URI_query, standalone_no_question_mark_prefix_expected) {
+TEST(standalone_no_question_mark_prefix_expected) {
   const sourcemeta::core::URI::Query query{"?foo=bar"};
   EXPECT_EQ(query.raw(), "?foo=bar");
   const auto value{query.at("?foo")};
-  ASSERT_TRUE(value.has_value());
+  EXPECT_TRUE(value.has_value());
   EXPECT_EQ(value.value(), "bar");
   EXPECT_FALSE(query.at("foo").has_value());
 }
 
-TEST(URI_query, iri_unicode_query) {
+TEST(iri_unicode_query) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/?key=caf\xC3\xA9")};
-  ASSERT_TRUE(uri.query().has_value());
+  EXPECT_TRUE(uri.query().has_value());
   EXPECT_EQ(uri.query().value().raw(), "key=caf\xC3\xA9");
 }

--- a/test/uri/uri_rebase_path_test.cc
+++ b/test/uri/uri_rebase_path_test.cc
@@ -1,216 +1,216 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_rebase_path, single_segment_suffix) {
+TEST(single_segment_suffix) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar", "/foo", "/qux")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/qux/bar");
 }
 
-TEST(URI_rebase_path, multi_segment_suffix) {
+TEST(multi_segment_suffix) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar/baz", "/foo", "/qux")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/qux/bar/baz");
 }
 
-TEST(URI_rebase_path, new_prefix_with_trailing_slash_no_duplicate) {
+TEST(new_prefix_with_trailing_slash_no_duplicate) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar/baz", "/foo", "/qux/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/qux/bar/baz");
 }
 
-TEST(URI_rebase_path, old_prefix_with_trailing_slash) {
+TEST(old_prefix_with_trailing_slash) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar", "/foo/", "/qux")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/qux/bar");
 }
 
-TEST(URI_rebase_path, exact_match_empty_suffix) {
+TEST(exact_match_empty_suffix) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo", "/foo", "/qux")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/qux");
 }
 
-TEST(URI_rebase_path, exact_match_new_prefix_with_trailing_slash) {
+TEST(exact_match_new_prefix_with_trailing_slash) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo", "/foo", "/qux/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/qux/");
 }
 
-TEST(URI_rebase_path, prefix_not_matched) {
+TEST(prefix_not_matched) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/bar/baz", "/foo", "/qux")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, component_boundary_mismatch_returns_nullopt) {
+TEST(component_boundary_mismatch_returns_nullopt) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foobar", "/foo", "/qux")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, new_prefix_is_full_url) {
+TEST(new_prefix_is_full_url) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo/bar", "/foo",
                                                        "https://example.com")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "https://example.com/bar");
 }
 
-TEST(URI_rebase_path, new_prefix_is_full_url_with_trailing_slash) {
+TEST(new_prefix_is_full_url_with_trailing_slash) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo/bar", "/foo",
                                                        "https://example.com/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "https://example.com/bar");
 }
 
-TEST(URI_rebase_path, new_prefix_is_full_url_with_path) {
+TEST(new_prefix_is_full_url_with_path) {
   const auto result{sourcemeta::core::URI::rebase_path(
       "/foo/bar", "/foo", "https://example.com/api")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "https://example.com/api/bar");
 }
 
-TEST(URI_rebase_path, new_prefix_empty_with_suffix) {
+TEST(new_prefix_empty_with_suffix) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo/bar", "/foo", "")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_rebase_path, new_prefix_empty_empty_suffix) {
+TEST(new_prefix_empty_empty_suffix) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo", "/foo", "")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_rebase_path, old_prefix_empty_strips_leading_slash) {
+TEST(old_prefix_empty_strips_leading_slash) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo/bar", "", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/foo/bar");
 }
 
-TEST(URI_rebase_path, old_prefix_empty_new_prefix_empty) {
+TEST(old_prefix_empty_new_prefix_empty) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo/bar", "", "")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo/bar");
 }
 
-TEST(URI_rebase_path, root_old_prefix) {
+TEST(root_old_prefix) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo/bar", "/", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/foo/bar");
 }
 
-TEST(URI_rebase_path, dot_segments_in_path_resolved) {
+TEST(dot_segments_in_path_resolved) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/./bar", "/foo", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/bar");
 }
 
-TEST(URI_rebase_path, dot_dot_resolution_does_not_escape_prefix) {
+TEST(dot_dot_resolution_does_not_escape_prefix) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/../etc", "/foo", "/x")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, dot_dot_collapses_within_path) {
+TEST(dot_dot_collapses_within_path) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/a/../bar", "/foo", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/bar");
 }
 
-TEST(URI_rebase_path, percent_encoded_data_preserved) {
+TEST(percent_encoded_data_preserved) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/a%2Fb", "/foo", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/a%2Fb");
 }
 
-TEST(URI_rebase_path, malformed_percent_returns_nullopt) {
+TEST(malformed_percent_returns_nullopt) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/%2", "/foo", "/x")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, lowercase_hex_normalised) {
+TEST(lowercase_hex_normalised) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/%2f", "/foo", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/%2F");
 }
 
-TEST(URI_rebase_path, non_absolute_path_returns_nullopt) {
+TEST(non_absolute_path_returns_nullopt) {
   const auto result{
       sourcemeta::core::URI::rebase_path("foo/bar", "/foo", "/x")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, non_absolute_old_prefix_returns_nullopt) {
+TEST(non_absolute_old_prefix_returns_nullopt) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar", "foo", "/x")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, trailing_slash_in_path_preserved) {
+TEST(trailing_slash_in_path_preserved) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar/", "/foo", "/x")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/bar/");
 }
 
-TEST(URI_rebase_path, new_prefix_is_filesystem_path) {
+TEST(new_prefix_is_filesystem_path) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar", "/foo", "/var/lib/data")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/var/lib/data/bar");
 }
 
-TEST(URI_rebase_path, deep_nesting) {
+TEST(deep_nesting) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/a/b/c/d/e", "/a/b/c", "/x/y")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/x/y/d/e");
 }
 
-TEST(URI_rebase_path, empty_inputs_all_empty) {
+TEST(empty_inputs_all_empty) {
   const auto result{sourcemeta::core::URI::rebase_path("", "", "")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_rebase_path, empty_path_with_non_empty_prefix_returns_nullopt) {
+TEST(empty_path_with_non_empty_prefix_returns_nullopt) {
   const auto result{sourcemeta::core::URI::rebase_path("", "/foo", "/x")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_rebase_path, new_prefix_with_only_slash) {
+TEST(new_prefix_with_only_slash) {
   const auto result{
       sourcemeta::core::URI::rebase_path("/foo/bar", "/foo", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/bar");
 }
 
-TEST(URI_rebase_path, new_prefix_with_only_slash_empty_suffix) {
+TEST(new_prefix_with_only_slash_empty_suffix) {
   const auto result{sourcemeta::core::URI::rebase_path("/foo", "/foo", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/");
 }
 
-TEST(URI_rebase_path, iri_unicode_segments) {
+TEST(iri_unicode_segments) {
   const auto result{sourcemeta::core::URI::rebase_path(
       "/caf\xC3\xA9/page", "/caf\xC3\xA9", "/menu")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/menu/page");
 }
 
-TEST(URI_rebase_path, iri_rejects_invalid_utf8) {
+TEST(iri_rejects_invalid_utf8) {
   // An invalid UTF-8 byte sequence in the path is not a valid path
   const auto result{sourcemeta::core::URI::rebase_path(
       "/caf\xC3/page", "/caf\xC3/page", "/menu")};

--- a/test/uri/uri_rebase_test.cc
+++ b/test/uri/uri_rebase_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_rebase, absolute_to_relative_match) {
+TEST(absolute_to_relative_match) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI base{"https://example.com/foo"};
   const sourcemeta::core::URI new_base{"/qux"};
@@ -10,7 +10,7 @@ TEST(URI_rebase, absolute_to_relative_match) {
   EXPECT_EQ(uri.recompose(), "/qux/bar/baz");
 }
 
-TEST(URI_rebase, absolute_to_relative_mismatch) {
+TEST(absolute_to_relative_mismatch) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI base{"https://another.com/test"};
   const sourcemeta::core::URI new_base{"/qux"};
@@ -18,7 +18,7 @@ TEST(URI_rebase, absolute_to_relative_mismatch) {
   EXPECT_EQ(uri.recompose(), "https://example.com/foo/bar/baz");
 }
 
-TEST(URI_rebase, absolute_to_relative_equal) {
+TEST(absolute_to_relative_equal) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI base{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI new_base{"/qux"};
@@ -26,7 +26,7 @@ TEST(URI_rebase, absolute_to_relative_equal) {
   EXPECT_EQ(uri.recompose(), "/qux");
 }
 
-TEST(URI_rebase, rvalue_new_base) {
+TEST(rvalue_new_base) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI base{"https://example.com/foo"};
   sourcemeta::core::URI new_base{"/qux"};
@@ -34,21 +34,21 @@ TEST(URI_rebase, rvalue_new_base) {
   EXPECT_EQ(uri.recompose(), "/qux/bar/baz");
 }
 
-TEST(URI_rebase, rvalue_new_base_temporary) {
+TEST(rvalue_new_base_temporary) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI base{"https://example.com/foo"};
   uri.rebase(base, sourcemeta::core::URI{"/qux"});
   EXPECT_EQ(uri.recompose(), "/qux/bar/baz");
 }
 
-TEST(URI_rebase, rvalue_new_base_with_scheme_and_authority) {
+TEST(rvalue_new_base_with_scheme_and_authority) {
   sourcemeta::core::URI uri{"https://example.com/foo/bar/baz"};
   const sourcemeta::core::URI base{"https://example.com/foo"};
   uri.rebase(base, sourcemeta::core::URI{"https://other.example.com/qux"});
   EXPECT_EQ(uri.recompose(), "https://other.example.com/qux/bar/baz");
 }
 
-TEST(URI_rebase, iri_flag_propagates_from_new_base) {
+TEST(iri_flag_propagates_from_new_base) {
   const auto base{sourcemeta::core::URI::from_iri("https://example.com/dir/")};
   const auto new_base{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9/")};

--- a/test/uri/uri_recompose_relative_test.cc
+++ b/test/uri/uri_recompose_relative_test.cc
@@ -1,99 +1,99 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_recompose_relative, full_url) {
+TEST(full_url) {
   const sourcemeta::core::URI uri{"https://example.com/foo/bar"};
   EXPECT_EQ(uri.recompose_relative(), "/foo/bar");
 }
 
-TEST(URI_recompose_relative, full_url_with_query) {
+TEST(full_url_with_query) {
   const sourcemeta::core::URI uri{"https://example.com/foo?x=1"};
   EXPECT_EQ(uri.recompose_relative(), "/foo?x=1");
 }
 
-TEST(URI_recompose_relative, full_url_with_fragment) {
+TEST(full_url_with_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo#bar"};
   EXPECT_EQ(uri.recompose_relative(), "/foo#bar");
 }
 
-TEST(URI_recompose_relative, full_url_with_query_and_fragment) {
+TEST(full_url_with_query_and_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo?x=1#bar"};
   EXPECT_EQ(uri.recompose_relative(), "/foo?x=1#bar");
 }
 
-TEST(URI_recompose_relative, json_pointer_fragment_preserved) {
+TEST(json_pointer_fragment_preserved) {
   const sourcemeta::core::URI uri{
       "https://example.com/meta/target#/definitions/foo"};
   EXPECT_EQ(uri.recompose_relative(), "/meta/target#/definitions/foo");
 }
 
-TEST(URI_recompose_relative, no_path) {
+TEST(no_path) {
   const sourcemeta::core::URI uri{"https://example.com"};
   EXPECT_EQ(uri.recompose_relative(), "");
 }
 
-TEST(URI_recompose_relative, no_path_with_fragment) {
+TEST(no_path_with_fragment) {
   const sourcemeta::core::URI uri{"https://example.com#bar"};
   EXPECT_EQ(uri.recompose_relative(), "#bar");
 }
 
-TEST(URI_recompose_relative, relative_input) {
+TEST(relative_input) {
   const sourcemeta::core::URI uri{"foo/bar"};
   EXPECT_EQ(uri.recompose_relative(), "foo/bar");
 }
 
-TEST(URI_recompose_relative, relative_input_with_fragment) {
+TEST(relative_input_with_fragment) {
   const sourcemeta::core::URI uri{"foo/bar#baz"};
   EXPECT_EQ(uri.recompose_relative(), "foo/bar#baz");
 }
 
-TEST(URI_recompose_relative, fragment_only) {
+TEST(fragment_only) {
   const sourcemeta::core::URI uri{"#bar"};
   EXPECT_EQ(uri.recompose_relative(), "#bar");
 }
 
-TEST(URI_recompose_relative, empty_uri) {
+TEST(empty_uri) {
   const sourcemeta::core::URI uri{""};
   EXPECT_EQ(uri.recompose_relative(), "");
 }
 
-TEST(URI_recompose_relative, path_only_with_query) {
+TEST(path_only_with_query) {
   const sourcemeta::core::URI uri{"https://example.com/?x=1&y=2"};
   EXPECT_EQ(uri.recompose_relative(), "/?x=1&y=2");
 }
 
-TEST(URI_recompose_relative, percent_encoded_path) {
+TEST(percent_encoded_path) {
   const sourcemeta::core::URI uri{"https://example.com/foo%20bar"};
   EXPECT_EQ(uri.recompose_relative(), "/foo%20bar");
 }
 
-TEST(URI_recompose_relative, query_only_no_path) {
+TEST(query_only_no_path) {
   const sourcemeta::core::URI uri{"https://example.com?x=1"};
   EXPECT_EQ(uri.recompose_relative(), "?x=1");
 }
 
-TEST(URI_recompose_relative, query_and_fragment_no_path) {
+TEST(query_and_fragment_no_path) {
   const sourcemeta::core::URI uri{"https://example.com?x=1#bar"};
   EXPECT_EQ(uri.recompose_relative(), "?x=1#bar");
 }
 
-TEST(URI_recompose_relative, path_noscheme_first_segment_colon_encoded) {
+TEST(path_noscheme_first_segment_colon_encoded) {
   const sourcemeta::core::URI uri{"urn:foo:bar"};
   EXPECT_EQ(uri.recompose_relative(), "foo%3Abar");
 }
 
-TEST(URI_recompose_relative, path_noscheme_colon_only_in_first_segment) {
+TEST(path_noscheme_colon_only_in_first_segment) {
   const sourcemeta::core::URI uri{"urn:foo:bar/baz:qux"};
   EXPECT_EQ(uri.recompose_relative(), "foo%3Abar/baz:qux");
 }
 
-TEST(URI_recompose_relative, path_absolute_first_segment_colon_preserved) {
+TEST(path_absolute_first_segment_colon_preserved) {
   const sourcemeta::core::URI uri{"https://example.com/foo:bar"};
   EXPECT_EQ(uri.recompose_relative(), "/foo:bar");
 }
 
-TEST(URI_recompose_relative, iri_preserves_ucschar) {
+TEST(iri_preserves_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("caf\xC3\xA9/page?q=\xCE\xB1")};
   EXPECT_EQ(uri.recompose_relative(), "caf\xC3\xA9/page?q=\xCE\xB1");

--- a/test/uri/uri_recompose_test.cc
+++ b/test/uri/uri_recompose_test.cc
@@ -1,69 +1,69 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_recompose, example_1) {
+TEST(example_1) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_EQ(uri.recompose(), "https://example.com/foo");
 }
 
-TEST(URI_recompose, example_2) {
+TEST(example_2) {
   const sourcemeta::core::URI uri{"https://example.com/foo/../bar"};
   // Without canonicalize(), path with ".." is preserved
   EXPECT_EQ(uri.recompose(), "https://example.com/foo/../bar");
 }
 
-TEST(URI_recompose, example_3) {
+TEST(example_3) {
   const sourcemeta::core::URI uri{"https://example.com/foo/%25/bar"};
   EXPECT_EQ(uri.recompose(), "https://example.com/foo/%25/bar");
 }
 
-TEST(URI_recompose, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_EQ(uri.recompose(), "urn:example:schema");
 }
 
-TEST(URI_recompose, https_with_empty_fragment) {
+TEST(https_with_empty_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo#"};
   EXPECT_EQ(uri.recompose(), "https://example.com/foo#");
 }
 
-TEST(URI_recompose, http_trailing_slash) {
+TEST(http_trailing_slash) {
   const sourcemeta::core::URI uri{"http://example.com/"};
   EXPECT_EQ(uri.recompose(), "http://example.com/");
 }
 
-TEST(URI_recompose, no_scheme) {
+TEST(no_scheme) {
   const sourcemeta::core::URI uri{"example.com/foo"};
   EXPECT_EQ(uri.recompose(), "example.com/foo");
 }
 
-TEST(URI_recompose, empty_fragment) {
+TEST(empty_fragment) {
   const sourcemeta::core::URI uri{"#"};
   EXPECT_EQ(uri.recompose(), "#");
 }
 
-TEST(URI_recompose, empty_uri_default_constructor) {
+TEST(empty_uri_default_constructor) {
   const sourcemeta::core::URI uri;
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_recompose, empty_uri_string_constructor) {
+TEST(empty_uri_string_constructor) {
   const sourcemeta::core::URI uri{""};
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_recompose, preserves_scheme_case) {
+TEST(preserves_scheme_case) {
   const sourcemeta::core::URI uri{"HtTpS://example.com/foo"};
   EXPECT_EQ(uri.recompose(), "HtTpS://example.com/foo");
 }
 
-TEST(URI_recompose, preserves_host_case) {
+TEST(preserves_host_case) {
   const sourcemeta::core::URI uri{"https://ExAmPlE.CoM/foo"};
   EXPECT_EQ(uri.recompose(), "https://ExAmPlE.CoM/foo");
 }
 
-TEST(URI_recompose, preserves_scheme_and_host_case) {
+TEST(preserves_scheme_and_host_case) {
   const sourcemeta::core::URI uri{"HtTp://ExAmPlE.CoM/foo"};
   EXPECT_EQ(uri.recompose(), "HtTp://ExAmPlE.CoM/foo");
 }
@@ -72,142 +72,142 @@ TEST(URI_recompose, preserves_scheme_and_host_case) {
 // preserved during recomposition. They are semantically distinct from
 // their literal counterparts.
 
-TEST(URI_recompose, encoded_slash_in_path) {
+TEST(encoded_slash_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/v1%2F2.json"};
   EXPECT_EQ(uri.recompose(), "http://example.com/v1%2F2.json");
 }
 
-TEST(URI_recompose, encoded_slash_vs_literal_slash_in_path) {
+TEST(encoded_slash_vs_literal_slash_in_path) {
   const sourcemeta::core::URI encoded{"http://example.com/v1%2F2.json"};
   const sourcemeta::core::URI literal{"http://example.com/v1/2.json"};
   EXPECT_NE(encoded.recompose(), literal.recompose());
 }
 
-TEST(URI_recompose, encoded_question_mark_in_path) {
+TEST(encoded_question_mark_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/foo%3Fbar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/foo%3Fbar");
   EXPECT_FALSE(uri.query().has_value());
 }
 
-TEST(URI_recompose, encoded_hash_in_path) {
+TEST(encoded_hash_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/foo%23bar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/foo%23bar");
   EXPECT_FALSE(uri.fragment().has_value());
 }
 
-TEST(URI_recompose, encoded_ampersand_in_query) {
+TEST(encoded_ampersand_in_query) {
   const sourcemeta::core::URI uri{"http://example.com/path?foo%26bar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/path?foo%26bar");
 }
 
-TEST(URI_recompose, encoded_hash_in_query) {
+TEST(encoded_hash_in_query) {
   const sourcemeta::core::URI uri{"http://example.com/path?foo%23bar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/path?foo%23bar");
   EXPECT_FALSE(uri.fragment().has_value());
 }
 
-TEST(URI_recompose, encoded_slash_in_fragment) {
+TEST(encoded_slash_in_fragment) {
   const sourcemeta::core::URI uri{"http://example.com/path#/foo%2Fbar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/path#/foo%2Fbar");
 }
 
-TEST(URI_recompose, encoded_colon_in_path) {
+TEST(encoded_colon_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/foo%3Abar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/foo%3Abar");
 }
 
-TEST(URI_recompose, encoded_at_in_path) {
+TEST(encoded_at_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/foo%40bar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/foo%40bar");
 }
 
-TEST(URI_recompose, multiple_encoded_reserved_in_path) {
+TEST(multiple_encoded_reserved_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/a%2Fb%3Fc%23d%40e"};
   EXPECT_EQ(uri.recompose(), "http://example.com/a%2Fb%3Fc%23d%40e");
 }
 
-TEST(URI_recompose, mixed_encoded_and_literal_reserved_in_path) {
+TEST(mixed_encoded_and_literal_reserved_in_path) {
   const sourcemeta::core::URI uri{"http://example.com/a/b%2Fc/d"};
   EXPECT_EQ(uri.recompose(), "http://example.com/a/b%2Fc/d");
 }
 
-TEST(URI_recompose, encoded_low_byte_zero_padded) {
+TEST(encoded_low_byte_zero_padded) {
   const sourcemeta::core::URI uri{"http://example.com/foo%0Abar"};
   EXPECT_EQ(uri.recompose(), "http://example.com/foo%0Abar");
 }
 
 // RFC 3986 Section 5.3: path-absolute without authority must preserve
 // the leading slash verbatim during recomposition
-TEST(URI_recompose, path_absolute_without_authority_file) {
+TEST(path_absolute_without_authority_file) {
   const sourcemeta::core::URI uri{"file:/path"};
   EXPECT_EQ(uri.recompose(), "file:/path");
 }
 
-TEST(URI_recompose, path_absolute_without_authority_multi_segment) {
+TEST(path_absolute_without_authority_multi_segment) {
   const sourcemeta::core::URI uri{"x:/a/b/c"};
   EXPECT_EQ(uri.recompose(), "x:/a/b/c");
 }
 
-TEST(URI_recompose, path_empty_with_scheme) {
+TEST(path_empty_with_scheme) {
   const sourcemeta::core::URI uri{"a:"};
   EXPECT_EQ(uri.recompose(), "a:");
 }
 
-TEST(URI_recompose, path_absolute_without_authority_roundtrip) {
+TEST(path_absolute_without_authority_roundtrip) {
   const sourcemeta::core::URI original{"file:/path"};
   const sourcemeta::core::URI roundtrip{original.recompose()};
   EXPECT_EQ(roundtrip.recompose(), "file:/path");
 }
 
-TEST(URI_recompose, ipvfuture_no_colon_in_content) {
+TEST(ipvfuture_no_colon_in_content) {
   const sourcemeta::core::URI uri{"http://[v1.test]/"};
   EXPECT_EQ(uri.host().value(), "v1.test");
   EXPECT_EQ(uri.recompose(), "http://[v1.test]/");
 }
 
-TEST(URI_recompose, ipvfuture_with_colon_in_content) {
+TEST(ipvfuture_with_colon_in_content) {
   const sourcemeta::core::URI uri{"http://[vFF.a:b]/"};
   EXPECT_EQ(uri.host().value(), "vFF.a:b");
   EXPECT_EQ(uri.recompose(), "http://[vFF.a:b]/");
 }
 
-TEST(URI_recompose, iri_ascii_recomposes_like_uri) {
+TEST(iri_ascii_recomposes_like_uri) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/path?q=1#f")};
   EXPECT_EQ(uri.recompose(), "https://example.com/path?q=1#f");
 }
 
-TEST(URI_recompose, iri_path_ucschar) {
+TEST(iri_path_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9")};
   EXPECT_EQ(uri.recompose(), "https://example.com/caf\xC3\xA9");
 }
 
-TEST(URI_recompose, iri_host_ucschar) {
+TEST(iri_host_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://\xE4\xBE\x8B\xE3\x81\x88.jp/")};
   EXPECT_EQ(uri.recompose(), "https://\xE4\xBE\x8B\xE3\x81\x88.jp/");
 }
 
-TEST(URI_recompose, iri_query_ucschar) {
+TEST(iri_query_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/?key=caf\xC3\xA9")};
   EXPECT_EQ(uri.recompose(), "https://example.com/?key=caf\xC3\xA9");
 }
 
-TEST(URI_recompose, iri_fragment_ucschar) {
+TEST(iri_fragment_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/#section-\xCE\xB1")};
   EXPECT_EQ(uri.recompose(), "https://example.com/#section-\xCE\xB1");
 }
 
-TEST(URI_recompose, iri_userinfo_ucschar) {
+TEST(iri_userinfo_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://user\xE5\x90\x8D@example.com/")};
   EXPECT_EQ(uri.recompose(), "https://user\xE5\x90\x8D@example.com/");
 }
 
-TEST(URI_recompose, iri_query_private_use) {
+TEST(iri_query_private_use) {
   // RFC 3987 permits private-use characters only in the query, where they must
   // round trip rather than being percent-encoded
   const auto uri{
@@ -215,13 +215,13 @@ TEST(URI_recompose, iri_query_private_use) {
   EXPECT_EQ(uri.recompose(), "https://example.com/?\xEE\x80\x80");
 }
 
-TEST(URI_recompose, iri_existing_percent_encoding_preserved) {
+TEST(iri_existing_percent_encoding_preserved) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/%25/caf\xC3\xA9")};
   EXPECT_EQ(uri.recompose(), "https://example.com/%25/caf\xC3\xA9");
 }
 
-TEST(URI_recompose, iri_all_components) {
+TEST(iri_all_components) {
   // Borrowed from the existing IRI syntax tests in this suite.
   const std::string input{
       "https://user\xE5\x90\x8D@\xE4\xBE\x8B\xE3\x81\x88.jp/"
@@ -229,14 +229,14 @@ TEST(URI_recompose, iri_all_components) {
   EXPECT_EQ(sourcemeta::core::URI::from_iri(input).recompose(), input);
 }
 
-TEST(URI_recompose, iri_four_byte_ucschar) {
+TEST(iri_four_byte_ucschar) {
   // A 4-byte UTF-8 character (here U+1F600) must be preserved literally
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/\xF0\x9F\x98\x80")};
   EXPECT_EQ(uri.recompose(), "https://example.com/\xF0\x9F\x98\x80");
 }
 
-TEST(URI_recompose, iri_lower_boundary_ucschar) {
+TEST(iri_lower_boundary_ucschar) {
   // U+00A0 is the lowest non-ASCII character an IRI may carry
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/\xC2\xA0")};

--- a/test/uri/uri_recompose_without_fragment_test.cc
+++ b/test/uri/uri_recompose_without_fragment_test.cc
@@ -1,14 +1,14 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_recompose_without_fragment, example_1) {
+TEST(example_1) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment(), "https://example.com/foo");
 }
 
-TEST(URI_recompose_without_fragment, example_2) {
+TEST(example_2) {
   const sourcemeta::core::URI uri{"https://example.com/foo/../bar"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   // Without canonicalize(), path with ".." is preserved
@@ -16,39 +16,39 @@ TEST(URI_recompose_without_fragment, example_2) {
             "https://example.com/foo/../bar");
 }
 
-TEST(URI_recompose_without_fragment, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(), "urn:example:schema");
 }
 
-TEST(URI_recompose_without_fragment, https_with_empty_fragment) {
+TEST(https_with_empty_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo#"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(),
             "https://example.com/foo");
 }
 
-TEST(URI_recompose_without_fragment, http_trailing_slash) {
+TEST(http_trailing_slash) {
   const sourcemeta::core::URI uri{"http://example.com/"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(), "http://example.com/");
 }
 
-TEST(URI_recompose_without_fragment, https_with_fragment) {
+TEST(https_with_fragment) {
   const sourcemeta::core::URI uri{"https://example.com/foo#bar"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(),
             "https://example.com/foo");
 }
 
-TEST(URI_recompose_without_fragment, urn_with_fragment) {
+TEST(urn_with_fragment) {
   const sourcemeta::core::URI uri{"urn:example:schema#test"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(), "urn:example:schema");
 }
 
-TEST(URI_recompose_without_fragment, tag_with_fragment) {
+TEST(tag_with_fragment) {
   const sourcemeta::core::URI uri{
       "tag:example.com,2024-06-12:some-unique-id#tag"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
@@ -56,35 +56,35 @@ TEST(URI_recompose_without_fragment, tag_with_fragment) {
             "tag:example.com,2024-06-12:some-unique-id");
 }
 
-TEST(URI_recompose_without_fragment, fragment_only) {
+TEST(fragment_only) {
   const sourcemeta::core::URI uri{"#bar"};
   EXPECT_FALSE(uri.recompose_without_fragment().has_value());
 }
 
-TEST(URI_recompose_without_fragment, preserves_scheme_case) {
+TEST(preserves_scheme_case) {
   const sourcemeta::core::URI uri{"HtTpS://example.com/foo#bar"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(),
             "HtTpS://example.com/foo");
 }
 
-TEST(URI_recompose_without_fragment, preserves_host_case) {
+TEST(preserves_host_case) {
   const sourcemeta::core::URI uri{"https://ExAmPlE.CoM/foo#bar"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(),
             "https://ExAmPlE.CoM/foo");
 }
 
-TEST(URI_recompose_without_fragment, preserves_scheme_and_host_case) {
+TEST(preserves_scheme_and_host_case) {
   const sourcemeta::core::URI uri{"HtTp://ExAmPlE.CoM/foo#bar"};
   EXPECT_TRUE(uri.recompose_without_fragment().has_value());
   EXPECT_EQ(uri.recompose_without_fragment().value(), "HtTp://ExAmPlE.CoM/foo");
 }
 
-TEST(URI_recompose_without_fragment, iri_preserves_ucschar) {
+TEST(iri_preserves_ucschar) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9#frag")};
   const auto result{uri.recompose_without_fragment()};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "https://example.com/caf\xC3\xA9");
 }

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -1,120 +1,120 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_relative_to, absolute_absolute_base_true_1) {
+TEST(absolute_absolute_base_true_1) {
   const sourcemeta::core::URI base{"https://www.example.com"};
   sourcemeta::core::URI uri{"https://www.example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "foo");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_true_2) {
+TEST(absolute_absolute_base_true_2) {
   const sourcemeta::core::URI base{"https://www.example.com/foo"};
   sourcemeta::core::URI uri{"https://www.example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_true_3) {
+TEST(absolute_absolute_base_true_3) {
   const sourcemeta::core::URI base{"https://www.example.com/foo"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=1"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "bar?q=1");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_true_4) {
+TEST(absolute_absolute_base_true_4) {
   const sourcemeta::core::URI base{"https://www.example.com/foo"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar#baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "bar#baz");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_1) {
+TEST(absolute_absolute_base_false_1) {
   const sourcemeta::core::URI base{"https://www.example.com/foo"};
   sourcemeta::core::URI uri{"http://www.example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "http://www.example.com/foo");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_2) {
+TEST(absolute_absolute_base_false_2) {
   const sourcemeta::core::URI base{"https://www.example.com/foo"};
   sourcemeta::core::URI uri{"https://www.example.com"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "https://www.example.com");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_3) {
+TEST(absolute_absolute_base_false_3) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
   sourcemeta::core::URI uri{"https://www.example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../foo");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_4) {
+TEST(absolute_absolute_base_false_4) {
   const sourcemeta::core::URI base{"https://foo.com"};
   sourcemeta::core::URI uri{"https://bar.com"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "https://bar.com");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_different_ports) {
+TEST(absolute_absolute_base_false_different_ports) {
   const sourcemeta::core::URI base{"http://localhost:8000"};
   sourcemeta::core::URI uri{"http://localhost:9000/schemas/test.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "http://localhost:9000/schemas/test.json");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_different_userinfo) {
+TEST(absolute_absolute_base_false_different_userinfo) {
   const sourcemeta::core::URI base{"https://alice@example.com/foo"};
   sourcemeta::core::URI uri{"https://bob@example.com/foo/bar"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "https://bob@example.com/foo/bar");
 }
 
-TEST(URI_relative_to, absolute_absolute_base_false_userinfo_vs_none) {
+TEST(absolute_absolute_base_false_userinfo_vs_none) {
   const sourcemeta::core::URI base{"https://example.com/foo"};
   sourcemeta::core::URI uri{"https://alice@example.com/foo/bar"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "https://alice@example.com/foo/bar");
 }
 
-TEST(URI_relative_to, absolute_relative_1) {
+TEST(absolute_relative_1) {
   const sourcemeta::core::URI base{"https://www.example.com"};
   sourcemeta::core::URI uri{"foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "foo");
 }
 
-TEST(URI_relative_to, absolute_relative_2) {
+TEST(absolute_relative_2) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar/baz"};
   sourcemeta::core::URI uri{"/qux"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "/qux");
 }
 
-TEST(URI_relative_to, relative_absolute_1) {
+TEST(relative_absolute_1) {
   const sourcemeta::core::URI base{"foo/bar"};
   sourcemeta::core::URI uri{"https://www.example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "https://www.example.com/foo");
 }
 
-TEST(URI_relative_to, relative_relative_1) {
+TEST(relative_relative_1) {
   const sourcemeta::core::URI base{"foo/bar"};
   sourcemeta::core::URI uri{"foo/bar/baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "foo/bar/baz");
 }
 
-TEST(URI_relative_to, urn_1) {
+TEST(urn_1) {
   const sourcemeta::core::URI base{"schema:"};
   sourcemeta::core::URI uri{"schema:myschema"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "myschema");
 }
 
-TEST(URI_relative_to, absolute_absolute_trailing_slash) {
+TEST(absolute_absolute_trailing_slash) {
   const sourcemeta::core::URI base{
       "https://github.com/apis-json/api-json/blob/develop/spec"};
   sourcemeta::core::URI uri{
@@ -123,56 +123,56 @@ TEST(URI_relative_to, absolute_absolute_trailing_slash) {
   EXPECT_EQ(uri.recompose(), "spec/");
 }
 
-TEST(URI_relative_to, target_is_prefix_of_base_parent) {
+TEST(target_is_prefix_of_base_parent) {
   const sourcemeta::core::URI base{"https://example.com/foo/bar/baz"};
   sourcemeta::core::URI uri{"https://example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../../foo");
 }
 
-TEST(URI_relative_to, target_is_one_level_up_at_root) {
+TEST(target_is_one_level_up_at_root) {
   const sourcemeta::core::URI base{"https://example.com/foo/bar"};
   sourcemeta::core::URI uri{"https://example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../foo");
 }
 
-TEST(URI_relative_to, target_is_root) {
+TEST(target_is_root) {
   const sourcemeta::core::URI base{"https://example.com/foo/bar"};
   sourcemeta::core::URI uri{"https://example.com/"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../");
 }
 
-TEST(URI_relative_to, base_ends_with_slash) {
+TEST(base_ends_with_slash) {
   const sourcemeta::core::URI base{"https://example.com/foo/"};
   sourcemeta::core::URI uri{"https://example.com/foo/bar"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "bar");
 }
 
-TEST(URI_relative_to, base_root_only) {
+TEST(base_root_only) {
   const sourcemeta::core::URI base{"https://example.com/"};
   sourcemeta::core::URI uri{"https://example.com/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "foo");
 }
 
-TEST(URI_relative_to, sibling_paths_same_directory) {
+TEST(sibling_paths_same_directory) {
   const sourcemeta::core::URI base{"https://example.com/schemas/bar.json"};
   sourcemeta::core::URI uri{"https://example.com/schemas/foo.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "foo.json");
 }
 
-TEST(URI_relative_to, double_slash_with_trailing_slash) {
+TEST(double_slash_with_trailing_slash) {
   const sourcemeta::core::URI base{"https://example.com/slash/"};
   sourcemeta::core::URI uri{"https://example.com/slash/file.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "file.json");
 }
 
-TEST(URI_relative_to, different_directories_same_host_needs_dotdot) {
+TEST(different_directories_same_host_needs_dotdot) {
   const sourcemeta::core::URI base{
       "https://example.com/schemas/with-rebase-same-host.json"};
   sourcemeta::core::URI uri{"https://example.com/bundling/single"};
@@ -180,77 +180,77 @@ TEST(URI_relative_to, different_directories_same_host_needs_dotdot) {
   EXPECT_EQ(uri.recompose(), "../bundling/single");
 }
 
-TEST(URI_relative_to, different_directories_same_host_needs_dotdot_2) {
+TEST(different_directories_same_host_needs_dotdot_2) {
   const sourcemeta::core::URI base{"https://example.com/foo/bar/baz.json"};
   sourcemeta::core::URI uri{"https://example.com/qux/test.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../../qux/test.json");
 }
 
-TEST(URI_relative_to, different_directories_same_host_needs_dotdot_3) {
+TEST(different_directories_same_host_needs_dotdot_3) {
   const sourcemeta::core::URI base{"https://example.com/a/b/c.json"};
   sourcemeta::core::URI uri{"https://example.com/d.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../../d.json");
 }
 
-TEST(URI_relative_to, file_same_directory) {
+TEST(file_same_directory) {
   const sourcemeta::core::URI base{"file:///home/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///home/user/schemas/other.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "other.json");
 }
 
-TEST(URI_relative_to, file_subdirectory) {
+TEST(file_subdirectory) {
   const sourcemeta::core::URI base{"file:///home/user/schemas"};
   sourcemeta::core::URI uri{"file:///home/user/schemas/sub/test.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "sub/test.json");
 }
 
-TEST(URI_relative_to, file_parent_directory) {
+TEST(file_parent_directory) {
   const sourcemeta::core::URI base{"file:///home/user/schemas/sub/base.json"};
   sourcemeta::core::URI uri{"file:///home/user/schemas/other.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../other.json");
 }
 
-TEST(URI_relative_to, file_different_root) {
+TEST(file_different_root) {
   const sourcemeta::core::URI base{"file:///home/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///var/data/test.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../../../var/data/test.json");
 }
 
-TEST(URI_relative_to, file_same_file) {
+TEST(file_same_file) {
   const sourcemeta::core::URI base{"file:///home/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///home/user/schemas/base.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_relative_to, file_with_fragment) {
+TEST(file_with_fragment) {
   const sourcemeta::core::URI base{"file:///home/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///home/user/schemas/other.json#/defs/foo"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "other.json#/defs/foo");
 }
 
-TEST(URI_relative_to, file_windows_same_directory) {
+TEST(file_windows_same_directory) {
   const sourcemeta::core::URI base{"file:///C:/Users/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///C:/Users/user/schemas/other.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "other.json");
 }
 
-TEST(URI_relative_to, file_windows_subdirectory) {
+TEST(file_windows_subdirectory) {
   const sourcemeta::core::URI base{"file:///C:/Users/user/schemas"};
   sourcemeta::core::URI uri{"file:///C:/Users/user/schemas/sub/test.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "sub/test.json");
 }
 
-TEST(URI_relative_to, file_windows_parent_directory) {
+TEST(file_windows_parent_directory) {
   const sourcemeta::core::URI base{
       "file:///C:/Users/user/schemas/sub/base.json"};
   sourcemeta::core::URI uri{"file:///C:/Users/user/schemas/other.json"};
@@ -258,21 +258,21 @@ TEST(URI_relative_to, file_windows_parent_directory) {
   EXPECT_EQ(uri.recompose(), "../other.json");
 }
 
-TEST(URI_relative_to, file_windows_different_drive) {
+TEST(file_windows_different_drive) {
   const sourcemeta::core::URI base{"file:///C:/Users/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///D:/Data/test.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "../../../../D:/Data/test.json");
 }
 
-TEST(URI_relative_to, file_windows_same_file) {
+TEST(file_windows_same_file) {
   const sourcemeta::core::URI base{"file:///C:/Users/user/schemas/base.json"};
   sourcemeta::core::URI uri{"file:///C:/Users/user/schemas/base.json"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI_relative_to, file_windows_with_fragment) {
+TEST(file_windows_with_fragment) {
   const sourcemeta::core::URI base{"file:///C:/Users/user/schemas/base.json"};
   sourcemeta::core::URI uri{
       "file:///C:/Users/user/schemas/other.json#/defs/foo"};
@@ -280,7 +280,7 @@ TEST(URI_relative_to, file_windows_with_fragment) {
   EXPECT_EQ(uri.recompose(), "other.json#/defs/foo");
 }
 
-TEST(URI_relative_to, iri_preserves_ucschar) {
+TEST(iri_preserves_ucschar) {
   const auto base{sourcemeta::core::URI::from_iri("https://example.com/dir/")};
   auto uri{
       sourcemeta::core::URI::from_iri("https://example.com/dir/caf\xC3\xA9")};
@@ -288,84 +288,84 @@ TEST(URI_relative_to, iri_preserves_ucschar) {
   EXPECT_EQ(uri.recompose(), "caf\xC3\xA9");
 }
 
-TEST(URI_relative_to, same_path_only_query_differs) {
+TEST(same_path_only_query_differs) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=1"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=1");
 }
 
-TEST(URI_relative_to, same_path_only_fragment_differs) {
+TEST(same_path_only_fragment_differs) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar#baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "#baz");
 }
 
-TEST(URI_relative_to, same_path_query_and_fragment_differ) {
+TEST(same_path_query_and_fragment_differ) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=1#baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=1#baz");
 }
 
-TEST(URI_relative_to, same_path_base_query_target_none) {
+TEST(same_path_base_query_target_none) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "bar");
 }
 
-TEST(URI_relative_to, same_path_base_query_target_fragment_only) {
+TEST(same_path_base_query_target_fragment_only) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar#baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "bar#baz");
 }
 
-TEST(URI_relative_to, same_path_base_query_target_other_query) {
+TEST(same_path_base_query_target_other_query) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/bar?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/bar?q=2"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=2");
 }
 
-TEST(URI_relative_to, same_directory_path_base_query_target_none) {
+TEST(same_directory_path_base_query_target_none) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "./");
 }
 
-TEST(URI_relative_to, same_directory_path_base_query_target_fragment) {
+TEST(same_directory_path_base_query_target_fragment) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/#baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "./#baz");
 }
 
-TEST(URI_relative_to, same_directory_path_target_query) {
+TEST(same_directory_path_target_query) {
   const sourcemeta::core::URI base{"https://www.example.com/foo/?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com/foo/?q=2"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=2");
 }
 
-TEST(URI_relative_to, authority_no_path_only_fragment_differs) {
+TEST(authority_no_path_only_fragment_differs) {
   const sourcemeta::core::URI base{"https://www.example.com"};
   sourcemeta::core::URI uri{"https://www.example.com#baz"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "#baz");
 }
 
-TEST(URI_relative_to, authority_no_path_only_query_differs) {
+TEST(authority_no_path_only_query_differs) {
   const sourcemeta::core::URI base{"https://www.example.com?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com?q=2"};
   uri.relative_to(base);
   EXPECT_EQ(uri.recompose(), "?q=2");
 }
 
-TEST(URI_relative_to, authority_no_path_base_query_target_none) {
+TEST(authority_no_path_base_query_target_none) {
   const sourcemeta::core::URI base{"https://www.example.com?q=1"};
   sourcemeta::core::URI uri{"https://www.example.com"};
   uri.relative_to(base);

--- a/test/uri/uri_resolve_from_test.cc
+++ b/test/uri/uri_resolve_from_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
@@ -9,399 +9,399 @@
 // This implementation extends RFC 3986 to support relative bases in specific
 // cases as a convenience feature.
 
-TEST(URI_resolve_from, extension_relative_base_unchanged) {
+TEST(extension_relative_base_unchanged) {
   const sourcemeta::core::URI base{"../foo"};
   sourcemeta::core::URI relative{"../baz"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "../baz");
 }
 
-TEST(URI_resolve_from, extension_fragment_on_relative_path) {
+TEST(extension_fragment_on_relative_path) {
   const sourcemeta::core::URI base{"foo"};
   sourcemeta::core::URI relative{"#/bar"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "foo#/bar");
 }
 
-TEST(URI_resolve_from, extension_base_relative_path_leading_slash) {
+TEST(extension_base_relative_path_leading_slash) {
   const sourcemeta::core::URI base{"/foo"};
   sourcemeta::core::URI relative{"#/bar"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "/foo#/bar");
 }
 
-TEST(URI_resolve_from, extension_relative_path_from_relative_path) {
+TEST(extension_relative_path_from_relative_path) {
   const sourcemeta::core::URI base{"foo/bar/baz"};
   sourcemeta::core::URI relative{"qux"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "foo/bar/qux");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_absolute_uri_with_scheme) {
+TEST(rfc3986_normal_absolute_uri_with_scheme) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g:h"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "g:h");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_path_g) {
+TEST(rfc3986_normal_relative_path_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_path_dot_g) {
+TEST(rfc3986_normal_relative_path_dot_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"./g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_path_g_slash) {
+TEST(rfc3986_normal_relative_path_g_slash) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g/"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_absolute_path) {
+TEST(rfc3986_normal_absolute_path) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"/g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/g");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_network_path) {
+TEST(rfc3986_normal_network_path) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"//g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://g");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_query_only) {
+TEST(rfc3986_normal_query_only) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"?y"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/d;p?y");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_with_query) {
+TEST(rfc3986_normal_relative_with_query) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g?y"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g?y");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_fragment_only) {
+TEST(rfc3986_normal_fragment_only) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"#s"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/d;p?q#s");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_with_fragment) {
+TEST(rfc3986_normal_relative_with_fragment) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g#s"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g#s");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_with_query_and_fragment) {
+TEST(rfc3986_normal_relative_with_query_and_fragment) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g?y#s"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g?y#s");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_path_parameter) {
+TEST(rfc3986_normal_path_parameter) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{";x"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/;x");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_with_parameter) {
+TEST(rfc3986_normal_relative_with_parameter) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g;x"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g;x");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_relative_with_param_query_fragment) {
+TEST(rfc3986_normal_relative_with_param_query_fragment) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g;x?y#s"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g;x?y#s");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_empty_reference) {
+TEST(rfc3986_normal_empty_reference) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{""};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/d;p?q");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dot_only) {
+TEST(rfc3986_normal_dot_only) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"."};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dot_slash) {
+TEST(rfc3986_normal_dot_slash) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"./"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dotdot_only) {
+TEST(rfc3986_normal_dotdot_only) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{".."};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dotdot_slash) {
+TEST(rfc3986_normal_dotdot_slash) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dotdot_g) {
+TEST(rfc3986_normal_dotdot_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/g");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dotdot_dotdot) {
+TEST(rfc3986_normal_dotdot_dotdot) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../.."};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dotdot_dotdot_slash) {
+TEST(rfc3986_normal_dotdot_dotdot_slash) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../../"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/");
 }
 
-TEST(URI_resolve_from, rfc3986_normal_dotdot_dotdot_g) {
+TEST(rfc3986_normal_dotdot_dotdot_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../../g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_excessive_dotdot_1) {
+TEST(rfc3986_abnormal_excessive_dotdot_1) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../../../g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_excessive_dotdot_2) {
+TEST(rfc3986_abnormal_excessive_dotdot_2) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"../../../../g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_absolute_with_dot) {
+TEST(rfc3986_abnormal_absolute_with_dot) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"/./g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_absolute_with_dotdot) {
+TEST(rfc3986_abnormal_absolute_with_dotdot) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"/../g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_g_dot) {
+TEST(rfc3986_abnormal_g_dot) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g."};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g.");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_dot_g) {
+TEST(rfc3986_abnormal_dot_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{".g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/.g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_g_dotdot) {
+TEST(rfc3986_abnormal_g_dotdot) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g.."};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g..");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_dotdot_g) {
+TEST(rfc3986_abnormal_dotdot_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"..g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/..g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_dot_dotdot_dot_g) {
+TEST(rfc3986_abnormal_dot_dotdot_dot_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"./../g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/g");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_dot_slash_g) {
+TEST(rfc3986_abnormal_dot_slash_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"./g/."};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g/");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_g_slash_dot_h) {
+TEST(rfc3986_abnormal_g_slash_dot_h) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g/./h"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g/h");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_g_dotdot_h) {
+TEST(rfc3986_abnormal_g_dotdot_h) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g/../h"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/h");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_g_semicolon_x_equal_1_dotdot_y) {
+TEST(rfc3986_abnormal_g_semicolon_x_equal_1_dotdot_y) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g;x=1/./y"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g;x=1/y");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_g_semicolon_x_equal_1_dotdot_dotdot_y) {
+TEST(rfc3986_abnormal_g_semicolon_x_equal_1_dotdot_dotdot_y) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g;x=1/../y"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/y");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_query_dot_slash_x) {
+TEST(rfc3986_abnormal_query_dot_slash_x) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g?y/./x"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g?y/./x");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_query_dotdot_x) {
+TEST(rfc3986_abnormal_query_dotdot_x) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g?y/../x"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g?y/../x");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_fragment_dot_slash_x) {
+TEST(rfc3986_abnormal_fragment_dot_slash_x) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g#s/./x"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g#s/./x");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_fragment_dotdot_x) {
+TEST(rfc3986_abnormal_fragment_dotdot_x) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"g#s/../x"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g#s/../x");
 }
 
-TEST(URI_resolve_from, rfc3986_abnormal_http_colon_g) {
+TEST(rfc3986_abnormal_http_colon_g) {
   const sourcemeta::core::URI base{"http://a/b/c/d;p?q"};
   sourcemeta::core::URI reference{"http:g"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http:g");
 }
 
-TEST(URI_resolve_from, absolute_relative_with_slash) {
+TEST(absolute_relative_with_slash) {
   const sourcemeta::core::URI base{"https://foobar.com/foo/bar"};
   sourcemeta::core::URI relative{"/baz"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "https://foobar.com/baz");
 }
 
-TEST(URI_resolve_from, example_1) {
+TEST(example_1) {
   const sourcemeta::core::URI base{"https://foobar.com/foo/bar"};
   sourcemeta::core::URI relative{"../baz"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "https://foobar.com/baz");
 }
 
-TEST(URI_resolve_from, add_fragment) {
+TEST(add_fragment) {
   const sourcemeta::core::URI base{"https://foobar.com/foo/bar"};
   sourcemeta::core::URI relative{"#baz"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "https://foobar.com/foo/bar#baz");
 }
 
-TEST(URI_resolve_from, change_fragment) {
+TEST(change_fragment) {
   const sourcemeta::core::URI base{"https://foobar.com/foo/bar#baz"};
   sourcemeta::core::URI relative{"#qux"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "https://foobar.com/foo/bar#qux");
 }
 
-TEST(URI_resolve_from, rfc3986_resolve_with_relative_path) {
+TEST(rfc3986_resolve_with_relative_path) {
   const sourcemeta::core::URI base{"s://h/a/c"};
   sourcemeta::core::URI relative_path{"../../b"};
   relative_path.resolve_from(base);
   EXPECT_EQ(relative_path.recompose(), "s://h/b");
 }
 
-TEST(URI_resolve_from, rfc3986_resolve_with_empty) {
+TEST(rfc3986_resolve_with_empty) {
   const sourcemeta::core::URI base{"s://h/a/c"};
   sourcemeta::core::URI empty{""};
   empty.resolve_from(base);
   EXPECT_EQ(empty.recompose(), "s://h/a/c");
 }
 
-TEST(URI_resolve_from, rfc3986_resolve_with_query) {
+TEST(rfc3986_resolve_with_query) {
   const sourcemeta::core::URI base{"s://h/a/c"};
   sourcemeta::core::URI query{"?x=y"};
   query.resolve_from(base);
   EXPECT_EQ(query.recompose(), "s://h/a/c?x=y");
 }
 
-TEST(URI_resolve_from, rfc3986_resolve_with_fragment) {
+TEST(rfc3986_resolve_with_fragment) {
   const sourcemeta::core::URI base{"s://h/a/c"};
   sourcemeta::core::URI fragment{"#x=y"};
   fragment.resolve_from(base);
   EXPECT_EQ(fragment.recompose(), "s://h/a/c#x=y");
 }
 
-TEST(URI_resolve_from, rfc3986_resolve_with_absolute_path) {
+TEST(rfc3986_resolve_with_absolute_path) {
   const sourcemeta::core::URI base{"s://h/a/c"};
   sourcemeta::core::URI absolute_path{"/././x"};
   absolute_path.resolve_from(base);
   EXPECT_EQ(absolute_path.recompose(), "s://h/x");
 }
 
-TEST(URI_resolve_from, file_1) {
+TEST(file_1) {
   const sourcemeta::core::URI base{"file:///foo/bar/baz"};
   sourcemeta::core::URI relative{"./qux"};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "file:///foo/bar/qux");
 }
 
-TEST(URI_resolve_from, file_from_path) {
+TEST(file_from_path) {
   const std::filesystem::path base_path{"/foo/bar/baz"};
   const auto base{sourcemeta::core::URI::from_path(base_path)};
   sourcemeta::core::URI relative{"./qux"};
@@ -409,42 +409,42 @@ TEST(URI_resolve_from, file_from_path) {
   EXPECT_EQ(relative.recompose(), "file:///foo/bar/qux");
 }
 
-TEST(URI_resolve_from, network_path_with_port) {
+TEST(network_path_with_port) {
   const sourcemeta::core::URI base{"http://example.com/path"};
   sourcemeta::core::URI reference{"//other.com:8080/newpath"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://other.com:8080/newpath");
 }
 
-TEST(URI_resolve_from, base_with_no_path) {
+TEST(base_with_no_path) {
   const sourcemeta::core::URI base{"http://example.com"};
   sourcemeta::core::URI reference{"path"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://example.com/path");
 }
 
-TEST(URI_resolve_from, base_with_trailing_slash) {
+TEST(base_with_trailing_slash) {
   const sourcemeta::core::URI base{"http://example.com/dir/"};
   sourcemeta::core::URI reference{"file"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://example.com/dir/file");
 }
 
-TEST(URI_resolve_from, query_replaces_base_query) {
+TEST(query_replaces_base_query) {
   const sourcemeta::core::URI base{"http://example.com/path?oldquery"};
   sourcemeta::core::URI reference{"?newquery"};
   reference.resolve_from(base);
   EXPECT_EQ(reference.recompose(), "http://example.com/path?newquery");
 }
 
-TEST(URI_resolve_from, iri_relative_reference_with_ucschar) {
+TEST(iri_relative_reference_with_ucschar) {
   const auto base{sourcemeta::core::URI::from_iri("https://example.com/dir/")};
   auto relative{sourcemeta::core::URI::from_iri("caf\xC3\xA9")};
   relative.resolve_from(base);
   EXPECT_EQ(relative.recompose(), "https://example.com/dir/caf\xC3\xA9");
 }
 
-TEST(URI_resolve_from, iri_preserves_base_ucschar) {
+TEST(iri_preserves_base_ucschar) {
   const auto base{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9/page")};
   auto relative{sourcemeta::core::URI::from_iri("other")};
@@ -452,7 +452,7 @@ TEST(URI_resolve_from, iri_preserves_base_ucschar) {
   EXPECT_EQ(relative.recompose(), "https://example.com/caf\xC3\xA9/other");
 }
 
-TEST(URI_resolve_from, iri_flag_propagates_from_base) {
+TEST(iri_flag_propagates_from_base) {
   const auto base{
       sourcemeta::core::URI::from_iri("https://example.com/caf\xC3\xA9/page")};
   sourcemeta::core::URI relative{"other"};
@@ -461,7 +461,7 @@ TEST(URI_resolve_from, iri_flag_propagates_from_base) {
   EXPECT_TRUE(relative.is_internationalized());
 }
 
-TEST(URI_resolve_from, iri_rfc3986_normal_example_path) {
+TEST(iri_rfc3986_normal_example_path) {
   // RFC 3986 Section 5.4.1 "Normal Examples", confirmed to resolve identically
   // when base and reference are parsed as IRIs.
   // https://www.rfc-editor.org/rfc/rfc3986#section-5.4.1
@@ -471,7 +471,7 @@ TEST(URI_resolve_from, iri_rfc3986_normal_example_path) {
   EXPECT_EQ(reference.recompose(), "http://a/b/c/g");
 }
 
-TEST(URI_resolve_from, iri_rfc3986_normal_example_query) {
+TEST(iri_rfc3986_normal_example_query) {
   // RFC 3986 Section 5.4.1 "Normal Examples", confirmed to resolve identically
   // when base and reference are parsed as IRIs.
   // https://www.rfc-editor.org/rfc/rfc3986#section-5.4.1
@@ -481,7 +481,7 @@ TEST(URI_resolve_from, iri_rfc3986_normal_example_query) {
   EXPECT_EQ(reference.recompose(), "http://a/b/c/d;p?y");
 }
 
-TEST(URI_resolve_from, iri_reference_against_plain_uri_base) {
+TEST(iri_reference_against_plain_uri_base) {
   // An IRI reference resolved against a plain URI base keeps its non-ASCII
   // characters literal
   const sourcemeta::core::URI base{"https://example.com/dir/"};

--- a/test/uri/uri_scheme_test.cc
+++ b/test/uri/uri_scheme_test.cc
@@ -1,37 +1,37 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_scheme, https_example_url) {
+TEST(https_example_url) {
   const sourcemeta::core::URI uri{"https://example.com/foo"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "https");
 }
 
-TEST(URI_scheme, http_example_url) {
+TEST(http_example_url) {
   const sourcemeta::core::URI uri{"http://example.com/foo"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "http");
 }
 
-TEST(URI_scheme, relative_url) {
+TEST(relative_url) {
   const sourcemeta::core::URI uri{"../foo"};
   EXPECT_FALSE(uri.scheme().has_value());
 }
 
-TEST(URI_scheme, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "urn");
 }
 
-TEST(URI_scheme, urn_with_fragment) {
+TEST(urn_with_fragment) {
   const sourcemeta::core::URI uri{"urn:example:schema#foo"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "urn");
 }
 
-TEST(URI_scheme, rfc3986_scheme_case_insensitive) {
+TEST(rfc3986_scheme_case_insensitive) {
   sourcemeta::core::URI uri1{"HTTP://example.com"};
   sourcemeta::core::URI uri2{"http://example.com"};
   // Without canonicalization, case is preserved
@@ -46,69 +46,69 @@ TEST(URI_scheme, rfc3986_scheme_case_insensitive) {
   EXPECT_EQ(uri1.scheme().value(), uri2.scheme().value());
 }
 
-TEST(URI_scheme, rfc3986_scheme_with_plus) {
+TEST(rfc3986_scheme_with_plus) {
   const sourcemeta::core::URI uri{"svn+ssh://example.com"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "svn+ssh");
 }
 
-TEST(URI_scheme, rfc3986_scheme_with_dash) {
+TEST(rfc3986_scheme_with_dash) {
   const sourcemeta::core::URI uri{"coap+tcp://example.com"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "coap+tcp");
 }
 
-TEST(URI_scheme, rfc3986_scheme_with_dot) {
+TEST(rfc3986_scheme_with_dot) {
   const sourcemeta::core::URI uri{"vnd.example://example.com"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "vnd.example");
 }
 
-TEST(URI_scheme, rfc3986_scheme_single_letter) {
+TEST(rfc3986_scheme_single_letter) {
   const sourcemeta::core::URI uri{"a://example.com"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "a");
 }
 
-TEST(URI_scheme, rfc3986_ftp_scheme) {
+TEST(rfc3986_ftp_scheme) {
   const sourcemeta::core::URI uri{"ftp://ftp.example.com/file.txt"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "ftp");
 }
 
-TEST(URI_scheme, rfc3986_file_scheme) {
+TEST(rfc3986_file_scheme) {
   const sourcemeta::core::URI uri{"file:///path/to/file"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "file");
 }
 
-TEST(URI_scheme, rfc3986_mailto_scheme) {
+TEST(rfc3986_mailto_scheme) {
   const sourcemeta::core::URI uri{"mailto:user@example.com"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "mailto");
 }
 
-TEST(URI_scheme, rfc3986_tel_scheme) {
+TEST(rfc3986_tel_scheme) {
   const sourcemeta::core::URI uri{"tel:+1-816-555-1212"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "tel");
 }
 
-TEST(URI_scheme, rfc3986_data_scheme) {
+TEST(rfc3986_data_scheme) {
   const sourcemeta::core::URI uri{"data:text/plain;base64,SGVsbG8="};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "data");
 }
 
-TEST(URI_scheme, rfc3986_tag_scheme) {
+TEST(rfc3986_tag_scheme) {
   const sourcemeta::core::URI uri{"tag:example.com,2023:resource"};
   EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "tag");
 }
 
-TEST(URI_scheme, iri_scheme) {
+TEST(iri_scheme) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://\xE4\xBE\x8B\xE3\x81\x88.jp/")};
-  ASSERT_TRUE(uri.scheme().has_value());
+  EXPECT_TRUE(uri.scheme().has_value());
   EXPECT_EQ(uri.scheme().value(), "https");
 }

--- a/test/uri/uri_strip_path_prefix_test.cc
+++ b/test/uri/uri_strip_path_prefix_test.cc
@@ -1,548 +1,546 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_strip_path_prefix, exact_match) {
+TEST(exact_match) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, exact_match_root) {
+TEST(exact_match_root) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, suffix_single_segment) {
+TEST(suffix_single_segment) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, suffix_multi_segment) {
+TEST(suffix_multi_segment) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar/baz", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar/baz");
 }
 
-TEST(URI_strip_path_prefix, prefix_with_trailing_slash_matches) {
+TEST(prefix_with_trailing_slash_matches) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/foo/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, prefix_with_trailing_slash_against_bare_path) {
+TEST(prefix_with_trailing_slash_against_bare_path) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo", "/foo/")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, path_with_trailing_slash) {
+TEST(path_with_trailing_slash) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo/", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, path_with_trailing_slash_both) {
+TEST(path_with_trailing_slash_both) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo/", "/foo/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, prefix_does_not_match) {
+TEST(prefix_does_not_match) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/bar/baz", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, component_boundary_required) {
+TEST(component_boundary_required) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foobar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, component_boundary_required_multi) {
+TEST(component_boundary_required_multi) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foobar/baz", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, suffix_with_trailing_slash) {
+TEST(suffix_with_trailing_slash) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar/", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar/");
 }
 
-TEST(URI_strip_path_prefix, empty_prefix_returns_path_without_leading_slash) {
+TEST(empty_prefix_returns_path_without_leading_slash) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo/bar", "")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo/bar");
 }
 
-TEST(URI_strip_path_prefix, empty_prefix_empty_path) {
+TEST(empty_prefix_empty_path) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("", "")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, empty_path_non_empty_prefix) {
+TEST(empty_path_non_empty_prefix) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, slash_prefix_matches_anything) {
+TEST(slash_prefix_matches_anything) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo/bar");
 }
 
-TEST(URI_strip_path_prefix, slash_prefix_against_root) {
+TEST(slash_prefix_against_root) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, deep_nesting) {
+TEST(deep_nesting) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/a/b/c/d/e/f", "/a/b/c")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "d/e/f");
 }
 
-TEST(URI_strip_path_prefix, full_match_deep) {
+TEST(full_match_deep) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/a/b/c", "/a/b/c")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, partial_prefix_with_extra_segment) {
+TEST(partial_prefix_with_extra_segment) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/a/b/cd", "/a/b/c")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, dot_segments_in_path_resolved) {
+TEST(dot_segments_in_path_resolved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/./bar", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, dot_dot_segments_in_path_resolved) {
+TEST(dot_dot_segments_in_path_resolved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/baz/../bar", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, dot_dot_does_not_escape_prefix) {
+TEST(dot_dot_does_not_escape_prefix) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/../etc", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, dot_dot_at_root_collapses) {
+TEST(dot_dot_at_root_collapses) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/..", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, many_dot_dot_at_root_collapses) {
+TEST(many_dot_dot_at_root_collapses) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/../../../foo", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo");
 }
 
-TEST(URI_strip_path_prefix, dot_segments_in_prefix_resolved) {
+TEST(dot_segments_in_prefix_resolved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/x/../foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, dot_only_path) {
+TEST(dot_only_path) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/.", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, percent_encoded_slash_kept_as_data) {
+TEST(percent_encoded_slash_kept_as_data) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%2Fb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%2Fb");
 }
 
-TEST(URI_strip_path_prefix, encoded_dot_dot_resolves_and_escapes_prefix) {
+TEST(encoded_dot_dot_resolves_and_escapes_prefix) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2E%2E/bar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, lowercase_hex_normalised_to_uppercase) {
+TEST(lowercase_hex_normalised_to_uppercase) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2f", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "%2F");
 }
 
-TEST(URI_strip_path_prefix, encoded_sub_delim_uppercased_not_decoded) {
+TEST(encoded_sub_delim_uppercased_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2a", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "%2A");
 }
 
-TEST(URI_strip_path_prefix, encoded_unreserved_decoded) {
+TEST(encoded_unreserved_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%41", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "A");
 }
 
-TEST(URI_strip_path_prefix, truncated_percent_encoding_rejected) {
+TEST(truncated_percent_encoding_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, percent_alone_rejected) {
+TEST(percent_alone_rejected) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo/%", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, non_hex_percent_rejected) {
+TEST(non_hex_percent_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%ZZ", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, empty_mid_segment_preserved) {
+TEST(empty_mid_segment_preserved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo//bar", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/bar");
 }
 
-TEST(URI_strip_path_prefix, space_in_path_rejected) {
+TEST(space_in_path_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo bar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, backslash_in_path_rejected) {
+TEST(backslash_in_path_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo\\bar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, control_char_in_path_rejected) {
+TEST(control_char_in_path_rejected) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo\x01"
                                                              "bar",
                                                              "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, question_mark_in_path_rejected) {
+TEST(question_mark_in_path_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo?bar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, hash_in_path_rejected) {
+TEST(hash_in_path_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo#bar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, non_absolute_path_rejected) {
+TEST(non_absolute_path_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("foo/bar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, non_absolute_prefix_rejected) {
+TEST(non_absolute_prefix_rejected) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, sub_delims_allowed_in_segment) {
+TEST(sub_delims_allowed_in_segment) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a!b$c&d'e", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a!b$c&d'e");
 }
 
-TEST(URI_strip_path_prefix, colon_and_at_allowed_in_segment) {
+TEST(colon_and_at_allowed_in_segment) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/user:pass@host", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "user:pass@host");
 }
 
-TEST(URI_strip_path_prefix, unreserved_allowed_in_segment) {
+TEST(unreserved_allowed_in_segment) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/abc-XYZ_123.~", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "abc-XYZ_123.~");
 }
 
-TEST(URI_strip_path_prefix, encoded_unreserved_in_prefix_matches_decoded) {
+TEST(encoded_unreserved_in_prefix_matches_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/%66oo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, percent_encoded_segment_matches_byte_for_byte) {
+TEST(percent_encoded_segment_matches_byte_for_byte) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%21/bar", "/foo/%21")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, encoded_sub_delim_not_equivalent_to_decoded) {
+TEST(encoded_sub_delim_not_equivalent_to_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%21/bar", "/foo/!")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, prefix_is_proper_prefix_segment_boundary) {
+TEST(prefix_is_proper_prefix_segment_boundary) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/foo/ba")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, deeply_nested_dot_dot_resolution) {
+TEST(deeply_nested_dot_dot_resolution) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/a/b/c/../../x", "/a")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "x");
 }
 
-TEST(URI_strip_path_prefix, prefix_ending_at_dot_segment_boundary) {
+TEST(prefix_ending_at_dot_segment_boundary) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar/.", "/foo/bar")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, trailing_empty_segments_preserved) {
+TEST(trailing_empty_segments_preserved) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("/foo//", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/");
 }
 
-TEST(URI_strip_path_prefix, multiple_trailing_empty_segments_preserved) {
+TEST(multiple_trailing_empty_segments_preserved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo///", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "//");
 }
 
-TEST(URI_strip_path_prefix, mid_and_trailing_empty_segments_preserved) {
+TEST(mid_and_trailing_empty_segments_preserved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo//bar//", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/bar//");
 }
 
-TEST(URI_strip_path_prefix, path_of_only_slashes_preserved) {
+TEST(path_of_only_slashes_preserved) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("////", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "///");
 }
 
-TEST(URI_strip_path_prefix, path_abempty_double_leading_slash) {
+TEST(path_abempty_double_leading_slash) {
   const auto result{sourcemeta::core::URI::strip_path_prefix("//foo/bar", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "/foo/bar");
 }
 
-TEST(URI_strip_path_prefix, encoded_hyphen_decoded) {
+TEST(encoded_hyphen_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%2Db", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a-b");
 }
 
-TEST(URI_strip_path_prefix, encoded_underscore_decoded) {
+TEST(encoded_underscore_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%5Fb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a_b");
 }
 
-TEST(URI_strip_path_prefix, encoded_period_decoded) {
+TEST(encoded_period_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%2Eb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a.b");
 }
 
-TEST(URI_strip_path_prefix, encoded_digit_decoded) {
+TEST(encoded_digit_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%30", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "0");
 }
 
-TEST(URI_strip_path_prefix, encoded_plus_not_decoded) {
+TEST(encoded_plus_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%2Bb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%2Bb");
 }
 
-TEST(URI_strip_path_prefix, encoded_semicolon_not_decoded) {
+TEST(encoded_semicolon_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%3Bb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%3Bb");
 }
 
-TEST(URI_strip_path_prefix, encoded_equals_not_decoded) {
+TEST(encoded_equals_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%3Db", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%3Db");
 }
 
-TEST(URI_strip_path_prefix, encoded_open_bracket_not_decoded) {
+TEST(encoded_open_bracket_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%5Bb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%5Bb");
 }
 
-TEST(URI_strip_path_prefix, encoded_null_byte_not_decoded) {
+TEST(encoded_null_byte_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%00", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "%00");
 }
 
-TEST(URI_strip_path_prefix, high_byte_percent_encoded_preserved) {
+TEST(high_byte_percent_encoded_preserved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%FF", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "%FF");
 }
 
-TEST(URI_strip_path_prefix, segment_named_three_dots_passes_through) {
+TEST(segment_named_three_dots_passes_through) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/.../bar", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), ".../bar");
 }
 
-TEST(URI_strip_path_prefix, encoded_three_dots_segment_passes_through) {
+TEST(encoded_three_dots_segment_passes_through) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2E%2E%2E", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "...");
 }
 
-TEST(URI_strip_path_prefix,
-     lowercase_encoded_dot_dot_resolves_after_normalisation) {
+TEST(lowercase_encoded_dot_dot_resolves_after_normalisation) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2e%2e/bar", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix, mixed_encoded_and_literal_unreserved) {
+TEST(mixed_encoded_and_literal_unreserved) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%62c%64", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "abcd");
 }
 
-TEST(URI_strip_path_prefix, lowercase_hex_in_prefix_normalised) {
+TEST(lowercase_hex_in_prefix_normalised) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%2F/bar", "/foo/%2f")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "bar");
 }
 
-TEST(URI_strip_path_prefix,
-     encoded_unreserved_in_prefix_equivalent_to_decoded) {
+TEST(encoded_unreserved_in_prefix_equivalent_to_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/bar", "/foo/%62%61%72")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "");
 }
 
-TEST(URI_strip_path_prefix, encoded_tilde_decoded) {
+TEST(encoded_tilde_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%7Ehome", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "~home");
 }
 
-TEST(URI_strip_path_prefix, encoded_at_not_decoded) {
+TEST(encoded_at_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/%40handle", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "%40handle");
 }
 
-TEST(URI_strip_path_prefix, encoded_colon_not_decoded) {
+TEST(encoded_colon_not_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%3Ab", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%3Ab");
 }
 
-TEST(URI_strip_path_prefix, encoded_slash_never_decoded) {
+TEST(encoded_slash_never_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo%2Fbar", "/foo")};
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(URI_strip_path_prefix, encoded_question_mark_never_decoded) {
+TEST(encoded_question_mark_never_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%3Fb", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%3Fb");
 }
 
-TEST(URI_strip_path_prefix, encoded_hash_never_decoded) {
+TEST(encoded_hash_never_decoded) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/a%23b", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "a%23b");
 }
 
-TEST(URI_strip_path_prefix, mixed_dot_segments_and_encoded_traversal) {
+TEST(mixed_dot_segments_and_encoded_traversal) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/foo/x/%2E%2E/y", "/foo")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "y");
 }
 
-TEST(URI_strip_path_prefix, encoded_dot_segment_resolved_at_root_collapses) {
+TEST(encoded_dot_segment_resolved_at_root_collapses) {
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/%2E%2E/foo", "/")};
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "foo");
 }
 
-TEST(URI_strip_path_prefix, iri_unicode_segments) {
+TEST(iri_unicode_segments) {
   const auto result{sourcemeta::core::URI::strip_path_prefix(
       "/caf\xC3\xA9/page", "/caf\xC3\xA9")};
-  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), "page");
 }
 
-TEST(URI_strip_path_prefix, iri_rejects_invalid_utf8) {
+TEST(iri_rejects_invalid_utf8) {
   // An invalid UTF-8 byte sequence in the path is not a valid path
   const auto result{
       sourcemeta::core::URI::strip_path_prefix("/caf\xC3/page", "/")};

--- a/test/uri/uri_test.cc
+++ b/test/uri/uri_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
@@ -6,44 +6,44 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
-TEST(URI, default_constructor) {
+TEST(default_constructor) {
   const sourcemeta::core::URI uri;
   EXPECT_TRUE(uri.empty());
   EXPECT_EQ(uri.recompose(), "");
 }
 
-TEST(URI, default_constructor_equals_empty_string) {
+TEST(default_constructor_equals_empty_string) {
   const sourcemeta::core::URI uri_default;
   const sourcemeta::core::URI uri_empty{""};
   EXPECT_EQ(uri_default, uri_empty);
 }
 
-TEST(URI, copy_constructor) {
+TEST(copy_constructor) {
   const sourcemeta::core::URI uri_1{"https://example.com"};
   const sourcemeta::core::URI uri_2{uri_1};
   EXPECT_EQ(uri_1.recompose(), uri_2.recompose());
 }
 
-TEST(URI, copy_constructor_empty) {
+TEST(copy_constructor_empty) {
   const sourcemeta::core::URI uri_1;
   const sourcemeta::core::URI uri_2{uri_1};
   EXPECT_TRUE(uri_2.empty());
   EXPECT_EQ(uri_1, uri_2);
 }
 
-TEST(URI, move_constructor) {
+TEST(move_constructor) {
   sourcemeta::core::URI uri_1{"https://example.com"};
   const sourcemeta::core::URI uri_2{std::move(uri_1)};
   EXPECT_EQ(uri_2.recompose(), "https://example.com");
 }
 
-TEST(URI, move_constructor_empty) {
+TEST(move_constructor_empty) {
   sourcemeta::core::URI uri_1;
   const sourcemeta::core::URI uri_2{std::move(uri_1)};
   EXPECT_TRUE(uri_2.empty());
 }
 
-TEST(URI, copy_assignment) {
+TEST(copy_assignment) {
   const sourcemeta::core::URI uri_1{"https://example.com"};
   sourcemeta::core::URI uri_2{"https://other.com"};
   uri_2 = uri_1;
@@ -51,7 +51,7 @@ TEST(URI, copy_assignment) {
   EXPECT_EQ(uri_2.recompose(), "https://example.com");
 }
 
-TEST(URI, copy_assignment_empty) {
+TEST(copy_assignment_empty) {
   const sourcemeta::core::URI uri_1;
   sourcemeta::core::URI uri_2{"https://example.com"};
   uri_2 = uri_1;
@@ -59,21 +59,21 @@ TEST(URI, copy_assignment_empty) {
   EXPECT_EQ(uri_1, uri_2);
 }
 
-TEST(URI, move_assignment) {
+TEST(move_assignment) {
   sourcemeta::core::URI uri_1{"https://example.com"};
   sourcemeta::core::URI uri_2{"https://other.com"};
   uri_2 = std::move(uri_1);
   EXPECT_EQ(uri_2.recompose(), "https://example.com");
 }
 
-TEST(URI, move_assignment_empty) {
+TEST(move_assignment_empty) {
   sourcemeta::core::URI uri_1;
   sourcemeta::core::URI uri_2{"https://example.com"};
   uri_2 = std::move(uri_1);
   EXPECT_TRUE(uri_2.empty());
 }
 
-TEST(URI, from_fragment) {
+TEST(from_fragment) {
   const auto uri{sourcemeta::core::URI::from_fragment("foo")};
   const auto fragment{uri.fragment()};
   EXPECT_TRUE(fragment.has_value());
@@ -81,7 +81,7 @@ TEST(URI, from_fragment) {
   EXPECT_EQ(uri.recompose(), "#foo");
 }
 
-TEST(URI, from_fragment_at) {
+TEST(from_fragment_at) {
   const auto uri{sourcemeta::core::URI::from_fragment("/@foo")};
   const auto fragment{uri.fragment()};
   EXPECT_TRUE(fragment.has_value());
@@ -89,7 +89,7 @@ TEST(URI, from_fragment_at) {
   EXPECT_EQ(uri.recompose(), "#/@foo");
 }
 
-TEST(URI, from_fragment_empty) {
+TEST(from_fragment_empty) {
   const auto uri{sourcemeta::core::URI::from_fragment("")};
   const auto fragment{uri.fragment()};
   EXPECT_TRUE(fragment.has_value());
@@ -97,7 +97,7 @@ TEST(URI, from_fragment_empty) {
   EXPECT_EQ(uri.recompose(), "#");
 }
 
-TEST(URI, from_fragment_with_hash) {
+TEST(from_fragment_with_hash) {
   const auto uri{sourcemeta::core::URI::from_fragment("#foo")};
   const auto fragment{uri.fragment()};
   EXPECT_TRUE(fragment.has_value());
@@ -105,7 +105,7 @@ TEST(URI, from_fragment_with_hash) {
   EXPECT_EQ(uri.recompose(), "#foo");
 }
 
-TEST(URI, from_fragment_with_hash_empty) {
+TEST(from_fragment_with_hash_empty) {
   const auto uri{sourcemeta::core::URI::from_fragment("#")};
   const auto fragment{uri.fragment()};
   EXPECT_TRUE(fragment.has_value());
@@ -113,13 +113,13 @@ TEST(URI, from_fragment_with_hash_empty) {
   EXPECT_EQ(uri.recompose(), "#");
 }
 
-TEST(URI, using_istream) {
+TEST(using_istream) {
   std::istringstream input{"https://example.com"};
   const sourcemeta::core::URI uri{input};
   EXPECT_EQ(uri.recompose(), "https://example.com");
 }
 
-TEST(URI, equality) {
+TEST(equality) {
   EXPECT_EQ(sourcemeta::core::URI{"https://example.com"},
             sourcemeta::core::URI{"https://example.com"});
   EXPECT_NE(sourcemeta::core::URI{"https://example.com"},
@@ -128,7 +128,7 @@ TEST(URI, equality) {
   EXPECT_EQ(self, self);
 }
 
-TEST(URI, map) {
+TEST(map) {
   std::map<sourcemeta::core::URI, bool> map;
   map.emplace("https://example.com", true);
   map.emplace("https://foo.com", false);
@@ -142,44 +142,44 @@ TEST(URI, map) {
   EXPECT_FALSE(map.at(sourcemeta::core::URI{"https://foo.com"}));
 }
 
-TEST(URI, from_string_view) {
+TEST(from_string_view) {
   const std::string_view input{"https://example.com/path"};
   const sourcemeta::core::URI uri{input};
   EXPECT_EQ(uri.recompose(), "https://example.com/path");
 }
 
-TEST(URI, from_string) {
+TEST(from_string) {
   const std::string input{"https://example.com/path"};
   const sourcemeta::core::URI uri{input};
   EXPECT_EQ(uri.recompose(), "https://example.com/path");
 }
 
-TEST(URI, from_string_literal) {
+TEST(from_string_literal) {
   const sourcemeta::core::URI uri{"https://example.com/path"};
   EXPECT_EQ(uri.recompose(), "https://example.com/path");
 }
 
-TEST(URI, resolve_from_string_constructed_base) {
+TEST(resolve_from_string_constructed_base) {
   const std::string base{"https://example.com"};
   sourcemeta::core::URI uri{"foo/bar"};
   uri.resolve_from(sourcemeta::core::URI{base});
   EXPECT_EQ(uri.recompose(), "https://example.com/foo/bar");
 }
 
-TEST(URI, resolve_from_string_view_constructed_base) {
+TEST(resolve_from_string_view_constructed_base) {
   const std::string_view base{"https://example.com"};
   sourcemeta::core::URI uri{"foo/bar"};
   uri.resolve_from(sourcemeta::core::URI{base});
   EXPECT_EQ(uri.recompose(), "https://example.com/foo/bar");
 }
 
-TEST(URI, canonicalize_from_string_view) {
+TEST(canonicalize_from_string_view) {
   const std::string_view input{"hTtP://ExAmPlE.com:80/TEST"};
   const auto result{sourcemeta::core::URI::canonicalize(input)};
   EXPECT_EQ(result, "http://example.com/TEST");
 }
 
-TEST(URI, canonicalize_from_string) {
+TEST(canonicalize_from_string) {
   const std::string input{"hTtP://ExAmPlE.com:80/TEST"};
   const auto result{sourcemeta::core::URI::canonicalize(input)};
   EXPECT_EQ(result, "http://example.com/TEST");

--- a/test/uri/uri_to_path_test.cc
+++ b/test/uri/uri_to_path_test.cc
@@ -1,135 +1,135 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_to_path, tag) {
+TEST(tag) {
   const sourcemeta::core::URI uri{"tag:yaml.org,2002:int"};
   const std::filesystem::path expected{"yaml.org,2002:int"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, urn) {
+TEST(urn) {
   const sourcemeta::core::URI uri{"urn:example:schema"};
   const std::filesystem::path expected{"example:schema"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, https_url_without_path) {
+TEST(https_url_without_path) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   const std::filesystem::path expected{""};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, https_url_with_path) {
+TEST(https_url_with_path) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo/bar"};
   const std::filesystem::path expected{"/foo/bar"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, relative) {
+TEST(relative) {
   const sourcemeta::core::URI uri{"../foo"};
   const std::filesystem::path expected{"../foo"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, unix_absolute) {
+TEST(unix_absolute) {
   const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
   const std::filesystem::path expected{"/foo/bar/baz"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, unix_with_space_and_reserved) {
+TEST(unix_with_space_and_reserved) {
   const sourcemeta::core::URI uri{
       "file:///foo/My%20Folder/has%23hash%3Fvalue%25"};
   const std::filesystem::path expected{"/foo/My Folder/has#hash?value%"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, unix_trailing_slash) {
+TEST(unix_trailing_slash) {
   const sourcemeta::core::URI uri{"file:///foo/bar/"};
   const std::filesystem::path expected{"/foo/bar/"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_drive_absolute) {
+TEST(windows_drive_absolute) {
   const sourcemeta::core::URI uri{"file:///C:/Program%20Files/Test"};
   const std::filesystem::path expected{R"(C:\Program Files\Test)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_drive_lowercase) {
+TEST(windows_drive_lowercase) {
   const sourcemeta::core::URI uri{"file:///c:/temp/logs"};
   const std::filesystem::path expected{R"(c:\temp\logs)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_drive_root) {
+TEST(windows_drive_root) {
   const sourcemeta::core::URI uri{"file:///D:/"};
   const std::filesystem::path expected{R"(D:\)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_trailing_slash) {
+TEST(windows_trailing_slash) {
   const sourcemeta::core::URI uri{"file:///C:/foo/bar/"};
   const std::filesystem::path expected{R"(C:\foo\bar\)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_percent_and_plus) {
+TEST(windows_percent_and_plus) {
   const sourcemeta::core::URI uri{"file:///C:/path/50%25+plus.txt"};
   const std::filesystem::path expected{R"(C:\path\50%+plus.txt)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, unicode_unix) {
+TEST(unicode_unix) {
   const sourcemeta::core::URI uri{"file:///data/%C3%A9clair.txt"};
   const std::filesystem::path expected{u8"/data/éclair.txt"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, unicode_windows) {
+TEST(unicode_windows) {
   const sourcemeta::core::URI uri{"file:///C:/data/r%C3%A9sum%C3%A9.doc"};
   const std::filesystem::path expected{u8R"(C:\data\résumé.doc)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_unc_simple) {
+TEST(windows_unc_simple) {
   const sourcemeta::core::URI uri{"file://server/share/file.txt"};
   const std::filesystem::path expected{R"(\\server\share\file.txt)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_unc_with_space) {
+TEST(windows_unc_with_space) {
   const sourcemeta::core::URI uri{"file://srv/My%20Docs/a%20b.txt"};
   const std::filesystem::path expected{R"(\\srv\My Docs\a b.txt)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, windows_unc_unicode) {
+TEST(windows_unc_unicode) {
   const sourcemeta::core::URI uri{"file://server/data/%C3%A9clair.txt"};
   const std::filesystem::path expected{u8R"(\\server\data\éclair.txt)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, localhost_treated_as_no_host) {
+TEST(localhost_treated_as_no_host) {
   const sourcemeta::core::URI uri{"file://localhost/foo/bar"};
   const std::filesystem::path expected{"/foo/bar"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, localhost_with_windows_drive) {
+TEST(localhost_with_windows_drive) {
   const sourcemeta::core::URI uri{"file://localhost/C:/foo"};
   const std::filesystem::path expected{R"(C:\foo)"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, localhost_uppercase) {
+TEST(localhost_uppercase) {
   const sourcemeta::core::URI uri{"file://LOCALHOST/foo/bar"};
   const std::filesystem::path expected{"/foo/bar"};
   EXPECT_EQ(uri.to_path(), expected);
 }
 
-TEST(URI_to_path, localhost_mixed_case) {
+TEST(localhost_mixed_case) {
   const sourcemeta::core::URI uri{"file://LocalHost/foo/bar"};
   const std::filesystem::path expected{"/foo/bar"};
   EXPECT_EQ(uri.to_path(), expected);

--- a/test/uri/uri_user_info_test.cc
+++ b/test/uri/uri_user_info_test.cc
@@ -1,8 +1,8 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uri.h>
 
-TEST(URI_user_info, working_example) {
+TEST(working_example) {
   sourcemeta::core::URI uri{"http://user:@host:80/"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user:");
@@ -10,59 +10,59 @@ TEST(URI_user_info, working_example) {
 
 // Note: Using the format "user:password" is depreacted.
 // But we would like to support it for users that would still use it.
-TEST(URI_user_info, depreacted_example) {
+TEST(depreacted_example) {
   sourcemeta::core::URI uri{"http://user:password@host:80/"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user:password");
 }
 
-TEST(URI_user_info, empty_example) {
+TEST(empty_example) {
   sourcemeta::core::URI uri{"http://host:80/"};
   EXPECT_FALSE(uri.userinfo().has_value());
 }
 
-TEST(URI_user_info, rfc3986_username_only) {
+TEST(rfc3986_username_only) {
   sourcemeta::core::URI uri{"http://user@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user");
 }
 
-TEST(URI_user_info, rfc3986_username_empty_password) {
+TEST(rfc3986_username_empty_password) {
   sourcemeta::core::URI uri{"http://user:@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user:");
 }
 
-TEST(URI_user_info, rfc3986_username_password) {
+TEST(rfc3986_username_password) {
   sourcemeta::core::URI uri{"http://user:secret@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user:secret");
 }
 
-TEST(URI_user_info, rfc3986_percent_encoded_userinfo) {
+TEST(rfc3986_percent_encoded_userinfo) {
   sourcemeta::core::URI uri{"http://user%20name:pass%20word@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user%20name:pass%20word");
 }
 
-TEST(URI_user_info, rfc3986_userinfo_with_subdelims) {
+TEST(rfc3986_userinfo_with_subdelims) {
   sourcemeta::core::URI uri{"http://user!$&'()*+,;=:pass@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user!$&'()*+,;=:pass");
 }
 
-TEST(URI_user_info, rfc3986_empty_userinfo_marker) {
+TEST(rfc3986_empty_userinfo_marker) {
   sourcemeta::core::URI uri{"http://@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "");
 }
 
-TEST(URI_user_info, rfc3986_no_authority) {
+TEST(rfc3986_no_authority) {
   sourcemeta::core::URI uri{"urn:example:resource"};
   EXPECT_FALSE(uri.userinfo().has_value());
 }
 
-TEST(URI_user_info, rfc3986_userinfo_with_at_sign) {
+TEST(rfc3986_userinfo_with_at_sign) {
   sourcemeta::core::URI uri{"http://user%40domain:pass@host/path"};
   EXPECT_TRUE(uri.userinfo().has_value());
   // Per RFC 3986 Section 2.2, %40 (@) is a reserved gen-delim
@@ -70,7 +70,7 @@ TEST(URI_user_info, rfc3986_userinfo_with_at_sign) {
   EXPECT_EQ(uri.userinfo().value(), "user%40domain:pass");
 }
 
-TEST(URI_user_info_setter, set_on_uri_without_userinfo) {
+TEST(set_on_uri_without_userinfo) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -78,7 +78,7 @@ TEST(URI_user_info_setter, set_on_uri_without_userinfo) {
   EXPECT_EQ(uri.recompose(), "http://user@host/path");
 }
 
-TEST(URI_user_info_setter, replace_existing_userinfo) {
+TEST(replace_existing_userinfo) {
   sourcemeta::core::URI uri{"http://user:pass@host/path"};
   uri.userinfo("alice");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -86,21 +86,21 @@ TEST(URI_user_info_setter, replace_existing_userinfo) {
   EXPECT_EQ(uri.recompose(), "http://alice@host/path");
 }
 
-TEST(URI_user_info_setter, clear_with_empty_string) {
+TEST(clear_with_empty_string) {
   sourcemeta::core::URI uri{"http://user:pass@host/path"};
   uri.userinfo("");
   EXPECT_FALSE(uri.userinfo().has_value());
   EXPECT_EQ(uri.recompose(), "http://host/path");
 }
 
-TEST(URI_user_info_setter, clear_when_already_absent) {
+TEST(clear_when_already_absent) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("");
   EXPECT_FALSE(uri.userinfo().has_value());
   EXPECT_EQ(uri.recompose(), "http://host/path");
 }
 
-TEST(URI_user_info_setter, set_with_colon) {
+TEST(set_with_colon) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user:secret");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -108,7 +108,7 @@ TEST(URI_user_info_setter, set_with_colon) {
   EXPECT_EQ(uri.recompose(), "http://user:secret@host/path");
 }
 
-TEST(URI_user_info_setter, percent_encoding_applied_on_recompose) {
+TEST(percent_encoding_applied_on_recompose) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user name");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -116,13 +116,13 @@ TEST(URI_user_info_setter, percent_encoding_applied_on_recompose) {
   EXPECT_EQ(uri.recompose(), "http://user%20name@host/path");
 }
 
-TEST(URI_user_info_setter, returns_reference_for_chaining) {
+TEST(returns_reference_for_chaining) {
   sourcemeta::core::URI uri{"http://host"};
   uri.userinfo("user").fragment("section");
   EXPECT_EQ(uri.recompose(), "http://user@host#section");
 }
 
-TEST(URI_user_info_setter, normalizes_unreserved_percent_encoding) {
+TEST(normalizes_unreserved_percent_encoding) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user%7Ename");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -130,7 +130,7 @@ TEST(URI_user_info_setter, normalizes_unreserved_percent_encoding) {
   EXPECT_EQ(uri.userinfo().value(), "user~name");
 }
 
-TEST(URI_user_info_setter, preserves_reserved_percent_encoding) {
+TEST(preserves_reserved_percent_encoding) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user%40name");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -138,7 +138,7 @@ TEST(URI_user_info_setter, preserves_reserved_percent_encoding) {
   EXPECT_EQ(uri.userinfo().value(), "user%40name");
 }
 
-TEST(URI_user_info_setter, matches_parsed_uri_for_unreserved_percent) {
+TEST(matches_parsed_uri_for_unreserved_percent) {
   sourcemeta::core::URI built{"http://host/path"};
   built.userinfo("user%7Ename");
   const sourcemeta::core::URI parsed{"http://user%7Ename@host/path"};
@@ -146,7 +146,7 @@ TEST(URI_user_info_setter, matches_parsed_uri_for_unreserved_percent) {
   EXPECT_EQ(built.recompose(), parsed.recompose());
 }
 
-TEST(URI_user_info_setter, percent_encodes_at_sign_on_recompose) {
+TEST(percent_encodes_at_sign_on_recompose) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user@domain");
   EXPECT_TRUE(uri.userinfo().has_value());
@@ -156,7 +156,7 @@ TEST(URI_user_info_setter, percent_encodes_at_sign_on_recompose) {
   EXPECT_EQ(uri.recompose(), "http://user%40domain@host/path");
 }
 
-TEST(URI_user_info_setter, recompose_roundtrip_after_at_sign_encoded) {
+TEST(recompose_roundtrip_after_at_sign_encoded) {
   sourcemeta::core::URI uri{"http://host/path"};
   uri.userinfo("user@domain");
   const auto recomposed{uri.recompose()};
@@ -166,9 +166,9 @@ TEST(URI_user_info_setter, recompose_roundtrip_after_at_sign_encoded) {
   EXPECT_EQ(parsed.userinfo().value(), "user%40domain");
 }
 
-TEST(URI_user_info, iri_unicode_userinfo) {
+TEST(iri_unicode_userinfo) {
   const auto uri{
       sourcemeta::core::URI::from_iri("https://user\xE5\x90\x8D@example.com/")};
-  ASSERT_TRUE(uri.userinfo().has_value());
+  EXPECT_TRUE(uri.userinfo().has_value());
   EXPECT_EQ(uri.userinfo().value(), "user\xE5\x90\x8D");
 }

--- a/test/yaml/CMakeLists.txt
+++ b/test/yaml/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME yaml
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME yaml
   SOURCES
     yaml_parse_test.cc
     yaml_parse_callback_test.cc

--- a/test/yaml/yaml_parse_callback_test.cc
+++ b/test/yaml/yaml_parse_callback_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/yaml.h>
@@ -60,56 +60,56 @@
   EXPECT_EQ(std::get<5>(traces.at(index)), expected_index);                    \
   EXPECT_EQ(std::get<6>(traces.at(index)), expected_property)
 
-TEST(YAML_parse_callback, yaml_true) {
+TEST(yaml_true) {
   const auto input{"true"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Boolean, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Boolean, 1, 4, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_false) {
+TEST(yaml_false) {
   const auto input{"false"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Boolean, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Boolean, 1, 5, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_null) {
+TEST(yaml_null) {
   const auto input{"null"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Null, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Null, 1, 4, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_string) {
+TEST(yaml_string) {
   const auto input{"\"foo\""};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, String, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, String, 1, 5, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_integer) {
+TEST(yaml_integer) {
   const auto input{"1234"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Integer, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Integer, 1, 4, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_real) {
+TEST(yaml_real) {
   const auto input{"3.5"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Real, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Real, 1, 3, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_empty_array) {
+TEST(yaml_empty_array) {
   const auto input{"[]"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Array, 1, 2, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_array_integers) {
+TEST(yaml_array_integers) {
   const auto input{"[1, 2, 3]"};
   PARSE_YAML_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -122,14 +122,14 @@ TEST(YAML_parse_callback, yaml_array_integers) {
   EXPECT_TRACE(7, Post, Array, 1, 9, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_empty_object) {
+TEST(yaml_empty_object) {
   const auto input{"{}"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Object, 1, 2, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_object_simple) {
+TEST(yaml_object_simple) {
   const auto input{"{\"foo\": \"bar\"}"};
   PARSE_YAML_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -138,7 +138,7 @@ TEST(YAML_parse_callback, yaml_object_simple) {
   EXPECT_TRACE(3, Post, Object, 1, 14, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_block_mapping_multiline) {
+TEST(yaml_block_mapping_multiline) {
   const auto input{"foo: bar\nbaz: qux\ntest: 123"};
   PARSE_YAML_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -151,7 +151,7 @@ TEST(YAML_parse_callback, yaml_block_mapping_multiline) {
   EXPECT_TRACE(7, Post, Object, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_block_sequence_multiline) {
+TEST(yaml_block_sequence_multiline) {
   const auto input{"- foo\n- bar\n- baz"};
   PARSE_YAML_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -164,7 +164,7 @@ TEST(YAML_parse_callback, yaml_block_sequence_multiline) {
   EXPECT_TRACE(7, Post, Array, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_nested_arrays) {
+TEST(yaml_nested_arrays) {
   const auto input{"[[1, 2], [3, 4]]"};
   PARSE_YAML_WITH_TRACES(document, input, 14);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -183,7 +183,7 @@ TEST(YAML_parse_callback, yaml_nested_arrays) {
   EXPECT_TRACE(13, Post, Array, 1, 16, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_nested_objects) {
+TEST(yaml_nested_objects) {
   const auto input{"{\"outer\": {\"inner\": \"value\"}}"};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -194,7 +194,7 @@ TEST(YAML_parse_callback, yaml_nested_objects) {
   EXPECT_TRACE(5, Post, Object, 1, 29, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_block_nested_objects) {
+TEST(yaml_block_nested_objects) {
   const auto input{"outer:\n  inner:\n    deep: value"};
   PARSE_YAML_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -207,7 +207,7 @@ TEST(YAML_parse_callback, yaml_block_nested_objects) {
   EXPECT_TRACE(7, Post, Object, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_block_nested_arrays) {
+TEST(yaml_block_nested_arrays) {
   const auto input{"- - foo\n  - bar\n- - baz"};
   PARSE_YAML_WITH_TRACES(document, input, 12);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -224,7 +224,7 @@ TEST(YAML_parse_callback, yaml_block_nested_arrays) {
   EXPECT_TRACE(11, Post, Array, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_mixed_block_and_flow) {
+TEST(yaml_mixed_block_and_flow) {
   const auto input{"array:\n  - {key: value}\n  - [1, 2, 3]"};
   PARSE_YAML_WITH_TRACES(document, input, 16);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -245,7 +245,7 @@ TEST(YAML_parse_callback, yaml_mixed_block_and_flow) {
   EXPECT_TRACE(15, Post, Object, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_quoted_strings) {
+TEST(yaml_quoted_strings) {
   const auto input{"single: 'foo bar'\ndouble: \"baz qux\""};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -256,7 +256,7 @@ TEST(YAML_parse_callback, yaml_quoted_strings) {
   EXPECT_TRACE(5, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_unquoted_strings) {
+TEST(yaml_unquoted_strings) {
   const auto input{"plain: hello world\nunquoted: test"};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -267,7 +267,7 @@ TEST(YAML_parse_callback, yaml_unquoted_strings) {
   EXPECT_TRACE(5, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_numbers_various_formats) {
+TEST(yaml_numbers_various_formats) {
   const auto input{"decimal: 42\nfloat: 3.5\nnegative: -10\nexponential: 1e10"};
   PARSE_YAML_WITH_TRACES(document, input, 10);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -282,7 +282,7 @@ TEST(YAML_parse_callback, yaml_numbers_various_formats) {
   EXPECT_TRACE(9, Post, Object, 5, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_booleans_all_forms) {
+TEST(yaml_booleans_all_forms) {
   const auto input{"bool_true: true\nbool_false: false"};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -293,7 +293,7 @@ TEST(YAML_parse_callback, yaml_booleans_all_forms) {
   EXPECT_TRACE(5, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_null_values) {
+TEST(yaml_null_values) {
   const auto input{"explicit_null: null\n"};
   PARSE_YAML_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -302,7 +302,7 @@ TEST(YAML_parse_callback, yaml_null_values) {
   EXPECT_TRACE(3, Post, Object, 2, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_empty_values) {
+TEST(yaml_empty_values) {
   const auto input{"empty_key:"};
   PARSE_YAML_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -311,7 +311,7 @@ TEST(YAML_parse_callback, yaml_empty_values) {
   EXPECT_TRACE(3, Post, Object, 2, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_simple_multiline_object) {
+TEST(yaml_simple_multiline_object) {
   const auto input{"name: Alice\nage: 30"};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -322,7 +322,7 @@ TEST(YAML_parse_callback, yaml_simple_multiline_object) {
   EXPECT_TRACE(5, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_array_of_objects) {
+TEST(yaml_array_of_objects) {
   const auto input{"[\n  {id: 1, name: foo},\n  {id: 2, name: bar}\n]"};
   PARSE_YAML_WITH_TRACES(document, input, 14);
   EXPECT_TRACE(0, Pre, Array, 1, 1, Root, 0, "");
@@ -341,7 +341,7 @@ TEST(YAML_parse_callback, yaml_array_of_objects) {
   EXPECT_TRACE(13, Post, Array, 4, 1, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_deeply_nested) {
+TEST(yaml_deeply_nested) {
   const auto input{"{a: {b: {c: {d: {e: 42}}}}}"};
   PARSE_YAML_WITH_TRACES(document, input, 12);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -358,7 +358,7 @@ TEST(YAML_parse_callback, yaml_deeply_nested) {
   EXPECT_TRACE(11, Post, Object, 1, 27, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_or_json_stub_test_1) {
+TEST(yaml_or_json_stub_test_1) {
   const auto input{std::filesystem::path{STUBS_PATH} / "test_1.yaml"};
   READ_YAML_OR_JSON_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -369,7 +369,7 @@ TEST(YAML_parse_callback, yaml_or_json_stub_test_1) {
   EXPECT_TRACE(5, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_or_json_stub_test_2) {
+TEST(yaml_or_json_stub_test_2) {
   const auto input{std::filesystem::path{STUBS_PATH} / "test_1.json"};
   READ_YAML_OR_JSON_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -380,7 +380,7 @@ TEST(YAML_parse_callback, yaml_or_json_stub_test_2) {
   EXPECT_TRACE(5, Post, Object, 4, 1, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_simple_anchor_and_alias) {
+TEST(yaml_simple_anchor_and_alias) {
   const auto input{"anchor: &node foo\nalias: *node"};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -391,7 +391,7 @@ TEST(YAML_parse_callback, yaml_simple_anchor_and_alias) {
   EXPECT_TRACE(5, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_anchor_object_with_alias) {
+TEST(yaml_anchor_object_with_alias) {
   const auto input{"original: &obj {x: 1, y: 2}\ncopy: *obj"};
   PARSE_YAML_WITH_TRACES(document, input, 14);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -410,7 +410,7 @@ TEST(YAML_parse_callback, yaml_anchor_object_with_alias) {
   EXPECT_TRACE(13, Post, Object, 3, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_anchor_array_with_multiple_aliases) {
+TEST(yaml_anchor_array_with_multiple_aliases) {
   const auto input{"items: &list [a, b, c]\nfirst: *list\nsecond: *list"};
   PARSE_YAML_WITH_TRACES(document, input, 26);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -441,7 +441,7 @@ TEST(YAML_parse_callback, yaml_anchor_array_with_multiple_aliases) {
   EXPECT_TRACE(25, Post, Object, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, yaml_nested_anchor_and_alias) {
+TEST(yaml_nested_anchor_and_alias) {
   const auto input{"outer:\n  inner: &val 42\n  ref: *val"};
   PARSE_YAML_WITH_TRACES(document, input, 8);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -454,21 +454,21 @@ TEST(YAML_parse_callback, yaml_nested_anchor_and_alias) {
   EXPECT_TRACE(7, Post, Object, 4, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, decimal_large_integer) {
+TEST(decimal_large_integer) {
   const auto input{"123456789012345678901234567890"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Decimal, 1, 30, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, decimal_high_precision_real) {
+TEST(decimal_high_precision_real) {
   const auto input{"3.141592653589793238462643383279"};
   PARSE_YAML_WITH_TRACES(document, input, 2);
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Decimal, 1, 32, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, decimal_in_object) {
+TEST(decimal_in_object) {
   const auto input{"large: 999999999999999999999999999999"};
   PARSE_YAML_WITH_TRACES(document, input, 4);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");
@@ -477,7 +477,7 @@ TEST(YAML_parse_callback, decimal_in_object) {
   EXPECT_TRACE(3, Post, Object, 2, 0, Root, 0, "");
 }
 
-TEST(YAML_parse_callback, scalar_alias_pre_post_balance) {
+TEST(scalar_alias_pre_post_balance) {
   const auto input{"anchor: &node foo\nalias: *node"};
   PARSE_YAML_WITH_TRACES(document, input, 6);
   EXPECT_TRACE(0, Pre, Object, 1, 1, Root, 0, "");

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
@@ -6,21 +6,21 @@
 
 #include <sstream>
 
-TEST(YAML_parse, scalar_1) {
+TEST(scalar_1) {
   const std::string input{"1"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   const sourcemeta::core::JSON expected{1};
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, scalar_2) {
+TEST(scalar_2) {
   const std::string input{"   1    "};
   const auto result{sourcemeta::core::parse_yaml(input)};
   const sourcemeta::core::JSON expected{1};
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_1) {
+TEST(object_1) {
   const std::string input{"hello: world\nfoo: 1\nbar: true"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -34,7 +34,7 @@ TEST(YAML_parse, object_1) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_2) {
+TEST(object_2) {
   const std::string input{"foo: >\n  bar\n  baz"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -46,7 +46,7 @@ TEST(YAML_parse, object_2) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_3) {
+TEST(object_3) {
   const std::string input{"version: \"1.29.2\""};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -58,7 +58,7 @@ TEST(YAML_parse, object_3) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_4) {
+TEST(object_4) {
   const std::string input{"version: \'1.29.2\'"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -70,7 +70,7 @@ TEST(YAML_parse, object_4) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_5) {
+TEST(object_5) {
   const std::string input{"version: 1.29.2"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -82,7 +82,7 @@ TEST(YAML_parse, object_5) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_6) {
+TEST(object_6) {
   const std::string input{"version: v1.29.2"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -94,7 +94,7 @@ TEST(YAML_parse, object_6) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, object_7) {
+TEST(object_7) {
   const std::string input{"version: 1.29v"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -106,7 +106,7 @@ TEST(YAML_parse, object_7) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, array_1) {
+TEST(array_1) {
   const std::string input{"- foo\n- true"};
 
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -117,7 +117,7 @@ TEST(YAML_parse, array_1) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, empty) {
+TEST(empty) {
   const std::string input{""};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -130,7 +130,7 @@ TEST(YAML_parse, empty) {
   }
 }
 
-TEST(YAML_parse, blank) {
+TEST(blank) {
   const std::string input{"    "};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -143,7 +143,7 @@ TEST(YAML_parse, blank) {
   }
 }
 
-TEST(YAML_parse, invalid_1) {
+TEST(invalid_1) {
   const std::string input{"{ xx"};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -156,7 +156,7 @@ TEST(YAML_parse, invalid_1) {
   }
 }
 
-TEST(YAML_parse, undefined_anchor) {
+TEST(undefined_anchor) {
   const std::string input{"alias: *unknown"};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -171,7 +171,7 @@ TEST(YAML_parse, undefined_anchor) {
   }
 }
 
-TEST(YAML_parse, stub_test_1) {
+TEST(stub_test_1) {
   const auto result{sourcemeta::core::read_yaml(
       std::filesystem::path{STUBS_PATH} / "test_1.yaml")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -182,7 +182,7 @@ TEST(YAML_parse, stub_test_1) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, yaml_or_json_stub_test_1) {
+TEST(yaml_or_json_stub_test_1) {
   const auto result{sourcemeta::core::read_yaml_or_json(
       std::filesystem::path{STUBS_PATH} / "test_1.yaml")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -193,7 +193,7 @@ TEST(YAML_parse, yaml_or_json_stub_test_1) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, yaml_or_json_stub_test_2) {
+TEST(yaml_or_json_stub_test_2) {
   const auto result{sourcemeta::core::read_yaml_or_json(
       std::filesystem::path{STUBS_PATH} / "test_1.json")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -204,7 +204,7 @@ TEST(YAML_parse, yaml_or_json_stub_test_2) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, file_not_exists) {
+TEST(file_not_exists) {
   try {
     sourcemeta::core::read_yaml(std::filesystem::path{STUBS_PATH} /
                                 "not_exists.yaml");
@@ -215,7 +215,7 @@ TEST(YAML_parse, file_not_exists) {
   }
 }
 
-TEST(YAML_parse, yaml_or_json_file_not_exists) {
+TEST(yaml_or_json_file_not_exists) {
   try {
     sourcemeta::core::read_yaml_or_json(std::filesystem::path{STUBS_PATH} /
                                         "not_exists.yaml");
@@ -226,7 +226,7 @@ TEST(YAML_parse, yaml_or_json_file_not_exists) {
   }
 }
 
-TEST(YAML_parse, read_yaml_invalid_carries_path) {
+TEST(read_yaml_invalid_carries_path) {
   try {
     sourcemeta::core::read_yaml(std::filesystem::path{STUBS_PATH} /
                                 "invalid.yaml");
@@ -240,7 +240,7 @@ TEST(YAML_parse, read_yaml_invalid_carries_path) {
   }
 }
 
-TEST(YAML_parse, istringstream) {
+TEST(istringstream) {
   std::istringstream stream{"hello: world\nfoo: 1\nbar: true"};
   const auto result{sourcemeta::core::parse_yaml(stream)};
 
@@ -253,7 +253,7 @@ TEST(YAML_parse, istringstream) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, multi_document_unix_line_endings) {
+TEST(multi_document_unix_line_endings) {
   std::istringstream stream{"---\nfoo\n---\nbar\n---\nbaz"};
 
   const auto doc1{sourcemeta::core::parse_yaml(stream)};
@@ -268,7 +268,7 @@ TEST(YAML_parse, multi_document_unix_line_endings) {
   EXPECT_EQ(stream.peek(), EOF);
 }
 
-TEST(YAML_parse, multi_document_windows_line_endings) {
+TEST(multi_document_windows_line_endings) {
   std::istringstream stream{"---\r\nfoo\r\n---\r\nbar\r\n---\r\nbaz"};
 
   const auto doc1{sourcemeta::core::parse_yaml(stream)};
@@ -283,7 +283,7 @@ TEST(YAML_parse, multi_document_windows_line_endings) {
   EXPECT_EQ(stream.peek(), EOF);
 }
 
-TEST(YAML_parse, decimal_large_integer) {
+TEST(decimal_large_integer) {
   const std::string input{"123456789012345678901234567890"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   const sourcemeta::core::JSON expected{
@@ -293,19 +293,19 @@ TEST(YAML_parse, decimal_large_integer) {
   EXPECT_EQ(result.to_decimal().to_string(), "123456789012345678901234567890");
 }
 
-TEST(YAML_parse, decimal_high_precision_real) {
+TEST(decimal_high_precision_real) {
   const std::string input{"3.141592653589793238462643383279"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_decimal());
 }
 
-TEST(YAML_parse, decimal_exponential_notation) {
+TEST(decimal_exponential_notation) {
   const std::string input{"1.234567890123456789012345678901e50"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_decimal());
 }
 
-TEST(YAML_parse, decimal_in_object) {
+TEST(decimal_in_object) {
   const std::string input{"large: 999999999999999999999999999999\n"
                           "precise: 2.718281828459045235360287471352"};
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -319,7 +319,7 @@ TEST(YAML_parse, decimal_in_object) {
             "999999999999999999999999999999");
 }
 
-TEST(YAML_parse, decimal_in_array) {
+TEST(decimal_in_array) {
   const std::string input{"- 123456789012345678901234567890\n"
                           "- 9.87654321098765432109876543210e100"};
   const auto result{sourcemeta::core::parse_yaml(input)};
@@ -330,7 +330,7 @@ TEST(YAML_parse, decimal_in_array) {
   EXPECT_TRUE(result.at(1).is_decimal());
 }
 
-TEST(YAML_parse, integer_with_leading_plus) {
+TEST(integer_with_leading_plus) {
   const std::string input{"+42"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   const sourcemeta::core::JSON expected{42};
@@ -338,7 +338,7 @@ TEST(YAML_parse, integer_with_leading_plus) {
   EXPECT_TRUE(result.is_integer());
 }
 
-TEST(YAML_parse, real_with_leading_plus) {
+TEST(real_with_leading_plus) {
   const std::string input{"+1.5"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   const sourcemeta::core::JSON expected{1.5};
@@ -346,7 +346,7 @@ TEST(YAML_parse, real_with_leading_plus) {
   EXPECT_TRUE(result.is_real());
 }
 
-TEST(YAML_parse, exponent_with_leading_plus) {
+TEST(exponent_with_leading_plus) {
   const std::string input{"+2E0"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   const sourcemeta::core::JSON expected{sourcemeta::core::Decimal{"2E0"}};
@@ -354,7 +354,7 @@ TEST(YAML_parse, exponent_with_leading_plus) {
   EXPECT_TRUE(result.is_decimal());
 }
 
-TEST(YAML_parse, real_long_small_decimal) {
+TEST(real_long_small_decimal) {
   const std::string input{
       "0.00000000000000000000000000000000000000000000000000000000000000000000"
       "1"};
@@ -363,42 +363,42 @@ TEST(YAML_parse, real_long_small_decimal) {
   EXPECT_EQ(result.to_real(), 1e-69);
 }
 
-TEST(YAML_parse, real_subnormal_decimal) {
+TEST(real_subnormal_decimal) {
   const std::string input{"0." + std::string(309, '0') + "5"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_real());
   EXPECT_EQ(result.to_real(), 5e-310);
 }
 
-TEST(YAML_parse, decimal_underflowing_decimal) {
+TEST(decimal_underflowing_decimal) {
   const std::string input{"0." + std::string(400, '0') + "1"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_decimal());
   EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{input});
 }
 
-TEST(YAML_parse, scientific_constant_planck) {
+TEST(scientific_constant_planck) {
   const std::string input{"6.62607E-34"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_decimal());
   EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{"6.62607E-34"});
 }
 
-TEST(YAML_parse, scientific_constant_elementary_charge) {
+TEST(scientific_constant_elementary_charge) {
   const std::string input{"1.60218E-19"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_decimal());
   EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{"1.60218E-19"});
 }
 
-TEST(YAML_parse, scientific_constant_boltzmann) {
+TEST(scientific_constant_boltzmann) {
   const std::string input{"1.38065E-23"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_decimal());
   EXPECT_EQ(result.to_decimal(), sourcemeta::core::Decimal{"1.38065E-23"});
 }
 
-TEST(YAML_parse, yaml_or_json_custom_extension_yaml_content) {
+TEST(yaml_or_json_custom_extension_yaml_content) {
   const auto result{sourcemeta::core::read_yaml_or_json(
       std::filesystem::path{STUBS_PATH} / "test_2.custom")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -409,7 +409,7 @@ TEST(YAML_parse, yaml_or_json_custom_extension_yaml_content) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, yaml_or_json_custom_extension_json_content) {
+TEST(yaml_or_json_custom_extension_json_content) {
   const auto result{sourcemeta::core::read_yaml_or_json(
       std::filesystem::path{STUBS_PATH} / "test_3.custom")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -420,7 +420,7 @@ TEST(YAML_parse, yaml_or_json_custom_extension_json_content) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, yaml_or_json_no_extension_yaml_content) {
+TEST(yaml_or_json_no_extension_yaml_content) {
   const auto result{sourcemeta::core::read_yaml_or_json(
       std::filesystem::path{STUBS_PATH} / "test_no_extension_yaml")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -431,7 +431,7 @@ TEST(YAML_parse, yaml_or_json_no_extension_yaml_content) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, yaml_or_json_no_extension_json_content) {
+TEST(yaml_or_json_no_extension_json_content) {
   const auto result{sourcemeta::core::read_yaml_or_json(
       std::filesystem::path{STUBS_PATH} / "test_no_extension_json")};
   const sourcemeta::core::JSON expected = sourcemeta::core::parse_json(R"JSON({
@@ -442,7 +442,7 @@ TEST(YAML_parse, yaml_or_json_no_extension_json_content) {
   EXPECT_EQ(result, expected);
 }
 
-TEST(YAML_parse, yaml_or_json_invalid_json_throws_json_error) {
+TEST(yaml_or_json_invalid_json_throws_json_error) {
   try {
     sourcemeta::core::read_yaml_or_json(std::filesystem::path{STUBS_PATH} /
                                         "invalid.json");
@@ -453,7 +453,7 @@ TEST(YAML_parse, yaml_or_json_invalid_json_throws_json_error) {
   }
 }
 
-TEST(YAML_parse, yaml_or_json_invalid_yaml_throws_yaml_error) {
+TEST(yaml_or_json_invalid_yaml_throws_yaml_error) {
   try {
     sourcemeta::core::read_yaml_or_json(std::filesystem::path{STUBS_PATH} /
                                         "invalid.yaml");
@@ -466,55 +466,55 @@ TEST(YAML_parse, yaml_or_json_invalid_yaml_throws_yaml_error) {
   }
 }
 
-TEST(YAML_parse, verbatim_tag_bool) {
+TEST(verbatim_tag_bool) {
   const std::string input{"!<tag:yaml.org,2002:bool> true"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_boolean());
   EXPECT_EQ(result, sourcemeta::core::JSON{true});
 }
 
-TEST(YAML_parse, verbatim_tag_int) {
+TEST(verbatim_tag_int) {
   const std::string input{"!<tag:yaml.org,2002:int> 42"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_integer());
   EXPECT_EQ(result, sourcemeta::core::JSON{42});
 }
 
-TEST(YAML_parse, verbatim_tag_null) {
+TEST(verbatim_tag_null) {
   const std::string input{"!<tag:yaml.org,2002:null> ~"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_null());
 }
 
-TEST(YAML_parse, verbatim_tag_str) {
+TEST(verbatim_tag_str) {
   const std::string input{"!<tag:yaml.org,2002:str> true"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_string());
   EXPECT_EQ(result, sourcemeta::core::JSON{"true"});
 }
 
-TEST(YAML_parse, verbatim_tag_float) {
+TEST(verbatim_tag_float) {
   const std::string input{"!<tag:yaml.org,2002:float> 3.14"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_real());
   EXPECT_DOUBLE_EQ(result.to_real(), 3.14);
 }
 
-TEST(YAML_parse, plain_scalar_triple_dash_value) {
+TEST(plain_scalar_triple_dash_value) {
   const std::string input{"key: ---"};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_object());
   EXPECT_EQ(result.at("key"), sourcemeta::core::JSON{"---"});
 }
 
-TEST(YAML_parse, plain_scalar_triple_dot_value) {
+TEST(plain_scalar_triple_dot_value) {
   const std::string input{"key: ..."};
   const auto result{sourcemeta::core::parse_yaml(input)};
   EXPECT_TRUE(result.is_object());
   EXPECT_EQ(result.at("key"), sourcemeta::core::JSON{"..."});
 }
 
-TEST(YAML_parse, invalid_hex_escape) {
+TEST(invalid_hex_escape) {
   const std::string input{"\"\\xGG\""};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -526,7 +526,7 @@ TEST(YAML_parse, invalid_hex_escape) {
   }
 }
 
-TEST(YAML_parse, invalid_unicode_escape_4) {
+TEST(invalid_unicode_escape_4) {
   const std::string input{"\"\\uZZZZ\""};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -538,7 +538,7 @@ TEST(YAML_parse, invalid_unicode_escape_4) {
   }
 }
 
-TEST(YAML_parse, invalid_unicode_escape_8) {
+TEST(invalid_unicode_escape_8) {
   const std::string input{"\"\\UZZZZZZZZ\""};
   try {
     sourcemeta::core::parse_yaml(input);
@@ -550,7 +550,7 @@ TEST(YAML_parse, invalid_unicode_escape_8) {
   }
 }
 
-TEST(YAML_parse, exponential_alias_expansion_is_bounded) {
+TEST(exponential_alias_expansion_is_bounded) {
   const std::string input{"a: &a [ x, x, x, x, x, x, x, x, x, x ]\n"
                           "b: &b [ *a, *a, *a, *a, *a, *a, *a, *a, *a, *a ]\n"
                           "c: &c [ *b, *b, *b, *b, *b, *b, *b, *b, *b, *b ]\n"

--- a/test/yaml/yaml_roundtrip_test.cc
+++ b/test/yaml/yaml_roundtrip_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/yaml.h>
@@ -13,14 +13,14 @@ static auto roundtrip(const std::string &input) -> std::string {
   return stream.str();
 }
 
-TEST(YAML_roundtrip, block_mapping_simple) {
+TEST(block_mapping_simple) {
   const std::string input{R"YAML(foo: bar
 baz: qux
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_nested) {
+TEST(block_mapping_nested) {
   const std::string input{R"YAML(foo:
   bar: baz
   qux: 1
@@ -28,7 +28,7 @@ TEST(YAML_roundtrip, block_mapping_nested) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_simple) {
+TEST(block_sequence_simple) {
   const std::string input{R"YAML(- one
 - two
 - three
@@ -36,7 +36,7 @@ TEST(YAML_roundtrip, block_sequence_simple) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_mappings) {
+TEST(sequence_of_mappings) {
   const std::string input{R"YAML(- foo: bar
   baz: qux
 - hello: world
@@ -44,7 +44,7 @@ TEST(YAML_roundtrip, sequence_of_mappings) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_sequence) {
+TEST(mapping_with_sequence) {
   const std::string input{R"YAML(foo:
   - one
   - two
@@ -52,7 +52,7 @@ TEST(YAML_roundtrip, mapping_with_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested) {
+TEST(deeply_nested) {
   const std::string input{R"YAML(a:
   b:
     c:
@@ -61,7 +61,7 @@ TEST(YAML_roundtrip, deeply_nested) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_sequences) {
+TEST(sequence_of_sequences) {
   const std::string input{R"YAML(- - a
   - b
 - - c
@@ -70,7 +70,7 @@ TEST(YAML_roundtrip, sequence_of_sequences) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_types_in_mapping) {
+TEST(mixed_types_in_mapping) {
   const std::string input{R"YAML(name: app
 count: 3
 enabled: true
@@ -79,7 +79,7 @@ null_val: null
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, kubernetes_like) {
+TEST(kubernetes_like) {
   const std::string input{R"YAML(apiVersion: v1
 kind: Service
 metadata:
@@ -97,7 +97,7 @@ spec:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, github_actions_like) {
+TEST(github_actions_like) {
   const std::string input{R"YAML(name: CI
 on:
   push:
@@ -114,19 +114,19 @@ jobs:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_value) {
+TEST(single_quoted_value) {
   const std::string input{R"YAML(foo: 'bar'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_value) {
+TEST(double_quoted_value) {
   const std::string input{R"YAML(foo: "bar"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_scalar_styles) {
+TEST(mixed_scalar_styles) {
   const std::string input{R"YAML(plain: hello
 single: 'world'
 double: "!"
@@ -134,21 +134,21 @@ double: "!"
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_in_sequence) {
+TEST(single_quoted_in_sequence) {
   const std::string input{R"YAML(- 'one'
 - 'two'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_in_sequence) {
+TEST(double_quoted_in_sequence) {
   const std::string input{R"YAML(- "one"
 - "two"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_scalar) {
+TEST(literal_block_scalar) {
   const std::string input{R"YAML(foo: |
   hello
   world
@@ -156,14 +156,14 @@ TEST(YAML_roundtrip, literal_block_scalar) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_strip) {
+TEST(literal_block_strip) {
   const std::string input{R"YAML(foo: |-
   hello
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_keep) {
+TEST(literal_block_keep) {
   const std::string input{R"YAML(foo: |+
   hello
 
@@ -171,7 +171,7 @@ TEST(YAML_roundtrip, literal_block_keep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_scalar) {
+TEST(folded_block_scalar) {
   const std::string input{R"YAML(foo: >
   hello
   world
@@ -179,14 +179,14 @@ TEST(YAML_roundtrip, folded_block_scalar) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_strip) {
+TEST(folded_block_strip) {
   const std::string input{R"YAML(foo: >-
   hello
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_keep) {
+TEST(folded_block_keep) {
   const std::string input{R"YAML(foo: >+
   hello
 
@@ -194,7 +194,7 @@ TEST(YAML_roundtrip, folded_block_keep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_multiline) {
+TEST(literal_block_multiline) {
   const std::string input{R"YAML(description: |
   This is a
   multi-line
@@ -203,7 +203,7 @@ TEST(YAML_roundtrip, literal_block_multiline) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_multiline) {
+TEST(folded_block_multiline) {
   const std::string input{R"YAML(description: >
   This is a
   multi-line
@@ -212,67 +212,67 @@ TEST(YAML_roundtrip, folded_block_multiline) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_empty) {
+TEST(single_quoted_empty) {
   const std::string input{R"YAML(foo: ''
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_empty) {
+TEST(double_quoted_empty) {
   const std::string input{R"YAML(foo: ""
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_with_special_chars) {
+TEST(single_quoted_with_special_chars) {
   const std::string input{R"YAML(foo: 'bar: baz'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_escapes) {
+TEST(double_quoted_with_escapes) {
   const std::string input{"foo: \"hello\\nworld\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_number_string) {
+TEST(single_quoted_number_string) {
   const std::string input{R"YAML(port: '8080'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_boolean_string) {
+TEST(double_quoted_boolean_string) {
   const std::string input{R"YAML(flag: "true"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping) {
+TEST(flow_mapping) {
   const std::string input{R"YAML(foo: {bar: baz, qux: 1}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence) {
+TEST(flow_sequence) {
   const std::string input{R"YAML(items: [1, 2, 3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_nested_in_block) {
+TEST(flow_nested_in_block) {
   const std::string input{R"YAML(foo: {bar: baz}
 items: [1, 2, 3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_strings) {
+TEST(flow_sequence_strings) {
   const std::string input{R"YAML(branches: [main, develop]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, github_actions_with_flow) {
+TEST(github_actions_with_flow) {
   const std::string input{R"YAML(name: CI
 on:
   push:
@@ -288,14 +288,14 @@ jobs:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, explicit_document_start) {
+TEST(explicit_document_start) {
   const std::string input{R"YAML(---
 foo: bar
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, explicit_document_end) {
+TEST(explicit_document_end) {
   const std::string input{R"YAML(---
 foo: bar
 ...
@@ -303,7 +303,7 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_with_sequence) {
+TEST(document_start_with_sequence) {
   const std::string input{R"YAML(---
 - one
 - two
@@ -312,7 +312,7 @@ TEST(YAML_roundtrip, document_start_with_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_everything) {
+TEST(mixed_everything) {
   const std::string input{R"YAML(---
 name: 'My App'
 version: "1.0"
@@ -329,7 +329,7 @@ nested:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_in_sequence) {
+TEST(block_scalar_in_sequence) {
   const std::string input{R"YAML(steps:
   - name: Build
     run: |
@@ -341,7 +341,7 @@ TEST(YAML_roundtrip, block_scalar_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_flow_and_block) {
+TEST(nested_flow_and_block) {
   const std::string input{R"YAML(rules:
   - pattern: "*.cc"
     options: {verbose: true, strict: false}
@@ -351,14 +351,14 @@ TEST(YAML_roundtrip, nested_flow_and_block) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_scalar) {
+TEST(anchor_scalar) {
   const std::string input{R"YAML(foo: &tag value
 bar: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_and_alias_mapping) {
+TEST(anchor_and_alias_mapping) {
   const std::string input{R"YAML(foo: &anchor
   bar: baz
 ref: *anchor
@@ -366,7 +366,7 @@ ref: *anchor
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_anchors) {
+TEST(multiple_anchors) {
   const std::string input{R"YAML(a: &x 1
 b: &y 2
 c: *x
@@ -375,7 +375,7 @@ d: *y
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_sequence) {
+TEST(anchor_sequence) {
   const std::string input{R"YAML(items: &list
   - one
   - two
@@ -384,7 +384,7 @@ ref: *list
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_reused_multiple) {
+TEST(anchor_reused_multiple) {
   const std::string input{R"YAML(a: &val hello
 b: *val
 c: *val
@@ -392,19 +392,19 @@ c: *val
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_mapping) {
+TEST(comment_before_mapping) {
   const std::string input{R"YAML(# header comment
 foo: bar
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_inline) {
+TEST(comment_inline) {
   const std::string input{"foo: bar # inline comment\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_keys) {
+TEST(comment_between_keys) {
   const std::string input{R"YAML(foo: bar
 # between
 baz: qux
@@ -412,7 +412,7 @@ baz: qux
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_value) {
+TEST(comment_before_value) {
   const std::string input{R"YAML(foo:
   # comment
   bar: baz
@@ -420,7 +420,7 @@ TEST(YAML_roundtrip, comment_before_value) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_sequence) {
+TEST(comment_before_sequence) {
   const std::string input{R"YAML(# items
 - one
 - two
@@ -428,12 +428,12 @@ TEST(YAML_roundtrip, comment_before_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_inline_sequence) {
+TEST(comment_inline_sequence) {
   const std::string input{"- one # first\n- two # second\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_comment_lines) {
+TEST(multiple_comment_lines) {
   const std::string input{R"YAML(# line 1
 # line 2
 foo: bar
@@ -441,19 +441,19 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_at_end) {
+TEST(comment_at_end) {
   const std::string input{R"YAML(foo: bar
 # trailing
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_inline_on_nested_key) {
+TEST(comment_inline_on_nested_key) {
   const std::string input{"foo: bar # comment\nbaz:\n  qux: 1\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_document_start) {
+TEST(comment_after_document_start) {
   const std::string input{R"YAML(---
 # comment after doc start
 foo: bar
@@ -461,7 +461,7 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_document_start) {
+TEST(comment_before_document_start) {
   const std::string input{R"YAML(# comment before doc start
 ---
 foo: bar
@@ -469,48 +469,48 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_inline_on_flow_mapping) {
+TEST(comment_inline_on_flow_mapping) {
   const std::string input{"foo: {a: 1} # flow comment\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_inline_on_flow_sequence) {
+TEST(comment_inline_on_flow_sequence) {
   const std::string input{"items: [1, 2] # list comment\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_last_key_in_mapping) {
+TEST(inline_comment_last_key_in_mapping) {
   const std::string input{"a: 1\nb: 2 # last\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_single_quoted) {
+TEST(anchor_with_single_quoted) {
   const std::string input{R"YAML(foo: &tag 'value'
 bar: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_double_quoted) {
+TEST(anchor_with_double_quoted) {
   const std::string input{"foo: &tag \"value\"\nbar: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_flow_mapping) {
+TEST(anchor_on_flow_mapping) {
   const std::string input{R"YAML(defaults: &defs {a: 1, b: 2}
 foo: *defs
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_flow_sequence) {
+TEST(anchor_on_flow_sequence) {
   const std::string input{R"YAML(items: &list [1, 2, 3]
 ref: *list
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_deeply_nested) {
+TEST(literal_block_deeply_nested) {
   const std::string input{R"YAML(outer:
   inner:
     script: |
@@ -520,7 +520,7 @@ TEST(YAML_roundtrip, literal_block_deeply_nested) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_deeply_nested) {
+TEST(folded_block_deeply_nested) {
   const std::string input{R"YAML(outer:
   inner:
     text: >
@@ -530,7 +530,7 @@ TEST(YAML_roundtrip, folded_block_deeply_nested) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_with_blank_lines) {
+TEST(literal_block_with_blank_lines) {
   const std::string input{R"YAML(foo: |
   first
 
@@ -539,7 +539,7 @@ TEST(YAML_roundtrip, literal_block_with_blank_lines) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_followed_by_key) {
+TEST(block_scalar_followed_by_key) {
   const std::string input{R"YAML(script: |
   echo hello
 next: value
@@ -547,21 +547,21 @@ next: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_in_sequence) {
+TEST(flow_mapping_in_sequence) {
   const std::string input{R"YAML(- {a: 1}
 - {b: 2}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_in_sequence) {
+TEST(flow_sequence_in_sequence) {
   const std::string input{R"YAML(- [1, 2]
 - [3, 4]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_flow_and_block_in_sequence) {
+TEST(mixed_flow_and_block_in_sequence) {
   const std::string input{R"YAML(- name: foo
   tags: [a, b]
 - name: bar
@@ -570,22 +570,22 @@ TEST(YAML_roundtrip, mixed_flow_and_block_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_scalar_plain) {
+TEST(single_scalar_plain) {
   const std::string input{"hello\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_scalar_quoted) {
+TEST(single_scalar_quoted) {
   const std::string input{"'hello'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_scalar_double_quoted) {
+TEST(single_scalar_double_quoted) {
   const std::string input{"\"hello\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_mixed_scalar_styles) {
+TEST(sequence_mixed_scalar_styles) {
   const std::string input{R"YAML(- plain
 - 'single'
 - "double"
@@ -593,25 +593,25 @@ TEST(YAML_roundtrip, sequence_mixed_scalar_styles) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, numeric_key) {
+TEST(numeric_key) {
   const std::string input{R"YAML("42": value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_like_key) {
+TEST(boolean_like_key) {
   const std::string input{R"YAML("true": value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_like_key) {
+TEST(null_like_key) {
   const std::string input{R"YAML("null": value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, triple_nested_sequence) {
+TEST(triple_nested_sequence) {
   const std::string input{R"YAML(- - - a
     - b
   - - c
@@ -619,7 +619,7 @@ TEST(YAML_roundtrip, triple_nested_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_sequence_items) {
+TEST(comment_between_sequence_items) {
   const std::string input{R"YAML(- one
 # between items
 - two
@@ -627,7 +627,7 @@ TEST(YAML_roundtrip, comment_between_sequence_items) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_block_scalar) {
+TEST(anchor_with_block_scalar) {
   const std::string input{R"YAML(template: &tmpl |
   hello world
 ref: *tmpl
@@ -635,7 +635,7 @@ ref: *tmpl
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_markers_with_comments) {
+TEST(document_markers_with_comments) {
   const std::string input{R"YAML(# header
 ---
 foo: bar
@@ -645,24 +645,24 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_inline_comments) {
+TEST(multiple_inline_comments) {
   const std::string input{"a: 1 # first\nb: 2 # second\nc: 3 # third\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_alias) {
+TEST(inline_comment_on_alias) {
   const std::string input{"foo: &tag value\nbar: *tag # reuse\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_key_with_nested_mapping) {
+TEST(inline_comment_on_key_with_nested_mapping) {
   const std::string input{R"YAML(foo: # config section
   bar: baz
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_key_with_nested_sequence) {
+TEST(inline_comment_on_key_with_nested_sequence) {
   const std::string input{R"YAML(items: # the list
   - one
   - two
@@ -670,12 +670,12 @@ TEST(YAML_roundtrip, inline_comment_on_key_with_nested_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_inline_comment) {
+TEST(anchor_with_inline_comment) {
   const std::string input{"foo: &tag value # tagged\nbar: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_nested_sequence_item) {
+TEST(comment_before_nested_sequence_item) {
   const std::string input{R"YAML(items:
   # first item
   - one
@@ -684,17 +684,17 @@ TEST(YAML_roundtrip, comment_before_nested_sequence_item) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_empty_flow_mapping) {
+TEST(inline_comment_on_empty_flow_mapping) {
   const std::string input{"foo: {} # empty\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_empty_flow_sequence) {
+TEST(inline_comment_on_empty_flow_sequence) {
   const std::string input{"foo: [] # empty\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_mapping_entries_in_sequence) {
+TEST(comment_between_mapping_entries_in_sequence) {
   const std::string input{R"YAML(- name: foo
   # separator
   value: 1
@@ -702,7 +702,7 @@ TEST(YAML_roundtrip, comment_between_mapping_entries_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_comments_before_key) {
+TEST(multiple_comments_before_key) {
   const std::string input{R"YAML(# line 1
 # line 2
 # line 3
@@ -711,7 +711,7 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_document_start_with_sequence) {
+TEST(comment_after_document_start_with_sequence) {
   const std::string input{R"YAML(---
 # list follows
 - one
@@ -720,17 +720,17 @@ TEST(YAML_roundtrip, comment_after_document_start_with_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_sequence_item_flow_mapping) {
+TEST(inline_comment_on_sequence_item_flow_mapping) {
   const std::string input{"- {a: 1} # first\n- {b: 2} # second\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_and_inline_same_key) {
+TEST(comment_before_and_inline_same_key) {
   const std::string input{"# before\nfoo: bar # inline\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_comment) {
+TEST(deeply_nested_comment) {
   const std::string input{R"YAML(a:
   b:
     # deep comment
@@ -739,7 +739,7 @@ TEST(YAML_roundtrip, deeply_nested_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_block_scalar) {
+TEST(comment_after_block_scalar) {
   const std::string input{R"YAML(script: |
   echo hello
 # next section
@@ -748,12 +748,12 @@ next: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_anchor_flow_mapping) {
+TEST(inline_comment_on_anchor_flow_mapping) {
   const std::string input{"defaults: &defs {a: 1} # defaults\nfoo: *defs\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_doc_start_and_end) {
+TEST(comment_between_doc_start_and_end) {
   const std::string input{R"YAML(---
 foo: bar
 # between markers
@@ -762,7 +762,7 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_anchors_with_comments) {
+TEST(multiple_anchors_with_comments) {
   const std::string input{R"YAML(# first anchor
 a: &x 1
 # second anchor
@@ -773,7 +773,7 @@ d: *y
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_sequence_with_nested_mappings) {
+TEST(comment_on_sequence_with_nested_mappings) {
   const std::string input{R"YAML(# steps
 - name: build
   run: make
@@ -784,7 +784,7 @@ TEST(YAML_roundtrip, comment_on_sequence_with_nested_mappings) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_value_then_comment_then_key) {
+TEST(null_value_then_comment_then_key) {
   const std::string input{R"YAML(a: null
 # comment
 b: 2
@@ -792,7 +792,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_non_first_key_with_nested_mapping) {
+TEST(inline_comment_on_non_first_key_with_nested_mapping) {
   const std::string input{R"YAML(first: 1
 second: # nested
   a: 2
@@ -800,7 +800,7 @@ second: # nested
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_non_first_key_with_nested_sequence) {
+TEST(inline_comment_on_non_first_key_with_nested_sequence) {
   const std::string input{R"YAML(first: 1
 second: # list
   - a
@@ -809,7 +809,7 @@ second: # list
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comments_at_every_nesting_level) {
+TEST(comments_at_every_nesting_level) {
   const std::string input{R"YAML(# top level
 a:
   # level 1
@@ -820,7 +820,7 @@ a:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_sequence_items_nested_mappings) {
+TEST(comment_between_sequence_items_nested_mappings) {
   const std::string input{R"YAML(- name: foo
   value: 1
 # separator
@@ -830,7 +830,7 @@ TEST(YAML_roundtrip, comment_between_sequence_items_nested_mappings) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_sequence_item_scalar) {
+TEST(inline_comment_on_sequence_item_scalar) {
   const std::string input{R"YAML(items:
   - one # first
   - two # second
@@ -839,7 +839,7 @@ TEST(YAML_roundtrip, inline_comment_on_sequence_item_scalar) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_then_comment_then_block_scalar) {
+TEST(block_scalar_then_comment_then_block_scalar) {
   const std::string input{R"YAML(a: |
   content1
 # between scalars
@@ -849,7 +849,7 @@ b: |
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_null_value_with_comment) {
+TEST(anchor_on_null_value_with_comment) {
   const std::string input{R"YAML(# comment before alias
 a: &tag value
 b: *tag
@@ -857,14 +857,14 @@ b: *tag
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_implicit_null) {
+TEST(anchor_on_implicit_null) {
   const std::string input{R"YAML(a: &tag
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_in_sequence_with_comments) {
+TEST(flow_sequence_in_sequence_with_comments) {
   const std::string input{R"YAML(# first list
 - [1, 2]
 # second list
@@ -873,13 +873,13 @@ TEST(YAML_roundtrip, flow_sequence_in_sequence_with_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_then_preceding_comment_same_key_series) {
+TEST(inline_comment_then_preceding_comment_same_key_series) {
   const std::string input{
       "a: 1 # on a\n# before b\nb: 2 # on b\n# before c\nc: 3\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_flow_in_nested_mapping) {
+TEST(comment_after_flow_in_nested_mapping) {
   const std::string input{R"YAML(outer:
   tags: [a, b] # tag list
   name: foo
@@ -887,7 +887,7 @@ TEST(YAML_roundtrip, comment_after_flow_in_nested_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_null_values_with_comments) {
+TEST(multiple_null_values_with_comments) {
   const std::string input{R"YAML(a: null
 b: null
 # comment
@@ -896,7 +896,7 @@ c: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_nested_mapping_first_key) {
+TEST(inline_comment_on_nested_mapping_first_key) {
   const std::string input{R"YAML(outer:
   inner: value # the value
   other: 2
@@ -904,7 +904,7 @@ TEST(YAML_roundtrip, inline_comment_on_nested_mapping_first_key) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_sequences_with_comments) {
+TEST(sequence_of_sequences_with_comments) {
   const std::string input{R"YAML(# outer
 - - a
   - b
@@ -915,7 +915,7 @@ TEST(YAML_roundtrip, sequence_of_sequences_with_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_alias_with_preceding_and_inline_comments) {
+TEST(anchor_alias_with_preceding_and_inline_comments) {
   const std::string input{R"YAML(# anchor def
 a: &tag value # anchor inline
 # alias ref
@@ -924,7 +924,7 @@ b: *tag # alias inline
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_sequence_with_comments) {
+TEST(deeply_nested_sequence_with_comments) {
   const std::string input{R"YAML(items:
   - sub:
       - deep # inline deep
@@ -933,7 +933,7 @@ TEST(YAML_roundtrip, deeply_nested_sequence_with_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_only_before_document_end) {
+TEST(comment_only_before_document_end) {
   const std::string input{R"YAML(---
 foo: bar
 # only comment
@@ -942,12 +942,12 @@ foo: bar
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_with_special_yaml_chars) {
+TEST(inline_comment_with_special_yaml_chars) {
   const std::string input{"foo: bar # { } [ ] : - * &\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_last_sequence_item_mapping) {
+TEST(comment_after_last_sequence_item_mapping) {
   const std::string input{R"YAML(- name: foo
   value: 1
 - name: bar
@@ -956,32 +956,32 @@ TEST(YAML_roundtrip, comment_after_last_sequence_item_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_key_null_value_with_inline_comment) {
+TEST(single_key_null_value_with_inline_comment) {
   const std::string input{"foo: null # empty\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_value) {
+TEST(implicit_null_value) {
   const std::string input{"foo:\nbar: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_with_inline_comment) {
+TEST(implicit_null_with_inline_comment) {
   const std::string input{"foo: # empty\nbar: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, explicit_null_value) {
+TEST(explicit_null_value) {
   const std::string input{"foo: null\nbar: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_multiple) {
+TEST(implicit_null_multiple) {
   const std::string input{"a:\nb:\nc: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, kubernetes_like_with_comments) {
+TEST(kubernetes_like_with_comments) {
   const std::string input{R"YAML(apiVersion: v1 # required
 kind: Service
 metadata:
@@ -998,7 +998,7 @@ spec:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_block_mapping_key_path) {
+TEST(inline_comment_on_block_mapping_key_path) {
   const std::string input{R"YAML(a: 1
 b: # nested via block key
   c: 2
@@ -1007,7 +1007,7 @@ b: # nested via block key
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_third_key_nested) {
+TEST(inline_comment_on_third_key_nested) {
   const std::string input{R"YAML(a: 1
 b: 2
 c: # third key nested
@@ -1016,12 +1016,12 @@ c: # third key nested
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_anchor_value) {
+TEST(comment_after_anchor_value) {
   const std::string input{"a: &x 1 # anchored\nb: *x\nc: *x # reused\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_nested_flow_sequence_non_first) {
+TEST(comment_after_nested_flow_sequence_non_first) {
   const std::string input{R"YAML(name: foo
 tags: [a, b] # the tags
 version: 1
@@ -1029,7 +1029,7 @@ version: 1
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, preceding_comment_on_second_nested_key) {
+TEST(preceding_comment_on_second_nested_key) {
   const std::string input{R"YAML(outer:
   a: 1
   # before b
@@ -1038,7 +1038,7 @@ TEST(YAML_roundtrip, preceding_comment_on_second_nested_key) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_nested_last_key) {
+TEST(inline_comment_on_nested_last_key) {
   const std::string input{R"YAML(outer:
   a: 1
   b: 2 # last nested
@@ -1046,7 +1046,7 @@ TEST(YAML_roundtrip, inline_comment_on_nested_last_key) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_nested_sequences) {
+TEST(comment_between_nested_sequences) {
   const std::string input{R"YAML(items:
   - one
   # between
@@ -1055,7 +1055,7 @@ TEST(YAML_roundtrip, comment_between_nested_sequences) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_value_in_sequence_with_comment) {
+TEST(flow_mapping_value_in_sequence_with_comment) {
   const std::string input{R"YAML(- name: foo
   config: {debug: true} # cfg
 - name: bar
@@ -1063,17 +1063,17 @@ TEST(YAML_roundtrip, flow_mapping_value_in_sequence_with_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_value_with_inline_comment) {
+TEST(double_quoted_value_with_inline_comment) {
   const std::string input{"foo: \"bar\" # quoted\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_value_with_inline_comment) {
+TEST(single_quoted_value_with_inline_comment) {
   const std::string input{"foo: 'bar' # quoted\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_between_commented_keys) {
+TEST(block_scalar_between_commented_keys) {
   const std::string input{R"YAML(# before script
 script: |
   echo hello
@@ -1083,7 +1083,7 @@ next: value # inline
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, three_level_nested_inline_comments) {
+TEST(three_level_nested_inline_comments) {
   const std::string input{R"YAML(a: # level 0
   b: # level 1
     c: value # level 2
@@ -1091,7 +1091,7 @@ TEST(YAML_roundtrip, three_level_nested_inline_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_doc_start_and_mapping) {
+TEST(comment_between_doc_start_and_mapping) {
   const std::string input{R"YAML(---
 # after start
 a: 1
@@ -1101,14 +1101,14 @@ a: 1
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, alias_in_sequence_with_comment) {
+TEST(alias_in_sequence_with_comment) {
   const std::string input{R"YAML(- &item value
 - *item # reused
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_comments_and_anchors_realistic) {
+TEST(mixed_comments_and_anchors_realistic) {
   const std::string input{R"YAML(# Database config
 database:
   host: localhost # default host
@@ -1124,7 +1124,7 @@ cache:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_item_with_flow_and_block_mixed) {
+TEST(sequence_item_with_flow_and_block_mixed) {
   const std::string input{R"YAML(- tags: [a, b] # tags
   name: foo
   script: |
@@ -1136,7 +1136,7 @@ TEST(YAML_roundtrip, sequence_item_with_flow_and_block_mixed) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_empty_flow_in_nested) {
+TEST(comment_after_empty_flow_in_nested) {
   const std::string input{R"YAML(outer:
   empty_map: {} # nothing here
   empty_list: [] # also nothing
@@ -1145,13 +1145,13 @@ TEST(YAML_roundtrip, comment_after_empty_flow_in_nested) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_every_key_in_nested) {
+TEST(inline_comment_every_key_in_nested) {
   const std::string input{
       "a: 1 # one\nb: 2 # two\nc: 3 # three\nd: 4 # four\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_preceding_comments_non_first_key) {
+TEST(multiple_preceding_comments_non_first_key) {
   const std::string input{R"YAML(a: 1
 # line 1
 # line 2
@@ -1161,7 +1161,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_sequence_first_item_is_mapping) {
+TEST(comment_on_sequence_first_item_is_mapping) {
   const std::string input{R"YAML(# first entry
 - key: value
   other: 2
@@ -1171,26 +1171,26 @@ TEST(YAML_roundtrip, comment_on_sequence_first_item_is_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_mapping_inside_first_seq_item) {
+TEST(inline_comment_on_mapping_inside_first_seq_item) {
   const std::string input{R"YAML(- a: 1 # on a
 - b: 2
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_mapping_inside_last_seq_item) {
+TEST(inline_comment_on_mapping_inside_last_seq_item) {
   const std::string input{R"YAML(- a: 1
 - b: 2 # on b
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, two_flow_collections_inline_comments) {
+TEST(two_flow_collections_inline_comments) {
   const std::string input{"a: [1, 2] # first\nb: {x: 1} # second\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_alias_in_sequence) {
+TEST(inline_comment_on_alias_in_sequence) {
   const std::string input{R"YAML(- &x hello
 - *x # reused
 - world
@@ -1198,7 +1198,7 @@ TEST(YAML_roundtrip, inline_comment_on_alias_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_nested_mapping_keys_deep) {
+TEST(comment_between_nested_mapping_keys_deep) {
   const std::string input{R"YAML(a:
   b:
     x: 1
@@ -1208,7 +1208,7 @@ TEST(YAML_roundtrip, comment_between_nested_mapping_keys_deep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_deeply_nested_last_key) {
+TEST(inline_comment_on_deeply_nested_last_key) {
   const std::string input{R"YAML(a:
   b:
     x: 1
@@ -1217,7 +1217,7 @@ TEST(YAML_roundtrip, inline_comment_on_deeply_nested_last_key) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, preceding_and_inline_on_every_key) {
+TEST(preceding_and_inline_on_every_key) {
   const std::string input{R"YAML(# before a
 a: 1 # on a
 # before b
@@ -1228,7 +1228,7 @@ c: 3 # on c
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_mapping_in_sequence_with_flow_and_comment) {
+TEST(nested_mapping_in_sequence_with_flow_and_comment) {
   const std::string input{R"YAML(- name: test
   env: {DEBUG: true} # env vars
   run: make
@@ -1236,14 +1236,14 @@ TEST(YAML_roundtrip, nested_mapping_in_sequence_with_flow_and_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_non_first_key_with_comment) {
+TEST(flow_sequence_non_first_key_with_comment) {
   const std::string input{R"YAML(name: CI
 branches: [main, develop] # tracked
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_nested_mapping_with_comments) {
+TEST(anchor_on_nested_mapping_with_comments) {
   const std::string input{R"YAML(defaults: &defs
   # default timeout
   timeout: 30
@@ -1255,7 +1255,7 @@ job:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_keep_with_comment_after) {
+TEST(block_scalar_keep_with_comment_after) {
   const std::string input{R"YAML(first: |+
   content
 
@@ -1265,7 +1265,7 @@ second: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_strip_with_comment_after) {
+TEST(block_scalar_strip_with_comment_after) {
   const std::string input{R"YAML(first: |-
   content
 # after block
@@ -1274,7 +1274,7 @@ second: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_then_comment_then_key) {
+TEST(folded_scalar_then_comment_then_key) {
   const std::string input{R"YAML(text: >
   folded content
 # separator
@@ -1283,7 +1283,7 @@ next: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_three_items_comments_between_each) {
+TEST(sequence_three_items_comments_between_each) {
   const std::string input{R"YAML(- one
 # between 1 and 2
 - two
@@ -1293,7 +1293,7 @@ TEST(YAML_roundtrip, sequence_three_items_comments_between_each) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_value_is_flow_then_nested_mapping) {
+TEST(mapping_value_is_flow_then_nested_mapping) {
   const std::string input{R"YAML(flow: {a: 1} # inline
 nested: # section
   b: 2
@@ -1302,7 +1302,7 @@ nested: # section
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, three_keys_middle_has_nested_with_comment) {
+TEST(three_keys_middle_has_nested_with_comment) {
   const std::string input{R"YAML(first: 1
 second: # has children
   a: 2
@@ -1312,7 +1312,7 @@ third: 4
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_in_mapping_with_preceding_comment) {
+TEST(sequence_in_mapping_with_preceding_comment) {
   const std::string input{R"YAML(config:
   name: app
   # the items
@@ -1323,7 +1323,7 @@ TEST(YAML_roundtrip, sequence_in_mapping_with_preceding_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, doc_start_comment_then_sequence) {
+TEST(doc_start_comment_then_sequence) {
   const std::string input{R"YAML(# header
 ---
 # after start
@@ -1333,18 +1333,18 @@ TEST(YAML_roundtrip, doc_start_comment_then_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_single_key_mapping) {
+TEST(inline_comment_on_single_key_mapping) {
   const std::string input{"foo: bar # only key\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_special_chars_in_text) {
+TEST(comment_special_chars_in_text) {
   const std::string input{
       "foo: bar # contains: colons, [brackets], {braces}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_flow_mapping_non_first_with_comment) {
+TEST(nested_flow_mapping_non_first_with_comment) {
   const std::string input{R"YAML(a: 1
 b: {x: 1, y: 2} # flow map
 c: 3
@@ -1352,7 +1352,7 @@ c: 3
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, four_level_nesting_with_comment) {
+TEST(four_level_nesting_with_comment) {
   const std::string input{R"YAML(a:
   b:
     c:
@@ -1362,7 +1362,7 @@ TEST(YAML_roundtrip, four_level_nesting_with_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_item_anchor_then_comment_on_next) {
+TEST(sequence_item_anchor_then_comment_on_next) {
   const std::string input{R"YAML(- &first one
 # between
 - two
@@ -1371,7 +1371,7 @@ TEST(YAML_roundtrip, sequence_item_anchor_then_comment_on_next) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_block_scalars_with_comments) {
+TEST(mixed_block_scalars_with_comments) {
   const std::string input{R"YAML(# literal
 a: |
   hello
@@ -1384,21 +1384,21 @@ c: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_sequence_dash) {
+TEST(inline_comment_on_sequence_dash) {
   const std::string input{R"YAML(- # comment
   value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_document_start) {
+TEST(inline_comment_on_document_start) {
   const std::string input{R"YAML(--- # start comment
 key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, trailing_comment_nested_sequence) {
+TEST(trailing_comment_nested_sequence) {
   const std::string input{R"YAML(items:
   - one
   - two
@@ -1407,21 +1407,21 @@ TEST(YAML_roundtrip, trailing_comment_nested_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_with_nested_mapping) {
+TEST(comment_on_dash_with_nested_mapping) {
   const std::string input{R"YAML(- # item comment
   key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_with_nested_sequence) {
+TEST(comment_on_dash_with_nested_sequence) {
   const std::string input{R"YAML(- # outer
   - inner
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_multiple_items) {
+TEST(comment_on_dash_multiple_items) {
   const std::string input{R"YAML(- # first
   one
 - # second
@@ -1431,14 +1431,14 @@ TEST(YAML_roundtrip, comment_on_dash_multiple_items) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_colon_with_next_line_value) {
+TEST(inline_comment_on_colon_with_next_line_value) {
   const std::string input{R"YAML(key: # on colon
   value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_comment_with_post_start_comments) {
+TEST(document_start_comment_with_post_start_comments) {
   const std::string input{R"YAML(--- # start
 # after start
 key: value
@@ -1446,7 +1446,7 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_end_inline_comment) {
+TEST(document_end_inline_comment) {
   const std::string input{R"YAML(---
 key: value
 ... # end
@@ -1454,7 +1454,7 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_sequence_item) {
+TEST(anchor_on_sequence_item) {
   const std::string input{R"YAML(- &first one
 - &second two
 - *first
@@ -1462,7 +1462,7 @@ TEST(YAML_roundtrip, anchor_on_sequence_item) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_with_indicator_comment) {
+TEST(block_scalar_with_indicator_comment) {
   const std::string input{R"YAML(key: | # block comment
   hello
   world
@@ -1470,7 +1470,7 @@ TEST(YAML_roundtrip, block_scalar_with_indicator_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_first_item_only) {
+TEST(comment_on_dash_first_item_only) {
   const std::string input{R"YAML(- # has comment
   first
 - second
@@ -1478,7 +1478,7 @@ TEST(YAML_roundtrip, comment_on_dash_first_item_only) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_comment_on_dash) {
+TEST(deeply_nested_comment_on_dash) {
   const std::string input{R"YAML(outer:
   - # nested
     inner: value
@@ -1486,7 +1486,7 @@ TEST(YAML_roundtrip, deeply_nested_comment_on_dash) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, alias_with_preceding_comment) {
+TEST(alias_with_preceding_comment) {
   const std::string input{R"YAML(a: &tag value
 # before alias
 b: *tag
@@ -1494,19 +1494,19 @@ b: *tag
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_flow_mapping_with_comment) {
+TEST(empty_flow_mapping_with_comment) {
   const std::string input{R"YAML(a: {} # empty
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_flow_sequence_with_comment) {
+TEST(empty_flow_sequence_with_comment) {
   const std::string input{R"YAML(a: [] # empty
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_comment_and_content) {
+TEST(document_start_comment_and_content) {
   const std::string input{R"YAML(--- # doc comment
 a: 1
 b: 2
@@ -1514,14 +1514,14 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_on_anchor_definition) {
+TEST(inline_comment_on_anchor_definition) {
   const std::string input{R"YAML(a: &tag value # on value
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_sequence_items_and_mapping) {
+TEST(comment_between_sequence_items_and_mapping) {
   const std::string input{R"YAML(items:
   - one
   # between
@@ -1531,7 +1531,7 @@ next: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_with_indicator_comment) {
+TEST(folded_scalar_with_indicator_comment) {
   const std::string input{R"YAML(key: > # folded comment
   hello
   world
@@ -1539,14 +1539,14 @@ TEST(YAML_roundtrip, folded_scalar_with_indicator_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_with_nested_mapping) {
+TEST(comment_on_colon_with_nested_mapping) {
   const std::string input{R"YAML(outer: # on outer
   inner: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_with_nested_sequence) {
+TEST(comment_on_colon_with_nested_sequence) {
   const std::string input{R"YAML(items: # on items
   - one
   - two
@@ -1554,7 +1554,7 @@ TEST(YAML_roundtrip, comment_on_colon_with_nested_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_with_block_scalar) {
+TEST(comment_on_colon_with_block_scalar) {
   const std::string input{R"YAML(text: |
   hello
   world
@@ -1562,14 +1562,14 @@ TEST(YAML_roundtrip, comment_on_colon_with_block_scalar) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_with_flow_mapping) {
+TEST(comment_on_dash_with_flow_mapping) {
   const std::string input{R"YAML(- # item
   {a: 1}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_with_anchor) {
+TEST(comment_on_dash_with_anchor) {
   const std::string input{R"YAML(- # anchored
   &tag value
 - *tag
@@ -1577,26 +1577,26 @@ TEST(YAML_roundtrip, comment_on_dash_with_anchor) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_and_inline_on_value) {
+TEST(comment_on_colon_and_inline_on_value) {
   const std::string input{"key: # on colon\n  value # on value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, strip_chomping_with_comment) {
+TEST(strip_chomping_with_comment) {
   const std::string input{R"YAML(key: |- # stripped
   hello
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, keep_chomping_with_comment) {
+TEST(keep_chomping_with_comment) {
   const std::string input{R"YAML(key: |+ # kept
   hello
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_comment_on_colon) {
+TEST(anchor_with_comment_on_colon) {
   const std::string input{R"YAML(a: # comment
   &tag value
 b: *tag
@@ -1604,7 +1604,7 @@ b: *tag
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_keys_with_colon_comments) {
+TEST(multiple_keys_with_colon_comments) {
   const std::string input{R"YAML(a: # first
   1
 b: # second
@@ -1614,14 +1614,14 @@ c: 3
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_null_item) {
+TEST(comment_on_dash_null_item) {
   const std::string input{R"YAML(- # null item
 - value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, leading_comment_and_document_start_comment) {
+TEST(leading_comment_and_document_start_comment) {
   const std::string input{R"YAML(# leading
 --- # start
 key: value
@@ -1629,7 +1629,7 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_end_comment_with_trailing) {
+TEST(document_end_comment_with_trailing) {
   const std::string input{R"YAML(---
 key: value
 ... # end
@@ -1638,7 +1638,7 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, pre_end_comment_and_end_comment) {
+TEST(pre_end_comment_and_end_comment) {
   const std::string input{R"YAML(---
 key: value
 # before end
@@ -1647,34 +1647,34 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_escapes_roundtrip) {
+TEST(double_quoted_with_escapes_roundtrip) {
   const std::string input{"key: \"hello\\nworld\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_with_inner_quotes) {
+TEST(single_quoted_with_inner_quotes) {
   const std::string input{"key: 'it''s here'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_nested_in_flow_sequence) {
+TEST(flow_mapping_nested_in_flow_sequence) {
   const std::string input{"- [{a: 1}, {b: 2}]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_nested_in_flow_mapping) {
+TEST(flow_sequence_nested_in_flow_mapping) {
   const std::string input{"{a: [1, 2], b: [3, 4]}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_mapping_value_with_comment_then_next_key) {
+TEST(empty_mapping_value_with_comment_then_next_key) {
   const std::string input{R"YAML(a: # empty
 b: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_mapping_entries) {
+TEST(comment_between_mapping_entries) {
   const std::string input{R"YAML(a: 1
 # between
 b: 2
@@ -1682,7 +1682,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_colon_indicator_comment) {
+TEST(deeply_nested_colon_indicator_comment) {
   const std::string input{R"YAML(level1:
   level2: # deep
     level3: value
@@ -1690,7 +1690,7 @@ TEST(YAML_roundtrip, deeply_nested_colon_indicator_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_indicator_comments_mapping_and_sequence) {
+TEST(mixed_indicator_comments_mapping_and_sequence) {
   const std::string input{R"YAML(data: # on data
   - # on dash
     item
@@ -1698,7 +1698,7 @@ TEST(YAML_roundtrip, mixed_indicator_comments_mapping_and_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_alias_same_key_implicit_null) {
+TEST(anchor_alias_same_key_implicit_null) {
   const std::string input{R"YAML(a: &x
 b: *x
 c: &y
@@ -1707,7 +1707,7 @@ d: *y
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_at_root) {
+TEST(block_sequence_at_root) {
   const std::string input{R"YAML(- a
 - b
 - c
@@ -1715,7 +1715,7 @@ TEST(YAML_roundtrip, block_sequence_at_root) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_empty_collections) {
+TEST(nested_empty_collections) {
   const std::string input{R"YAML(a: {}
 b: []
 c: {x: {}}
@@ -1723,7 +1723,7 @@ c: {x: {}}
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, string_keys_that_look_numeric) {
+TEST(string_keys_that_look_numeric) {
   const std::string input{R"YAML("1": one
 "2": two
 "10": ten
@@ -1731,14 +1731,14 @@ TEST(YAML_roundtrip, string_keys_that_look_numeric) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_values_mixed_styles) {
+TEST(boolean_values_mixed_styles) {
   const std::string input{R"YAML(a: true
 b: false
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_explicit_in_sequence) {
+TEST(null_explicit_in_sequence) {
   const std::string input{R"YAML(- null
 - value
 - null
@@ -1746,33 +1746,33 @@ TEST(YAML_roundtrip, null_explicit_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_with_comment_after) {
+TEST(flow_mapping_with_comment_after) {
   const std::string input{R"YAML(data: {a: 1, b: 2} # inline
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_with_comment_after) {
+TEST(flow_sequence_with_comment_after) {
   const std::string input{R"YAML(data: [1, 2, 3] # list
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_flow_collection) {
+TEST(anchor_on_flow_collection) {
   const std::string input{R"YAML(a: &tag {x: 1}
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_flow_sequence_with_alias) {
+TEST(anchor_on_flow_sequence_with_alias) {
   const std::string input{R"YAML(a: &tag [1, 2]
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_block_scalar) {
+TEST(anchor_on_block_scalar) {
   const std::string input{R"YAML(a: &tag |
   hello
 b: *tag
@@ -1780,14 +1780,14 @@ b: *tag
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_implicit_null_with_comment) {
+TEST(comment_on_colon_implicit_null_with_comment) {
   const std::string input{R"YAML(a: # null with comment
 b: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_every_dash_in_sequence) {
+TEST(comment_on_every_dash_in_sequence) {
   const std::string input{R"YAML(- # a
   one
 - # b
@@ -1798,7 +1798,7 @@ TEST(YAML_roundtrip, comment_on_every_dash_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_mappings_with_comments) {
+TEST(sequence_of_mappings_with_comments) {
   const std::string input{R"YAML(# first item
 - name: alice
   age: 30
@@ -1809,7 +1809,7 @@ TEST(YAML_roundtrip, sequence_of_mappings_with_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_then_sequence_then_mapping) {
+TEST(mapping_then_sequence_then_mapping) {
   const std::string input{R"YAML(config:
   items:
     - key: val
@@ -1817,39 +1817,39 @@ TEST(YAML_roundtrip, mapping_then_sequence_then_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_empty_string) {
+TEST(double_quoted_empty_string) {
   const std::string input{"key: \"\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_empty_string) {
+TEST(single_quoted_empty_string) {
   const std::string input{"key: ''\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_strip_empty_lines) {
+TEST(literal_block_strip_empty_lines) {
   const std::string input{R"YAML(key: |-
   hello
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_keep_trailing_newlines) {
+TEST(literal_block_keep_trailing_newlines) {
   const std::string input{"key: |+\n  hello\n\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_single_entry) {
+TEST(flow_mapping_single_entry) {
   const std::string input{"{key: value}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_single_entry) {
+TEST(flow_sequence_single_entry) {
   const std::string input{"[value]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_flow_and_block_in_mapping) {
+TEST(mixed_flow_and_block_in_mapping) {
   const std::string input{R"YAML(block_key: block_value
 flow_key: {nested: value}
 list_key: [a, b, c]
@@ -1857,7 +1857,7 @@ list_key: [a, b, c]
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, alias_in_sequence) {
+TEST(alias_in_sequence) {
   const std::string input{R"YAML(- &item value
 - *item
 - *item
@@ -1865,7 +1865,7 @@ TEST(YAML_roundtrip, alias_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indicator_comment_then_inline_comment_different_key) {
+TEST(indicator_comment_then_inline_comment_different_key) {
   const std::string input{R"YAML(a: # indicator
   value
 b: plain # inline
@@ -1873,12 +1873,12 @@ b: plain # inline
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_flow_three_levels) {
+TEST(nested_flow_three_levels) {
   const std::string input{"{a: {b: {c: 1}}}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_in_mapping_value_with_indicator_comment) {
+TEST(sequence_in_mapping_value_with_indicator_comment) {
   const std::string input{R"YAML(key: # on key
   - first
   - second
@@ -1886,7 +1886,7 @@ TEST(YAML_roundtrip, sequence_in_mapping_value_with_indicator_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_in_sequence_with_indicator_comment) {
+TEST(mapping_in_sequence_with_indicator_comment) {
   const std::string input{R"YAML(- # entry
   name: alice
   age: 30
@@ -1894,7 +1894,7 @@ TEST(YAML_roundtrip, mapping_in_sequence_with_indicator_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_nested_block_mapping) {
+TEST(anchor_on_nested_block_mapping) {
   const std::string input{R"YAML(a: &ref
   x: 1
   y: 2
@@ -1903,7 +1903,7 @@ b: *ref
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_nested_block_sequence) {
+TEST(anchor_on_nested_block_sequence) {
   const std::string input{R"YAML(a: &ref
   - 1
   - 2
@@ -1912,12 +1912,12 @@ b: *ref
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, integer_value_document) {
+TEST(integer_value_document) {
   const std::string input{"42\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, all_comment_types_combined) {
+TEST(all_comment_types_combined) {
   const std::string input{R"YAML(# leading
 --- # start
 # after start
@@ -1933,21 +1933,21 @@ b: # on colon
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_with_double_quoted) {
+TEST(comment_on_dash_with_double_quoted) {
   const std::string input{R"YAML(- # quoted
   "hello world"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_with_single_quoted) {
+TEST(comment_on_dash_with_single_quoted) {
   const std::string input{R"YAML(- # quoted
   'hello world'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_with_all_null) {
+TEST(sequence_with_all_null) {
   const std::string input{R"YAML(-
 -
 -
@@ -1955,7 +1955,7 @@ TEST(YAML_roundtrip, sequence_with_all_null) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_all_implicit_null) {
+TEST(mapping_with_all_implicit_null) {
   const std::string input{R"YAML(a:
 b:
 c:
@@ -1963,7 +1963,7 @@ c:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_implicit_null_with_inline_comment) {
+TEST(sequence_implicit_null_with_inline_comment) {
   const std::string input{R"YAML(- # first
 - # second
 - # third
@@ -1971,7 +1971,7 @@ TEST(YAML_roundtrip, sequence_implicit_null_with_inline_comment) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_implicit_null_with_inline_comment) {
+TEST(mapping_implicit_null_with_inline_comment) {
   const std::string input{R"YAML(a: # first
 b: # second
 c: # third
@@ -1979,7 +1979,7 @@ c: # third
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_multiline_with_blank_lines) {
+TEST(literal_block_multiline_with_blank_lines) {
   const std::string input{R"YAML(key: |
   line one
 
@@ -1988,7 +1988,7 @@ TEST(YAML_roundtrip, literal_block_multiline_with_blank_lines) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_multiline_with_blank_lines) {
+TEST(folded_block_multiline_with_blank_lines) {
   const std::string input{R"YAML(key: >
   line one
 
@@ -1997,47 +1997,47 @@ TEST(YAML_roundtrip, folded_block_multiline_with_blank_lines) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_special_chars) {
+TEST(double_quoted_with_special_chars) {
   const std::string input{"key: \"hello\\tworld\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_empty_with_anchor) {
+TEST(flow_mapping_empty_with_anchor) {
   const std::string input{R"YAML(a: &tag {}
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_empty_with_anchor) {
+TEST(flow_sequence_empty_with_anchor) {
   const std::string input{R"YAML(a: &tag []
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_last_sequence_item) {
+TEST(comment_after_last_sequence_item) {
   const std::string input{R"YAML(- one
 - two # last
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_last_mapping_value) {
+TEST(comment_after_last_mapping_value) {
   const std::string input{R"YAML(a: 1
 b: 2 # last
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, alias_as_sequence_item_with_comment) {
+TEST(alias_as_sequence_item_with_comment) {
   const std::string input{R"YAML(- &tag value
 - *tag # reuse
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_scalar_styles_in_mapping) {
+TEST(mixed_scalar_styles_in_mapping) {
   const std::string input{R"YAML(plain: hello
 single: 'world'
 double: "foo"
@@ -2045,7 +2045,7 @@ double: "foo"
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_scalar_styles_in_sequence) {
+TEST(mixed_scalar_styles_in_sequence) {
   const std::string input{R"YAML(- hello
 - 'world'
 - "foo"
@@ -2053,19 +2053,19 @@ TEST(YAML_roundtrip, mixed_scalar_styles_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_multiple_entries_with_styles) {
+TEST(flow_mapping_multiple_entries_with_styles) {
   const std::string input{"{a: 1, b: 'two', c: \"three\"}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_flow_mappings) {
+TEST(sequence_of_flow_mappings) {
   const std::string input{R"YAML(- {name: alice}
 - {name: bob}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_in_block_sequence_in_mapping) {
+TEST(block_mapping_in_block_sequence_in_mapping) {
   const std::string input{R"YAML(users:
   - name: alice
     role: admin
@@ -2075,28 +2075,28 @@ TEST(YAML_roundtrip, block_mapping_in_block_sequence_in_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_first_key_in_mapping) {
+TEST(comment_before_first_key_in_mapping) {
   const std::string input{R"YAML(# header comment
 key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_with_flow_mapping_value) {
+TEST(comment_on_colon_with_flow_mapping_value) {
   const std::string input{R"YAML(key: # on key
   {a: 1}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_with_flow_sequence_value) {
+TEST(comment_on_colon_with_flow_sequence_value) {
   const std::string input{R"YAML(key: # on key
   [1, 2]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_alias_with_flow_collection) {
+TEST(anchor_alias_with_flow_collection) {
   const std::string input{R"YAML(defaults: &def
   timeout: 30
   retries: 3
@@ -2107,13 +2107,13 @@ production:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_pair_flow_mapping_in_sequence) {
+TEST(single_pair_flow_mapping_in_sequence) {
   const std::string input{R"YAML(- {key: value}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_block_sequences) {
+TEST(nested_block_sequences) {
   const std::string input{R"YAML(-
   - a
   - b
@@ -2124,7 +2124,7 @@ TEST(YAML_roundtrip, nested_block_sequences) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_nested_block_sequences) {
+TEST(comment_on_dash_nested_block_sequences) {
   const std::string input{R"YAML(- # outer1
   - a
   - b
@@ -2134,7 +2134,7 @@ TEST(YAML_roundtrip, comment_on_dash_nested_block_sequences) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_value_between_keys) {
+TEST(empty_value_between_keys) {
   const std::string input{R"YAML(a:
 b: value
 c:
@@ -2142,28 +2142,28 @@ c:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, literal_block_single_line) {
+TEST(literal_block_single_line) {
   const std::string input{R"YAML(key: |
   single line
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_single_line) {
+TEST(folded_block_single_line) {
   const std::string input{R"YAML(key: >
   single line
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_explicit_null) {
+TEST(anchor_on_explicit_null) {
   const std::string input{R"YAML(a: &tag null
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, true_false_null_as_quoted_strings) {
+TEST(true_false_null_as_quoted_strings) {
   const std::string input{R"YAML(a: "true"
 b: "false"
 c: "null"
@@ -2171,7 +2171,7 @@ c: "null"
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, yes_no_on_off_plain_scalars) {
+TEST(yes_no_on_off_plain_scalars) {
   const std::string input{R"YAML(a: yes
 b: no
 c: on
@@ -2180,42 +2180,42 @@ d: off
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, explicit_null_roundtrip) {
+TEST(explicit_null_roundtrip) {
   const std::string input{R"YAML(a: null
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_values) {
+TEST(float_values) {
   const std::string input{R"YAML(a: 1.5
 b: -3.14
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, large_integer) {
+TEST(large_integer) {
   const std::string input{R"YAML(big: 9999999999
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_integer) {
+TEST(negative_integer) {
   const std::string input{R"YAML(neg: -42
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, colon_in_double_quoted_scalar) {
+TEST(colon_in_double_quoted_scalar) {
   const std::string input{"key: \"value: with colon\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, hash_in_quoted_string) {
+TEST(hash_in_quoted_string) {
   const std::string input{"key: \"value # not a comment\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_with_literal_block) {
+TEST(comment_on_colon_with_literal_block) {
   const std::string input{R"YAML(key: # before block
   |
   hello
@@ -2223,7 +2223,7 @@ TEST(YAML_roundtrip, comment_on_colon_with_literal_block) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_end_no_content_comments) {
+TEST(document_start_end_no_content_comments) {
   const std::string input{R"YAML(--- # doc
 key: value
 ...
@@ -2231,7 +2231,7 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_with_preceding_and_inline_comments) {
+TEST(sequence_with_preceding_and_inline_comments) {
   const std::string input{R"YAML(# before first
 - one # after first
 # before second
@@ -2240,7 +2240,7 @@ TEST(YAML_roundtrip, sequence_with_preceding_and_inline_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_mixed_with_comments) {
+TEST(deeply_nested_mixed_with_comments) {
   const std::string input{R"YAML(root:
   # section
   items:
@@ -2250,49 +2250,49 @@ TEST(YAML_roundtrip, deeply_nested_mixed_with_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_single_quoted) {
+TEST(anchor_on_single_quoted) {
   const std::string input{R"YAML(a: &tag 'hello'
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_double_quoted) {
+TEST(anchor_on_double_quoted) {
   const std::string input{R"YAML(a: &tag "hello"
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_integer) {
+TEST(anchor_on_integer) {
   const std::string input{R"YAML(a: &tag 42
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_boolean) {
+TEST(anchor_on_boolean) {
   const std::string input{R"YAML(a: &tag true
 b: *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_item_on_next_line_scalar) {
+TEST(sequence_item_on_next_line_scalar) {
   const std::string input{R"YAML(-
   value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_item_on_next_line_mapping) {
+TEST(sequence_item_on_next_line_mapping) {
   const std::string input{R"YAML(-
   key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_mixed_same_and_next_line) {
+TEST(sequence_mixed_same_and_next_line) {
   const std::string input{R"YAML(- inline
 -
   next_line
@@ -2301,7 +2301,7 @@ TEST(YAML_roundtrip, sequence_mixed_same_and_next_line) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_dash_then_next_item_inline) {
+TEST(comment_on_dash_then_next_item_inline) {
   const std::string input{R"YAML(- # commented
   value
 - inline
@@ -2309,7 +2309,7 @@ TEST(YAML_roundtrip, comment_on_dash_then_next_item_inline) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_next_line_value) {
+TEST(anchor_on_next_line_value) {
   const std::string input{R"YAML(-
   &tag value
 - *tag
@@ -2317,7 +2317,7 @@ TEST(YAML_roundtrip, anchor_on_next_line_value) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_next_line_sequences) {
+TEST(deeply_nested_next_line_sequences) {
   const std::string input{R"YAML(-
   -
     -
@@ -2326,7 +2326,7 @@ TEST(YAML_roundtrip, deeply_nested_next_line_sequences) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_literal_in_next_line_sequence_item) {
+TEST(block_literal_in_next_line_sequence_item) {
   const std::string input{R"YAML(-
   |
   hello
@@ -2334,21 +2334,21 @@ TEST(YAML_roundtrip, block_literal_in_next_line_sequence_item) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_in_next_line_sequence_item) {
+TEST(flow_mapping_in_next_line_sequence_item) {
   const std::string input{R"YAML(-
   {a: 1}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_in_next_line_sequence_item) {
+TEST(flow_sequence_in_next_line_sequence_item) {
   const std::string input{R"YAML(-
   [1, 2, 3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_anchors_and_aliases) {
+TEST(multiple_anchors_and_aliases) {
   const std::string input{R"YAML(x: &a 1
 y: &b 2
 z: &c 3
@@ -2359,43 +2359,43 @@ r: *c
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, alias_in_flow_mapping) {
+TEST(alias_in_flow_mapping) {
   const std::string input{R"YAML(a: &tag value
 b: {ref: *tag}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, alias_in_flow_sequence) {
+TEST(alias_in_flow_sequence) {
   const std::string input{R"YAML(a: &tag value
 b: [*tag, other]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, long_plain_scalar) {
+TEST(long_plain_scalar) {
   const std::string input{
       "key: this is a fairly long plain scalar value that stays on one line\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_chars_in_double_quoted) {
+TEST(special_chars_in_double_quoted) {
   const std::string input{"key: \"line1\\nline2\\ttab\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_value_is_integer_zero) {
+TEST(mapping_value_is_integer_zero) {
   const std::string input{R"YAML(a: 0
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_value_is_empty_string_double_quoted) {
+TEST(mapping_value_is_empty_string_double_quoted) {
   const std::string input{"a: \"\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_integers) {
+TEST(sequence_of_integers) {
   const std::string input{R"YAML(- 1
 - 2
 - 3
@@ -2403,7 +2403,7 @@ TEST(YAML_roundtrip, sequence_of_integers) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_booleans) {
+TEST(sequence_of_booleans) {
   const std::string input{R"YAML(- true
 - false
 - true
@@ -2411,7 +2411,7 @@ TEST(YAML_roundtrip, sequence_of_booleans) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_mixed_types) {
+TEST(sequence_of_mixed_types) {
   const std::string input{R"YAML(- hello
 - 42
 - true
@@ -2420,7 +2420,7 @@ TEST(YAML_roundtrip, sequence_of_mixed_types) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_mixed_value_types) {
+TEST(mapping_with_mixed_value_types) {
   const std::string input{R"YAML(str: hello
 int: 42
 bool: true
@@ -2429,7 +2429,7 @@ nil: null
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_implicit_null_mapping_value) {
+TEST(comment_on_implicit_null_mapping_value) {
   const std::string input{R"YAML(a: # null a
 b: # null b
 c: value
@@ -2437,7 +2437,7 @@ c: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, preceding_comment_on_nested_mapping_key) {
+TEST(preceding_comment_on_nested_mapping_key) {
   const std::string input{R"YAML(outer:
   # before inner
   inner: value
@@ -2445,7 +2445,7 @@ TEST(YAML_roundtrip, preceding_comment_on_nested_mapping_key) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, preceding_comment_on_nested_sequence_item) {
+TEST(preceding_comment_on_nested_sequence_item) {
   const std::string input{R"YAML(items:
   # before first
   - one
@@ -2455,7 +2455,7 @@ TEST(YAML_roundtrip, preceding_comment_on_nested_sequence_item) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_and_preceding_alternating) {
+TEST(inline_and_preceding_alternating) {
   const std::string input{R"YAML(a: 1 # on a
 # before b
 b: 2
@@ -2465,7 +2465,7 @@ c: 3 # on c
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_strip_with_anchor) {
+TEST(block_scalar_strip_with_anchor) {
   const std::string input{R"YAML(a: &tag |-
   hello
 b: *tag
@@ -2473,12 +2473,12 @@ b: *tag
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_keep_with_anchor) {
+TEST(block_scalar_keep_with_anchor) {
   const std::string input{"a: &tag |+\n  hello\n\nb: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_with_anchor) {
+TEST(folded_scalar_with_anchor) {
   const std::string input{R"YAML(a: &tag >
   hello
   world
@@ -2487,7 +2487,7 @@ b: *tag
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_with_next_line_then_inline_then_next_line) {
+TEST(sequence_with_next_line_then_inline_then_next_line) {
   const std::string input{R"YAML(-
   first
 - second
@@ -2497,7 +2497,7 @@ TEST(YAML_roundtrip, sequence_with_next_line_then_inline_then_next_line) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indicator_comment_on_colon_with_nested_mapping_deep) {
+TEST(indicator_comment_on_colon_with_nested_mapping_deep) {
   const std::string input{R"YAML(a: # level1
   b: # level2
     c: value
@@ -2505,7 +2505,7 @@ TEST(YAML_roundtrip, indicator_comment_on_colon_with_nested_mapping_deep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indicator_comment_mixed_with_nested_and_inline) {
+TEST(indicator_comment_mixed_with_nested_and_inline) {
   const std::string input{R"YAML(config: # config section
   name: test # the name
   items: # items section
@@ -2515,7 +2515,7 @@ TEST(YAML_roundtrip, indicator_comment_mixed_with_nested_and_inline) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_in_block_with_preceding_comment) {
+TEST(flow_in_block_with_preceding_comment) {
   const std::string input{R"YAML(# tags
 tags: [a, b, c]
 # names
@@ -2524,7 +2524,7 @@ names: [x, y]
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_markers_with_all_comment_types) {
+TEST(document_markers_with_all_comment_types) {
   const std::string input{R"YAML(# leading 1
 # leading 2
 --- # start
@@ -2537,21 +2537,21 @@ a: 1
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_implicit_null_in_sequence) {
+TEST(anchor_on_implicit_null_in_sequence) {
   const std::string input{R"YAML(- &tag
 - *tag
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, next_line_value_with_inline_comment_on_value) {
+TEST(next_line_value_with_inline_comment_on_value) {
   const std::string input{R"YAML(-
   value # comment on value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, next_line_mapping_with_inline_comments) {
+TEST(next_line_mapping_with_inline_comments) {
   const std::string input{R"YAML(-
   a: 1 # on a
   b: 2 # on b
@@ -2559,7 +2559,7 @@ TEST(YAML_roundtrip, next_line_mapping_with_inline_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, three_level_mapping_with_all_indicator_comments) {
+TEST(three_level_mapping_with_all_indicator_comments) {
   const std::string input{R"YAML(root: # root
   mid: # mid
     leaf: value
@@ -2567,7 +2567,7 @@ TEST(YAML_roundtrip, three_level_mapping_with_all_indicator_comments) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_in_mapping_next_line_style) {
+TEST(sequence_in_mapping_next_line_style) {
   const std::string input{R"YAML(items:
   -
     a
@@ -2577,24 +2577,24 @@ TEST(YAML_roundtrip, sequence_in_mapping_next_line_style) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_item_sequence_next_line) {
+TEST(single_item_sequence_next_line) {
   const std::string input{R"YAML(-
   only_item
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key) {
+TEST(double_quoted_key) {
   const std::string input{"\"special key\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_key) {
+TEST(single_quoted_key) {
   const std::string input{"'special key': value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_mapping_five_levels) {
+TEST(deeply_nested_mapping_five_levels) {
   const std::string input{R"YAML(a:
   b:
     c:
@@ -2604,36 +2604,36 @@ TEST(YAML_roundtrip, deeply_nested_mapping_five_levels) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_key_with_spaces) {
+TEST(mapping_key_with_spaces) {
   const std::string input{R"YAML(key with spaces: value
 another key: other
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_empty) {
+TEST(flow_mapping_empty) {
   const std::string input{"{}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_empty) {
+TEST(flow_sequence_empty) {
   const std::string input{"[]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_single_entry) {
+TEST(block_mapping_single_entry) {
   const std::string input{R"YAML(only: entry
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_single_entry) {
+TEST(block_sequence_single_entry) {
   const std::string input{R"YAML(- only
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, complex_real_world_config) {
+TEST(complex_real_world_config) {
   const std::string input{R"YAML(# Application config
 app:
   name: myapp # app name
@@ -2657,7 +2657,7 @@ features:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_between_mapping_entries) {
+TEST(blank_line_between_mapping_entries) {
   const std::string input{R"YAML(a: 1
 
 b: 2
@@ -2665,7 +2665,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_between_sequence_items) {
+TEST(blank_line_between_sequence_items) {
   const std::string input{R"YAML(- one
 
 - two
@@ -2673,7 +2673,7 @@ TEST(YAML_roundtrip, blank_line_between_sequence_items) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_blank_lines) {
+TEST(multiple_blank_lines) {
   const std::string input{R"YAML(a: 1
 
 
@@ -2682,7 +2682,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_before_comment) {
+TEST(blank_line_before_comment) {
   const std::string input{R"YAML(a: 1
 
 # comment
@@ -2691,7 +2691,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_after_comment) {
+TEST(blank_line_after_comment) {
   const std::string input{R"YAML(# first group
 a: 1
 
@@ -2701,7 +2701,7 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_in_nested_mapping) {
+TEST(blank_line_in_nested_mapping) {
   const std::string input{R"YAML(outer:
   a: 1
 
@@ -2710,7 +2710,7 @@ TEST(YAML_roundtrip, blank_line_in_nested_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_in_nested_sequence) {
+TEST(blank_line_in_nested_sequence) {
   const std::string input{R"YAML(items:
   - first
 
@@ -2719,7 +2719,7 @@ TEST(YAML_roundtrip, blank_line_in_nested_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_between_sections_with_comments) {
+TEST(blank_line_between_sections_with_comments) {
   const std::string input{R"YAML(# Section A
 a: 1
 
@@ -2732,7 +2732,7 @@ c: 3
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, no_blank_lines) {
+TEST(no_blank_lines) {
   const std::string input{R"YAML(a: 1
 b: 2
 c: 3
@@ -2740,7 +2740,7 @@ c: 3
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_with_document_markers) {
+TEST(blank_line_with_document_markers) {
   const std::string input{R"YAML(---
 a: 1
 
@@ -2750,14 +2750,14 @@ b: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indent_width_four_spaces) {
+TEST(indent_width_four_spaces) {
   const std::string input{R"YAML(parent:
     child: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indent_width_four_spaces_nested) {
+TEST(indent_width_four_spaces_nested) {
   const std::string input{R"YAML(a:
     b:
         c: value
@@ -2765,7 +2765,7 @@ TEST(YAML_roundtrip, indent_width_four_spaces_nested) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indent_width_four_spaces_sequence) {
+TEST(indent_width_four_spaces_sequence) {
   const std::string input{R"YAML(items:
     - one
     - two
@@ -2773,14 +2773,14 @@ TEST(YAML_roundtrip, indent_width_four_spaces_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indent_width_three_spaces) {
+TEST(indent_width_three_spaces) {
   const std::string input{R"YAML(parent:
    child: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, indent_width_four_mapping_and_sequence) {
+TEST(indent_width_four_mapping_and_sequence) {
   const std::string input{R"YAML(config:
     name: test
     items:
@@ -2790,17 +2790,17 @@ TEST(YAML_roundtrip, indent_width_four_mapping_and_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_with_special_chars) {
+TEST(double_quoted_key_with_special_chars) {
   const std::string input{"\"key: with colon\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_key_plain_value) {
+TEST(single_quoted_key_plain_value) {
   const std::string input{"'my-key': 42\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_key_styles) {
+TEST(mixed_key_styles) {
   const std::string input{R"YAML(plain_key: 1
 'single key': 2
 "double key": 3
@@ -2808,14 +2808,14 @@ TEST(YAML_roundtrip, mixed_key_styles) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, quoted_key_with_nested_value) {
+TEST(quoted_key_with_nested_value) {
   const std::string input{R"YAML("my key":
   child: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_with_extra_indent) {
+TEST(block_scalar_with_extra_indent) {
   const std::string input{R"YAML(key: |
   normal
     indented
@@ -2824,7 +2824,7 @@ TEST(YAML_roundtrip, block_scalar_with_extra_indent) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_block_with_extra_indent) {
+TEST(folded_block_with_extra_indent) {
   const std::string input{R"YAML(key: >
   normal
     indented
@@ -2833,97 +2833,97 @@ TEST(YAML_roundtrip, folded_block_with_extra_indent) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_quoted_keys) {
+TEST(flow_mapping_quoted_keys) {
   const std::string input{"{\"a b\": 1, 'c d': 2}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_quoted_values) {
+TEST(flow_mapping_quoted_values) {
   const std::string input{"{a: 'one', b: \"two\"}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_quoted_values) {
+TEST(flow_sequence_quoted_values) {
   const std::string input{"['one', \"two\", three]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, tilde_null) {
+TEST(tilde_null) {
   const std::string input{"key: ~\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_inf) {
+TEST(special_float_inf) {
   const std::string input{"key: .inf\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_neg_inf) {
+TEST(special_float_neg_inf) {
   const std::string input{"key: -.inf\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_nan) {
+TEST(special_float_nan) {
   const std::string input{"key: .nan\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_key_with_apostrophe) {
+TEST(single_quoted_key_with_apostrophe) {
   const std::string input{"'it''s': value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_single_quoted_key) {
+TEST(empty_single_quoted_key) {
   const std::string input{"'': value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_double_quoted_key) {
+TEST(empty_double_quoted_key) {
   const std::string input{"\"\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, value_with_hash_quoted) {
+TEST(value_with_hash_quoted) {
   const std::string input{"key: '#not-a-comment'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_false) {
+TEST(anchor_on_false) {
   const std::string input{"a: &tag false\nb: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_float) {
+TEST(anchor_on_float) {
   const std::string input{"a: &tag 3.14\nb: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_flow_sequences) {
+TEST(nested_flow_sequences) {
   const std::string input{"[[1, 2], [3, [4, 5]]]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_null_and_bool) {
+TEST(flow_mapping_null_and_bool) {
   const std::string input{"{a: null, b: true, c: false}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, zero_in_sequence) {
+TEST(zero_in_sequence) {
   const std::string input{"- 0\n- 0.0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_backslash) {
+TEST(double_quoted_backslash) {
   const std::string input{"key: \"path\\\\to\\\\file\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, false_key) {
+TEST(false_key) {
   const std::string input{"\"false\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, blank_line_between_sequence_mappings) {
+TEST(blank_line_between_sequence_mappings) {
   const std::string input{R"YAML(- name: alice
 
 - name: bob
@@ -2931,222 +2931,222 @@ TEST(YAML_roundtrip, blank_line_between_sequence_mappings) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_root_with_doc_markers) {
+TEST(flow_mapping_root_with_doc_markers) {
   const std::string input{"---\n{a: 1}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_root_with_doc_markers) {
+TEST(flow_sequence_root_with_doc_markers) {
   const std::string input{"---\n[1, 2]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, scalar_doc_with_markers) {
+TEST(scalar_doc_with_markers) {
   const std::string input{"---\nhello\n...\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_doc) {
+TEST(boolean_doc) {
   const std::string input{"true\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_doc) {
+TEST(null_doc) {
   const std::string input{"null\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_doc) {
+TEST(float_doc) {
   const std::string input{"3.14\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_integer_doc) {
+TEST(negative_integer_doc) {
   const std::string input{"-42\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_true_capitalized) {
+TEST(boolean_true_capitalized) {
   const std::string input{"key: True\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_true_uppercase) {
+TEST(boolean_true_uppercase) {
   const std::string input{"key: TRUE\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_false_capitalized) {
+TEST(boolean_false_capitalized) {
   const std::string input{"key: False\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_false_uppercase) {
+TEST(boolean_false_uppercase) {
   const std::string input{"key: FALSE\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_capitalized) {
+TEST(null_capitalized) {
   const std::string input{"key: Null\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_uppercase) {
+TEST(null_uppercase) {
   const std::string input{"key: NULL\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_inf_capitalized) {
+TEST(special_float_inf_capitalized) {
   const std::string input{"key: .Inf\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_inf_uppercase) {
+TEST(special_float_inf_uppercase) {
   const std::string input{"key: .INF\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_pos_inf) {
+TEST(special_float_pos_inf) {
   const std::string input{"key: +.inf\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_neg_inf_capitalized) {
+TEST(special_float_neg_inf_capitalized) {
   const std::string input{"key: -.Inf\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_neg_inf_uppercase) {
+TEST(special_float_neg_inf_uppercase) {
   const std::string input{"key: -.INF\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_nan_capitalized) {
+TEST(special_float_nan_capitalized) {
   const std::string input{"key: .NaN\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_float_nan_uppercase) {
+TEST(special_float_nan_uppercase) {
   const std::string input{"key: .NAN\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, octal_number) {
+TEST(octal_number) {
   const std::string input{"key: 0o77\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, hex_number) {
+TEST(hex_number) {
   const std::string input{"key: 0x3A\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_one_point_zero) {
+TEST(float_one_point_zero) {
   const std::string input{"key: 1.0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_two_point_zero) {
+TEST(float_two_point_zero) {
   const std::string input{"key: 2.0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_hundred_point_zero) {
+TEST(float_hundred_point_zero) {
   const std::string input{"key: 100.0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, scientific_notation) {
+TEST(scientific_notation) {
   const std::string input{"key: 1e3\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, scientific_notation_negative_exponent) {
+TEST(scientific_notation_negative_exponent) {
   const std::string input{"key: 1.5e-2\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_key_true) {
+TEST(boolean_key_true) {
   const std::string input{"true: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_key_false) {
+TEST(boolean_key_false) {
   const std::string input{"false: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_key_capitalized) {
+TEST(boolean_key_capitalized) {
   const std::string input{"True: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_key) {
+TEST(null_key) {
   const std::string input{"null: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, tilde_key) {
+TEST(tilde_key) {
   const std::string input{"~: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, number_key) {
+TEST(number_key) {
   const std::string input{"123: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_key) {
+TEST(float_key) {
   const std::string input{"3.14: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_tilde_null) {
+TEST(flow_mapping_tilde_null) {
   const std::string input{"{a: ~, b: null}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_special_floats) {
+TEST(flow_mapping_special_floats) {
   const std::string input{"{a: .inf, b: .nan}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_boolean_variants) {
+TEST(flow_mapping_boolean_variants) {
   const std::string input{"{a: True, b: FALSE}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_tilde_null) {
+TEST(flow_sequence_tilde_null) {
   const std::string input{"[~, null]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_special_floats) {
+TEST(flow_sequence_special_floats) {
   const std::string input{"[.inf, -.inf, .nan]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_boolean_variants) {
+TEST(flow_sequence_boolean_variants) {
   const std::string input{"[True, FALSE, true, false]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_number_key) {
+TEST(flow_mapping_number_key) {
   const std::string input{"{123: value}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_boolean_key) {
+TEST(flow_mapping_boolean_key) {
   const std::string input{"{true: value}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_null_key) {
+TEST(flow_mapping_null_key) {
   const std::string input{"{null: value}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_block_with_special_values) {
+TEST(nested_block_with_special_values) {
   const std::string input{R"YAML(config:
   nullable: ~
   enabled: True
@@ -3156,7 +3156,7 @@ TEST(YAML_roundtrip, nested_block_with_special_values) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_special_values) {
+TEST(sequence_of_special_values) {
   const std::string input{R"YAML(- ~
 - null
 - True
@@ -3169,7 +3169,7 @@ TEST(YAML_roundtrip, sequence_of_special_values) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_special_keys_and_values) {
+TEST(mixed_special_keys_and_values) {
   const std::string input{R"YAML(true: false
 null: ~
 123: 456
@@ -3178,14 +3178,14 @@ null: ~
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_block_mapping) {
+TEST(implicit_null_block_mapping) {
   const std::string input{R"YAML(key:
 next: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_implicit_nulls) {
+TEST(multiple_implicit_nulls) {
   const std::string input{R"YAML(a:
 b:
 c: value
@@ -3193,7 +3193,7 @@ c: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_with_explicit_null) {
+TEST(implicit_null_with_explicit_null) {
   const std::string input{R"YAML(implicit:
 explicit: null
 tilde: ~
@@ -3201,19 +3201,19 @@ tilde: ~
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_in_block_mapping) {
+TEST(flow_sequence_in_block_mapping) {
   const std::string input{R"YAML(key: [1, 2, 3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_in_block_mapping) {
+TEST(flow_mapping_in_block_mapping) {
   const std::string input{R"YAML(key: {a: 1, b: 2}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_flow_and_block) {
+TEST(mixed_flow_and_block) {
   const std::string input{R"YAML(config:
   name: test
   ports: [80, 443]
@@ -3222,7 +3222,7 @@ TEST(YAML_roundtrip, mixed_flow_and_block) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_flow_mappings_multiple) {
+TEST(sequence_of_flow_mappings_multiple) {
   const std::string input{R"YAML(- {a: 1}
 - {b: 2}
 - {c: 3}
@@ -3230,97 +3230,97 @@ TEST(YAML_roundtrip, sequence_of_flow_mappings_multiple) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_tab_escape) {
+TEST(double_quoted_tab_escape) {
   const std::string input{"key: \"col1\\tcol2\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_carriage_return) {
+TEST(double_quoted_carriage_return) {
   const std::string input{"key: \"line1\\rline2\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_null_char) {
+TEST(double_quoted_null_char) {
   const std::string input{"key: \"before\\0after\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_quote_escape) {
+TEST(double_quoted_quote_escape) {
   const std::string input{"key: \"she said \\\"hello\\\"\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_multiple_escapes) {
+TEST(double_quoted_multiple_escapes) {
   const std::string input{"key: \"line1\\nline2\\ttab\\\\backslash\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_special_value_true) {
+TEST(single_quoted_special_value_true) {
   const std::string input{"key: 'true'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_special_value_null) {
+TEST(single_quoted_special_value_null) {
   const std::string input{"key: 'null'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_number) {
+TEST(double_quoted_number) {
   const std::string input{"key: \"123\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_number) {
+TEST(single_quoted_number) {
   const std::string input{"key: '456'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_float) {
+TEST(negative_float) {
   const std::string input{"key: -3.14\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, small_float) {
+TEST(small_float) {
   const std::string input{"key: 0.001\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, large_integer_as_value) {
+TEST(large_integer_as_value) {
   const std::string input{"key: 99999999999999999999\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_large_integer_as_value) {
+TEST(negative_large_integer_as_value) {
   const std::string input{"key: -99999999999999999999\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, zero_float) {
+TEST(zero_float) {
   const std::string input{"key: 0.0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_zero) {
+TEST(negative_zero) {
   const std::string input{"key: -0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_mixed_key_quoting) {
+TEST(flow_mapping_mixed_key_quoting) {
   const std::string input{"{\"a b\": 1, plain: 2, 'quoted': 3}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_special_value_keys) {
+TEST(flow_mapping_special_value_keys) {
   const std::string input{"{true: 1, null: 2, 123: 3}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_literal_strip) {
+TEST(block_scalar_literal_strip) {
   const std::string input{"key: |-\n  text without trailing newline\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_literal_keep) {
+TEST(block_scalar_literal_keep) {
   const std::string input{R"YAML(key: |+
   text with trailing newlines
 
@@ -3328,12 +3328,12 @@ TEST(YAML_roundtrip, block_scalar_literal_keep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_folded_strip) {
+TEST(block_scalar_folded_strip) {
   const std::string input{"key: >-\n  folded without trailing newline\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_folded_keep) {
+TEST(block_scalar_folded_keep) {
   const std::string input{R"YAML(key: >+
   folded with trailing newlines
 
@@ -3341,13 +3341,13 @@ TEST(YAML_roundtrip, block_scalar_folded_keep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_with_special_values_in_block) {
+TEST(flow_sequence_with_special_values_in_block) {
   const std::string input{R"YAML(values: [~, null, True, .inf, 0x3A]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_flow_in_block) {
+TEST(deeply_nested_flow_in_block) {
   const std::string input{R"YAML(a:
   b:
     c: {x: [1, 2], y: {z: 3}}
@@ -3355,32 +3355,32 @@ TEST(YAML_roundtrip, deeply_nested_flow_in_block) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_flow_sequence_roundtrip) {
+TEST(anchor_on_flow_sequence_roundtrip) {
   const std::string input{"a: &tag [1, 2, 3]\nb: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_flow_mapping_roundtrip) {
+TEST(anchor_on_flow_mapping_roundtrip) {
   const std::string input{"a: &tag {x: 1}\nb: *tag\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_key_inf) {
+TEST(special_key_inf) {
   const std::string input{".inf: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_key_nan) {
+TEST(special_key_nan) {
   const std::string input{".nan: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, special_key_tilde_with_special_value) {
+TEST(special_key_tilde_with_special_value) {
   const std::string input{"~: ~\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, all_null_variants_in_sequence) {
+TEST(all_null_variants_in_sequence) {
   const std::string input{R"YAML(- null
 - Null
 - NULL
@@ -3389,7 +3389,7 @@ TEST(YAML_roundtrip, all_null_variants_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, all_boolean_variants_in_sequence) {
+TEST(all_boolean_variants_in_sequence) {
   const std::string input{R"YAML(- true
 - True
 - TRUE
@@ -3400,7 +3400,7 @@ TEST(YAML_roundtrip, all_boolean_variants_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, all_inf_variants_in_sequence) {
+TEST(all_inf_variants_in_sequence) {
   const std::string input{R"YAML(- .inf
 - .Inf
 - .INF
@@ -3414,7 +3414,7 @@ TEST(YAML_roundtrip, all_inf_variants_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, all_nan_variants_in_sequence) {
+TEST(all_nan_variants_in_sequence) {
   const std::string input{R"YAML(- .nan
 - .NaN
 - .NAN
@@ -3422,7 +3422,7 @@ TEST(YAML_roundtrip, all_nan_variants_in_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, hex_variants) {
+TEST(hex_variants) {
   const std::string input{R"YAML(- 0x0
 - 0xFF
 - 0x1A2B
@@ -3430,7 +3430,7 @@ TEST(YAML_roundtrip, hex_variants) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, octal_variants) {
+TEST(octal_variants) {
   const std::string input{R"YAML(- 0o0
 - 0o77
 - 0o777
@@ -3438,7 +3438,7 @@ TEST(YAML_roundtrip, octal_variants) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, scientific_notation_variants) {
+TEST(scientific_notation_variants) {
   const std::string input{R"YAML(- 1e3
 - 1E3
 - 1.5e-2
@@ -3448,12 +3448,12 @@ TEST(YAML_roundtrip, scientific_notation_variants) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_implicit_null) {
+TEST(flow_implicit_null) {
   const std::string input{"{a: , b: 1}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, real_world_docker_compose) {
+TEST(real_world_docker_compose) {
   const std::string input{R"YAML(version: '3.8'
 services:
   web:
@@ -3475,7 +3475,7 @@ services:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, real_world_github_actions) {
+TEST(real_world_github_actions) {
   const std::string input{R"YAML(name: CI
 on:
   push:
@@ -3500,151 +3500,151 @@ jobs:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_hex_escape) {
+TEST(double_quoted_hex_escape) {
   const std::string input{"key: \"\\x41\\x42\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_unicode_escape_u) {
+TEST(double_quoted_unicode_escape_u) {
   const std::string input{"key: \"\\u0041\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_escaped_slash) {
+TEST(double_quoted_escaped_slash) {
   const std::string input{"key: \"path\\/to\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_bell_escape) {
+TEST(double_quoted_bell_escape) {
   const std::string input{"key: \"\\a\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_escape_char) {
+TEST(double_quoted_escape_char) {
   const std::string input{"key: \"\\e\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_backspace_escape) {
+TEST(double_quoted_backspace_escape) {
   const std::string input{"key: \"\\b\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_next_line_escape) {
+TEST(double_quoted_next_line_escape) {
   const std::string input{"key: \"\\N\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_nbsp_escape) {
+TEST(double_quoted_nbsp_escape) {
   const std::string input{"key: \"\\_\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_line_continuation) {
+TEST(double_quoted_line_continuation) {
   const std::string input{"key: \"hello \\\n  world\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_multiline) {
+TEST(single_quoted_multiline) {
   const std::string input{"key: 'hello\n  world'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_literal_newline_multiline) {
+TEST(double_quoted_literal_newline_multiline) {
   const std::string input{"key: \"line1\n  line2\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_only) {
+TEST(document_start_only) {
   const std::string input{"---\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_explicit_indent_indicator) {
+TEST(block_scalar_explicit_indent_indicator) {
   const std::string input{R"YAML(key: |2
    leading space
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_all_implicit_nulls) {
+TEST(flow_mapping_all_implicit_nulls) {
   const std::string input{"{a: , b: , c: }\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_scalar_with_bare_hash) {
+TEST(plain_scalar_with_bare_hash) {
   const std::string input{"key: foo#bar\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_scalar_with_bare_colon) {
+TEST(plain_scalar_with_bare_colon) {
   const std::string input{"key: http://example.com\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_no_space_after_hash) {
+TEST(comment_no_space_after_hash) {
   const std::string input{"#comment\nkey: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_double_hash) {
+TEST(comment_double_hash) {
   const std::string input{"key: value ## double hash\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_leading_space) {
+TEST(double_quoted_leading_space) {
   const std::string input{"key: \" leading space\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_trailing_space) {
+TEST(double_quoted_trailing_space) {
   const std::string input{"key: \"trailing space \"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, large_float_many_decimals) {
+TEST(large_float_many_decimals) {
   const std::string input{"key: 3.141592653589793\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, positive_zero) {
+TEST(positive_zero) {
   const std::string input{"key: +0\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_dots_and_hyphens) {
+TEST(anchor_with_dots_and_hyphens) {
   const std::string input{"a: &my-anchor.1 value\nb: *my-anchor.1\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_with_newline) {
+TEST(double_quoted_key_with_newline) {
   const std::string input{"\"multi\\nline\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, root_flow_sequence_with_quoted_keys) {
+TEST(root_flow_sequence_with_quoted_keys) {
   const std::string input{"[{\"a b\": 1}, {'c d': 2}]\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, unicode_plain_scalar) {
+TEST(unicode_plain_scalar) {
   const std::string input{R"YAML(key: café résumé
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, unicode_emoji_value) {
+TEST(unicode_emoji_value) {
   const std::string input{R"YAML(mood: happy 😀
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_indent_before_strip) {
+TEST(block_scalar_indent_before_strip) {
   const std::string input{"key: |2-\n   leading space\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_indent_before_keep) {
+TEST(block_scalar_indent_before_keep) {
   const std::string input{R"YAML(key: |2+
    leading space
 
@@ -3652,69 +3652,69 @@ TEST(YAML_roundtrip, block_scalar_indent_before_keep) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_indent_before_strip) {
+TEST(folded_scalar_indent_before_strip) {
   const std::string input{"key: >2-\n   leading space\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_standard_order_strip_indent) {
+TEST(block_scalar_standard_order_strip_indent) {
   const std::string input{"key: |-2\n   leading space\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_escaped_slash) {
+TEST(double_quoted_key_escaped_slash) {
   const std::string input{"\"path\\/to\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_bell_escape) {
+TEST(double_quoted_key_bell_escape) {
   const std::string input{"\"\\a\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_backspace_escape) {
+TEST(double_quoted_key_backspace_escape) {
   const std::string input{"\"\\b\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_escape_char) {
+TEST(double_quoted_key_escape_char) {
   const std::string input{"\"\\e\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_next_line_escape) {
+TEST(double_quoted_key_next_line_escape) {
   const std::string input{"\"\\N\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_nbsp_escape) {
+TEST(double_quoted_key_nbsp_escape) {
   const std::string input{"\"\\_\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_hex_escape) {
+TEST(double_quoted_key_hex_escape) {
   const std::string input{"\"\\x41\\x42\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_key_unicode_escape) {
+TEST(double_quoted_key_unicode_escape) {
   const std::string input{"\"\\u0041\": value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_double_quoted_key_bell) {
+TEST(flow_mapping_double_quoted_key_bell) {
   const std::string input{"{\"\\a\": value}\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_scalar) {
+TEST(multiline_plain_scalar) {
   const std::string input{R"YAML(key: this is a long
   plain scalar value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_scalar_three_lines) {
+TEST(multiline_plain_scalar_three_lines) {
   const std::string input{R"YAML(key: line one
   line two
   line three
@@ -3722,7 +3722,7 @@ TEST(YAML_roundtrip, multiline_plain_scalar_three_lines) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_scalar_with_blank_line) {
+TEST(multiline_plain_scalar_with_blank_line) {
   const std::string input{R"YAML(key: line one
 
   line three
@@ -3730,62 +3730,62 @@ TEST(YAML_roundtrip, multiline_plain_scalar_with_blank_line) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_scalar_in_sequence) {
+TEST(multiline_plain_scalar_in_sequence) {
   const std::string input{R"YAML(- this is a long
   plain scalar value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_with_escaped_quote) {
+TEST(single_quoted_with_escaped_quote) {
   const std::string input{R"YAML(key: 'it''s working'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_key_with_escaped_quote) {
+TEST(single_quoted_key_with_escaped_quote) {
   const std::string input{R"YAML('it''s': value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_scalar_with_hash_no_space) {
+TEST(plain_scalar_with_hash_no_space) {
   const std::string input{R"YAML(key: value#not_a_comment
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_with_urls) {
+TEST(flow_sequence_with_urls) {
   const std::string input{R"YAML(urls: [http://example.com, https://test.org]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_flow_sequences_matrix) {
+TEST(nested_flow_sequences_matrix) {
   const std::string input{R"YAML(matrix: [[1, 2], [3, 4]]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_flow_mappings) {
+TEST(nested_flow_mappings) {
   const std::string input{R"YAML(data: {a: {x: 1}, b: {y: 2}}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_flow_mapping) {
+TEST(empty_flow_mapping) {
   const std::string input{R"YAML(empty: {}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_flow_sequence) {
+TEST(empty_flow_sequence) {
   const std::string input{R"YAML(empty: []
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_literal_with_empty_lines) {
+TEST(block_literal_with_empty_lines) {
   const std::string input{R"YAML(content: |
   line one
 
@@ -3794,7 +3794,7 @@ TEST(YAML_roundtrip, block_literal_with_empty_lines) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_folded_basic) {
+TEST(block_folded_basic) {
   const std::string input{R"YAML(content: >
   this is a long text
   that spans multiple lines
@@ -3802,51 +3802,51 @@ TEST(YAML_roundtrip, block_folded_basic) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_literal_keep_trailing_blanks) {
+TEST(block_literal_keep_trailing_blanks) {
   const std::string input{"content: |+\n  text\n\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_in_sequence) {
+TEST(implicit_null_in_sequence) {
   const std::string input{R"YAML(-
 - value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_implicit_null_value) {
+TEST(flow_mapping_implicit_null_value) {
   const std::string input{R"YAML({a: , b: 2}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_implicit_null_mapping) {
+TEST(anchor_on_implicit_null_mapping) {
   const std::string input{R"YAML(key: &anchor
 next: *anchor
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, large_integer_roundtrip) {
+TEST(large_integer_roundtrip) {
   const std::string input{R"YAML(big: 99999999999999999
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_precision) {
+TEST(float_precision) {
   const std::string input{R"YAML(pi: 3.14159265358979
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, explicit_document_start_only) {
+TEST(explicit_document_start_only) {
   const std::string input{R"YAML(---
 key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, explicit_document_start_and_end) {
+TEST(explicit_document_start_and_end) {
   const std::string input{R"YAML(---
 key: value
 ...
@@ -3854,31 +3854,31 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, root_level_scalar_plain) {
+TEST(root_level_scalar_plain) {
   const std::string input{R"YAML(hello world
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, root_level_scalar_quoted) {
+TEST(root_level_scalar_quoted) {
   const std::string input{R"YAML("hello world"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, root_level_flow_sequence) {
+TEST(root_level_flow_sequence) {
   const std::string input{R"YAML([1, 2, 3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, root_level_flow_mapping) {
+TEST(root_level_flow_mapping) {
   const std::string input{R"YAML({a: 1, b: 2}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_block_and_flow) {
+TEST(mixed_block_and_flow) {
   const std::string input{R"YAML(block:
   key1: [1, 2]
   key2: {a: b}
@@ -3886,7 +3886,7 @@ TEST(YAML_roundtrip, mixed_block_and_flow) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_of_mappings_multikey) {
+TEST(sequence_of_mappings_multikey) {
   const std::string input{R"YAML(- name: Alice
   age: 30
 - name: Bob
@@ -3895,55 +3895,55 @@ TEST(YAML_roundtrip, sequence_of_mappings_multikey) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_empty_value) {
+TEST(single_quoted_empty_value) {
   const std::string input{R"YAML(key: ''
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_empty_value) {
+TEST(double_quoted_empty_value) {
   const std::string input{R"YAML(key: ""
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, colon_in_plain_scalar) {
+TEST(colon_in_plain_scalar) {
   const std::string input{R"YAML(key: http://example.com
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, integer_key) {
+TEST(integer_key) {
   const std::string input{R"YAML(123: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, float_key_plain) {
+TEST(float_key_plain) {
   const std::string input{R"YAML(1.5: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_value_true_lowercase) {
+TEST(boolean_value_true_lowercase) {
   const std::string input{R"YAML(key: true
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, boolean_value_false_lowercase) {
+TEST(boolean_value_false_lowercase) {
   const std::string input{R"YAML(key: false
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_value_lowercase) {
+TEST(null_value_lowercase) {
   const std::string input{R"YAML(key: null
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_with_mixed_types) {
+TEST(sequence_with_mixed_types) {
   const std::string input{R"YAML(- 1
 - two
 - true
@@ -3953,25 +3953,25 @@ TEST(YAML_roundtrip, sequence_with_mixed_types) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_with_strings) {
+TEST(flow_sequence_with_strings) {
   const std::string input{R"YAML(items: [hello, world]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_double_quoted_value) {
+TEST(multiline_double_quoted_value) {
   const std::string input{"key: \"line one\\nline two\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_strip_no_trailing_newline) {
+TEST(block_scalar_strip_no_trailing_newline) {
   const std::string input{R"YAML(content: |-
   no trailing newline
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_anchors_and_aliases_four_keys) {
+TEST(multiple_anchors_and_aliases_four_keys) {
   const std::string input{R"YAML(first: &a hello
 second: &b world
 ref_a: *a
@@ -3980,7 +3980,7 @@ ref_b: *b
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_mapping) {
+TEST(anchor_on_mapping) {
   const std::string input{R"YAML(defaults: &defaults
   color: red
   size: large
@@ -3991,50 +3991,50 @@ custom:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_scalar_with_colon_no_space) {
+TEST(plain_scalar_with_colon_no_space) {
   const std::string input{R"YAML(key: value:stuff
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_nested_in_flow_sequence_two_items) {
+TEST(flow_mapping_nested_in_flow_sequence_two_items) {
   const std::string input{R"YAML(items: [{a: 1}, {b: 2}]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_nested_in_flow_mapping_three_items) {
+TEST(flow_sequence_nested_in_flow_mapping_three_items) {
   const std::string input{R"YAML(data: {list: [1, 2, 3]}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_with_newline) {
+TEST(single_quoted_with_newline) {
   const std::string input{"key: 'line one\\nline two'\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_tab) {
+TEST(double_quoted_with_tab) {
   const std::string input{"key: \"value\\twith\\ttabs\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_null_escape) {
+TEST(double_quoted_with_null_escape) {
   const std::string input{"key: \"null\\0char\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_unicode_escape_4digit) {
+TEST(double_quoted_with_unicode_escape_4digit) {
   const std::string input{"key: \"\\u0048ello\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_backslash_escape) {
+TEST(double_quoted_with_backslash_escape) {
   const std::string input{"key: \"back\\\\slash\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_sequence_value) {
+TEST(mapping_with_sequence_value) {
   const std::string input{R"YAML(fruits:
   - apple
   - banana
@@ -4044,45 +4044,45 @@ vegetables:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, three_indent_width) {
+TEST(three_indent_width) {
   const std::string input{R"YAML(outer:
    inner: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, four_indent_width) {
+TEST(four_indent_width) {
   const std::string input{R"YAML(outer:
     inner: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_single_quoted_value) {
+TEST(flow_mapping_single_quoted_value) {
   const std::string input{R"YAML({key: 'value'}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_double_quoted_value) {
+TEST(flow_mapping_double_quoted_value) {
   const std::string input{R"YAML({key: "value"}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_single_quoted) {
+TEST(flow_sequence_single_quoted) {
   const std::string input{R"YAML(['hello', 'world']
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_double_quoted) {
+TEST(flow_sequence_double_quoted) {
   const std::string input{R"YAML(["hello", "world"]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_with_explicit_document_and_comment) {
+TEST(block_mapping_with_explicit_document_and_comment) {
   const std::string input{R"YAML(---
 # top comment
 key: value
@@ -4090,92 +4090,92 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_before_sequence_item) {
+TEST(comment_before_sequence_item) {
   const std::string input{R"YAML(# comment
 - item
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, inline_comment_after_mapping_value) {
+TEST(inline_comment_after_mapping_value) {
   const std::string input{R"YAML(key: value # comment
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_on_colon_indicator) {
+TEST(comment_on_colon_indicator) {
   const std::string input{R"YAML(parent: # comment
   child: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, unicode_value) {
+TEST(unicode_value) {
   const std::string input{"key: \xC3\xA9\xC3\xA0\xC3\xBC\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, unicode_key) {
+TEST(unicode_key) {
   const std::string input{"\xC3\xA9\xC3\xA0\xC3\xBC: value\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_with_integer_values) {
+TEST(flow_mapping_with_integer_values) {
   const std::string input{R"YAML({x: 1, y: 2, z: 3}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_boolean_values) {
+TEST(flow_mapping_boolean_values) {
   const std::string input{R"YAML({enabled: true, disabled: false}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_integer_value) {
+TEST(negative_integer_value) {
   const std::string input{R"YAML(value: -42
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_float_value) {
+TEST(negative_float_value) {
   const std::string input{R"YAML(value: -3.14
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, positive_float_with_exponent) {
+TEST(positive_float_with_exponent) {
   const std::string input{R"YAML(value: 1.5e10
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, string_that_looks_like_number) {
+TEST(string_that_looks_like_number) {
   const std::string input{R"YAML(zip: "01onal"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_empty_string_value) {
+TEST(flow_mapping_empty_string_value) {
   const std::string input{R"YAML({key: ""}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_special_chars_in_value) {
+TEST(block_mapping_special_chars_in_value) {
   const std::string input{R"YAML(key: "hello: world"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_scalar_value) {
+TEST(anchor_on_scalar_value) {
   const std::string input{R"YAML(key: &ref value
 other: *ref
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_block_sequence) {
+TEST(anchor_on_block_sequence) {
   const std::string input{R"YAML(list: &items
   - one
   - two
@@ -4184,32 +4184,32 @@ copy: *items
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_scalar_starting_with_special) {
+TEST(plain_scalar_starting_with_special) {
   const std::string input{R"YAML(key: ---not-a-document
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_item_flow_sequence) {
+TEST(single_item_flow_sequence) {
   const std::string input{R"YAML(items: [only]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_item_flow_mapping) {
+TEST(single_item_flow_mapping) {
   const std::string input{R"YAML(data: {only: one}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_literal_single_line) {
+TEST(block_literal_single_line) {
   const std::string input{R"YAML(content: |
   single line
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_with_empty_line) {
+TEST(folded_scalar_with_empty_line) {
   const std::string input{R"YAML(content: >
   first paragraph
 
@@ -4218,19 +4218,19 @@ TEST(YAML_roundtrip, folded_scalar_with_empty_line) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_strip) {
+TEST(folded_scalar_strip) {
   const std::string input{R"YAML(content: >-
   no trailing newline
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_keep) {
+TEST(folded_scalar_keep) {
   const std::string input{"content: >+\n  keep trailing\n\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_literal_multiple_paragraphs) {
+TEST(block_literal_multiple_paragraphs) {
   const std::string input{R"YAML(content: |
   paragraph one
   continues here
@@ -4241,7 +4241,7 @@ TEST(YAML_roundtrip, block_literal_multiple_paragraphs) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_scalar_styles_all_five) {
+TEST(mixed_scalar_styles_all_five) {
   const std::string input{R"YAML(plain: hello
 single: 'world'
 double: "foo"
@@ -4253,7 +4253,7 @@ folded: >
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_mapping_with_flow_value) {
+TEST(nested_mapping_with_flow_value) {
   const std::string input{R"YAML(config:
   ports: [80, 443]
   hosts:
@@ -4263,7 +4263,7 @@ TEST(YAML_roundtrip, nested_mapping_with_flow_value) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_mapping_entries_two_keys) {
+TEST(comment_between_mapping_entries_two_keys) {
   const std::string input{R"YAML(first: 1
 # comment between
 second: 2
@@ -4271,7 +4271,7 @@ second: 2
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_between_sequence_items_two) {
+TEST(comment_between_sequence_items_two) {
   const std::string input{R"YAML(- first
 # comment between
 - second
@@ -4279,103 +4279,103 @@ TEST(YAML_roundtrip, comment_between_sequence_items_two) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_no_spaces) {
+TEST(flow_mapping_no_spaces) {
   const std::string input{R"YAML({a: 1,b: 2}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_no_spaces) {
+TEST(flow_sequence_no_spaces) {
   const std::string input{R"YAML([1,2,3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_pair_mapping) {
+TEST(single_pair_mapping) {
   const std::string input{R"YAML(key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_item_sequence) {
+TEST(single_item_sequence) {
   const std::string input{R"YAML(- item
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_end_marker) {
+TEST(document_end_marker) {
   const std::string input{R"YAML(key: value
 ...
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, scientific_notation_uppercase) {
+TEST(scientific_notation_uppercase) {
   const std::string input{R"YAML(value: 1.5E10
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, scientific_notation_negative_exponent_value) {
+TEST(scientific_notation_negative_exponent_value) {
   const std::string input{R"YAML(value: 1.5e-3
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, compact_flow_mapping_three_entries) {
+TEST(compact_flow_mapping_three_entries) {
   const std::string input{R"YAML({a: 1,b: 2,c: 3}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, compact_flow_sequence_strings) {
+TEST(compact_flow_sequence_strings) {
   const std::string input{R"YAML([a,b,c]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, compact_nested_flow) {
+TEST(compact_nested_flow) {
   const std::string input{R"YAML({a: [1,2],b: [3,4]}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_key_tilde) {
+TEST(null_key_tilde) {
   const std::string input{R"YAML(~: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, null_key_word) {
+TEST(null_key_word) {
   const std::string input{R"YAML(null: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_key_quoted) {
+TEST(empty_key_quoted) {
   const std::string input{R"YAML("": value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_sequence_same_line) {
+TEST(nested_sequence_same_line) {
   const std::string input{R"YAML(- - a
   - b
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_literal_with_trailing_spaces_in_content) {
+TEST(block_literal_with_trailing_spaces_in_content) {
   const std::string input{"content: |\n  line one\n  line two\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_clip_multiple_trailing) {
+TEST(block_scalar_clip_multiple_trailing) {
   const std::string input{"content: |\n  text\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_scalar_as_sequence_item) {
+TEST(multiline_plain_scalar_as_sequence_item) {
   const std::string input{R"YAML(- first line
   second line
 - other
@@ -4383,44 +4383,44 @@ TEST(YAML_roundtrip, multiline_plain_scalar_as_sequence_item) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_single_null) {
+TEST(flow_sequence_single_null) {
   const std::string input{R"YAML([null]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_with_null) {
+TEST(flow_sequence_with_null) {
   const std::string input{R"YAML([1, null, 3]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_with_null_value) {
+TEST(flow_mapping_with_null_value) {
   const std::string input{R"YAML({key: null}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_space_escape) {
+TEST(double_quoted_with_space_escape) {
   const std::string input{"key: \"hello\\x20world\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_double_quoted_value) {
+TEST(anchor_with_double_quoted_value) {
   const std::string input{R"YAML(key: &ref "quoted value"
 other: *ref
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_with_single_quoted_value) {
+TEST(anchor_with_single_quoted_value) {
   const std::string input{R"YAML(key: &ref 'quoted value'
 other: *ref
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_four_indent) {
+TEST(block_mapping_four_indent) {
   const std::string input{R"YAML(outer:
     nested:
         deep: value
@@ -4428,7 +4428,7 @@ TEST(YAML_roundtrip, block_mapping_four_indent) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_in_mapping_four_indent) {
+TEST(sequence_in_mapping_four_indent) {
   const std::string input{R"YAML(list:
     - one
     - two
@@ -4436,7 +4436,7 @@ TEST(YAML_roundtrip, sequence_in_mapping_four_indent) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, two_comments_before_key) {
+TEST(two_comments_before_key) {
   const std::string input{R"YAML(# first comment
 # second comment
 key: value
@@ -4444,7 +4444,7 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, empty_line_between_comments) {
+TEST(empty_line_between_comments) {
   const std::string input{R"YAML(# comment one
 
 # comment two
@@ -4453,20 +4453,20 @@ key: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, comment_after_document_end) {
+TEST(comment_after_document_end) {
   const std::string input{R"YAML(key: value
 ... # end comment
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_with_anchor_value) {
+TEST(flow_mapping_with_anchor_value) {
   const std::string input{R"YAML({key: &ref value, other: *ref}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_value_in_nested_mapping) {
+TEST(multiline_plain_value_in_nested_mapping) {
   const std::string input{R"YAML(outer:
   key: line one
     line two
@@ -4474,30 +4474,30 @@ TEST(YAML_roundtrip, multiline_plain_value_in_nested_mapping) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_multiline_literal) {
+TEST(double_quoted_multiline_literal) {
   const std::string input{"key: \"line one\\nline two\\nline three\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_with_double_quote_inside) {
+TEST(single_quoted_with_double_quote_inside) {
   const std::string input{R"YAML(key: 'say "hello"'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, double_quoted_with_single_quote_inside) {
+TEST(double_quoted_with_single_quote_inside) {
   const std::string input{"key: \"it's fine\"\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, sequence_with_inline_comments) {
+TEST(sequence_with_inline_comments) {
   const std::string input{R"YAML(- one # first
 - two # second
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_inline_comments_multiple) {
+TEST(mapping_with_inline_comments_multiple) {
   const std::string input{R"YAML(a: 1 # first
 b: 2 # second
 c: 3 # third
@@ -4505,57 +4505,57 @@ c: 3 # third
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_after_comment_on_indicator) {
+TEST(block_scalar_after_comment_on_indicator) {
   const std::string input{R"YAML(content: | # block comment
   the content
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, folded_scalar_after_comment_on_indicator) {
+TEST(folded_scalar_after_comment_on_indicator) {
   const std::string input{R"YAML(content: > # folded comment
   the content
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_in_flow_sequence) {
+TEST(anchor_in_flow_sequence) {
   const std::string input{R"YAML([&ref hello, *ref]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_with_flow_mapping_items) {
+TEST(flow_sequence_with_flow_mapping_items) {
   const std::string input{R"YAML([{a: 1, b: 2}, {c: 3}]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, compact_flow_mapping_with_quoted_values) {
+TEST(compact_flow_mapping_with_quoted_values) {
   const std::string input{R"YAML({a: "x",b: "y"}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, compact_flow_sequence_with_quoted_values) {
+TEST(compact_flow_sequence_with_quoted_values) {
   const std::string input{R"YAML(["a","b","c"]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_single_quoted_key) {
+TEST(block_mapping_single_quoted_key) {
   const std::string input{R"YAML('quoted key': value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_mapping_double_quoted_key) {
+TEST(block_mapping_double_quoted_key) {
   const std::string input{R"YAML("quoted key": value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_block_scalars) {
+TEST(multiple_block_scalars) {
   const std::string input{R"YAML(first: |
   content one
 second: |
@@ -4564,7 +4564,7 @@ second: |
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_scalar_in_sequence_two_items) {
+TEST(block_scalar_in_sequence_two_items) {
   const std::string input{R"YAML(- |
   literal text
 - |
@@ -4573,7 +4573,7 @@ TEST(YAML_roundtrip, block_scalar_in_sequence_two_items) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, nested_mapping_with_block_scalar) {
+TEST(nested_mapping_with_block_scalar) {
   const std::string input{R"YAML(outer:
   inner: |
     block content
@@ -4581,7 +4581,7 @@ TEST(YAML_roundtrip, nested_mapping_with_block_scalar) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiline_plain_scalar_with_continuation_indent) {
+TEST(multiline_plain_scalar_with_continuation_indent) {
   const std::string input{R"YAML(key: first line
   continuation
   more continuation
@@ -4590,25 +4590,25 @@ next: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_null_key_value) {
+TEST(flow_mapping_null_key_value) {
   const std::string input{R"YAML({null: value}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_integer_key_value) {
+TEST(flow_mapping_integer_key_value) {
   const std::string input{R"YAML({42: value}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_mapping_boolean_key_value) {
+TEST(flow_mapping_boolean_key_value) {
   const std::string input{R"YAML({true: value}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_with_empty_items) {
+TEST(block_sequence_with_empty_items) {
   const std::string input{R"YAML(-
 -
 - value
@@ -4616,56 +4616,56 @@ TEST(YAML_roundtrip, block_sequence_with_empty_items) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, deeply_nested_flow_in_block_sequence) {
+TEST(deeply_nested_flow_in_block_sequence) {
   const std::string input{R"YAML(- key: [1, 2]
 - other: {a: b}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, quoted_value_with_colon_space) {
+TEST(quoted_value_with_colon_space) {
   const std::string input{R"YAML(key: "has: colon"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, quoted_value_with_hash) {
+TEST(quoted_value_with_hash) {
   const std::string input{R"YAML(key: "has # hash"
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, single_quoted_value_with_colon) {
+TEST(single_quoted_value_with_colon) {
   const std::string input{R"YAML(key: 'has: colon'
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_value_with_bracket) {
+TEST(plain_value_with_bracket) {
   const std::string input{R"YAML(key: value [not flow]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_value_with_brace) {
+TEST(plain_value_with_brace) {
   const std::string input{R"YAML(key: value {not flow}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, leading_comment_before_mapping) {
+TEST(leading_comment_before_mapping) {
   const std::string input{R"YAML(# leading comment
 key: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, trailing_comment_after_document) {
+TEST(trailing_comment_after_document) {
   const std::string input{"key: value\n# trailing comment\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_with_comments_per_item) {
+TEST(block_sequence_with_comments_per_item) {
   const std::string input{R"YAML(# item one
 - one
 # item two
@@ -4676,19 +4676,19 @@ TEST(YAML_roundtrip, block_sequence_with_comments_per_item) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, flow_sequence_empty_string_items) {
+TEST(flow_sequence_empty_string_items) {
   const std::string input{R"YAML(["", "", ""]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_very_long_key) {
+TEST(mapping_with_very_long_key) {
   const std::string input{R"YAML(this_is_a_very_long_key_name: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mixed_indent_mapping_and_sequence) {
+TEST(mixed_indent_mapping_and_sequence) {
   const std::string input{R"YAML(mapping:
   list:
     - item1
@@ -4698,7 +4698,7 @@ TEST(YAML_roundtrip, mixed_indent_mapping_and_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, real_world_docker_compose_nginx) {
+TEST(real_world_docker_compose_nginx) {
   const std::string input{R"YAML(services:
   web:
     image: nginx:latest
@@ -4713,7 +4713,7 @@ TEST(YAML_roundtrip, real_world_docker_compose_nginx) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, real_world_kubernetes_config) {
+TEST(real_world_kubernetes_config) {
   const std::string input{R"YAML(apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -4728,33 +4728,33 @@ data:
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, plain_value_ending_with_colon) {
+TEST(plain_value_ending_with_colon) {
   const std::string input{R"YAML(key: 10:30
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, multiple_colons_in_plain_value) {
+TEST(multiple_colons_in_plain_value) {
   const std::string input{R"YAML(time: 10:30:45
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_of_flow_mappings) {
+TEST(block_sequence_of_flow_mappings) {
   const std::string input{R"YAML(- {name: Alice, age: 30}
 - {name: Bob, age: 25}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, block_sequence_of_flow_sequences) {
+TEST(block_sequence_of_flow_sequences) {
   const std::string input{R"YAML(- [1, 2, 3]
 - [4, 5, 6]
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, mapping_with_empty_flow_collections) {
+TEST(mapping_with_empty_flow_collections) {
   const std::string input{R"YAML(empty_list: []
 empty_map: {}
 normal: value
@@ -4762,117 +4762,117 @@ normal: value
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, tilde_null_in_sequence) {
+TEST(tilde_null_in_sequence) {
   const std::string input{R"YAML(- ~
 - value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, Null_capitalized) {
+TEST(Null_capitalized) {
   const std::string input{R"YAML(key: Null
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, NULL_uppercase) {
+TEST(NULL_uppercase) {
   const std::string input{R"YAML(key: NULL
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, True_capitalized) {
+TEST(True_capitalized) {
   const std::string input{R"YAML(key: True
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, FALSE_uppercase) {
+TEST(FALSE_uppercase) {
   const std::string input{R"YAML(key: FALSE
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, yes_as_string_value) {
+TEST(yes_as_string_value) {
   const std::string input{R"YAML(key: yes
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, no_as_string_value) {
+TEST(no_as_string_value) {
   const std::string input{R"YAML(key: no
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, on_as_string_value) {
+TEST(on_as_string_value) {
   const std::string input{R"YAML(key: on
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, off_as_string_value) {
+TEST(off_as_string_value) {
   const std::string input{R"YAML(key: off
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, octal_number_mode) {
+TEST(octal_number_mode) {
   const std::string input{R"YAML(mode: 0o755
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, hex_number_color) {
+TEST(hex_number_color) {
   const std::string input{R"YAML(color: 0xFF00FF
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, positive_infinity) {
+TEST(positive_infinity) {
   const std::string input{R"YAML(value: .inf
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_infinity) {
+TEST(negative_infinity) {
   const std::string input{R"YAML(value: -.inf
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, not_a_number) {
+TEST(not_a_number) {
   const std::string input{R"YAML(value: .nan
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, Inf_capitalized) {
+TEST(Inf_capitalized) {
   const std::string input{R"YAML(value: .Inf
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, NaN_capitalized) {
+TEST(NaN_capitalized) {
   const std::string input{R"YAML(value: .NaN
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, zero_float_variations) {
+TEST(zero_float_variations) {
   const std::string input{R"YAML(a: 0.0
 b: 0
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, negative_zero_float) {
+TEST(negative_zero_float) {
   const std::string input{R"YAML(key: -0.0
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_with_block_sequence) {
+TEST(document_start_with_block_sequence) {
   const std::string input{R"YAML(---
 - one
 - two
@@ -4880,25 +4880,25 @@ TEST(YAML_roundtrip, document_start_with_block_sequence) {
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, document_start_with_flow_mapping) {
+TEST(document_start_with_flow_mapping) {
   const std::string input{R"YAML(---
 {key: value}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, compact_flow_with_special_values) {
+TEST(compact_flow_with_special_values) {
   const std::string input{R"YAML({a: true,b: null,c: 42}
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, root_scalar_with_inline_comment) {
+TEST(root_scalar_with_inline_comment) {
   const std::string input{"hello # comment\n"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_block_sequence_with_inline_comment) {
+TEST(anchor_on_block_sequence_with_inline_comment) {
   const std::string input{R"YAML(list: &anchor # comment
   - item
 ref: *anchor
@@ -4906,7 +4906,7 @@ ref: *anchor
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, anchor_on_block_mapping_with_inline_comment) {
+TEST(anchor_on_block_mapping_with_inline_comment) {
   const std::string input{R"YAML(config: &defaults # defaults
   color: red
   size: large
@@ -4915,14 +4915,14 @@ ref: *defaults
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_anchor_with_inline_comment) {
+TEST(implicit_null_anchor_with_inline_comment) {
   const std::string input{R"YAML(key: &anchor # comment
 next: value
 )YAML"};
   EXPECT_EQ(roundtrip(input), input);
 }
 
-TEST(YAML_roundtrip, implicit_null_anchor_with_inline_comment_sequence) {
+TEST(implicit_null_anchor_with_inline_comment_sequence) {
   const std::string input{R"YAML(- &anchor # comment
 - value
 )YAML"};

--- a/test/yaml/yaml_stringify_test.cc
+++ b/test/yaml/yaml_stringify_test.cc
@@ -1,143 +1,143 @@
-#include <gtest/gtest.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/yaml.h>
 
 #include <sstream> // std::ostringstream
 
-TEST(YAML_stringify, null) {
+TEST(null) {
   const sourcemeta::core::JSON document{nullptr};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "null\n");
 }
 
-TEST(YAML_stringify, true_value) {
+TEST(true_value) {
   const sourcemeta::core::JSON document{true};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "true\n");
 }
 
-TEST(YAML_stringify, false_value) {
+TEST(false_value) {
   const sourcemeta::core::JSON document{false};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "false\n");
 }
 
-TEST(YAML_stringify, integer_positive) {
+TEST(integer_positive) {
   const sourcemeta::core::JSON document{42};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "42\n");
 }
 
-TEST(YAML_stringify, integer_negative) {
+TEST(integer_negative) {
   const sourcemeta::core::JSON document{-7};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "-7\n");
 }
 
-TEST(YAML_stringify, integer_zero) {
+TEST(integer_zero) {
   const sourcemeta::core::JSON document{0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "0\n");
 }
 
-TEST(YAML_stringify, integer_large) {
+TEST(integer_large) {
   const sourcemeta::core::JSON document{9999999};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "9999999\n");
 }
 
-TEST(YAML_stringify, integer_large_negative) {
+TEST(integer_large_negative) {
   const sourcemeta::core::JSON document{-9999999};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "-9999999\n");
 }
 
-TEST(YAML_stringify, real_zero) {
+TEST(real_zero) {
   const sourcemeta::core::JSON document{0.0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "0.0\n");
 }
 
-TEST(YAML_stringify, real_positive_fractional) {
+TEST(real_positive_fractional) {
   const sourcemeta::core::JSON document{3.14};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "3.14\n");
 }
 
-TEST(YAML_stringify, real_negative_fractional) {
+TEST(real_negative_fractional) {
   const sourcemeta::core::JSON document{-2.5};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "-2.5\n");
 }
 
-TEST(YAML_stringify, real_positive_whole) {
+TEST(real_positive_whole) {
   const sourcemeta::core::JSON document{5.0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "5.0\n");
 }
 
-TEST(YAML_stringify, real_negative_whole) {
+TEST(real_negative_whole) {
   const sourcemeta::core::JSON document{-10.0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "-10.0\n");
 }
 
-TEST(YAML_stringify, real_large_whole) {
+TEST(real_large_whole) {
   const sourcemeta::core::JSON document{1000000.0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "1000000.0\n");
 }
 
-TEST(YAML_stringify, real_small_fractional) {
+TEST(real_small_fractional) {
   const sourcemeta::core::JSON document{0.001};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "0.001\n");
 }
 
-TEST(YAML_stringify, real_one) {
+TEST(real_one) {
   const sourcemeta::core::JSON document{1.0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "1.0\n");
 }
 
-TEST(YAML_stringify, real_negative_one) {
+TEST(real_negative_one) {
   const sourcemeta::core::JSON document{-1.0};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "-1.0\n");
 }
 
-TEST(YAML_stringify, real_large_fractional) {
+TEST(real_large_fractional) {
   const sourcemeta::core::JSON document{1234.56};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "1234.56\n");
 }
 
-TEST(YAML_stringify, real_half) {
+TEST(real_half) {
   const sourcemeta::core::JSON document{0.5};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "0.5\n");
 }
 
-TEST(YAML_stringify, decimal_large_integer) {
+TEST(decimal_large_integer) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{static_cast<std::int64_t>(1000000)}};
   std::ostringstream stream;
@@ -145,7 +145,7 @@ TEST(YAML_stringify, decimal_large_integer) {
   EXPECT_EQ(stream.str(), "1.000000e+6\n");
 }
 
-TEST(YAML_stringify, decimal_high_precision_real) {
+TEST(decimal_high_precision_real) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"3.14159265358979"}};
   std::ostringstream stream;
@@ -153,14 +153,14 @@ TEST(YAML_stringify, decimal_high_precision_real) {
   EXPECT_EQ(stream.str(), "3.14159265358979e+0\n");
 }
 
-TEST(YAML_stringify, decimal_exponential_notation) {
+TEST(decimal_exponential_notation) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"0.001"}};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "1e-3\n");
 }
 
-TEST(YAML_stringify, decimal_in_object) {
+TEST(decimal_in_object) {
   auto document{sourcemeta::core::JSON::make_object()};
   document.assign("value",
                   sourcemeta::core::JSON{sourcemeta::core::Decimal{42}});
@@ -169,7 +169,7 @@ TEST(YAML_stringify, decimal_in_object) {
   EXPECT_EQ(stream.str(), "value: 4.2e+1\n");
 }
 
-TEST(YAML_stringify, decimal_in_array) {
+TEST(decimal_in_array) {
   auto document{sourcemeta::core::JSON::make_array()};
   document.push_back(sourcemeta::core::JSON{sourcemeta::core::Decimal{42}});
   std::ostringstream stream;
@@ -177,7 +177,7 @@ TEST(YAML_stringify, decimal_in_array) {
   EXPECT_EQ(stream.str(), "- 4.2e+1\n");
 }
 
-TEST(YAML_stringify, decimal_negative) {
+TEST(decimal_negative) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{static_cast<std::int64_t>(-42)}};
   std::ostringstream stream;
@@ -185,7 +185,7 @@ TEST(YAML_stringify, decimal_negative) {
   EXPECT_EQ(stream.str(), "-4.2e+1\n");
 }
 
-TEST(YAML_stringify, real_in_object) {
+TEST(real_in_object) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "pi": 3.14 })JSON")};
   std::ostringstream stream;
@@ -193,14 +193,14 @@ TEST(YAML_stringify, real_in_object) {
   EXPECT_EQ(stream.str(), "pi: 3.14\n");
 }
 
-TEST(YAML_stringify, real_in_array) {
+TEST(real_in_array) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 1.5, 2.5 ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- 1.5\n- 2.5\n");
 }
 
-TEST(YAML_stringify, sequence_mixed_with_real) {
+TEST(sequence_mixed_with_real) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON([ 1, 2.5, "three" ])JSON")};
   std::ostringstream stream;
@@ -208,532 +208,532 @@ TEST(YAML_stringify, sequence_mixed_with_real) {
   EXPECT_EQ(stream.str(), "- 1\n- 2.5\n- three\n");
 }
 
-TEST(YAML_stringify, plain_string) {
+TEST(plain_string) {
   const sourcemeta::core::JSON document{"hello"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "hello\n");
 }
 
-TEST(YAML_stringify, plain_string_with_dash_in_middle) {
+TEST(plain_string_with_dash_in_middle) {
   const sourcemeta::core::JSON document{"foo-bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "foo-bar\n");
 }
 
-TEST(YAML_stringify, plain_string_with_colon_no_space) {
+TEST(plain_string_with_colon_no_space) {
   const sourcemeta::core::JSON document{"http://example.com"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "http://example.com\n");
 }
 
-TEST(YAML_stringify, plain_string_with_dot) {
+TEST(plain_string_with_dot) {
   const sourcemeta::core::JSON document{"file.txt"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "file.txt\n");
 }
 
-TEST(YAML_stringify, plain_string_with_underscore) {
+TEST(plain_string_with_underscore) {
   const sourcemeta::core::JSON document{"my_var"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "my_var\n");
 }
 
-TEST(YAML_stringify, plain_string_with_slash) {
+TEST(plain_string_with_slash) {
   const sourcemeta::core::JSON document{"path/to/file"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "path/to/file\n");
 }
 
-TEST(YAML_stringify, plain_string_with_quotes_inside) {
+TEST(plain_string_with_quotes_inside) {
   const sourcemeta::core::JSON document{"say \"hello\""};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "say \"hello\"\n");
 }
 
-TEST(YAML_stringify, plain_string_with_backslash) {
+TEST(plain_string_with_backslash) {
   const sourcemeta::core::JSON document{"back\\slash"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "back\\slash\n");
 }
 
-TEST(YAML_stringify, plain_string_with_parentheses) {
+TEST(plain_string_with_parentheses) {
   const sourcemeta::core::JSON document{"foo(bar)"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "foo(bar)\n");
 }
 
-TEST(YAML_stringify, plain_string_with_equals) {
+TEST(plain_string_with_equals) {
   const sourcemeta::core::JSON document{"a=b"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "a=b\n");
 }
 
-TEST(YAML_stringify, plain_string_single_char) {
+TEST(plain_string_single_char) {
   const sourcemeta::core::JSON document{"x"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "x\n");
 }
 
-TEST(YAML_stringify, string_quoting_true_lowercase) {
+TEST(string_quoting_true_lowercase) {
   const sourcemeta::core::JSON document{"true"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"true\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_True) {
+TEST(string_quoting_True) {
   const sourcemeta::core::JSON document{"True"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"True\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_TRUE) {
+TEST(string_quoting_TRUE) {
   const sourcemeta::core::JSON document{"TRUE"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"TRUE\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_false_lowercase) {
+TEST(string_quoting_false_lowercase) {
   const sourcemeta::core::JSON document{"false"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"false\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_False) {
+TEST(string_quoting_False) {
   const sourcemeta::core::JSON document{"False"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"False\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_FALSE) {
+TEST(string_quoting_FALSE) {
   const sourcemeta::core::JSON document{"FALSE"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"FALSE\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_null_lowercase) {
+TEST(string_quoting_null_lowercase) {
   const sourcemeta::core::JSON document{"null"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"null\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_Null) {
+TEST(string_quoting_Null) {
   const sourcemeta::core::JSON document{"Null"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"Null\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_NULL) {
+TEST(string_quoting_NULL) {
   const sourcemeta::core::JSON document{"NULL"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"NULL\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_tilde) {
+TEST(string_quoting_tilde) {
   const sourcemeta::core::JSON document{"~"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"~\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_integer) {
+TEST(string_quoting_integer) {
   const sourcemeta::core::JSON document{"42"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"42\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_negative_integer) {
+TEST(string_quoting_negative_integer) {
   const sourcemeta::core::JSON document{"-7"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"-7\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_float) {
+TEST(string_quoting_float) {
   const sourcemeta::core::JSON document{"3.14"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"3.14\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_scientific) {
+TEST(string_quoting_scientific) {
   const sourcemeta::core::JSON document{"1e10"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"1e10\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_hex) {
+TEST(string_quoting_hex) {
   const sourcemeta::core::JSON document{"0xFF"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"0xFF\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_octal) {
+TEST(string_quoting_octal) {
   const sourcemeta::core::JSON document{"0o77"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"0o77\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_positive_sign) {
+TEST(string_quoting_positive_sign) {
   const sourcemeta::core::JSON document{"+5"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"+5\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_zero) {
+TEST(string_quoting_zero) {
   const sourcemeta::core::JSON document{"0"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"0\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_inf) {
+TEST(string_quoting_inf) {
   const sourcemeta::core::JSON document{".inf"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\".inf\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_Inf) {
+TEST(string_quoting_Inf) {
   const sourcemeta::core::JSON document{".Inf"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\".Inf\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_negative_inf) {
+TEST(string_quoting_negative_inf) {
   const sourcemeta::core::JSON document{"-.inf"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"-.inf\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_nan) {
+TEST(string_quoting_nan) {
   const sourcemeta::core::JSON document{".nan"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\".nan\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_NaN) {
+TEST(string_quoting_NaN) {
   const sourcemeta::core::JSON document{".NaN"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\".NaN\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_document_start) {
+TEST(string_quoting_document_start) {
   const sourcemeta::core::JSON document{"---"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"---\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_document_end) {
+TEST(string_quoting_document_end) {
   const sourcemeta::core::JSON document{"..."};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"...\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_document_start_with_space) {
+TEST(string_quoting_document_start_with_space) {
   const sourcemeta::core::JSON document{"--- foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"--- foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_document_end_with_space) {
+TEST(string_quoting_document_end_with_space) {
   const sourcemeta::core::JSON document{"... foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"... foo\"\n");
 }
 
-TEST(YAML_stringify, string_four_dashes_plain) {
+TEST(string_four_dashes_plain) {
   const sourcemeta::core::JSON document{"----"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "----\n");
 }
 
-TEST(YAML_stringify, string_four_dots_plain) {
+TEST(string_four_dots_plain) {
   const sourcemeta::core::JSON document{"...."};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "....\n");
 }
 
-TEST(YAML_stringify, string_quoting_trailing_colon) {
+TEST(string_quoting_trailing_colon) {
   const sourcemeta::core::JSON document{"foo:"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"foo:\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_just_colon) {
+TEST(string_quoting_just_colon) {
   const sourcemeta::core::JSON document{":"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\":\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_colon_space) {
+TEST(string_quoting_colon_space) {
   const sourcemeta::core::JSON document{"foo: bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"foo: bar\"\n");
 }
 
-TEST(YAML_stringify, string_plain_colon_no_space) {
+TEST(string_plain_colon_no_space) {
   const sourcemeta::core::JSON document{"a:b:c"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "a:b:c\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_ampersand) {
+TEST(string_quoting_starts_with_ampersand) {
   const sourcemeta::core::JSON document{"&foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"&foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_asterisk) {
+TEST(string_quoting_starts_with_asterisk) {
   const sourcemeta::core::JSON document{"*foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"*foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_open_bracket) {
+TEST(string_quoting_starts_with_open_bracket) {
   const sourcemeta::core::JSON document{"[foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"[foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_close_bracket) {
+TEST(string_quoting_starts_with_close_bracket) {
   const sourcemeta::core::JSON document{"]foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"]foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_open_brace) {
+TEST(string_quoting_starts_with_open_brace) {
   const sourcemeta::core::JSON document{"{foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"{foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_close_brace) {
+TEST(string_quoting_starts_with_close_brace) {
   const sourcemeta::core::JSON document{"}foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"}foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_hash) {
+TEST(string_quoting_starts_with_hash) {
   const sourcemeta::core::JSON document{"#comment"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"#comment\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_comma) {
+TEST(string_quoting_starts_with_comma) {
   const sourcemeta::core::JSON document{",foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\",foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_exclamation) {
+TEST(string_quoting_starts_with_exclamation) {
   const sourcemeta::core::JSON document{"!tag"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"!tag\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_pipe) {
+TEST(string_quoting_starts_with_pipe) {
   const sourcemeta::core::JSON document{"|literal"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"|literal\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_greater) {
+TEST(string_quoting_starts_with_greater) {
   const sourcemeta::core::JSON document{">folded"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\">folded\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_single_quote) {
+TEST(string_quoting_starts_with_single_quote) {
   const sourcemeta::core::JSON document{"'hello'"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"'hello'\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_double_quote) {
+TEST(string_quoting_starts_with_double_quote) {
   const sourcemeta::core::JSON document{"\"hello\""};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"\\\"hello\\\"\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_percent) {
+TEST(string_quoting_starts_with_percent) {
   const sourcemeta::core::JSON document{"%TAG"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"%TAG\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_at) {
+TEST(string_quoting_starts_with_at) {
   const sourcemeta::core::JSON document{"@foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"@foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_starts_with_backtick) {
+TEST(string_quoting_starts_with_backtick) {
   const sourcemeta::core::JSON document{"`foo"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"`foo\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_dash_space) {
+TEST(string_quoting_dash_space) {
   const sourcemeta::core::JSON document{"- item"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"- item\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_question_space) {
+TEST(string_quoting_question_space) {
   const sourcemeta::core::JSON document{"? key"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"? key\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_colon_space_start) {
+TEST(string_quoting_colon_space_start) {
   const sourcemeta::core::JSON document{": value"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\": value\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_lone_dash) {
+TEST(string_quoting_lone_dash) {
   const sourcemeta::core::JSON document{"-"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"-\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_lone_question) {
+TEST(string_quoting_lone_question) {
   const sourcemeta::core::JSON document{"?"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"?\"\n");
 }
 
-TEST(YAML_stringify, string_empty) {
+TEST(string_empty) {
   const sourcemeta::core::JSON document{""};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_leading_space) {
+TEST(string_quoting_leading_space) {
   const sourcemeta::core::JSON document{" hello"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\" hello\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_trailing_space) {
+TEST(string_quoting_trailing_space) {
   const sourcemeta::core::JSON document{"hello "};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"hello \"\n");
 }
 
-TEST(YAML_stringify, string_quoting_all_spaces) {
+TEST(string_quoting_all_spaces) {
   const sourcemeta::core::JSON document{"   "};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"   \"\n");
 }
 
-TEST(YAML_stringify, string_quoting_newline) {
+TEST(string_quoting_newline) {
   const sourcemeta::core::JSON document{"line1\nline2"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"line1\\nline2\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_tab) {
+TEST(string_quoting_tab) {
   const sourcemeta::core::JSON document{"col1\tcol2"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"col1\\tcol2\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_carriage_return) {
+TEST(string_quoting_carriage_return) {
   const sourcemeta::core::JSON document{"line1\rline2"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"line1\\rline2\"\n");
 }
 
-TEST(YAML_stringify, string_quoting_space_hash) {
+TEST(string_quoting_space_hash) {
   const sourcemeta::core::JSON document{"foo #bar"};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "\"foo #bar\"\n");
 }
 
-TEST(YAML_stringify, empty_object) {
+TEST(empty_object) {
   const auto document{sourcemeta::core::parse_json(R"JSON({})JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "{}\n");
 }
 
-TEST(YAML_stringify, empty_array) {
+TEST(empty_array) {
   const auto document{sourcemeta::core::parse_json(R"JSON([])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "[]\n");
 }
 
-TEST(YAML_stringify, mapping_string_value_needs_quoting) {
+TEST(mapping_string_value_needs_quoting) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "key": "true" })JSON")};
   std::ostringstream stream;
@@ -741,7 +741,7 @@ TEST(YAML_stringify, mapping_string_value_needs_quoting) {
   EXPECT_EQ(stream.str(), "key: \"true\"\n");
 }
 
-TEST(YAML_stringify, mapping_key_needs_quoting) {
+TEST(mapping_key_needs_quoting) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "null": "value" })JSON")};
   std::ostringstream stream;
@@ -749,21 +749,21 @@ TEST(YAML_stringify, mapping_key_needs_quoting) {
   EXPECT_EQ(stream.str(), "\"null\": value\n");
 }
 
-TEST(YAML_stringify, mapping_with_empty_nested_object) {
+TEST(mapping_with_empty_nested_object) {
   const auto document{sourcemeta::core::parse_json(R"JSON({ "foo": {} })JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "foo: {}\n");
 }
 
-TEST(YAML_stringify, mapping_with_empty_nested_array) {
+TEST(mapping_with_empty_nested_array) {
   const auto document{sourcemeta::core::parse_json(R"JSON({ "foo": [] })JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "foo: []\n");
 }
 
-TEST(YAML_stringify, mapping_with_null_value) {
+TEST(mapping_with_null_value) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "key": null })JSON")};
   std::ostringstream stream;
@@ -771,7 +771,7 @@ TEST(YAML_stringify, mapping_with_null_value) {
   EXPECT_EQ(stream.str(), "key: null\n");
 }
 
-TEST(YAML_stringify, mapping_with_boolean_value) {
+TEST(mapping_with_boolean_value) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "enabled": true })JSON")};
   std::ostringstream stream;
@@ -779,7 +779,7 @@ TEST(YAML_stringify, mapping_with_boolean_value) {
   EXPECT_EQ(stream.str(), "enabled: true\n");
 }
 
-TEST(YAML_stringify, mapping_with_integer_value) {
+TEST(mapping_with_integer_value) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "count": 42 })JSON")};
   std::ostringstream stream;
@@ -787,7 +787,7 @@ TEST(YAML_stringify, mapping_with_integer_value) {
   EXPECT_EQ(stream.str(), "count: 42\n");
 }
 
-TEST(YAML_stringify, mapping_single_key) {
+TEST(mapping_single_key) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "only": "one" })JSON")};
   std::ostringstream stream;
@@ -795,7 +795,7 @@ TEST(YAML_stringify, mapping_single_key) {
   EXPECT_EQ(stream.str(), "only: one\n");
 }
 
-TEST(YAML_stringify, mapping_key_with_trailing_colon) {
+TEST(mapping_key_with_trailing_colon) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "foo:": "bar" })JSON")};
   std::ostringstream stream;
@@ -803,7 +803,7 @@ TEST(YAML_stringify, mapping_key_with_trailing_colon) {
   EXPECT_EQ(stream.str(), "\"foo:\": bar\n");
 }
 
-TEST(YAML_stringify, mapping_key_with_space) {
+TEST(mapping_key_with_space) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "my key": "value" })JSON")};
   std::ostringstream stream;
@@ -811,7 +811,7 @@ TEST(YAML_stringify, mapping_key_with_space) {
   EXPECT_EQ(stream.str(), "my key: value\n");
 }
 
-TEST(YAML_stringify, mapping_key_empty_string) {
+TEST(mapping_key_empty_string) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON({ "": "value" })JSON")};
   std::ostringstream stream;
@@ -819,49 +819,49 @@ TEST(YAML_stringify, mapping_key_empty_string) {
   EXPECT_EQ(stream.str(), "\"\": value\n");
 }
 
-TEST(YAML_stringify, sequence_with_empty_object) {
+TEST(sequence_with_empty_object) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ {} ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- {}\n");
 }
 
-TEST(YAML_stringify, sequence_with_empty_array) {
+TEST(sequence_with_empty_array) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ [] ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- []\n");
 }
 
-TEST(YAML_stringify, sequence_single_null) {
+TEST(sequence_single_null) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ null ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- null\n");
 }
 
-TEST(YAML_stringify, sequence_single_boolean) {
+TEST(sequence_single_boolean) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ true ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- true\n");
 }
 
-TEST(YAML_stringify, sequence_single_integer) {
+TEST(sequence_single_integer) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ 99 ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- 99\n");
 }
 
-TEST(YAML_stringify, sequence_single_string) {
+TEST(sequence_single_string) {
   const auto document{sourcemeta::core::parse_json(R"JSON([ "hello" ])JSON")};
   std::ostringstream stream;
   sourcemeta::core::stringify_yaml(document, stream);
   EXPECT_EQ(stream.str(), "- hello\n");
 }
 
-TEST(YAML_stringify, sequence_mixed_types) {
+TEST(sequence_mixed_types) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON([ 1, "two", true, null ])JSON")};
   std::ostringstream stream;
@@ -869,7 +869,7 @@ TEST(YAML_stringify, sequence_mixed_types) {
   EXPECT_EQ(stream.str(), "- 1\n- two\n- true\n- null\n");
 }
 
-TEST(YAML_stringify, sequence_with_quoted_strings) {
+TEST(sequence_with_quoted_strings) {
   const auto document{
       sourcemeta::core::parse_json(R"JSON([ "true", "42", "null" ])JSON")};
   std::ostringstream stream;


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

