### PR TITLE
Support test fixtures in `src/lang/test`

### DIFF
--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -214,7 +214,9 @@ auto test_expect_comparison(std::string_view file, int line,
 #define TEST(name) SOURCEMETA_CORE_TEST_REGISTER(name)
 
 // The fixture name is used as a base class and in token pasting, neither of
-// which can be parenthesized
+// which can be parenthesized. The registration symbol is keyed on the test name
+// alone so that reusing a name within a file is a redefinition error, matching
+// the behavior of a plain test.
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define SOURCEMETA_CORE_TEST_REGISTER_FIXTURE(fixture, name)                   \
   namespace {                                                                  \
@@ -222,14 +224,13 @@ auto test_expect_comparison(std::string_view file, int line,
     auto sourcemeta_test_body() -> void;                                       \
   };                                                                           \
   }                                                                            \
-  [[maybe_unused]] static const int                                            \
-      sourcemeta_test_registration_##fixture##_##name =                        \
-          ::sourcemeta::core::test_register(                                   \
-              ::sourcemeta::core::test_suite_from_path(__FILE__), #name,       \
-              __FILE__, __LINE__, [] {                                         \
-                sourcemeta_test_fixture_##fixture##_##name instance;           \
-                instance.sourcemeta_test_body();                               \
-              });                                                              \
+  [[maybe_unused]] static const int sourcemeta_test_registration_##name =      \
+      ::sourcemeta::core::test_register(                                       \
+          ::sourcemeta::core::test_suite_from_path(__FILE__), #name, __FILE__, \
+          __LINE__, [] {                                                       \
+            sourcemeta_test_fixture_##fixture##_##name instance;               \
+            instance.sourcemeta_test_body();                                   \
+          });                                                                  \
   auto sourcemeta_test_fixture_##fixture##_##name::sourcemeta_test_body()->void
 // NOLINTEND(bugprone-macro-parentheses)
 

--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -213,6 +213,29 @@ auto test_expect_comparison(std::string_view file, int line,
 
 #define TEST(name) SOURCEMETA_CORE_TEST_REGISTER(name)
 
+// The fixture name is used as a base class and in token pasting, neither of
+// which can be parenthesized
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define SOURCEMETA_CORE_TEST_REGISTER_FIXTURE(fixture, name)                   \
+  namespace {                                                                  \
+  struct sourcemeta_test_fixture_##fixture##_##name final : public fixture {   \
+    auto sourcemeta_test_body() -> void;                                       \
+  };                                                                           \
+  }                                                                            \
+  [[maybe_unused]] static const int                                            \
+      sourcemeta_test_registration_##fixture##_##name =                        \
+          ::sourcemeta::core::test_register(                                   \
+              ::sourcemeta::core::test_suite_from_path(__FILE__), #name,       \
+              __FILE__, __LINE__, [] {                                         \
+                sourcemeta_test_fixture_##fixture##_##name instance;           \
+                instance.sourcemeta_test_body();                               \
+              });                                                              \
+  auto sourcemeta_test_fixture_##fixture##_##name::sourcemeta_test_body()->void
+// NOLINTEND(bugprone-macro-parentheses)
+
+#define TEST_F(fixture, name)                                                  \
+  SOURCEMETA_CORE_TEST_REGISTER_FIXTURE(fixture, name)
+
 #define SOURCEMETA_CORE_TEST_COMPARE(actual, expected, comparator, operation)  \
   ::sourcemeta::core::test_expect_comparison(                                  \
       __FILE__, __LINE__, #actual " " operation " " #expected,                 \

--- a/test/crypto/crypto_base64_test.cc
+++ b/test/crypto/crypto_base64_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream> // std::ostringstream
 #include <string>  // std::string

--- a/test/crypto/crypto_base64url_test.cc
+++ b/test/crypto/crypto_base64url_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream> // std::ostringstream
 #include <string>  // std::string

--- a/test/crypto/crypto_crc32_test.cc
+++ b/test/crypto/crypto_crc32_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint> // std::uint32_t
 #include <string>  // std::string

--- a/test/crypto/crypto_ecdsa_test.cc
+++ b/test/crypto/crypto_ecdsa_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <optional>    // std::optional

--- a/test/crypto/crypto_eddsa_test.cc
+++ b/test/crypto/crypto_eddsa_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <optional>    // std::optional

--- a/test/crypto/crypto_fnv128_test.cc
+++ b/test/crypto/crypto_fnv128_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>
 #include <cstdint>

--- a/test/crypto/crypto_rsassa_pkcs1_v15_test.cc
+++ b/test/crypto/crypto_rsassa_pkcs1_v15_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <optional>    // std::optional

--- a/test/crypto/crypto_rsassa_pss_test.cc
+++ b/test/crypto/crypto_rsassa_pss_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <optional>    // std::optional

--- a/test/crypto/crypto_sha1_test.cc
+++ b/test/crypto/crypto_sha1_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 #include <string>

--- a/test/crypto/crypto_sha256_test.cc
+++ b/test/crypto/crypto_sha256_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>   // std::array
 #include <cstdint> // std::uint8_t

--- a/test/crypto/crypto_sha384_test.cc
+++ b/test/crypto/crypto_sha384_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>   // std::array
 #include <cstdint> // std::uint8_t

--- a/test/crypto/crypto_sha512_test.cc
+++ b/test/crypto/crypto_sha512_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>   // std::array
 #include <cstdint> // std::uint8_t

--- a/test/crypto/crypto_uuid_test.cc
+++ b/test/crypto/crypto_uuid_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 TEST(regex) {
   const auto uuid{sourcemeta::core::uuidv4()};

--- a/test/css/css2_color_keyword_test.cc
+++ b/test/css/css2_color_keyword_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/css.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_aqua) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color_keyword("aqua"));

--- a/test/css/css2_color_test.cc
+++ b/test/css/css2_color_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/css.h>
+#include <sourcemeta/core/test.h>
 
 TEST(suite_valid_keyword_fuchsia) {
   EXPECT_TRUE(sourcemeta::core::is_css2_color("fuchsia"));

--- a/test/css/css2_hex_color_test.cc
+++ b/test/css/css2_hex_color_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/css.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_six_digit_lower) {
   EXPECT_TRUE(sourcemeta::core::is_css2_hex_color("#cc8899"));

--- a/test/css/css2_rgb_function_test.cc
+++ b/test/css/css2_rgb_function_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/css.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_int_basic) {
   EXPECT_TRUE(sourcemeta::core::is_css2_rgb_function("rgb(255, 0, 128)"));

--- a/test/dns/hostname_test.cc
+++ b/test/dns/hostname_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/dns.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/dns/idn_hostname_test.cc
+++ b/test/dns/idn_hostname_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/dns.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/email/email_test.cc
+++ b/test/email/email_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/email.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/email/idn_email_test.cc
+++ b/test/email/idn_email_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/email.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/error/error_file_test.cc
+++ b/test/error/error_file_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/error.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem>
 #include <stdexcept>

--- a/test/gzip/gzip_streambuf_test.cc
+++ b/test/gzip/gzip_streambuf_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/gzip.h>
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>    // std::array
 #include <cstddef>  // std::size_t

--- a/test/gzip/gzip_test.cc
+++ b/test/gzip/gzip_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/gzip.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint> // std::uint8_t
 #include <cstring> // std::memcmp

--- a/test/html/html_encoder_test.cc
+++ b/test/html/html_encoder_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/html.h>
+#include <sourcemeta/core/test.h>
 
 TEST(example_1) {
   sourcemeta::core::HTMLWriter document;

--- a/test/html/html_escape_test.cc
+++ b/test/html/html_escape_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/html.h>
+#include <sourcemeta/core/test.h>
 
 TEST(empty_string) {
   std::string text = "";

--- a/test/http/ci/http_system_request_test.cc
+++ b/test/http/ci/http_system_request_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono> // std::chrono::milliseconds
 

--- a/test/http/http_accept_includes_all_test.cc
+++ b/test/http/http_accept_includes_all_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 TEST(empty_header_returns_true) {
   EXPECT_TRUE(sourcemeta::core::http_accept_includes_all(

--- a/test/http/http_accumulate_header_line_test.cc
+++ b/test/http/http_accumulate_header_line_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_message.h>
+#include <sourcemeta/core/test.h>
 
 #include <string> // std::string
 

--- a/test/http/http_cache_control_max_age_test.cc
+++ b/test/http/http_cache_control_max_age_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono> // std::chrono::seconds
 

--- a/test/http/http_content_type_matches_test.cc
+++ b/test/http/http_content_type_matches_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 TEST(exact_match) {
   EXPECT_TRUE(sourcemeta::core::http_content_type_matches("application/json",

--- a/test/http/http_error_test.cc
+++ b/test/http/http_error_test.cc
@@ -1,8 +1,7 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_error.h>
 #include <sourcemeta/core/http_method.h>
 #include <sourcemeta/core/http_status.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional> // std::optional
 #include <string>   // std::string

--- a/test/http/http_header_find_test.cc
+++ b/test/http/http_header_find_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_message.h>
+#include <sourcemeta/core/test.h>
 
 #include <functional> // std::less
 #include <map>        // std::map

--- a/test/http/http_is_status_line_test.cc
+++ b/test/http/http_is_status_line_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_message.h>
+#include <sourcemeta/core/test.h>
 
 TEST(http_1_1) {
   EXPECT_TRUE(sourcemeta::core::http_is_status_line("HTTP/1.1 200 OK"));

--- a/test/http/http_make_problem_details_test.cc
+++ b/test/http/http_make_problem_details_test.cc
@@ -1,8 +1,7 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_problem.h>
 #include <sourcemeta/core/http_status.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(defaults_only_with_not_found_status) {
   const auto body{sourcemeta::core::http_make_problem_details(

--- a/test/http/http_match_accept_language_test.cc
+++ b/test/http/http_match_accept_language_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 TEST(exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en", {"en", "fr"}),

--- a/test/http/http_match_accept_test.cc
+++ b/test/http/http_match_accept_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 TEST(exact_match) {
   EXPECT_EQ(sourcemeta::core::http_match_accept(

--- a/test/http/http_method_test.cc
+++ b/test/http/http_method_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_method.h>
+#include <sourcemeta/core/test.h>
 
 TEST(get_token) {
   EXPECT_EQ(

--- a/test/http/http_negotiate_encoding_test.cc
+++ b/test/http/http_negotiate_encoding_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 TEST(empty_header_returns_identity) {
   const auto result{sourcemeta::core::http_negotiate_encoding(

--- a/test/http/http_parse_bearer_test.cc
+++ b/test/http/http_parse_bearer_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
 
 TEST(plain_token) {
   EXPECT_EQ(sourcemeta::core::http_parse_bearer("Bearer abc123"), "abc123");

--- a/test/http/http_parse_headers_test.cc
+++ b/test/http/http_parse_headers_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_message.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>      // std::string
 #include <string_view> // std::string_view

--- a/test/http/http_serialize_headers_test.cc
+++ b/test/http/http_serialize_headers_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_message.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>      // std::string
 #include <string_view> // std::string_view

--- a/test/http/http_status_from_code_test.cc
+++ b/test/http/http_status_from_code_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_status.h>
+#include <sourcemeta/core/test.h>
 
 TEST(continue_100) {
   EXPECT_EQ(sourcemeta::core::http_status_from_code(100),

--- a/test/http/http_status_test.cc
+++ b/test/http/http_status_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/http_status.h>
+#include <sourcemeta/core/test.h>
 
 TEST(ok_fields) {
   EXPECT_EQ(sourcemeta::core::HTTP_STATUS_OK.code, 200);

--- a/test/idna/idna_classify_label_test.cc
+++ b/test/idna/idna_classify_label_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional>
 #include <string>

--- a/test/idna/idna_is_valid_a_label_test.cc
+++ b/test/idna/idna_is_valid_a_label_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 #include <string> // std::string
 

--- a/test/idna/idna_is_valid_u_label_test.cc
+++ b/test/idna/idna_is_valid_u_label_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 #include <string> // std::u32string
 

--- a/test/idna/idna_passes_bidi_rule_test.cc
+++ b/test/idna/idna_passes_bidi_rule_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 TEST(condition_1_first_char_latin_letter) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_bidi_rule(U"abc"));

--- a/test/idna/idna_passes_contextj_test.cc
+++ b/test/idna/idna_passes_contextj_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 TEST(zwj_preceded_by_devanagari_virama) {
   // Devanagari KA (U+0915) + VIRAMA (U+094D) + ZWJ (U+200D)

--- a/test/idna/idna_passes_contexto_test.cc
+++ b/test/idna/idna_passes_contexto_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 TEST(middle_dot_between_latin_l) {
   EXPECT_TRUE(sourcemeta::core::idna_passes_contexto(U"l\u00B7l", 1));

--- a/test/idna/idna_property_test.cc
+++ b/test/idna/idna_property_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/idna.h>
+#include <sourcemeta/core/test.h>
 
 TEST(ascii_letter) {
   EXPECT_EQ(sourcemeta::core::idna_property(U'a'),

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME io
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME io
   SOURCES
     io_atomic_directory_swap_test.cc
     io_atomic_write_file_test.cc

--- a/test/io/io_atomic_directory_swap_test.cc
+++ b/test/io/io_atomic_directory_swap_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem> // std::filesystem
 #include <fstream>    // std::ofstream, std::ifstream

--- a/test/io/io_atomic_directory_swap_test.cc
+++ b/test/io/io_atomic_directory_swap_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
@@ -6,7 +6,7 @@
 #include <fstream>    // std::ofstream, std::ifstream
 #include <string>     // std::string
 
-TEST(IO_atomic_directory_swap, creates_when_original_absent) {
+TEST(creates_when_original_absent) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-atomic-"};
   const auto original{workspace.path() / "original"};
@@ -29,7 +29,7 @@ TEST(IO_atomic_directory_swap, creates_when_original_absent) {
   EXPECT_EQ(content, "hello");
 }
 
-TEST(IO_atomic_directory_swap, swaps_existing_directories) {
+TEST(swaps_existing_directories) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-atomic-"};
   const auto original{workspace.path() / "original"};
@@ -62,7 +62,7 @@ TEST(IO_atomic_directory_swap, swaps_existing_directories) {
   EXPECT_EQ(old_content, "old");
 }
 
-TEST(IO_atomic_directory_swap, old_directory_preserved_at_replacement_path) {
+TEST(old_directory_preserved_at_replacement_path) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-atomic-"};
   const auto original{workspace.path() / "original"};
@@ -83,7 +83,7 @@ TEST(IO_atomic_directory_swap, old_directory_preserved_at_replacement_path) {
   EXPECT_FALSE(std::filesystem::exists(replacement / "file.txt"));
 }
 
-TEST(IO_atomic_directory_swap, preserves_nested_structure) {
+TEST(preserves_nested_structure) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-atomic-"};
   const auto original{workspace.path() / "original"};
@@ -112,7 +112,7 @@ TEST(IO_atomic_directory_swap, preserves_nested_structure) {
   EXPECT_FALSE(std::filesystem::exists(replacement / "root.txt"));
 }
 
-TEST(IO_atomic_directory_swap, no_leftover_temporary) {
+TEST(no_leftover_temporary) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-atomic-"};
   const auto original{workspace.path() / "original"};
@@ -129,7 +129,6 @@ TEST(IO_atomic_directory_swap, no_leftover_temporary) {
   for (const auto &entry :
        std::filesystem::directory_iterator{workspace.path()}) {
     const auto filename{entry.path().filename().string()};
-    EXPECT_FALSE(filename.starts_with(".swap-"))
-        << "leftover temporary directory found: " << filename;
+    EXPECT_FALSE(filename.starts_with(".swap-"));
   }
 }

--- a/test/io/io_atomic_write_file_test.cc
+++ b/test/io/io_atomic_write_file_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>        // std::array
 #include <cstddef>      // std::byte

--- a/test/io/io_atomic_write_file_test.cc
+++ b/test/io/io_atomic_write_file_test.cc
@@ -1,24 +1,28 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
-#include <array>      // std::array
-#include <cstddef>    // std::byte
-#include <filesystem> // std::filesystem
-#include <fstream>    // std::ifstream, std::istreambuf_iterator
-#include <ios>        // std::ios::binary
-#include <ostream>    // std::ostream
-#include <span>       // std::span
-#include <stdexcept>  // std::runtime_error
-#include <string>     // std::string
+#include <array>        // std::array
+#include <cstddef>      // std::byte
+#include <filesystem>   // std::filesystem
+#include <fstream>      // std::ifstream, std::istreambuf_iterator
+#include <ios>          // std::ios::binary
+#include <ostream>      // std::ostream
+#include <span>         // std::span
+#include <stdexcept>    // std::runtime_error
+#include <string>       // std::string
+#include <system_error> // std::error_code
 
-class IOAtomicWriteFileTest : public ::testing::Test {
+class IOAtomicWriteFileTest {
 protected:
-  void SetUp() override {
+  IOAtomicWriteFileTest() {
     std::filesystem::create_directories(this->workspace);
   }
 
-  void TearDown() override { std::filesystem::remove_all(this->workspace); }
+  ~IOAtomicWriteFileTest() {
+    std::error_code error;
+    std::filesystem::remove_all(this->workspace, error);
+  }
 
   // The tests are always sequential, so using the same path is safe
   std::filesystem::path workspace{std::filesystem::path{BUILD_DIRECTORY} /

--- a/test/io/io_binary_test.cc
+++ b/test/io/io_binary_test.cc
@@ -228,8 +228,6 @@ TEST(read_past_end_of_stringstream_throws) {
     FAIL();
   } catch (const sourcemeta::core::IOReadOutOfBoundsError &error) {
     EXPECT_STREQ(error.what(), "Read past the end of the underlying data");
-  } catch (...) {
-    FAIL();
   }
 }
 
@@ -389,8 +387,6 @@ TEST_F(IOBinaryTest, seek_past_end_throws_via_file) {
     FAIL();
   } catch (const sourcemeta::core::IOReadOutOfBoundsError &error) {
     EXPECT_STREQ(error.what(), "Read past the end of the underlying data");
-  } catch (...) {
-    FAIL();
   }
 }
 
@@ -409,8 +405,6 @@ TEST_F(IOBinaryTest, get_past_end_throws_via_file) {
     FAIL();
   } catch (const sourcemeta::core::IOReadOutOfBoundsError &error) {
     EXPECT_STREQ(error.what(), "Read past the end of the underlying data");
-  } catch (...) {
-    FAIL();
   }
 }
 

--- a/test/io/io_binary_test.cc
+++ b/test/io/io_binary_test.cc
@@ -1,16 +1,16 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
 #include <array>   // std::array
 #include <cstddef> // std::byte
 #include <cstdint> // std::uint8_t, std::uint16_t, std::uint32_t, std::uint64_t
-#include <filesystem> // std::filesystem
-#include <fstream>    // std::ofstream
-#include <ios>        // std::ios::binary
-#include <sstream>    // std::istringstream, std::ostringstream
-#include <string>     // std::string
-#include <tuple>      // std::ignore
+#include <filesystem>   // std::filesystem
+#include <fstream>      // std::ofstream
+#include <ios>          // std::ios::binary
+#include <sstream>      // std::istringstream, std::ostringstream
+#include <string>       // std::string
+#include <system_error> // std::error_code
 
 namespace {
 
@@ -25,13 +25,14 @@ struct ExampleHeader {
 
 } // namespace
 
-class IOBinaryTest : public ::testing::Test {
+class IOBinaryTest {
 protected:
-  void SetUp() override {
-    std::filesystem::create_directories(this->workspace);
-  }
+  IOBinaryTest() { std::filesystem::create_directories(this->workspace); }
 
-  void TearDown() override { std::filesystem::remove_all(this->workspace); }
+  ~IOBinaryTest() {
+    std::error_code error;
+    std::filesystem::remove_all(this->workspace, error);
+  }
 
   // The tests are always sequential, so using the same path is safe
   std::filesystem::path workspace{std::filesystem::path{BUILD_DIRECTORY} /
@@ -42,43 +43,43 @@ protected:
 // BinaryWriter — std::ostream backend
 // -----------------------------------------------------------------------------
 
-TEST(IO_BinaryWriter, put_byte_emits_one_byte) {
+TEST(put_byte_emits_one_byte) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   writer.put_byte(0x42);
   const auto bytes{stream.str()};
-  ASSERT_EQ(bytes.size(), 1);
+  EXPECT_EQ(bytes.size(), 1);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[0]), 0x42);
 }
 
-TEST(IO_BinaryWriter, put_word_emits_two_bytes_little_endian) {
+TEST(put_word_emits_two_bytes_little_endian) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   writer.put_word(0xCAFE);
   const auto bytes{stream.str()};
-  ASSERT_EQ(bytes.size(), 2);
+  EXPECT_EQ(bytes.size(), 2);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[0]), 0xFE);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[1]), 0xCA);
 }
 
-TEST(IO_BinaryWriter, put_dword_emits_four_bytes_little_endian) {
+TEST(put_dword_emits_four_bytes_little_endian) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   writer.put_dword(0xDEADBEEF);
   const auto bytes{stream.str()};
-  ASSERT_EQ(bytes.size(), 4);
+  EXPECT_EQ(bytes.size(), 4);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[0]), 0xEF);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[1]), 0xBE);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[2]), 0xAD);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[3]), 0xDE);
 }
 
-TEST(IO_BinaryWriter, put_qword_emits_eight_bytes_little_endian) {
+TEST(put_qword_emits_eight_bytes_little_endian) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   writer.put_qword(0x0123456789ABCDEFULL);
   const auto bytes{stream.str()};
-  ASSERT_EQ(bytes.size(), 8);
+  EXPECT_EQ(bytes.size(), 8);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[0]), 0xEF);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[1]), 0xCD);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[2]), 0xAB);
@@ -89,27 +90,27 @@ TEST(IO_BinaryWriter, put_qword_emits_eight_bytes_little_endian) {
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[7]), 0x01);
 }
 
-TEST(IO_BinaryWriter, put_bytes_emits_raw_buffer) {
+TEST(put_bytes_emits_raw_buffer) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   constexpr std::array<std::byte, 3> payload{
       {std::byte{0xDE}, std::byte{0xAD}, std::byte{0xBE}}};
   writer.put_bytes(payload.data(), payload.size());
   const auto bytes{stream.str()};
-  ASSERT_EQ(bytes.size(), 3);
+  EXPECT_EQ(bytes.size(), 3);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[0]), 0xDE);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[1]), 0xAD);
   EXPECT_EQ(static_cast<std::uint8_t>(bytes[2]), 0xBE);
 }
 
-TEST(IO_BinaryWriter, put_bytes_zero_length_is_noop) {
+TEST(put_bytes_zero_length_is_noop) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   writer.put_bytes(nullptr, 0);
   EXPECT_EQ(stream.str().size(), 0);
 }
 
-TEST(IO_BinaryWriter, put_pod_via_put_bytes) {
+TEST(put_pod_via_put_bytes) {
   const ExampleHeader expected{0xDEADBEEF, 7, 0x42, 1024};
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
@@ -118,7 +119,7 @@ TEST(IO_BinaryWriter, put_pod_via_put_bytes) {
   EXPECT_EQ(stream.str().size(), sizeof(ExampleHeader));
 }
 
-TEST(IO_BinaryWriter, position_advances_after_writes) {
+TEST(position_advances_after_writes) {
   std::ostringstream stream;
   sourcemeta::core::BinaryWriter writer{stream};
   EXPECT_EQ(writer.position(), 0);
@@ -134,13 +135,13 @@ TEST(IO_BinaryWriter, position_advances_after_writes) {
 // BinaryReader — std::istream backend
 // -----------------------------------------------------------------------------
 
-TEST(IO_BinaryReader, get_byte_from_stringstream) {
+TEST(get_byte_from_stringstream) {
   std::istringstream input{"X"};
   sourcemeta::core::BinaryReader reader{input};
   EXPECT_EQ(reader.get_byte(), 'X');
 }
 
-TEST(IO_BinaryReader, get_word_roundtrip_via_stringstream) {
+TEST(get_word_roundtrip_via_stringstream) {
   std::ostringstream output;
   sourcemeta::core::BinaryWriter writer{output};
   writer.put_word(0xCAFE);
@@ -150,7 +151,7 @@ TEST(IO_BinaryReader, get_word_roundtrip_via_stringstream) {
   EXPECT_EQ(reader.get_word(), 0xCAFE);
 }
 
-TEST(IO_BinaryReader, get_dword_roundtrip_via_stringstream) {
+TEST(get_dword_roundtrip_via_stringstream) {
   std::ostringstream output;
   sourcemeta::core::BinaryWriter writer{output};
   writer.put_dword(0x12345678);
@@ -161,7 +162,7 @@ TEST(IO_BinaryReader, get_dword_roundtrip_via_stringstream) {
   EXPECT_EQ(reader.position(), sizeof(std::uint32_t));
 }
 
-TEST(IO_BinaryReader, get_qword_roundtrip_via_stringstream) {
+TEST(get_qword_roundtrip_via_stringstream) {
   std::ostringstream output;
   sourcemeta::core::BinaryWriter writer{output};
   writer.put_qword(0x0123456789ABCDEFULL);
@@ -172,7 +173,7 @@ TEST(IO_BinaryReader, get_qword_roundtrip_via_stringstream) {
   EXPECT_EQ(reader.position(), sizeof(std::uint64_t));
 }
 
-TEST(IO_BinaryReader, get_pod_roundtrip_via_stringstream) {
+TEST(get_pod_roundtrip_via_stringstream) {
   const ExampleHeader expected{0xDEADBEEF, 7, 0x42, 1024};
   std::ostringstream output;
   sourcemeta::core::BinaryWriter writer{output};
@@ -189,7 +190,7 @@ TEST(IO_BinaryReader, get_pod_roundtrip_via_stringstream) {
   EXPECT_EQ(actual.payload_size, expected.payload_size);
 }
 
-TEST(IO_BinaryReader, sequential_gets_from_stringstream) {
+TEST(sequential_gets_from_stringstream) {
   std::ostringstream output;
   sourcemeta::core::BinaryWriter writer{output};
   writer.put_dword(10);
@@ -206,7 +207,7 @@ TEST(IO_BinaryReader, sequential_gets_from_stringstream) {
   EXPECT_EQ(reader.position(), 12);
 }
 
-TEST(IO_BinaryReader, seek_on_stringstream) {
+TEST(seek_on_stringstream) {
   std::ostringstream output;
   sourcemeta::core::BinaryWriter writer{output};
   writer.put_dword(0xAAAAAAAA);
@@ -220,14 +221,20 @@ TEST(IO_BinaryReader, seek_on_stringstream) {
   EXPECT_EQ(reader.get_dword(), 0xCCCCCCCC);
 }
 
-TEST(IO_BinaryReader, read_past_end_of_stringstream_throws) {
+TEST(read_past_end_of_stringstream_throws) {
   std::istringstream input{"AB"};
   sourcemeta::core::BinaryReader reader{input};
-  EXPECT_THROW(std::ignore = reader.get_dword(),
-               sourcemeta::core::IOReadOutOfBoundsError);
+  try {
+    [[maybe_unused]] const auto value{reader.get_dword()};
+    FAIL();
+  } catch (const sourcemeta::core::IOReadOutOfBoundsError &error) {
+    EXPECT_STREQ(error.what(), "Read past the end of the underlying data");
+  } catch (...) {
+    FAIL();
+  }
 }
 
-TEST(IO_BinaryReader, has_more_data_on_stringstream) {
+TEST(has_more_data_on_stringstream) {
   std::istringstream input{"ABC"};
   sourcemeta::core::BinaryReader reader{input};
   EXPECT_TRUE(reader.has_more_data());
@@ -239,13 +246,13 @@ TEST(IO_BinaryReader, has_more_data_on_stringstream) {
   EXPECT_FALSE(reader.has_more_data());
 }
 
-TEST(IO_BinaryReader, has_more_data_on_empty_stringstream) {
+TEST(has_more_data_on_empty_stringstream) {
   std::istringstream input{""};
   sourcemeta::core::BinaryReader reader{input};
   EXPECT_FALSE(reader.has_more_data());
 }
 
-TEST(IO_BinaryReader, has_more_data_treats_null_byte_as_data) {
+TEST(has_more_data_treats_null_byte_as_data) {
   // A null byte at the cursor is a legitimate value, not end-of-stream.
   std::istringstream input{std::string(1, '\0')};
   sourcemeta::core::BinaryReader reader{input};
@@ -378,8 +385,14 @@ TEST_F(IOBinaryTest, seek_past_end_throws_via_file) {
 
   const sourcemeta::core::FileView view{path};
   sourcemeta::core::BinaryReader reader{view};
-  EXPECT_THROW(reader.seek(view.size() + 1),
-               sourcemeta::core::IOReadOutOfBoundsError);
+  try {
+    reader.seek(view.size() + 1);
+    FAIL();
+  } catch (const sourcemeta::core::IOReadOutOfBoundsError &error) {
+    EXPECT_STREQ(error.what(), "Read past the end of the underlying data");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST_F(IOBinaryTest, get_past_end_throws_via_file) {
@@ -392,8 +405,14 @@ TEST_F(IOBinaryTest, get_past_end_throws_via_file) {
 
   const sourcemeta::core::FileView view{path};
   sourcemeta::core::BinaryReader reader{view};
-  EXPECT_THROW(std::ignore = reader.get_dword(),
-               sourcemeta::core::IOReadOutOfBoundsError);
+  try {
+    [[maybe_unused]] const auto value{reader.get_dword()};
+    FAIL();
+  } catch (const sourcemeta::core::IOReadOutOfBoundsError &error) {
+    EXPECT_STREQ(error.what(), "Read past the end of the underlying data");
+  } catch (...) {
+    FAIL();
+  }
 }
 
 TEST_F(IOBinaryTest, get_byte_span_roundtrip_via_file) {
@@ -426,8 +445,8 @@ TEST_F(IOBinaryTest, has_more_data_on_file_view) {
   const sourcemeta::core::FileView view{path};
   sourcemeta::core::BinaryReader reader{view};
   EXPECT_TRUE(reader.has_more_data());
-  std::ignore = reader.get_byte();
+  [[maybe_unused]] const auto first_byte{reader.get_byte()};
   EXPECT_TRUE(reader.has_more_data());
-  std::ignore = reader.get_byte();
+  [[maybe_unused]] const auto second_byte{reader.get_byte()};
   EXPECT_FALSE(reader.has_more_data());
 }

--- a/test/io/io_binary_test.cc
+++ b/test/io/io_binary_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>   // std::array
 #include <cstddef> // std::byte

--- a/test/io/io_bytestream_test.cc
+++ b/test/io/io_bytestream_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstddef> // std::byte
 #include <cstdint> // std::uint8_t

--- a/test/io/io_bytestream_test.cc
+++ b/test/io/io_bytestream_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
@@ -7,18 +7,18 @@
 #include <string>  // std::string
 #include <vector>  // std::vector
 
-TEST(IO_bytestream, input_empty_list) {
+TEST(input_empty_list) {
   sourcemeta::core::InputByteStream stream{};
   EXPECT_EQ(stream.peek(), std::char_traits<char>::eof());
 }
 
-TEST(IO_bytestream, input_single_byte_read) {
+TEST(input_single_byte_read) {
   sourcemeta::core::InputByteStream stream{0x42};
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x42u);
   EXPECT_EQ(stream.get(), std::char_traits<char>::eof());
 }
 
-TEST(IO_bytestream, input_reads_bytes_in_order) {
+TEST(input_reads_bytes_in_order) {
   sourcemeta::core::InputByteStream stream{0x01, 0x02, 0x03};
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x01u);
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x02u);
@@ -26,14 +26,14 @@ TEST(IO_bytestream, input_reads_bytes_in_order) {
   EXPECT_EQ(stream.get(), std::char_traits<char>::eof());
 }
 
-TEST(IO_bytestream, input_preserves_high_bit_bytes) {
+TEST(input_preserves_high_bit_bytes) {
   sourcemeta::core::InputByteStream stream{0xff, 0x80, 0x7f};
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0xffu);
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x80u);
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x7fu);
 }
 
-TEST(IO_bytestream, input_preserves_embedded_nuls) {
+TEST(input_preserves_embedded_nuls) {
   sourcemeta::core::InputByteStream stream{0x00, 0x01, 0x00};
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x00u);
   EXPECT_EQ(static_cast<std::uint8_t>(stream.get()), 0x01u);
@@ -41,7 +41,7 @@ TEST(IO_bytestream, input_preserves_embedded_nuls) {
   EXPECT_EQ(stream.get(), std::char_traits<char>::eof());
 }
 
-TEST(IO_bytestream, input_peek_does_not_advance) {
+TEST(input_peek_does_not_advance) {
   sourcemeta::core::InputByteStream stream{0xaa, 0xbb};
   EXPECT_EQ(static_cast<std::uint8_t>(stream.peek()), 0xaau);
   EXPECT_EQ(static_cast<std::uint8_t>(stream.peek()), 0xaau);
@@ -49,12 +49,12 @@ TEST(IO_bytestream, input_peek_does_not_advance) {
   EXPECT_EQ(static_cast<std::uint8_t>(stream.peek()), 0xbbu);
 }
 
-TEST(IO_bytestream, output_starts_empty) {
+TEST(output_starts_empty) {
   const sourcemeta::core::OutputByteStream stream;
   EXPECT_TRUE(stream.bytes().empty());
 }
 
-TEST(IO_bytestream, output_captures_put_calls) {
+TEST(output_captures_put_calls) {
   sourcemeta::core::OutputByteStream stream;
   stream.put('A');
   stream.put('B');
@@ -62,7 +62,7 @@ TEST(IO_bytestream, output_captures_put_calls) {
   EXPECT_EQ(stream.bytes(), expected);
 }
 
-TEST(IO_bytestream, output_captures_high_bit_bytes) {
+TEST(output_captures_high_bit_bytes) {
   sourcemeta::core::OutputByteStream stream;
   stream.put(static_cast<char>(0xff));
   stream.put(static_cast<char>(0x80));
@@ -70,7 +70,7 @@ TEST(IO_bytestream, output_captures_high_bit_bytes) {
   EXPECT_EQ(stream.bytes(), expected);
 }
 
-TEST(IO_bytestream, output_captures_embedded_nuls) {
+TEST(output_captures_embedded_nuls) {
   sourcemeta::core::OutputByteStream stream;
   stream.put('\0');
   stream.put('\x01');
@@ -80,7 +80,7 @@ TEST(IO_bytestream, output_captures_embedded_nuls) {
   EXPECT_EQ(stream.bytes(), expected);
 }
 
-TEST(IO_bytestream, output_captures_write_calls) {
+TEST(output_captures_write_calls) {
   sourcemeta::core::OutputByteStream stream;
   const std::string payload{"hello"};
   stream.write(payload.data(), static_cast<std::streamsize>(payload.size()));

--- a/test/io/io_canonical_test.cc
+++ b/test/io/io_canonical_test.cc
@@ -1,14 +1,14 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
-TEST(IO_canonical, test_txt) {
+TEST(test_txt) {
   const auto path{sourcemeta::core::canonical(
       std::filesystem::path{STUBS_DIRECTORY} / "test.txt")};
   EXPECT_EQ(path, std::filesystem::path{STUBS_DIRECTORY} / "test.txt");
 }
 
-TEST(IO_canonical, not_exists) {
+TEST(not_exists) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "foo.txt"};
   try {
     sourcemeta::core::canonical(path);
@@ -23,7 +23,7 @@ TEST(IO_canonical, not_exists) {
 // Creating symlinks on Windows requires elevated privileges, which CI
 // runners typically lack.
 #if !defined(_WIN32)
-TEST(IO_canonical, unmapped_error_surfaces_as_filesystem_error) {
+TEST(unmapped_error_surfaces_as_filesystem_error) {
   const auto loop_path{std::filesystem::path{BUILD_DIRECTORY} /
                        "sourcemeta_core_io_canonical_loop"};
   std::filesystem::remove(loop_path);

--- a/test/io/io_canonical_test.cc
+++ b/test/io/io_canonical_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 TEST(test_txt) {
   const auto path{sourcemeta::core::canonical(

--- a/test/io/io_fileview_test.cc
+++ b/test/io/io_fileview_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint>     // std::uint32_t
 #include <filesystem>  // std::filesystem

--- a/test/io/io_fileview_test.cc
+++ b/test/io/io_fileview_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
@@ -6,13 +6,13 @@
 #include <filesystem>  // std::filesystem
 #include <string_view> // std::string_view
 
-TEST(IO_FileView, size) {
+TEST(size) {
   const sourcemeta::core::FileView view{std::filesystem::path{STUBS_DIRECTORY} /
                                         "fileview.bin"};
   EXPECT_EQ(view.size(), 20);
 }
 
-TEST(IO_FileView, as_header) {
+TEST(as_header) {
   struct Header {
     std::uint32_t magic;
     std::uint32_t version;
@@ -28,7 +28,7 @@ TEST(IO_FileView, as_header) {
   EXPECT_EQ(header->count, 42);
 }
 
-TEST(IO_FileView, as_with_offset) {
+TEST(as_with_offset) {
   struct Data {
     std::uint32_t value1;
     std::uint32_t value2;
@@ -42,7 +42,7 @@ TEST(IO_FileView, as_with_offset) {
   EXPECT_EQ(data->value2, 0xCAFEBABE);
 }
 
-TEST(IO_FileView, file_not_found) {
+TEST(file_not_found) {
   try {
     sourcemeta::core::FileView(std::filesystem::path{STUBS_DIRECTORY} /
                                "nonexistent.bin");
@@ -53,7 +53,7 @@ TEST(IO_FileView, file_not_found) {
   }
 }
 
-TEST(IO_FileView, empty_file_does_not_throw) {
+TEST(empty_file_does_not_throw) {
   const sourcemeta::core::TemporaryDirectory directory{
       std::filesystem::temp_directory_path(), ".fileview-"};
   const auto path{directory.path() / "empty.bin"};

--- a/test/io/io_flush_test.cc
+++ b/test/io/io_flush_test.cc
@@ -1,13 +1,13 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
-TEST(IO_flush, test_txt) {
+TEST(test_txt) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "test.txt"};
   sourcemeta::core::flush(path);
 }
 
-TEST(IO_flush, not_exists) {
+TEST(not_exists) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "foo.txt"};
 
   try {

--- a/test/io/io_flush_test.cc
+++ b/test/io/io_flush_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 TEST(test_txt) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "test.txt"};

--- a/test/io/io_for_each_line_test.cc
+++ b/test/io/io_for_each_line_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
@@ -7,36 +7,36 @@
 #include <string_view> // std::string_view
 #include <vector>      // std::vector
 
-TEST(IO_for_each_line, multiple_lines_with_trailing_newline) {
+TEST(multiple_lines_with_trailing_newline) {
   std::istringstream stream{"alpha\nbeta\ngamma\n"};
   std::vector<std::string> lines;
   sourcemeta::core::for_each_line(
       stream, [&](const std::string_view line) { lines.emplace_back(line); });
-  ASSERT_EQ(lines.size(), 3);
+  EXPECT_EQ(lines.size(), 3);
   EXPECT_EQ(lines.at(0), "alpha");
   EXPECT_EQ(lines.at(1), "beta");
   EXPECT_EQ(lines.at(2), "gamma");
 }
 
-TEST(IO_for_each_line, multiple_lines_no_trailing_newline) {
+TEST(multiple_lines_no_trailing_newline) {
   std::istringstream stream{"alpha\nbeta\ngamma"};
   std::vector<std::string> lines;
   sourcemeta::core::for_each_line(
       stream, [&](const std::string_view line) { lines.emplace_back(line); });
-  ASSERT_EQ(lines.size(), 3);
+  EXPECT_EQ(lines.size(), 3);
   EXPECT_EQ(lines.at(2), "gamma");
 }
 
-TEST(IO_for_each_line, single_line) {
+TEST(single_line) {
   std::istringstream stream{"only one line"};
   std::vector<std::string> lines;
   sourcemeta::core::for_each_line(
       stream, [&](const std::string_view line) { lines.emplace_back(line); });
-  ASSERT_EQ(lines.size(), 1);
+  EXPECT_EQ(lines.size(), 1);
   EXPECT_EQ(lines.at(0), "only one line");
 }
 
-TEST(IO_for_each_line, empty_stream_invokes_callback_zero_times) {
+TEST(empty_stream_invokes_callback_zero_times) {
   std::istringstream stream{""};
   std::size_t count{0};
   sourcemeta::core::for_each_line(stream,
@@ -44,50 +44,50 @@ TEST(IO_for_each_line, empty_stream_invokes_callback_zero_times) {
   EXPECT_EQ(count, 0);
 }
 
-TEST(IO_for_each_line, blank_lines_preserved) {
+TEST(blank_lines_preserved) {
   std::istringstream stream{"\nfoo\n\nbar\n"};
   std::vector<std::string> lines;
   sourcemeta::core::for_each_line(
       stream, [&](const std::string_view line) { lines.emplace_back(line); });
-  ASSERT_EQ(lines.size(), 4);
+  EXPECT_EQ(lines.size(), 4);
   EXPECT_EQ(lines.at(0), "");
   EXPECT_EQ(lines.at(1), "foo");
   EXPECT_EQ(lines.at(2), "");
   EXPECT_EQ(lines.at(3), "bar");
 }
 
-TEST(IO_for_each_line, view_references_per_iteration_buffer) {
+TEST(view_references_per_iteration_buffer) {
   std::istringstream stream{"alpha\nbeta\n"};
   std::vector<std::size_t> sizes;
   sourcemeta::core::for_each_line(stream, [&](const std::string_view line) {
     sizes.push_back(line.size());
   });
-  ASSERT_EQ(sizes.size(), 2);
+  EXPECT_EQ(sizes.size(), 2);
   EXPECT_EQ(sizes.at(0), 5);
   EXPECT_EQ(sizes.at(1), 4);
 }
 
-TEST(IO_for_each_line, strips_trailing_carriage_return) {
+TEST(strips_trailing_carriage_return) {
   std::istringstream stream{"alpha\r\nbeta\r\n"};
   std::vector<std::string> lines;
   sourcemeta::core::for_each_line(
       stream, [&](const std::string_view line) { lines.emplace_back(line); });
-  ASSERT_EQ(lines.size(), 2);
+  EXPECT_EQ(lines.size(), 2);
   EXPECT_EQ(lines.at(0), "alpha");
   EXPECT_EQ(lines.at(1), "beta");
 }
 
-TEST(IO_for_each_line, carriage_return_only_line_becomes_empty) {
+TEST(carriage_return_only_line_becomes_empty) {
   std::istringstream stream{"\r\nfoo\r\n"};
   std::vector<std::string> lines;
   sourcemeta::core::for_each_line(
       stream, [&](const std::string_view line) { lines.emplace_back(line); });
-  ASSERT_EQ(lines.size(), 2);
+  EXPECT_EQ(lines.size(), 2);
   EXPECT_EQ(lines.at(0), "");
   EXPECT_EQ(lines.at(1), "foo");
 }
 
-TEST(IO_for_each_line, only_newlines) {
+TEST(only_newlines) {
   std::istringstream stream{"\n\n\n"};
   std::size_t count{0};
   sourcemeta::core::for_each_line(stream, [&](const std::string_view line) {

--- a/test/io/io_for_each_line_test.cc
+++ b/test/io/io_for_each_line_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>     // std::istringstream
 #include <string>      // std::string

--- a/test/io/io_hardlink_directory_test.cc
+++ b/test/io/io_hardlink_directory_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem> // std::filesystem
 #include <fstream>    // std::ofstream, std::ifstream

--- a/test/io/io_hardlink_directory_test.cc
+++ b/test/io/io_hardlink_directory_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
@@ -6,7 +6,7 @@
 #include <fstream>    // std::ofstream, std::ifstream
 #include <string>     // std::string
 
-TEST(IO_hardlink_directory, mirrors_structure) {
+TEST(mirrors_structure) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-hardlink-"};
   const auto source{workspace.path() / "source"};
@@ -23,7 +23,7 @@ TEST(IO_hardlink_directory, mirrors_structure) {
   EXPECT_TRUE(std::filesystem::is_directory(destination / "subdir"));
 }
 
-TEST(IO_hardlink_directory, files_share_inodes) {
+TEST(files_share_inodes) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-hardlink-"};
   const auto source{workspace.path() / "source"};
@@ -40,7 +40,7 @@ TEST(IO_hardlink_directory, files_share_inodes) {
                                           destination / "file.txt"));
 }
 
-TEST(IO_hardlink_directory, unlink_then_write_independence) {
+TEST(unlink_then_write_independence) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-hardlink-"};
   const auto source{workspace.path() / "source"};
@@ -65,7 +65,7 @@ TEST(IO_hardlink_directory, unlink_then_write_independence) {
   EXPECT_EQ(destination_content, "modified");
 }
 
-TEST(IO_hardlink_directory, empty_source) {
+TEST(empty_source) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-hardlink-"};
   const auto source{workspace.path() / "source"};
@@ -80,7 +80,7 @@ TEST(IO_hardlink_directory, empty_source) {
   EXPECT_TRUE(std::filesystem::is_empty(destination));
 }
 
-TEST(IO_hardlink_directory, deeply_nested) {
+TEST(deeply_nested) {
   const sourcemeta::core::TemporaryDirectory workspace{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-hardlink-"};
   const auto source{workspace.path() / "source"};

--- a/test/io/io_is_lexically_under_path_test.cc
+++ b/test/io/io_is_lexically_under_path_test.cc
@@ -1,94 +1,94 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
 #include <string_view> // std::string_view
 
-TEST(IO_is_lexically_under_path, relative_exact_match) {
+TEST(relative_exact_match) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_nested) {
+TEST(relative_nested) {
   const std::filesystem::path path{"foo/bar/baz"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_sibling) {
+TEST(relative_sibling) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{"foo/baz"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_unrelated_branches) {
+TEST(relative_unrelated_branches) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{"baz"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_same_chars_not_component) {
+TEST(relative_same_chars_not_component) {
   const std::filesystem::path path{"foo/barbaz"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_prefix_longer_than_path) {
+TEST(relative_prefix_longer_than_path) {
   const std::filesystem::path path{"foo"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_trailing_slash_prefix) {
+TEST(relative_trailing_slash_prefix) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{"foo/bar/"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_repeated_slashes) {
+TEST(relative_repeated_slashes) {
   const std::filesystem::path path{"foo//bar//baz"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_dot_normalization) {
+TEST(relative_dot_normalization) {
   const std::filesystem::path path{"foo/./bar"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_dotdot_net_under_prefix) {
+TEST(relative_dotdot_net_under_prefix) {
   const std::filesystem::path path{"foo/x/../bar"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_dotdot_escapes_prefix) {
+TEST(relative_dotdot_escapes_prefix) {
   const std::filesystem::path path{"foo/bar/../../etc"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_dotdot_smuggled_inside_after_match) {
+TEST(relative_dotdot_smuggled_inside_after_match) {
   const std::filesystem::path path{"foo/bar/x/../../baz"};
   const std::filesystem::path prefix{"foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_empty_prefix) {
+TEST(relative_empty_prefix) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_string_view_arguments) {
+TEST(relative_string_view_arguments) {
   const std::string_view path{"foo/bar/baz"};
   const std::string_view prefix{"foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, relative_string_view_not_under) {
+TEST(relative_string_view_not_under) {
   const std::string_view path{"foo/barbaz"};
   const std::string_view prefix{"foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
@@ -96,25 +96,25 @@ TEST(IO_is_lexically_under_path, relative_string_view_not_under) {
 
 #ifndef _WIN32
 
-TEST(IO_is_lexically_under_path, posix_absolute_nested) {
+TEST(posix_absolute_nested) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, posix_absolute_traversal_into_etc) {
+TEST(posix_absolute_traversal_into_etc) {
   const std::filesystem::path path{"/foo/../../etc/passwd"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, posix_root_prefix_matches_everything) {
+TEST(posix_root_prefix_matches_everything) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/"};
   EXPECT_TRUE(sourcemeta::core::is_lexically_under_path(path, prefix));
 }
 
-TEST(IO_is_lexically_under_path, posix_relative_vs_absolute) {
+TEST(posix_relative_vs_absolute) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_FALSE(sourcemeta::core::is_lexically_under_path(path, prefix));

--- a/test/io/io_is_lexically_under_path_test.cc
+++ b/test/io/io_is_lexically_under_path_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <string_view> // std::string_view
 

--- a/test/io/io_is_under_path_test.cc
+++ b/test/io/io_is_under_path_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #ifdef _WIN32
 

--- a/test/io/io_is_under_path_test.cc
+++ b/test/io/io_is_under_path_test.cc
@@ -1,34 +1,34 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
 #ifdef _WIN32
 
-TEST(IO_is_under_path, windows_case_insensitive) {
+TEST(windows_case_insensitive) {
   const std::filesystem::path path{"C:\\Foo\\Bar"};
   const std::filesystem::path prefix{"C:\\foo"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, windows_different_drive) {
+TEST(windows_different_drive) {
   const std::filesystem::path path{"D:\\Foo\\Bar"};
   const std::filesystem::path prefix{"C:\\Foo"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, windows_drive_letter_no_slash) {
+TEST(windows_drive_letter_no_slash) {
   const std::filesystem::path path{"C:folder\\sub"};
   const std::filesystem::path prefix{"C:folder"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, windows_unc_path) {
+TEST(windows_unc_path) {
   const std::filesystem::path path{"\\\\server\\share\\folder\\file.txt"};
   const std::filesystem::path prefix{"\\\\server\\share\\folder"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, windows_same_chars_not_component) {
+TEST(windows_same_chars_not_component) {
   const std::filesystem::path path{"C:\\foo\\barbaz"};
   const std::filesystem::path prefix{"C:\\foo\\bar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
@@ -36,205 +36,205 @@ TEST(IO_is_under_path, windows_same_chars_not_component) {
 
 #else
 
-TEST(IO_is_under_path, posix_exact_match) {
+TEST(posix_exact_match) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_nested_dir) {
+TEST(posix_nested_dir) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_same_chars_not_component) {
+TEST(posix_same_chars_not_component) {
   const std::filesystem::path path{"/foo/barbaz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_reverse_substring_attack) {
+TEST(posix_reverse_substring_attack) {
   const std::filesystem::path path{"/foo"};
   const std::filesystem::path prefix{"/foobar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_partial_component_with_dot) {
+TEST(posix_partial_component_with_dot) {
   const std::filesystem::path path{"/foo.bar/baz"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_trailing_slash) {
+TEST(posix_trailing_slash) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/foo/bar/"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_relative_vs_absolute) {
+TEST(posix_relative_vs_absolute) {
   const std::filesystem::path path{"foo/bar"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dot_normalization) {
+TEST(posix_dot_normalization) {
   const std::filesystem::path path{"/foo/./bar"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_multiple_dot_segments) {
+TEST(posix_multiple_dot_segments) {
   const std::filesystem::path path{"/foo/./bar/./baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_normalization) {
+TEST(posix_dotdot_normalization) {
   const std::filesystem::path path{"/foo/baz/../bar"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_net_under_prefix) {
+TEST(posix_dotdot_net_under_prefix) {
   const std::filesystem::path path{"/foo/x/../bar/y"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_escapes_prefix) {
+TEST(posix_dotdot_escapes_prefix) {
   const std::filesystem::path path{"/foo/bar/../../etc/passwd"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_smuggled_inside_after_match) {
+TEST(posix_dotdot_smuggled_inside_after_match) {
   const std::filesystem::path path{"/foo/bar/x/../../baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_escape_then_return) {
+TEST(posix_dotdot_escape_then_return) {
   const std::filesystem::path path{"/foo/bar/../bar/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_escape_then_return_sibling) {
+TEST(posix_dotdot_escape_then_return_sibling) {
   const std::filesystem::path path{"/foo/bar/../bar2/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_at_path_start_clamps_at_root) {
+TEST(posix_dotdot_at_path_start_clamps_at_root) {
   const std::filesystem::path path{"/../../etc"};
   const std::filesystem::path prefix{"/etc"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_in_prefix_resolved_in_place) {
+TEST(posix_dotdot_in_prefix_resolved_in_place) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo/bar/../bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dotdot_in_prefix_escapes_to_unrelated) {
+TEST(posix_dotdot_in_prefix_escapes_to_unrelated) {
   const std::filesystem::path path{"/baz/qux"};
   const std::filesystem::path prefix{"/foo/bar/../../../baz"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_path_traversal_into_etc) {
+TEST(posix_path_traversal_into_etc) {
   const std::filesystem::path path{"/foo/../../etc/passwd"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_double_slash_path) {
+TEST(posix_double_slash_path) {
   const std::filesystem::path path{"//foo//bar//baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_double_slash_prefix) {
+TEST(posix_double_slash_prefix) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"//foo//bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_only_slashes_path) {
+TEST(posix_only_slashes_path) {
   const std::filesystem::path path{"////"};
   const std::filesystem::path prefix{"/"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_root_prefix_matches_everything) {
+TEST(posix_root_prefix_matches_everything) {
   const std::filesystem::path path{"/foo/bar/baz/qux"};
   const std::filesystem::path prefix{"/"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_trailing_dot_on_path) {
+TEST(posix_trailing_dot_on_path) {
   const std::filesystem::path path{"/foo/bar/."};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_trailing_dotdot_cancels_last) {
+TEST(posix_trailing_dotdot_cancels_last) {
   const std::filesystem::path path{"/foo/bar/baz/.."};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_dot_only_path) {
+TEST(posix_dot_only_path) {
   const std::filesystem::path path{"/."};
   const std::filesystem::path prefix{"/"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_complex_traversal_smuggle) {
+TEST(posix_complex_traversal_smuggle) {
   const std::filesystem::path path{"/foo/bar/zzz/../../../etc/foo/bar"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_root_path) {
+TEST(posix_root_path) {
   const std::filesystem::path path{"/"};
   const std::filesystem::path prefix{"/"};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_empty_prefix) {
+TEST(posix_empty_prefix) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_empty_path) {
+TEST(posix_empty_path) {
   const std::filesystem::path path{};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_empty_empty) {
+TEST(posix_empty_empty) {
   const std::filesystem::path path{};
   const std::filesystem::path prefix{};
   EXPECT_TRUE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_prefix_longer_than_path) {
+TEST(posix_prefix_longer_than_path) {
   const std::filesystem::path path{"/foo"};
   const std::filesystem::path prefix{"/foo/bar/baz"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_prefix_one_component_longer) {
+TEST(posix_prefix_one_component_longer) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/foo/bar/baz"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));
 }
 
-TEST(IO_is_under_path, posix_unrelated_branches) {
+TEST(posix_unrelated_branches) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/baz"};
   EXPECT_FALSE(sourcemeta::core::is_under_path(path, prefix));

--- a/test/io/io_read_file_test.cc
+++ b/test/io/io_read_file_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <algorithm>
 #include <sstream>

--- a/test/io/io_read_file_test.cc
+++ b/test/io/io_read_file_test.cc
@@ -1,11 +1,11 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
 #include <algorithm>
 #include <sstream>
 
-TEST(IO_read_file, text_file) {
+TEST(text_file) {
   auto stream{sourcemeta::core::read_file(
       std::filesystem::path{STUBS_DIRECTORY} / "test.txt")};
   std::ostringstream contents;
@@ -17,7 +17,7 @@ TEST(IO_read_file, text_file) {
   EXPECT_EQ(result, "Hello World\n");
 }
 
-TEST(IO_read_file, directory) {
+TEST(directory) {
   const std::filesystem::path path{STUBS_DIRECTORY};
   try {
     sourcemeta::core::read_file(path);
@@ -29,7 +29,7 @@ TEST(IO_read_file, directory) {
   }
 }
 
-TEST(IO_read_file, not_exists) {
+TEST(not_exists) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "missing.txt"};
   try {
     sourcemeta::core::read_file(path);

--- a/test/io/io_read_to_string_test.cc
+++ b/test/io/io_read_to_string_test.cc
@@ -1,46 +1,48 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
-#include <algorithm> // std::remove
-#include <fstream>   // std::ofstream
-#include <sstream>   // std::istringstream
-#include <string>    // std::string
+#include <algorithm>    // std::remove
+#include <filesystem>   // std::filesystem
+#include <fstream>      // std::ofstream
+#include <sstream>      // std::istringstream
+#include <string>       // std::string
+#include <system_error> // std::error_code
 
 #if !defined(_WIN32)
 #include <sys/stat.h> // mkfifo, S_IRUSR, S_IWUSR
 #include <thread>     // std::thread
 #endif
 
-TEST(IO_read_to_string, empty_stream) {
+TEST(empty_stream) {
   std::istringstream stream{""};
   EXPECT_EQ(sourcemeta::core::read_to_string(stream), "");
 }
 
-TEST(IO_read_to_string, single_line) {
+TEST(single_line) {
   std::istringstream stream{"hello"};
   EXPECT_EQ(sourcemeta::core::read_to_string(stream), "hello");
 }
 
-TEST(IO_read_to_string, multiple_lines) {
+TEST(multiple_lines) {
   std::istringstream stream{"line one\nline two\nline three"};
   EXPECT_EQ(sourcemeta::core::read_to_string(stream),
             "line one\nline two\nline three");
 }
 
-TEST(IO_read_to_string, large_input) {
+TEST(large_input) {
   const std::string payload(8192, 'a');
   std::istringstream stream{payload};
   EXPECT_EQ(sourcemeta::core::read_to_string(stream), payload);
 }
 
-TEST(IO_read_to_string, leaves_stream_at_eof) {
+TEST(leaves_stream_at_eof) {
   std::istringstream stream{"hello"};
   sourcemeta::core::read_to_string(stream);
   EXPECT_EQ(stream.peek(), std::char_traits<char>::eof());
 }
 
-TEST(IO_read_file_to_string, stub_text_file) {
+TEST(stub_text_file) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "test.txt"};
   auto contents{sourcemeta::core::read_file_to_string(path)};
   contents.erase(std::remove(contents.begin(), contents.end(), '\r'),
@@ -48,7 +50,7 @@ TEST(IO_read_file_to_string, stub_text_file) {
   EXPECT_EQ(contents, "Hello World\n");
 }
 
-TEST(IO_read_file_to_string, directory) {
+TEST(directory) {
   const std::filesystem::path path{STUBS_DIRECTORY};
   try {
     sourcemeta::core::read_file_to_string(path);
@@ -60,7 +62,7 @@ TEST(IO_read_file_to_string, directory) {
   }
 }
 
-TEST(IO_read_file_to_string, missing_file_throws) {
+TEST(missing_file_throws) {
   const auto path{std::filesystem::path{STUBS_DIRECTORY} / "no-such-file.txt"};
   try {
     sourcemeta::core::read_file_to_string(path);
@@ -72,13 +74,16 @@ TEST(IO_read_file_to_string, missing_file_throws) {
   }
 }
 
-class IOReadFileToStringTest : public ::testing::Test {
+class IOReadFileToStringTest {
 protected:
-  void SetUp() override {
+  IOReadFileToStringTest() {
     std::filesystem::create_directories(this->workspace);
   }
 
-  void TearDown() override { std::filesystem::remove_all(this->workspace); }
+  ~IOReadFileToStringTest() {
+    std::error_code error;
+    std::filesystem::remove_all(this->workspace, error);
+  }
 
   // The tests are always sequential, so using the same path is safe
   std::filesystem::path workspace{
@@ -117,7 +122,7 @@ TEST_F(IOReadFileToStringTest, fifo) {
 
   const auto path{this->workspace / "fifo"};
   std::filesystem::remove(path);
-  ASSERT_EQ(::mkfifo(path.c_str(), S_IRUSR | S_IWUSR), 0);
+  EXPECT_EQ(::mkfifo(path.c_str(), S_IRUSR | S_IWUSR), 0);
   std::thread writer{[&path]() {
     std::ofstream stream{path};
     stream << "piped payload\nsecond line\n";

--- a/test/io/io_read_to_string_test.cc
+++ b/test/io/io_read_to_string_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <algorithm>    // std::remove
 #include <filesystem>   // std::filesystem

--- a/test/io/io_strip_path_prefix_test.cc
+++ b/test/io/io_strip_path_prefix_test.cc
@@ -1,69 +1,69 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
 #ifndef _WIN32
 
-TEST(IO_strip_path_prefix, posix_nested_dir) {
+TEST(posix_nested_dir) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"bar/baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_single_component_suffix) {
+TEST(posix_single_component_suffix) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"bar"});
 }
 
-TEST(IO_strip_path_prefix, posix_exact_match) {
+TEST(posix_exact_match) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{});
 }
 
-TEST(IO_strip_path_prefix, posix_not_under_same_chars) {
+TEST(posix_not_under_same_chars) {
   const std::filesystem::path path{"/foo/barbaz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_not_under_unrelated) {
+TEST(posix_not_under_unrelated) {
   const std::filesystem::path path{"/other/place"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_reverse_substring_returns_original) {
+TEST(posix_reverse_substring_returns_original) {
   const std::filesystem::path path{"/foo"};
   const std::filesystem::path prefix{"/foobar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_partial_component_with_dot_returns_original) {
+TEST(posix_partial_component_with_dot_returns_original) {
   const std::filesystem::path path{"/foo.bar/baz"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_dot_normalization) {
+TEST(posix_dot_normalization) {
   const std::filesystem::path path{"/foo/./bar/baz"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"bar/baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_normalization) {
+TEST(posix_dotdot_normalization) {
   const std::filesystem::path path{"/foo/x/../bar/baz"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"bar/baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_suffix_is_clean) {
+TEST(posix_dotdot_suffix_is_clean) {
   const std::filesystem::path path{"/foo/x/../bar/y"};
   const std::filesystem::path prefix{"/foo/bar"};
   const auto result{sourcemeta::core::strip_path_prefix(path, prefix)};
@@ -71,139 +71,139 @@ TEST(IO_strip_path_prefix, posix_dotdot_suffix_is_clean) {
   EXPECT_EQ(result.string().find(".."), std::string::npos);
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_escapes_prefix_returns_original) {
+TEST(posix_dotdot_escapes_prefix_returns_original) {
   const std::filesystem::path path{"/foo/bar/../../etc/passwd"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_smuggled_returns_original) {
+TEST(posix_dotdot_smuggled_returns_original) {
   const std::filesystem::path path{"/foo/bar/x/../../baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_escape_then_return) {
+TEST(posix_dotdot_escape_then_return) {
   const std::filesystem::path path{"/foo/bar/../bar/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_escape_to_sibling_returns_original) {
+TEST(posix_dotdot_escape_to_sibling_returns_original) {
   const std::filesystem::path path{"/foo/bar/../bar2/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_at_path_start_clamps_at_root) {
+TEST(posix_dotdot_at_path_start_clamps_at_root) {
   const std::filesystem::path path{"/../../foo/bar"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"bar"});
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_in_prefix_resolved_in_place) {
+TEST(posix_dotdot_in_prefix_resolved_in_place) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo/bar/../bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_dotdot_in_prefix_escapes_to_unrelated) {
+TEST(posix_dotdot_in_prefix_escapes_to_unrelated) {
   const std::filesystem::path path{"/baz/qux"};
   const std::filesystem::path prefix{"/foo/bar/../../../baz"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"qux"});
 }
 
-TEST(IO_strip_path_prefix, posix_traversal_into_etc_returns_original) {
+TEST(posix_traversal_into_etc_returns_original) {
   const std::filesystem::path path{"/foo/../../etc/passwd"};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_complex_traversal_smuggle_returns_original) {
+TEST(posix_complex_traversal_smuggle_returns_original) {
   const std::filesystem::path path{"/foo/bar/zzz/../../../etc/foo/bar"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_double_slash_path) {
+TEST(posix_double_slash_path) {
   const std::filesystem::path path{"//foo//bar//baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_double_slash_prefix) {
+TEST(posix_double_slash_prefix) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"//foo//bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_trailing_slash_on_prefix) {
+TEST(posix_trailing_slash_on_prefix) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo/bar/"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_trailing_dot_on_path) {
+TEST(posix_trailing_dot_on_path) {
   const std::filesystem::path path{"/foo/bar/."};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{});
 }
 
-TEST(IO_strip_path_prefix, posix_trailing_dotdot_cancels_last) {
+TEST(posix_trailing_dotdot_cancels_last) {
   const std::filesystem::path path{"/foo/bar/baz/.."};
   const std::filesystem::path prefix{"/foo/bar"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{});
 }
 
-TEST(IO_strip_path_prefix, posix_root_prefix_returns_full_path_components) {
+TEST(posix_root_prefix_returns_full_path_components) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{"foo/bar/baz"});
 }
 
-TEST(IO_strip_path_prefix, posix_root_path) {
+TEST(posix_root_path) {
   const std::filesystem::path path{"/"};
   const std::filesystem::path prefix{"/"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{});
 }
 
-TEST(IO_strip_path_prefix, posix_empty_path) {
+TEST(posix_empty_path) {
   const std::filesystem::path path{};
   const std::filesystem::path prefix{"/foo"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_empty_empty) {
+TEST(posix_empty_empty) {
   const std::filesystem::path path{};
   const std::filesystem::path prefix{};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),
             std::filesystem::path{});
 }
 
-TEST(IO_strip_path_prefix, posix_prefix_longer_than_path) {
+TEST(posix_prefix_longer_than_path) {
   const std::filesystem::path path{"/foo"};
   const std::filesystem::path prefix{"/foo/bar/baz"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_unrelated_branches) {
+TEST(posix_unrelated_branches) {
   const std::filesystem::path path{"/foo/bar"};
   const std::filesystem::path prefix{"/baz"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix), path);
 }
 
-TEST(IO_strip_path_prefix, posix_returned_suffix_has_no_dotdot) {
+TEST(posix_returned_suffix_has_no_dotdot) {
   const std::filesystem::path path{"/foo/bar/zzz/../baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   const auto result{sourcemeta::core::strip_path_prefix(path, prefix)};
@@ -211,14 +211,14 @@ TEST(IO_strip_path_prefix, posix_returned_suffix_has_no_dotdot) {
   EXPECT_EQ(result.string().find(".."), std::string::npos);
 }
 
-TEST(IO_strip_path_prefix, posix_returned_suffix_has_no_leading_separator) {
+TEST(posix_returned_suffix_has_no_leading_separator) {
   const std::filesystem::path path{"/foo/bar/baz"};
   const std::filesystem::path prefix{"/foo/bar"};
   const auto result{sourcemeta::core::strip_path_prefix(path, prefix)};
   EXPECT_FALSE(result.is_absolute());
 }
 
-TEST(IO_strip_path_prefix, posix_only_slashes_under_root) {
+TEST(posix_only_slashes_under_root) {
   const std::filesystem::path path{"////"};
   const std::filesystem::path prefix{"/"};
   EXPECT_EQ(sourcemeta::core::strip_path_prefix(path, prefix),

--- a/test/io/io_strip_path_prefix_test.cc
+++ b/test/io/io_strip_path_prefix_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #ifndef _WIN32
 

--- a/test/io/io_temporary_test.cc
+++ b/test/io/io_temporary_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem> // std::filesystem
 #include <fstream>    // std::ofstream

--- a/test/io/io_temporary_test.cc
+++ b/test/io/io_temporary_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
@@ -6,21 +6,21 @@
 #include <fstream>    // std::ofstream
 #include <string>     // std::string
 
-TEST(IO_TemporaryDirectory, creates_directory) {
+TEST(creates_directory) {
   const auto parent{std::filesystem::path{BUILD_DIRECTORY}};
   const sourcemeta::core::TemporaryDirectory temporary{parent, ".test-"};
   EXPECT_TRUE(std::filesystem::exists(temporary.path()));
   EXPECT_TRUE(std::filesystem::is_directory(temporary.path()));
 }
 
-TEST(IO_TemporaryDirectory, unique_names) {
+TEST(unique_names) {
   const auto parent{std::filesystem::path{BUILD_DIRECTORY}};
   const sourcemeta::core::TemporaryDirectory first{parent, ".test-"};
   const sourcemeta::core::TemporaryDirectory second{parent, ".test-"};
   EXPECT_NE(first.path(), second.path());
 }
 
-TEST(IO_TemporaryDirectory, custom_prefix) {
+TEST(custom_prefix) {
   const auto parent{std::filesystem::path{BUILD_DIRECTORY}};
   const sourcemeta::core::TemporaryDirectory temporary{parent,
                                                        ".my-test-prefix-"};
@@ -28,7 +28,7 @@ TEST(IO_TemporaryDirectory, custom_prefix) {
   EXPECT_TRUE(filename.starts_with(".my-test-prefix-"));
 }
 
-TEST(IO_TemporaryDirectory, removed_on_destruction) {
+TEST(removed_on_destruction) {
   std::filesystem::path path_copy;
   {
     const sourcemeta::core::TemporaryDirectory temporary{
@@ -39,7 +39,7 @@ TEST(IO_TemporaryDirectory, removed_on_destruction) {
   EXPECT_FALSE(std::filesystem::exists(path_copy));
 }
 
-TEST(IO_TemporaryDirectory, removed_on_destruction_non_empty) {
+TEST(removed_on_destruction_non_empty) {
   std::filesystem::path path_copy;
   {
     const sourcemeta::core::TemporaryDirectory temporary{
@@ -53,14 +53,14 @@ TEST(IO_TemporaryDirectory, removed_on_destruction_non_empty) {
   EXPECT_FALSE(std::filesystem::exists(path_copy));
 }
 
-TEST(IO_TemporaryDirectory, inside_parent) {
+TEST(inside_parent) {
   const auto parent{
       std::filesystem::canonical(std::filesystem::path{BUILD_DIRECTORY})};
   const sourcemeta::core::TemporaryDirectory temporary{parent, ".test-"};
   EXPECT_EQ(temporary.path().parent_path(), parent);
 }
 
-TEST(IO_TemporaryDirectory, creates_nonexistent_parent) {
+TEST(creates_nonexistent_parent) {
   const sourcemeta::core::TemporaryDirectory unique_parent{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-parent-"};
   const auto parent{unique_parent.path() / "nonexistent"};
@@ -70,7 +70,7 @@ TEST(IO_TemporaryDirectory, creates_nonexistent_parent) {
   EXPECT_TRUE(std::filesystem::is_directory(temporary.path()));
 }
 
-TEST(IO_TemporaryDirectory, creates_nested_nonexistent_parents) {
+TEST(creates_nested_nonexistent_parents) {
   const sourcemeta::core::TemporaryDirectory unique_parent{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-parent-"};
   const auto parent{unique_parent.path() / "nested_a" / "nested_b"};
@@ -80,7 +80,7 @@ TEST(IO_TemporaryDirectory, creates_nested_nonexistent_parents) {
   EXPECT_TRUE(std::filesystem::is_directory(temporary.path()));
 }
 
-TEST(IO_TemporaryDirectory, parent_is_a_file) {
+TEST(parent_is_a_file) {
   const sourcemeta::core::TemporaryDirectory unique_parent{
       std::filesystem::path{BUILD_DIRECTORY}, ".test-parent-"};
   const auto file_path{unique_parent.path() / "test_parent_file"};

--- a/test/io/io_weakly_canonical_test.cc
+++ b/test/io/io_weakly_canonical_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 TEST(test_txt) {
   const auto path{sourcemeta::core::weakly_canonical(

--- a/test/io/io_weakly_canonical_test.cc
+++ b/test/io/io_weakly_canonical_test.cc
@@ -1,96 +1,96 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
-TEST(IO_weakly_canonical, test_txt) {
+TEST(test_txt) {
   const auto path{sourcemeta::core::weakly_canonical(
       std::filesystem::path{STUBS_DIRECTORY} / "test.txt")};
   EXPECT_EQ(path, std::filesystem::path{STUBS_DIRECTORY} / "test.txt");
 }
 
-TEST(IO_weakly_canonical, not_exists) {
+TEST(not_exists) {
   const auto path{sourcemeta::core::weakly_canonical(
       std::filesystem::path{STUBS_DIRECTORY} / "foo.txt")};
   EXPECT_EQ(path, std::filesystem::path{STUBS_DIRECTORY} / "foo.txt");
 }
 
-TEST(IO_weakly_canonical, empty) {
+TEST(empty) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(std::filesystem::path{}),
             std::filesystem::path{});
 }
 
 #ifndef _WIN32
 
-TEST(IO_weakly_canonical, posix_trailing_slash) {
+TEST(posix_trailing_slash) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(std::filesystem::path{"/tmp/"}),
             sourcemeta::core::weakly_canonical(std::filesystem::path{"/tmp"}));
 }
 
-TEST(IO_weakly_canonical, posix_dot_segment_middle) {
+TEST(posix_dot_segment_middle) {
   EXPECT_EQ(
       sourcemeta::core::weakly_canonical(std::filesystem::path{"/foo/./bar"}),
       std::filesystem::path{"/foo/bar"});
 }
 
-TEST(IO_weakly_canonical, posix_dot_segment_end) {
+TEST(posix_dot_segment_end) {
   EXPECT_EQ(
       sourcemeta::core::weakly_canonical(std::filesystem::path{"/foo/bar/."}),
       std::filesystem::path{"/foo/bar"});
 }
 
-TEST(IO_weakly_canonical, posix_dotdot_cancels_preceding) {
+TEST(posix_dotdot_cancels_preceding) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(
                 std::filesystem::path{"/foo/bar/../baz"}),
             std::filesystem::path{"/foo/baz"});
 }
 
-TEST(IO_weakly_canonical, posix_dotdot_chain_clamps_at_root) {
+TEST(posix_dotdot_chain_clamps_at_root) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(
                 std::filesystem::path{"/foo/bar/../../../etc"}),
             std::filesystem::path{"/etc"});
 }
 
-TEST(IO_weakly_canonical, posix_dotdot_at_start_clamps_at_root) {
+TEST(posix_dotdot_at_start_clamps_at_root) {
   EXPECT_EQ(
       sourcemeta::core::weakly_canonical(std::filesystem::path{"/../../foo"}),
       std::filesystem::path{"/foo"});
 }
 
-TEST(IO_weakly_canonical, posix_double_slash) {
+TEST(posix_double_slash) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(
                 std::filesystem::path{"//foo//bar//baz"}),
             std::filesystem::path{"/foo/bar/baz"});
 }
 
-TEST(IO_weakly_canonical, posix_only_slashes) {
+TEST(posix_only_slashes) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(std::filesystem::path{"////"}),
             std::filesystem::path{"/"});
 }
 
-TEST(IO_weakly_canonical, posix_dot_only) {
+TEST(posix_dot_only) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(std::filesystem::path{"/."}),
             std::filesystem::path{"/"});
 }
 
-TEST(IO_weakly_canonical, posix_trailing_dotdot_cancels_last) {
+TEST(posix_trailing_dotdot_cancels_last) {
   EXPECT_EQ(
       sourcemeta::core::weakly_canonical(std::filesystem::path{"/foo/bar/.."}),
       std::filesystem::path{"/foo"});
 }
 
-TEST(IO_weakly_canonical, posix_mixed_dot_and_dotdot) {
+TEST(posix_mixed_dot_and_dotdot) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(
                 std::filesystem::path{"/foo/./bar/../baz/."}),
             std::filesystem::path{"/foo/baz"});
 }
 
-TEST(IO_weakly_canonical, posix_traversal_through_existing_root) {
+TEST(posix_traversal_through_existing_root) {
   EXPECT_EQ(sourcemeta::core::weakly_canonical(
                 std::filesystem::path{"/foo/../etc/passwd"}),
             std::filesystem::path{"/etc/passwd"});
 }
 
-TEST(IO_weakly_canonical, posix_no_change_for_clean_path) {
+TEST(posix_no_change_for_clean_path) {
   EXPECT_EQ(
       sourcemeta::core::weakly_canonical(std::filesystem::path{"/foo/bar/baz"}),
       std::filesystem::path{"/foo/bar/baz"});

--- a/test/io/io_write_file_test.cc
+++ b/test/io/io_write_file_test.cc
@@ -1,24 +1,26 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/io.h>
 
-#include <array>      // std::array
-#include <cstddef>    // std::byte
-#include <filesystem> // std::filesystem
-#include <fstream>    // std::ifstream, std::istreambuf_iterator
-#include <ios>        // std::ios::binary
-#include <ostream>    // std::ostream
-#include <span>       // std::span
-#include <stdexcept>  // std::runtime_error
-#include <string>     // std::string
+#include <array>        // std::array
+#include <cstddef>      // std::byte
+#include <filesystem>   // std::filesystem
+#include <fstream>      // std::ifstream, std::istreambuf_iterator
+#include <ios>          // std::ios::binary
+#include <ostream>      // std::ostream
+#include <span>         // std::span
+#include <stdexcept>    // std::runtime_error
+#include <string>       // std::string
+#include <system_error> // std::error_code
 
-class IOWriteFileTest : public ::testing::Test {
+class IOWriteFileTest {
 protected:
-  void SetUp() override {
-    std::filesystem::create_directories(this->workspace);
-  }
+  IOWriteFileTest() { std::filesystem::create_directories(this->workspace); }
 
-  void TearDown() override { std::filesystem::remove_all(this->workspace); }
+  ~IOWriteFileTest() {
+    std::error_code error;
+    std::filesystem::remove_all(this->workspace, error);
+  }
 
   // The tests are always sequential, so using the same path is safe
   std::filesystem::path workspace{std::filesystem::path{BUILD_DIRECTORY} /

--- a/test/io/io_write_file_test.cc
+++ b/test/io/io_write_file_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>        // std::array
 #include <cstddef>      // std::byte

--- a/test/ip/ipv4_test.cc
+++ b/test/ip/ipv4_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/ip.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_all_zeros) { EXPECT_TRUE(sourcemeta::core::is_ipv4("0.0.0.0")); }
 

--- a/test/ip/ipv6_test.cc
+++ b/test/ip/ipv6_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/ip.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_unspecified) { EXPECT_TRUE(sourcemeta::core::is_ipv6("::")); }
 

--- a/test/jose/jose_algorithm_test.cc
+++ b/test/jose/jose_algorithm_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/test.h>
 
 TEST(rs256) {
   const auto result{sourcemeta::core::to_jws_algorithm("RS256")};

--- a/test/jose/jose_cookbook_test.cc
+++ b/test/jose/jose_cookbook_test.cc
@@ -1,9 +1,8 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem>  // std::filesystem::path
 #include <string>      // std::string

--- a/test/jose/jose_jwk_test.cc
+++ b/test/jose/jose_jwk_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional> // std::optional
 #include <string>   // std::string

--- a/test/jose/jose_jwks_provider_test.cc
+++ b/test/jose/jose_jwks_provider_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>       // std::array
 #include <chrono>      // std::chrono

--- a/test/jose/jose_jwks_test.cc
+++ b/test/jose/jose_jwks_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional> // std::optional
 #include <string>   // std::string

--- a/test/jose/jose_jws_verify_signature_test.cc
+++ b/test/jose/jose_jws_verify_signature_test.cc
@@ -1,8 +1,7 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional>    // std::nullopt
 #include <string>      // std::string

--- a/test/jose/jose_jwt_check_claims_test.cc
+++ b/test/jose/jose_jwt_check_claims_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>      // std::chrono::system_clock, std::chrono::seconds
 #include <string>      // std::string

--- a/test/jose/jose_jwt_test.cc
+++ b/test/jose/jose_jwt_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/test.h>
 
 #include <chrono>   // std::chrono::system_clock, std::chrono::milliseconds
 #include <optional> // std::optional

--- a/test/jose/jose_jwt_verify_signature_test.cc
+++ b/test/jose/jose_jwt_verify_signature_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>      // std::string
 #include <string_view> // std::string_view

--- a/test/jose/jose_jwt_verify_test.cc
+++ b/test/jose/jose_jwt_verify_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jose.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <array>       // std::array
 #include <chrono>      // std::chrono::system_clock

--- a/test/json/json_array_test.cc
+++ b/test/json/json_array_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <algorithm>
 #include <set>

--- a/test/json/json_boolean_test.cc
+++ b/test/json/json_boolean_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(true_value) {
   const sourcemeta::core::JSON document{true};

--- a/test/json/json_decimal_test.cc
+++ b/test/json/json_decimal_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(positive) {
   const sourcemeta::core::Decimal value{42};

--- a/test/json/json_error_test.cc
+++ b/test/json/json_error_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>   // std::exception
 #include <string>      // std::string

--- a/test/json/json_format_test.cc
+++ b/test/json/json_format_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <format> // std::format
 #include <string> // std::string

--- a/test/json/json_hash_test.cc
+++ b/test/json/json_hash_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(hash_empty) {
   const sourcemeta::core::PropertyHashJSON<sourcemeta::core::JSON::String>

--- a/test/json/json_integer_test.cc
+++ b/test/json/json_integer_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(positive) {
   const sourcemeta::core::JSON document{10};

--- a/test/json/json_null_test.cc
+++ b/test/json/json_null_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(nullptr_value) {
   const sourcemeta::core::JSON document{nullptr};

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <stdexcept> // std::out_of_range
 

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <algorithm>
 #include <map>

--- a/test/json/json_parse_callback_test.cc
+++ b/test/json/json_parse_callback_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 #include <tuple>

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>
 #include <sstream>

--- a/test/json/json_parse_roundtrip_test.cc
+++ b/test/json/json_parse_roundtrip_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 

--- a/test/json/json_parse_test.cc
+++ b/test/json/json_parse_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 #include <string>

--- a/test/json/json_prettify_test.cc
+++ b/test/json/json_prettify_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 

--- a/test/json/json_real_test.cc
+++ b/test/json/json_real_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <cmath>
 #include <limits>

--- a/test/json/json_string_test.cc
+++ b/test/json/json_string_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 #include <string_view>

--- a/test/json/json_stringify_test.cc
+++ b/test/json/json_stringify_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 

--- a/test/json/json_try_parse_test.cc
+++ b/test/json/json_try_parse_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_object) {
   const auto document{sourcemeta::core::try_parse_json("{ \"foo\": 1 }")};

--- a/test/json/json_type_test.cc
+++ b/test/json/json_type_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstddef>       // std::size_t
 #include <functional>    // std::reference_wrapper

--- a/test/jsonl/jsonl_gzip_parse_error_test.cc
+++ b/test/jsonl/jsonl_gzip_parse_error_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/gzip.h>
 #include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint>   // std::uint8_t
 #include <exception> // std::exception

--- a/test/jsonl/jsonl_gzip_parse_test.cc
+++ b/test/jsonl/jsonl_gzip_parse_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/gzip.h>
 #include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint> // std::uint8_t
 #include <sstream> // std::istringstream

--- a/test/jsonl/jsonl_parse_error_test.cc
+++ b/test/jsonl/jsonl_parse_error_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>
 #include <sstream>

--- a/test/jsonl/jsonl_parse_test.cc
+++ b/test/jsonl/jsonl_parse_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonl.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 #include <vector>

--- a/test/jsonld/jsonld_compact_test.cc
+++ b/test/jsonld/jsonld_compact_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/test.h>
 
 TEST(compact_to_relative_true_relativises_against_base) {
   const auto input = sourcemeta::core::parse_json(R"([

--- a/test/jsonld/jsonld_expand_error_test.cc
+++ b/test/jsonld/jsonld_expand_error_test.cc
@@ -1,8 +1,7 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional> // std::optional, std::nullopt
 #include <string>   // std::string

--- a/test/jsonld/jsonld_expand_test.cc
+++ b/test/jsonld/jsonld_expand_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/test.h>
 
 #include <optional> // std::optional, std::nullopt
 

--- a/test/jsonld/jsonld_flatten_test.cc
+++ b/test/jsonld/jsonld_flatten_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/test.h>
 
 TEST(nested_anonymous_node_gets_blank_node_identifier) {
   const auto input = sourcemeta::core::parse_json(R"([

--- a/test/jsonld/jsonld_is_expanded_test.cc
+++ b/test/jsonld/jsonld_is_expanded_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/test.h>
 
 TEST(empty_array) {
   const auto document = sourcemeta::core::parse_json("[]");

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -1,8 +1,7 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <functional> // std::cref
 

--- a/test/jsonpointer/jsonpointer_concat_test.cc
+++ b/test/jsonpointer/jsonpointer_concat_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(multi_multi) {
   const sourcemeta::core::Pointer left{"foo", "bar"};

--- a/test/jsonpointer/jsonpointer_empty_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_empty_pointer_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(is_empty) {
   EXPECT_TRUE(sourcemeta::core::empty_pointer.empty());

--- a/test/jsonpointer/jsonpointer_error_test.cc
+++ b/test/jsonpointer/jsonpointer_error_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>   // std::exception
 #include <string>      // std::string

--- a/test/jsonpointer/jsonpointer_fragment_to_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_fragment_to_pointer_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/uri.h>
 
 TEST(uri_with_base_and_fragment) {

--- a/test/jsonpointer/jsonpointer_get_test.cc
+++ b/test/jsonpointer/jsonpointer_get_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(integer_property) {
   const sourcemeta::core::JSON document = sourcemeta::core::parse_json(R"JSON({

--- a/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_zero) { EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0")); }
 

--- a/test/jsonpointer/jsonpointer_json_auto_test.cc
+++ b/test/jsonpointer/jsonpointer_json_auto_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(foo_bar_baz) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};

--- a/test/jsonpointer/jsonpointer_parse_error_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_error_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>
 #include <string>

--- a/test/jsonpointer/jsonpointer_parse_test.cc
+++ b/test/jsonpointer/jsonpointer_parse_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 #include <string_view>

--- a/test/jsonpointer/jsonpointer_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_pointer_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <type_traits>
 #include <unordered_map>

--- a/test/jsonpointer/jsonpointer_position_test.cc
+++ b/test/jsonpointer/jsonpointer_position_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(track_1) {
   const auto input{R"JSON([

--- a/test/jsonpointer/jsonpointer_rebase_test.cc
+++ b/test/jsonpointer/jsonpointer_rebase_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(first_property_for_one) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};

--- a/test/jsonpointer/jsonpointer_remove_test.cc
+++ b/test/jsonpointer/jsonpointer_remove_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(array_element) {
   sourcemeta::core::JSON document =

--- a/test/jsonpointer/jsonpointer_resolve_from_test.cc
+++ b/test/jsonpointer/jsonpointer_resolve_from_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(mismatch_base_shorter) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};

--- a/test/jsonpointer/jsonpointer_set_test.cc
+++ b/test/jsonpointer/jsonpointer_set_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(property_to_integer) {
   sourcemeta::core::JSON document =

--- a/test/jsonpointer/jsonpointer_slice_test.cc
+++ b/test/jsonpointer/jsonpointer_slice_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(from_zero) {
   const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};

--- a/test/jsonpointer/jsonpointer_starts_with_initial_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_initial_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(property_prefix_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};

--- a/test/jsonpointer/jsonpointer_starts_with_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(property_prefix_true) {
   const sourcemeta::core::Pointer pointer{"foo", "bar"};

--- a/test/jsonpointer/jsonpointer_stringify_test.cc
+++ b/test/jsonpointer/jsonpointer_stringify_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream>
 

--- a/test/jsonpointer/jsonpointer_to_string_test.cc
+++ b/test/jsonpointer/jsonpointer_to_string_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(empty) {
   const sourcemeta::core::Pointer pointer;

--- a/test/jsonpointer/jsonpointer_to_uri_test.cc
+++ b/test/jsonpointer/jsonpointer_to_uri_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/uri.h>
 
 TEST(empty) {

--- a/test/jsonpointer/jsonpointer_token_test.cc
+++ b/test/jsonpointer/jsonpointer_token_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <type_traits>
 

--- a/test/jsonpointer/jsonpointer_try_get_test.cc
+++ b/test/jsonpointer/jsonpointer_try_get_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 TEST(empty_on_integer) {
   const sourcemeta::core::JSON document{5};

--- a/test/jsonpointer/jsonpointer_walker_test.cc
+++ b/test/jsonpointer/jsonpointer_walker_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 
 #include <set>
 #include <string>

--- a/test/jsonpointer/jsonpointer_weakpointer_test.cc
+++ b/test/jsonpointer/jsonpointer_weakpointer_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/uri.h>
 
 #include <functional>

--- a/test/langtag/langtag_test.cc
+++ b/test/langtag/langtag_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/langtag.h>
+#include <sourcemeta/core/test.h>
 
 // RFC 5646 Appendix A: simple language subtag
 TEST(rfc_simple_language_subtag) {

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/test.h>
 
 #include <cmath>   // std::isnan, std::isinf
 #include <cstdint> // std::int32_t, std::int64_t, std::uint32_t, std::uint64_t

--- a/test/numeric/numeric_parse_test.cc
+++ b/test/numeric/numeric_parse_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint>     // std::int64_t, std::uint64_t
 #include <string>      // std::string

--- a/test/numeric/numeric_uint128_test.cc
+++ b/test/numeric/numeric_uint128_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint> // std::uint64_t, std::int64_t
 

--- a/test/numeric/numeric_util_test.cc
+++ b/test/numeric/numeric_util_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/test.h>
 
 #include <cmath>   // std::nextafter
 #include <cstdint> // std::int64_t, std::uint64_t, std::uint8_t

--- a/test/numeric/numeric_zigzag_test.cc
+++ b/test/numeric/numeric_zigzag_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/test.h>
 
 #include <cstdint> // std::int64_t, std::uint64_t
 #include <limits>  // std::numeric_limits

--- a/test/options/options_test.cc
+++ b/test/options/options_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/options.h>
+#include <sourcemeta/core/test.h>
 
 TEST(long_option_equals_parses_value_with_equal_sign) {
   sourcemeta::core::Options app;

--- a/test/parallel/parallel_for_each_test.cc
+++ b/test/parallel/parallel_for_each_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/parallel.h>
+#include <sourcemeta/core/test.h>
 
 #include <algorithm>
 #include <atomic>

--- a/test/process/process_spawn_test_unix.cc
+++ b/test/process/process_spawn_test_unix.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/process.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem> // std::filesystem::path
 

--- a/test/process/process_spawn_test_windows.cc
+++ b/test/process/process_spawn_test_windows.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/process.h>
+#include <sourcemeta/core/test.h>
 
 #include <filesystem> // std::filesystem::path
 

--- a/test/punycode/punycode_decode_test.cc
+++ b/test/punycode/punycode_decode_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/punycode.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream> // std::istringstream, std::ostringstream
 #include <string>  // std::string

--- a/test/punycode/punycode_encode_test.cc
+++ b/test/punycode/punycode_encode_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/punycode.h>
+#include <sourcemeta/core/test.h>
 
 #include <sstream> // std::istringstream, std::ostringstream
 #include <string>  // std::string

--- a/test/regex/regex_is_ecma_test.cc
+++ b/test/regex/regex_is_ecma_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 TEST(suite_valid_basic) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("([abc])+\\s+$"));

--- a/test/regex/regex_matches_ecma262_test.cc
+++ b/test/regex/regex_matches_ecma262_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/regex/regex_matches_if_valid_test.cc
+++ b/test/regex/regex_matches_if_valid_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/regex/regex_matches_rfc9485_test.cc
+++ b/test/regex/regex_matches_rfc9485_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>
 

--- a/test/regex/regex_test.cc
+++ b/test/regex/regex_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 #include <string>      // std::string
 #include <string_view> // std::string_view

--- a/test/regex/regex_to_regex_test.cc
+++ b/test/regex/regex_to_regex_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_1) {
   const auto regex{sourcemeta::core::to_regex("^foo")};

--- a/test/semver/semver_compare_test.cc
+++ b/test/semver/semver_compare_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 TEST(major_less) {
   EXPECT_LT(sourcemeta::core::SemVer{"1.0.0"},

--- a/test/semver/semver_from_test.cc
+++ b/test/semver/semver_from_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 TEST(valid_basic) {
   const auto result = sourcemeta::core::SemVer::from("1.2.3");

--- a/test/semver/semver_parse_error_loose_test.cc
+++ b/test/semver/semver_parse_error_loose_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>
 

--- a/test/semver/semver_parse_error_test.cc
+++ b/test/semver/semver_parse_error_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>
 

--- a/test/semver/semver_parse_loose_test.cc
+++ b/test/semver/semver_parse_loose_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 TEST(v_prefix_full) {
   const sourcemeta::core::SemVer version{"v1.2.3",

--- a/test/semver/semver_parse_test.cc
+++ b/test/semver/semver_parse_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 TEST(zero_zero_zero) {
   const sourcemeta::core::SemVer version{"0.0.0"};

--- a/test/semver/semver_to_string_test.cc
+++ b/test/semver/semver_to_string_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/semver.h>
+#include <sourcemeta/core/test.h>
 
 TEST(basic) {
   EXPECT_EQ(sourcemeta::core::SemVer{"1.2.3"}.to_string(), "1.2.3");

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -20,6 +20,11 @@ add_executable(sourcemeta_core_test_filter
 target_link_libraries(sourcemeta_core_test_filter
   PRIVATE sourcemeta::core::test)
 
+add_executable(sourcemeta_core_test_fixture
+  test_fixture.cc "${SOURCEMETA_CORE_TEST_DRIVER_MAIN}")
+target_link_libraries(sourcemeta_core_test_fixture
+  PRIVATE sourcemeta::core::test)
+
 if(WIN32)
   set(SOURCEMETA_CORE_TEST_RUNNER powershell -ExecutionPolicy Bypass -File
     "${CMAKE_CURRENT_SOURCE_DIR}/test_runner.ps1")
@@ -54,3 +59,7 @@ add_test(NAME core.test.filter_short COMMAND ${SOURCEMETA_CORE_TEST_RUNNER}
 add_test(NAME core.test.filter_none COMMAND ${SOURCEMETA_CORE_TEST_RUNNER}
   "$<TARGET_FILE:sourcemeta_core_test_filter>" 0
   "${CMAKE_CURRENT_SOURCE_DIR}/test_filter_none.txt" --filter nonexistent)
+
+add_test(NAME core.test.fixture COMMAND ${SOURCEMETA_CORE_TEST_RUNNER}
+  "$<TARGET_FILE:sourcemeta_core_test_fixture>" 0
+  "${CMAKE_CURRENT_SOURCE_DIR}/test_fixture.txt")

--- a/test/test/test_fixture.cc
+++ b/test/test/test_fixture.cc
@@ -1,0 +1,22 @@
+#include <sourcemeta/core/test.h>
+
+namespace {
+int live_instances{0};
+}
+
+class ExampleFixture {
+protected:
+  ExampleFixture() { live_instances += 1; }
+  ~ExampleFixture() { live_instances -= 1; }
+  int value{42};
+};
+
+TEST_F(ExampleFixture, sees_constructed_member) {
+  EXPECT_EQ(this->value, 42);
+  EXPECT_EQ(live_instances, 1);
+}
+
+TEST_F(ExampleFixture, teardown_runs_between_tests) {
+  EXPECT_EQ(this->value, 42);
+  EXPECT_EQ(live_instances, 1);
+}

--- a/test/test/test_fixture.txt
+++ b/test/test/test_fixture.txt
@@ -1,0 +1,5 @@
+TAP version 14
+1..2
+ok 1 - test_fixture.sees_constructed_member
+ok 2 - test_fixture.teardown_runs_between_tests
+# 2 passed, 0 failed

--- a/test/text/text_bytes_to_hex_test.cc
+++ b/test/text/text_bytes_to_hex_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string

--- a/test/text/text_equals_ignore_case_test.cc
+++ b/test/text/text_equals_ignore_case_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string_view> // std::string_view

--- a/test/text/text_hex_to_bytes_test.cc
+++ b/test/text/text_hex_to_bytes_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string

--- a/test/text/text_is_alpha_test.cc
+++ b/test/text/text_is_alpha_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 TEST(lowercase_letters) {

--- a/test/text/text_is_alphanum_test.cc
+++ b/test/text/text_is_alphanum_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 TEST(letters) {

--- a/test/text/text_is_digit_test.cc
+++ b/test/text/text_is_digit_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 TEST(digits) {

--- a/test/text/text_is_lowercase_test.cc
+++ b/test/text/text_is_lowercase_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <filesystem>

--- a/test/text/text_join_to_test.cc
+++ b/test/text/text_join_to_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <array>       // std::array

--- a/test/text/text_pad_left_test.cc
+++ b/test/text/text_pad_left_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string

--- a/test/text/text_remove_suffix_ignore_case_test.cc
+++ b/test/text/text_remove_suffix_ignore_case_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string_view> // std::string_view

--- a/test/text/text_split_once_test.cc
+++ b/test/text/text_split_once_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 TEST(char_delimiter_in_middle) {

--- a/test/text/text_split_test.cc
+++ b/test/text/text_split_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <cstddef>     // std::size_t

--- a/test/text/text_strip_left_test.cc
+++ b/test/text/text_strip_left_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string

--- a/test/text/text_strip_right_test.cc
+++ b/test/text/text_strip_right_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 TEST(no_trailing_character) {

--- a/test/text/text_take_until_test.cc
+++ b/test/text/text_take_until_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 TEST(marker_in_middle) {

--- a/test/text/text_to_lowercase_test.cc
+++ b/test/text/text_to_lowercase_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <filesystem>

--- a/test/text/text_to_title_case_test.cc
+++ b/test/text/text_to_title_case_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string

--- a/test/text/text_trim_test.cc
+++ b/test/text/text_trim_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string_view> // std::string_view

--- a/test/text/text_truncate_test.cc
+++ b/test/text/text_truncate_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/text.h>
 
 #include <string> // std::string

--- a/test/time/is_leap_year_test.cc
+++ b/test/time/is_leap_year_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(year_zero) { EXPECT_TRUE(sourcemeta::core::is_leap_year(0)); }

--- a/test/time/max_day_in_month_test.cc
+++ b/test/time/max_day_in_month_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(january_2024) {

--- a/test/time/rfc3339_datetime_test.cc
+++ b/test/time/rfc3339_datetime_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(valid_rfc_example_1) {

--- a/test/time/rfc3339_duration_test.cc
+++ b/test/time/rfc3339_duration_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(valid_year_only) {

--- a/test/time/rfc3339_fulldate_test.cc
+++ b/test/time/rfc3339_fulldate_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(valid_basic) {

--- a/test/time/rfc3339_fulltime_test.cc
+++ b/test/time/rfc3339_fulltime_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(valid_basic_zulu) {

--- a/test/time/rfc3339_partialtime_no_secfrac_test.cc
+++ b/test/time/rfc3339_partialtime_no_secfrac_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/time.h>
 
 TEST(valid_basic) {

--- a/test/unicode/unicode_bidi_class_test.cc
+++ b/test/unicode/unicode_bidi_class_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(null) {

--- a/test/unicode/unicode_canonical_composition_test.cc
+++ b/test/unicode/unicode_canonical_composition_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <optional>

--- a/test/unicode/unicode_canonical_decomposition_test.cc
+++ b/test/unicode/unicode_canonical_decomposition_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <string_view>

--- a/test/unicode/unicode_codepoint_to_utf8_test.cc
+++ b/test/unicode/unicode_codepoint_to_utf8_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <sstream> // std::ostringstream

--- a/test/unicode/unicode_combining_class_test.cc
+++ b/test/unicode/unicode_combining_class_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_letter) { EXPECT_EQ(sourcemeta::core::combining_class(U'A'), 0); }

--- a/test/unicode/unicode_is_combining_mark_test.cc
+++ b/test/unicode/unicode_is_combining_mark_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_letter) { EXPECT_FALSE(sourcemeta::core::is_combining_mark(U'A')); }

--- a/test/unicode/unicode_is_iprivate_test.cc
+++ b/test/unicode/unicode_is_iprivate_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_letter_excluded) {

--- a/test/unicode/unicode_is_nfc_test.cc
+++ b/test/unicode/unicode_is_nfc_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(empty) { EXPECT_TRUE(sourcemeta::core::is_nfc(U"")); }

--- a/test/unicode/unicode_is_surrogate_test.cc
+++ b/test/unicode/unicode_is_surrogate_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(null) { EXPECT_FALSE(sourcemeta::core::is_surrogate(0x0000)); }

--- a/test/unicode/unicode_is_ucschar_test.cc
+++ b/test/unicode/unicode_is_ucschar_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 // ASCII range is excluded from ucschar (those are in the URI ASCII set)

--- a/test/unicode/unicode_is_utf8_continuation_test.cc
+++ b/test/unicode/unicode_is_utf8_continuation_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_null_rejected) {

--- a/test/unicode/unicode_is_valid_codepoint_test.cc
+++ b/test/unicode/unicode_is_valid_codepoint_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(null) { EXPECT_TRUE(sourcemeta::core::is_valid_codepoint(0x0000)); }

--- a/test/unicode/unicode_joining_type_test.cc
+++ b/test/unicode/unicode_joining_type_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_letter) {

--- a/test/unicode/unicode_nfc_quick_check_test.cc
+++ b/test/unicode/unicode_nfc_quick_check_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_letter) {

--- a/test/unicode/unicode_nfc_test.cc
+++ b/test/unicode/unicode_nfc_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <string>

--- a/test/unicode/unicode_script_test.cc
+++ b/test/unicode/unicode_script_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(null) {

--- a/test/unicode/unicode_utf8_codepoint_byte_count_test.cc
+++ b/test/unicode/unicode_utf8_codepoint_byte_count_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_null) {

--- a/test/unicode/unicode_utf8_codepoint_length_test.cc
+++ b/test/unicode/unicode_utf8_codepoint_length_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <string> // std::string

--- a/test/unicode/unicode_utf8_decode_test.cc
+++ b/test/unicode/unicode_utf8_decode_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii) {

--- a/test/unicode/unicode_utf8_lead_byte_size_test.cc
+++ b/test/unicode/unicode_utf8_lead_byte_size_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 TEST(ascii_null) { EXPECT_EQ(sourcemeta::core::utf8_lead_byte_size(0x00), 1u); }

--- a/test/unicode/unicode_utf8_to_utf32_test.cc
+++ b/test/unicode/unicode_utf8_to_utf32_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <sstream> // std::istringstream

--- a/test/unicode/unicode_utf8_to_wide_test.cc
+++ b/test/unicode/unicode_utf8_to_wide_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <string>      // std::wstring

--- a/test/unicode/unicode_wide_to_utf8_test.cc
+++ b/test/unicode/unicode_wide_to_utf8_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/unicode.h>
 
 #include <string>      // std::string

--- a/test/uri/uri_canonicalize_test.cc
+++ b/test/uri/uri_canonicalize_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(example_1) {

--- a/test/uri/uri_empty_test.cc
+++ b/test/uri/uri_empty_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(empty_default_constructor) {

--- a/test/uri/uri_extension_test.cc
+++ b/test/uri/uri_extension_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 #include <sstream>

--- a/test/uri/uri_fragment_test.cc
+++ b/test/uri/uri_fragment_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(https_no_fragment) {

--- a/test/uri/uri_from_iri_test.cc
+++ b/test/uri/uri_from_iri_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(parses_and_round_trips_unicode) {

--- a/test/uri/uri_from_path_test.cc
+++ b/test/uri/uri_from_path_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(unix_absolute) {

--- a/test/uri/uri_has_same_authority_test.cc
+++ b/test/uri/uri_has_same_authority_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(same_host_same_port) {

--- a/test/uri/uri_host_test.cc
+++ b/test/uri/uri_host_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(https_example_url) {

--- a/test/uri/uri_is_absolute_test.cc
+++ b/test/uri/uri_is_absolute_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(example_url) {

--- a/test/uri/uri_is_file_test.cc
+++ b/test/uri/uri_is_file_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(mailto) {

--- a/test/uri/uri_is_gen_delim_test.cc
+++ b/test/uri/uri_is_gen_delim_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(all_generic_delimiters) {

--- a/test/uri/uri_is_internationalized_test.cc
+++ b/test/uri/uri_is_internationalized_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 #include <sstream> // std::istringstream

--- a/test/uri/uri_is_ipv4_test.cc
+++ b/test/uri/uri_is_ipv4_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(ipv4_simple) {

--- a/test/uri/uri_is_ipv6_test.cc
+++ b/test/uri/uri_is_ipv6_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 // Insipred from https://datatracker.ietf.org/doc/html/rfc2732#section-2

--- a/test/uri/uri_is_iri_test.cc
+++ b/test/uri/uri_is_iri_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(ascii_https_absolute) {

--- a/test/uri/uri_is_mailto_test.cc
+++ b/test/uri/uri_is_mailto_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(success) {

--- a/test/uri/uri_is_relative_test.cc
+++ b/test/uri/uri_is_relative_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(dot_slash) {

--- a/test/uri/uri_is_scheme_test.cc
+++ b/test/uri/uri_is_scheme_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(common_schemes) {

--- a/test/uri/uri_is_tag_test.cc
+++ b/test/uri/uri_is_tag_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(tag) {

--- a/test/uri/uri_is_urn_test.cc
+++ b/test/uri/uri_is_urn_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(urn_1) {

--- a/test/uri/uri_parse_test.cc
+++ b/test/uri/uri_parse_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 // Inspired from

--- a/test/uri/uri_path_test.cc
+++ b/test/uri/uri_path_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 #include <string>

--- a/test/uri/uri_port_test.cc
+++ b/test/uri/uri_port_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(https_example_url_no_port) {

--- a/test/uri/uri_query_test.cc
+++ b/test/uri/uri_query_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 #include <utility> // std::pair

--- a/test/uri/uri_rebase_path_test.cc
+++ b/test/uri/uri_rebase_path_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(single_segment_suffix) {

--- a/test/uri/uri_rebase_test.cc
+++ b/test/uri/uri_rebase_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(absolute_to_relative_match) {

--- a/test/uri/uri_recompose_relative_test.cc
+++ b/test/uri/uri_recompose_relative_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(full_url) {

--- a/test/uri/uri_recompose_test.cc
+++ b/test/uri/uri_recompose_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(example_1) {

--- a/test/uri/uri_recompose_without_fragment_test.cc
+++ b/test/uri/uri_recompose_without_fragment_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(example_1) {

--- a/test/uri/uri_relative_to_test.cc
+++ b/test/uri/uri_relative_to_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(absolute_absolute_base_true_1) {

--- a/test/uri/uri_resolve_from_test.cc
+++ b/test/uri/uri_resolve_from_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 // NON-STANDARD EXTENSION: Relative-to-Relative Resolution

--- a/test/uri/uri_scheme_test.cc
+++ b/test/uri/uri_scheme_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(https_example_url) {

--- a/test/uri/uri_strip_path_prefix_test.cc
+++ b/test/uri/uri_strip_path_prefix_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(exact_match) {

--- a/test/uri/uri_test.cc
+++ b/test/uri/uri_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 #include <map>

--- a/test/uri/uri_to_path_test.cc
+++ b/test/uri/uri_to_path_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(tag) {

--- a/test/uri/uri_user_info_test.cc
+++ b/test/uri/uri_user_info_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uri.h>
 
 TEST(working_example) {

--- a/test/uritemplate/CMakeLists.txt
+++ b/test/uritemplate/CMakeLists.txt
@@ -1,4 +1,4 @@
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME uritemplate
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uritemplate
   SOURCES
     uritemplate_helpers.h
     uritemplate_test.cc

--- a/test/uritemplate/uritemplate_expand_test.cc
+++ b/test/uritemplate/uritemplate_expand_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uritemplate.h>
 
@@ -9,7 +9,7 @@
 #include <tuple>         // std::make_tuple
 #include <unordered_map> // std::unordered_map
 
-TEST(URITemplate_expand, empty_template) {
+TEST(empty_template) {
   const sourcemeta::core::URITemplate uri_template{""};
   const auto result =
       uri_template.expand([](const std::string_view) { return std::nullopt; });
@@ -17,7 +17,7 @@ TEST(URITemplate_expand, empty_template) {
   EXPECT_EQ(result, "");
 }
 
-TEST(URITemplate_expand, literal_only) {
+TEST(literal_only) {
   const sourcemeta::core::URITemplate uri_template{
       "http://example.com/path/to/resource"};
   const auto result =
@@ -26,7 +26,7 @@ TEST(URITemplate_expand, literal_only) {
   EXPECT_EQ(result, "http://example.com/path/to/resource");
 }
 
-TEST(URITemplate_expand, single_variable) {
+TEST(single_variable) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -41,7 +41,7 @@ TEST(URITemplate_expand, single_variable) {
   EXPECT_EQ(result, "value");
 }
 
-TEST(URITemplate_expand, literal_then_variable) {
+TEST(literal_then_variable) {
   const sourcemeta::core::URITemplate uri_template{"http://example.com/{id}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -55,7 +55,7 @@ TEST(URITemplate_expand, literal_then_variable) {
   EXPECT_EQ(result, "http://example.com/123");
 }
 
-TEST(URITemplate_expand, variable_then_literal) {
+TEST(variable_then_literal) {
   const sourcemeta::core::URITemplate uri_template{"{id}/resource"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -69,7 +69,7 @@ TEST(URITemplate_expand, variable_then_literal) {
   EXPECT_EQ(result, "456/resource");
 }
 
-TEST(URITemplate_expand, literal_variable_literal) {
+TEST(literal_variable_literal) {
   const sourcemeta::core::URITemplate uri_template{
       "http://example.com/~{username}/"};
   const auto result = uri_template.expand(
@@ -84,7 +84,7 @@ TEST(URITemplate_expand, literal_variable_literal) {
   EXPECT_EQ(result, "http://example.com/~john/");
 }
 
-TEST(URITemplate_expand, multiple_variables) {
+TEST(multiple_variables) {
   const sourcemeta::core::URITemplate uri_template{
       "/users/{id}/posts/{postId}"};
   const auto result = uri_template.expand(
@@ -101,7 +101,7 @@ TEST(URITemplate_expand, multiple_variables) {
   EXPECT_EQ(result, "/users/42/posts/99");
 }
 
-TEST(URITemplate_expand, adjacent_variables) {
+TEST(adjacent_variables) {
   const sourcemeta::core::URITemplate uri_template{"{x}{y}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -121,7 +121,7 @@ TEST(URITemplate_expand, adjacent_variables) {
 
 // See RFC 6570 Section 3.2.1: undefined variables expand to empty string
 // https://www.rfc-editor.org/rfc/rfc6570#section-3.2.1
-TEST(URITemplate_expand, undefined_variable) {
+TEST(undefined_variable) {
   const sourcemeta::core::URITemplate uri_template{"{undefined}"};
   const auto result =
       uri_template.expand([](const std::string_view) { return std::nullopt; });
@@ -129,7 +129,7 @@ TEST(URITemplate_expand, undefined_variable) {
   EXPECT_EQ(result, "");
 }
 
-TEST(URITemplate_expand, partial_variables_defined) {
+TEST(partial_variables_defined) {
   const sourcemeta::core::URITemplate uri_template{
       "/users/{id}/posts/{postId}"};
   const auto result = uri_template.expand(
@@ -144,7 +144,7 @@ TEST(URITemplate_expand, partial_variables_defined) {
   EXPECT_EQ(result, "/users/42/posts/");
 }
 
-TEST(URITemplate_expand, undefined_between_literals) {
+TEST(undefined_between_literals) {
   const sourcemeta::core::URITemplate uri_template{"start/{undefined}/end"};
   const auto result =
       uri_template.expand([](const std::string_view) { return std::nullopt; });
@@ -152,7 +152,7 @@ TEST(URITemplate_expand, undefined_between_literals) {
   EXPECT_EQ(result, "start//end");
 }
 
-TEST(URITemplate_expand, empty_value) {
+TEST(empty_value) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -166,7 +166,7 @@ TEST(URITemplate_expand, empty_value) {
   EXPECT_EQ(result, "");
 }
 
-TEST(URITemplate_expand, percent_encode_space) {
+TEST(percent_encode_space) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -181,7 +181,7 @@ TEST(URITemplate_expand, percent_encode_space) {
   EXPECT_EQ(result, "hello%20world");
 }
 
-TEST(URITemplate_expand, percent_encode_slash) {
+TEST(percent_encode_slash) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -196,7 +196,7 @@ TEST(URITemplate_expand, percent_encode_slash) {
   EXPECT_EQ(result, "foo%2Fbar");
 }
 
-TEST(URITemplate_expand, percent_encode_reserved_chars) {
+TEST(percent_encode_reserved_chars) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -211,7 +211,7 @@ TEST(URITemplate_expand, percent_encode_reserved_chars) {
   EXPECT_EQ(result, "%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D");
 }
 
-TEST(URITemplate_expand, unreserved_chars_not_encoded) {
+TEST(unreserved_chars_not_encoded) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -226,7 +226,7 @@ TEST(URITemplate_expand, unreserved_chars_not_encoded) {
   EXPECT_EQ(result, "azAZ09-._~");
 }
 
-TEST(URITemplate_expand, percent_encode_unicode) {
+TEST(percent_encode_unicode) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -240,7 +240,7 @@ TEST(URITemplate_expand, percent_encode_unicode) {
   EXPECT_EQ(result, "caf%C3%A9");
 }
 
-TEST(URITemplate_expand, with_std_map) {
+TEST(with_std_map) {
   const sourcemeta::core::URITemplate uri_template{
       "http://example.com/{resource}/{id}"};
   const std::map<std::string, std::string> variables{{"resource", "users"},
@@ -249,7 +249,7 @@ TEST(URITemplate_expand, with_std_map) {
   EXPECT_EQ(result, "http://example.com/users/123");
 }
 
-TEST(URITemplate_expand, with_std_unordered_map) {
+TEST(with_std_unordered_map) {
   const sourcemeta::core::URITemplate uri_template{
       "/users/{id}/posts/{postId}"};
   const std::unordered_map<std::string, std::string> variables{
@@ -258,7 +258,7 @@ TEST(URITemplate_expand, with_std_unordered_map) {
   EXPECT_EQ(result, "/users/42/posts/99");
 }
 
-TEST(URITemplate_expand, with_std_map_partial) {
+TEST(with_std_map_partial) {
   const sourcemeta::core::URITemplate uri_template{
       "/users/{id}/posts/{postId}"};
   const std::map<std::string, std::string> variables{{"id", "42"}};
@@ -266,14 +266,14 @@ TEST(URITemplate_expand, with_std_map_partial) {
   EXPECT_EQ(result, "/users/42/posts/");
 }
 
-TEST(URITemplate_expand, with_std_map_empty) {
+TEST(with_std_map_empty) {
   const sourcemeta::core::URITemplate uri_template{"/users/{id}"};
   const std::map<std::string, std::string> variables{};
   const auto result = uri_template.expand(variables);
   EXPECT_EQ(result, "/users/");
 }
 
-TEST(URITemplate_expand, rfc6570_level1_var) {
+TEST(rfc6570_level1_var) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -281,7 +281,7 @@ TEST(URITemplate_expand, rfc6570_level1_var) {
   EXPECT_EQ(result, "value");
 }
 
-TEST(URITemplate_expand, rfc6570_level1_hello) {
+TEST(rfc6570_level1_hello) {
   const sourcemeta::core::URITemplate uri_template{"{hello}"};
   const std::map<std::string, std::string> variables{{"hello", "Hello World!"}};
   const auto result = uri_template.expand(variables);
@@ -289,7 +289,7 @@ TEST(URITemplate_expand, rfc6570_level1_hello) {
   EXPECT_EQ(result, "Hello%20World%21");
 }
 
-TEST(URITemplate_expand, reserved_expansion_simple) {
+TEST(reserved_expansion_simple) {
   const sourcemeta::core::URITemplate uri_template{"{+var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -304,7 +304,7 @@ TEST(URITemplate_expand, reserved_expansion_simple) {
   EXPECT_EQ(result, "value");
 }
 
-TEST(URITemplate_expand, reserved_expansion_preserves_reserved) {
+TEST(reserved_expansion_preserves_reserved) {
   const sourcemeta::core::URITemplate uri_template{"{+path}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -319,7 +319,7 @@ TEST(URITemplate_expand, reserved_expansion_preserves_reserved) {
   EXPECT_EQ(result, "/foo/bar");
 }
 
-TEST(URITemplate_expand, reserved_expansion_all_reserved_chars) {
+TEST(reserved_expansion_all_reserved_chars) {
   const sourcemeta::core::URITemplate uri_template{"{+reserved}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -334,7 +334,7 @@ TEST(URITemplate_expand, reserved_expansion_all_reserved_chars) {
   EXPECT_EQ(result, ":/?#[]@!$&'()*+,;=");
 }
 
-TEST(URITemplate_expand, reserved_expansion_encodes_non_reserved) {
+TEST(reserved_expansion_encodes_non_reserved) {
   const sourcemeta::core::URITemplate uri_template{"{+var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -351,7 +351,7 @@ TEST(URITemplate_expand, reserved_expansion_encodes_non_reserved) {
 
 // See RFC 6570 Section 3.2.1: undefined variables expand to empty string
 // https://www.rfc-editor.org/rfc/rfc6570#section-3.2.1
-TEST(URITemplate_expand, reserved_expansion_undefined) {
+TEST(reserved_expansion_undefined) {
   const sourcemeta::core::URITemplate uri_template{"{+undefined}"};
   const auto result =
       uri_template.expand([](const std::string_view) { return std::nullopt; });
@@ -359,7 +359,7 @@ TEST(URITemplate_expand, reserved_expansion_undefined) {
   EXPECT_EQ(result, "");
 }
 
-TEST(URITemplate_expand, fragment_expansion_simple) {
+TEST(fragment_expansion_simple) {
   const sourcemeta::core::URITemplate uri_template{"{#var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -374,7 +374,7 @@ TEST(URITemplate_expand, fragment_expansion_simple) {
   EXPECT_EQ(result, "#value");
 }
 
-TEST(URITemplate_expand, fragment_expansion_preserves_reserved) {
+TEST(fragment_expansion_preserves_reserved) {
   const sourcemeta::core::URITemplate uri_template{"{#path}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -389,7 +389,7 @@ TEST(URITemplate_expand, fragment_expansion_preserves_reserved) {
   EXPECT_EQ(result, "#/foo/bar");
 }
 
-TEST(URITemplate_expand, fragment_expansion_encodes_non_reserved) {
+TEST(fragment_expansion_encodes_non_reserved) {
   const sourcemeta::core::URITemplate uri_template{"{#var}"};
   const auto result = uri_template.expand(
       [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
@@ -406,7 +406,7 @@ TEST(URITemplate_expand, fragment_expansion_encodes_non_reserved) {
 
 // See RFC 6570 Section 3.2.1: undefined variables expand to empty string
 // https://www.rfc-editor.org/rfc/rfc6570#section-3.2.1
-TEST(URITemplate_expand, fragment_expansion_undefined) {
+TEST(fragment_expansion_undefined) {
   const sourcemeta::core::URITemplate uri_template{"{#undefined}"};
   const auto result =
       uri_template.expand([](const std::string_view) { return std::nullopt; });
@@ -414,7 +414,7 @@ TEST(URITemplate_expand, fragment_expansion_undefined) {
   EXPECT_EQ(result, "");
 }
 
-TEST(URITemplate_expand, rfc6570_level2_reserved) {
+TEST(rfc6570_level2_reserved) {
   const sourcemeta::core::URITemplate uri_template{"{+path}/here"};
   const std::map<std::string, std::string> variables{{"path", "/foo/bar"}};
   const auto result = uri_template.expand(variables);
@@ -422,7 +422,7 @@ TEST(URITemplate_expand, rfc6570_level2_reserved) {
   EXPECT_EQ(result, "/foo/bar/here");
 }
 
-TEST(URITemplate_expand, rfc6570_level2_fragment) {
+TEST(rfc6570_level2_fragment) {
   const sourcemeta::core::URITemplate uri_template{"X{#var}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -430,7 +430,7 @@ TEST(URITemplate_expand, rfc6570_level2_fragment) {
   EXPECT_EQ(result, "X#value");
 }
 
-TEST(URITemplate_expand, variable_list_two) {
+TEST(variable_list_two) {
   const sourcemeta::core::URITemplate uri_template{"{x,y}"};
   const std::map<std::string, std::string> variables{{"x", "1024"},
                                                      {"y", "768"}};
@@ -439,7 +439,7 @@ TEST(URITemplate_expand, variable_list_two) {
   EXPECT_EQ(result, "1024,768");
 }
 
-TEST(URITemplate_expand, variable_list_three) {
+TEST(variable_list_three) {
   const sourcemeta::core::URITemplate uri_template{"{x,hello,y}"};
   const std::map<std::string, std::string> variables{
       {"x", "1024"}, {"hello", "Hello World!"}, {"y", "768"}};
@@ -448,7 +448,7 @@ TEST(URITemplate_expand, variable_list_three) {
   EXPECT_EQ(result, "1024,Hello%20World%21,768");
 }
 
-TEST(URITemplate_expand, variable_list_with_literal) {
+TEST(variable_list_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"map?{x,y}"};
   const std::map<std::string, std::string> variables{{"x", "1024"},
                                                      {"y", "768"}};
@@ -457,7 +457,7 @@ TEST(URITemplate_expand, variable_list_with_literal) {
   EXPECT_EQ(result, "map?1024,768");
 }
 
-TEST(URITemplate_expand, variable_list_partial_undefined) {
+TEST(variable_list_partial_undefined) {
   const sourcemeta::core::URITemplate uri_template{"{x,undefined,y}"};
   const std::map<std::string, std::string> variables{{"x", "1024"},
                                                      {"y", "768"}};
@@ -466,7 +466,7 @@ TEST(URITemplate_expand, variable_list_partial_undefined) {
   EXPECT_EQ(result, "1024,768");
 }
 
-TEST(URITemplate_expand, variable_list_all_undefined) {
+TEST(variable_list_all_undefined) {
   const sourcemeta::core::URITemplate uri_template{"{a,b,c}"};
   const std::map<std::string, std::string> variables{};
   const auto result = uri_template.expand(variables);
@@ -474,7 +474,7 @@ TEST(URITemplate_expand, variable_list_all_undefined) {
   EXPECT_EQ(result, "");
 }
 
-TEST(URITemplate_expand, reserved_expansion_variable_list) {
+TEST(reserved_expansion_variable_list) {
   const sourcemeta::core::URITemplate uri_template{"{+x,hello,y}"};
   const std::map<std::string, std::string> variables{
       {"x", "1024"}, {"hello", "Hello World!"}, {"y", "768"}};
@@ -483,7 +483,7 @@ TEST(URITemplate_expand, reserved_expansion_variable_list) {
   EXPECT_EQ(result, "1024,Hello%20World!,768");
 }
 
-TEST(URITemplate_expand, reserved_expansion_variable_list_with_path) {
+TEST(reserved_expansion_variable_list_with_path) {
   const sourcemeta::core::URITemplate uri_template{"{+path,x}/here"};
   const std::map<std::string, std::string> variables{{"path", "/foo/bar"},
                                                      {"x", "1024"}};
@@ -492,7 +492,7 @@ TEST(URITemplate_expand, reserved_expansion_variable_list_with_path) {
   EXPECT_EQ(result, "/foo/bar,1024/here");
 }
 
-TEST(URITemplate_expand, fragment_expansion_variable_list) {
+TEST(fragment_expansion_variable_list) {
   const sourcemeta::core::URITemplate uri_template{"{#x,hello,y}"};
   const std::map<std::string, std::string> variables{
       {"x", "1024"}, {"hello", "Hello World!"}, {"y", "768"}};
@@ -501,7 +501,7 @@ TEST(URITemplate_expand, fragment_expansion_variable_list) {
   EXPECT_EQ(result, "#1024,Hello%20World!,768");
 }
 
-TEST(URITemplate_expand, fragment_expansion_variable_list_with_path) {
+TEST(fragment_expansion_variable_list_with_path) {
   const sourcemeta::core::URITemplate uri_template{"{#path,x}/here"};
   const std::map<std::string, std::string> variables{{"path", "/foo/bar"},
                                                      {"x", "1024"}};
@@ -510,7 +510,7 @@ TEST(URITemplate_expand, fragment_expansion_variable_list_with_path) {
   EXPECT_EQ(result, "#/foo/bar,1024/here");
 }
 
-TEST(URITemplate_expand, label_expansion_single) {
+TEST(label_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"X{.var}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -518,7 +518,7 @@ TEST(URITemplate_expand, label_expansion_single) {
   EXPECT_EQ(result, "X.value");
 }
 
-TEST(URITemplate_expand, label_expansion_multiple) {
+TEST(label_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"X{.x,y}"};
   const std::map<std::string, std::string> variables{{"x", "1024"},
                                                      {"y", "768"}};
@@ -527,7 +527,7 @@ TEST(URITemplate_expand, label_expansion_multiple) {
   EXPECT_EQ(result, "X.1024.768");
 }
 
-TEST(URITemplate_expand, path_expansion_single) {
+TEST(path_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"{/var}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -535,7 +535,7 @@ TEST(URITemplate_expand, path_expansion_single) {
   EXPECT_EQ(result, "/value");
 }
 
-TEST(URITemplate_expand, path_expansion_multiple) {
+TEST(path_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{/var,x}/here"};
   const std::map<std::string, std::string> variables{{"var", "value"},
                                                      {"x", "1024"}};
@@ -544,7 +544,7 @@ TEST(URITemplate_expand, path_expansion_multiple) {
   EXPECT_EQ(result, "/value/1024/here");
 }
 
-TEST(URITemplate_expand, path_parameter_expansion_multiple) {
+TEST(path_parameter_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{;x,y}"};
   const std::map<std::string, std::string> variables{{"x", "1024"},
                                                      {"y", "768"}};
@@ -553,7 +553,7 @@ TEST(URITemplate_expand, path_parameter_expansion_multiple) {
   EXPECT_EQ(result, ";x=1024;y=768");
 }
 
-TEST(URITemplate_expand, path_parameter_expansion_with_empty) {
+TEST(path_parameter_expansion_with_empty) {
   const sourcemeta::core::URITemplate uri_template{"{;x,y,empty}"};
   const std::map<std::string, std::string> variables{
       {"x", "1024"}, {"y", "768"}, {"empty", ""}};
@@ -562,7 +562,7 @@ TEST(URITemplate_expand, path_parameter_expansion_with_empty) {
   EXPECT_EQ(result, ";x=1024;y=768;empty");
 }
 
-TEST(URITemplate_expand, query_expansion_multiple) {
+TEST(query_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{?x,y}"};
   const std::map<std::string, std::string> variables{{"x", "1024"},
                                                      {"y", "768"}};
@@ -571,7 +571,7 @@ TEST(URITemplate_expand, query_expansion_multiple) {
   EXPECT_EQ(result, "?x=1024&y=768");
 }
 
-TEST(URITemplate_expand, query_expansion_with_empty) {
+TEST(query_expansion_with_empty) {
   const sourcemeta::core::URITemplate uri_template{"{?x,y,empty}"};
   const std::map<std::string, std::string> variables{
       {"x", "1024"}, {"y", "768"}, {"empty", ""}};
@@ -580,7 +580,7 @@ TEST(URITemplate_expand, query_expansion_with_empty) {
   EXPECT_EQ(result, "?x=1024&y=768&empty=");
 }
 
-TEST(URITemplate_expand, query_continuation_expansion) {
+TEST(query_continuation_expansion) {
   const sourcemeta::core::URITemplate uri_template{"?fixed=yes{&x}"};
   const std::map<std::string, std::string> variables{{"x", "1024"}};
   const auto result = uri_template.expand(variables);
@@ -588,7 +588,7 @@ TEST(URITemplate_expand, query_continuation_expansion) {
   EXPECT_EQ(result, "?fixed=yes&x=1024");
 }
 
-TEST(URITemplate_expand, query_continuation_expansion_multiple) {
+TEST(query_continuation_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{&x,y,empty}"};
   const std::map<std::string, std::string> variables{
       {"x", "1024"}, {"y", "768"}, {"empty", ""}};
@@ -597,7 +597,7 @@ TEST(URITemplate_expand, query_continuation_expansion_multiple) {
   EXPECT_EQ(result, "&x=1024&y=768&empty=");
 }
 
-TEST(URITemplate_expand, prefix_modifier_short) {
+TEST(prefix_modifier_short) {
   const sourcemeta::core::URITemplate uri_template{"{var:3}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -605,7 +605,7 @@ TEST(URITemplate_expand, prefix_modifier_short) {
   EXPECT_EQ(result, "val");
 }
 
-TEST(URITemplate_expand, prefix_modifier_exact) {
+TEST(prefix_modifier_exact) {
   const sourcemeta::core::URITemplate uri_template{"{var:5}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -613,7 +613,7 @@ TEST(URITemplate_expand, prefix_modifier_exact) {
   EXPECT_EQ(result, "value");
 }
 
-TEST(URITemplate_expand, prefix_modifier_longer_than_value) {
+TEST(prefix_modifier_longer_than_value) {
   const sourcemeta::core::URITemplate uri_template{"{var:30}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -621,7 +621,7 @@ TEST(URITemplate_expand, prefix_modifier_longer_than_value) {
   EXPECT_EQ(result, "value");
 }
 
-TEST(URITemplate_expand, reserved_with_prefix) {
+TEST(reserved_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{+path:6}/here"};
   const std::map<std::string, std::string> variables{{"path", "/foo/bar"}};
   const auto result = uri_template.expand(variables);
@@ -629,7 +629,7 @@ TEST(URITemplate_expand, reserved_with_prefix) {
   EXPECT_EQ(result, "/foo/b/here");
 }
 
-TEST(URITemplate_expand, fragment_with_prefix) {
+TEST(fragment_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{#path:6}/here"};
   const std::map<std::string, std::string> variables{{"path", "/foo/bar"}};
   const auto result = uri_template.expand(variables);
@@ -637,7 +637,7 @@ TEST(URITemplate_expand, fragment_with_prefix) {
   EXPECT_EQ(result, "#/foo/b/here");
 }
 
-TEST(URITemplate_expand, label_with_prefix) {
+TEST(label_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"X{.var:3}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -645,7 +645,7 @@ TEST(URITemplate_expand, label_with_prefix) {
   EXPECT_EQ(result, "X.val");
 }
 
-TEST(URITemplate_expand, path_with_prefix) {
+TEST(path_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{/var:1,var}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -653,7 +653,7 @@ TEST(URITemplate_expand, path_with_prefix) {
   EXPECT_EQ(result, "/v/value");
 }
 
-TEST(URITemplate_expand, path_param_with_prefix) {
+TEST(path_param_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{;hello:5}"};
   const std::map<std::string, std::string> variables{{"hello", "Hello World!"}};
   const auto result = uri_template.expand(variables);
@@ -661,7 +661,7 @@ TEST(URITemplate_expand, path_param_with_prefix) {
   EXPECT_EQ(result, ";hello=Hello");
 }
 
-TEST(URITemplate_expand, query_with_prefix) {
+TEST(query_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{?var:3}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -669,7 +669,7 @@ TEST(URITemplate_expand, query_with_prefix) {
   EXPECT_EQ(result, "?var=val");
 }
 
-TEST(URITemplate_expand, query_continuation_with_prefix) {
+TEST(query_continuation_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{&var:3}"};
   const std::map<std::string, std::string> variables{{"var", "value"}};
   const auto result = uri_template.expand(variables);
@@ -677,7 +677,7 @@ TEST(URITemplate_expand, query_continuation_with_prefix) {
   EXPECT_EQ(result, "&var=val");
 }
 
-TEST(URITemplate_expand, list_no_explode) {
+TEST(list_no_explode) {
   const sourcemeta::core::URITemplate uri_template{"{list}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(
@@ -701,7 +701,7 @@ TEST(URITemplate_expand, list_no_explode) {
   EXPECT_EQ(result, "red,green,blue");
 }
 
-TEST(URITemplate_expand, list_explode_path) {
+TEST(list_explode_path) {
   const sourcemeta::core::URITemplate uri_template{"{/list*}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(
@@ -725,7 +725,7 @@ TEST(URITemplate_expand, list_explode_path) {
   EXPECT_EQ(result, "/red/green/blue");
 }
 
-TEST(URITemplate_expand, list_explode_query) {
+TEST(list_explode_query) {
   const sourcemeta::core::URITemplate uri_template{"{?list*}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(
@@ -749,7 +749,7 @@ TEST(URITemplate_expand, list_explode_query) {
   EXPECT_EQ(result, "?list=red&list=green&list=blue");
 }
 
-TEST(URITemplate_expand, list_explode_label) {
+TEST(list_explode_label) {
   const sourcemeta::core::URITemplate uri_template{"{.list*}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(
@@ -773,7 +773,7 @@ TEST(URITemplate_expand, list_explode_label) {
   EXPECT_EQ(result, ".red.green.blue");
 }
 
-TEST(URITemplate_expand, object_no_explode) {
+TEST(object_no_explode) {
   const sourcemeta::core::URITemplate uri_template{"{keys}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(
@@ -795,7 +795,7 @@ TEST(URITemplate_expand, object_no_explode) {
   EXPECT_EQ(result, "one,1,two,2");
 }
 
-TEST(URITemplate_expand, object_explode_query) {
+TEST(object_explode_query) {
   const sourcemeta::core::URITemplate uri_template{"{?keys*}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(
@@ -817,7 +817,7 @@ TEST(URITemplate_expand, object_explode_query) {
   EXPECT_EQ(result, "?one=1&two=2");
 }
 
-TEST(URITemplate_expand, object_explode_path_param) {
+TEST(object_explode_path_param) {
   const sourcemeta::core::URITemplate uri_template{"{;keys*}"};
   std::size_t call_count = 0;
   const auto result = uri_template.expand(

--- a/test/uritemplate/uritemplate_expand_test.cc
+++ b/test/uritemplate/uritemplate_expand_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uritemplate.h>
 
 #include <map>           // std::map

--- a/test/uritemplate/uritemplate_parse_error_test.cc
+++ b/test/uritemplate/uritemplate_parse_error_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uritemplate.h>
 
@@ -13,174 +13,104 @@
   }                                                                            \
   EXPECT_FALSE(sourcemeta::core::URITemplate::is_uritemplate(input))
 
-TEST(URITemplate_parse_error, unclosed_brace) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var", 1);
-}
+TEST(unclosed_brace) { EXPECT_URITEMPLATE_PARSE_ERROR("{var", 1); }
 
-TEST(URITemplate_parse_error, unclosed_brace_at_end) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("foo{", 4);
-}
+TEST(unclosed_brace_at_end) { EXPECT_URITEMPLATE_PARSE_ERROR("foo{", 4); }
 
-TEST(URITemplate_parse_error, empty_variable) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{}", 2);
-}
+TEST(empty_variable) { EXPECT_URITEMPLATE_PARSE_ERROR("{}", 2); }
 
-TEST(URITemplate_parse_error, unmatched_close_brace) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("foo}bar", 4);
-}
+TEST(unmatched_close_brace) { EXPECT_URITEMPLATE_PARSE_ERROR("foo}bar", 4); }
 
-TEST(URITemplate_parse_error, invalid_varname_start) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{-var}", 2);
-}
+TEST(invalid_varname_start) { EXPECT_URITEMPLATE_PARSE_ERROR("{-var}", 2); }
 
-TEST(URITemplate_parse_error, invalid_character_in_varname) {
+TEST(invalid_character_in_varname) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{var!name}", 5);
 }
 
-TEST(URITemplate_parse_error, dot_at_end) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var.}", 6);
-}
+TEST(dot_at_end) { EXPECT_URITEMPLATE_PARSE_ERROR("{var.}", 6); }
 
-TEST(URITemplate_parse_error, consecutive_dots) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{foo..bar}", 6);
-}
+TEST(consecutive_dots) { EXPECT_URITEMPLATE_PARSE_ERROR("{foo..bar}", 6); }
 
-TEST(URITemplate_parse_error, incomplete_percent_encoding) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{%3}", 2);
-}
+TEST(incomplete_percent_encoding) { EXPECT_URITEMPLATE_PARSE_ERROR("{%3}", 2); }
 
-TEST(URITemplate_parse_error, invalid_percent_encoding) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{%GG}", 2);
-}
+TEST(invalid_percent_encoding) { EXPECT_URITEMPLATE_PARSE_ERROR("{%GG}", 2); }
 
-TEST(URITemplate_parse_error, reserved_expansion_empty) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{+}", 3);
-}
+TEST(reserved_expansion_empty) { EXPECT_URITEMPLATE_PARSE_ERROR("{+}", 3); }
 
-TEST(URITemplate_parse_error, reserved_expansion_unclosed) {
+TEST(reserved_expansion_unclosed) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{+var", 1);
 }
 
-TEST(URITemplate_parse_error, fragment_expansion_empty) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{#}", 3);
-}
+TEST(fragment_expansion_empty) { EXPECT_URITEMPLATE_PARSE_ERROR("{#}", 3); }
 
-TEST(URITemplate_parse_error, fragment_expansion_unclosed) {
+TEST(fragment_expansion_unclosed) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{#var", 1);
 }
 
-TEST(URITemplate_parse_error, variable_list_trailing_comma) {
+TEST(variable_list_trailing_comma) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{x,}", 4);
 }
 
-TEST(URITemplate_parse_error, variable_list_empty_between_commas) {
+TEST(variable_list_empty_between_commas) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{x,,y}", 4);
 }
 
-TEST(URITemplate_parse_error, prefix_zero) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var:0}", 6);
-}
+TEST(prefix_zero) { EXPECT_URITEMPLATE_PARSE_ERROR("{var:0}", 6); }
 
-TEST(URITemplate_parse_error, prefix_too_large) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var:10000}", 10);
-}
+TEST(prefix_too_large) { EXPECT_URITEMPLATE_PARSE_ERROR("{var:10000}", 10); }
 
-TEST(URITemplate_parse_error, prefix_no_digits) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var:}", 6);
-}
+TEST(prefix_no_digits) { EXPECT_URITEMPLATE_PARSE_ERROR("{var:}", 6); }
 
-TEST(URITemplate_parse_error, reserved_operator_equals) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{=var}", 2);
-}
+TEST(reserved_operator_equals) { EXPECT_URITEMPLATE_PARSE_ERROR("{=var}", 2); }
 
-TEST(URITemplate_parse_error, reserved_operator_pipe) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{|var}", 2);
-}
+TEST(reserved_operator_pipe) { EXPECT_URITEMPLATE_PARSE_ERROR("{|var}", 2); }
 
-TEST(URITemplate_parse_error, reserved_operator_exclamation) {
+TEST(reserved_operator_exclamation) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{!var}", 2);
 }
 
-TEST(URITemplate_parse_error, reserved_operator_at) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{@var}", 2);
-}
+TEST(reserved_operator_at) { EXPECT_URITEMPLATE_PARSE_ERROR("{@var}", 2); }
 
-TEST(URITemplate_parse_error, prefix_and_explode) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var:3*}", 7);
-}
+TEST(prefix_and_explode) { EXPECT_URITEMPLATE_PARSE_ERROR("{var:3*}", 7); }
 
-TEST(URITemplate_parse_error, explode_and_prefix) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var*:3}", 6);
-}
+TEST(explode_and_prefix) { EXPECT_URITEMPLATE_PARSE_ERROR("{var*:3}", 6); }
 
-TEST(URITemplate_parse_error, variable_list_leading_comma) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{,x}", 2);
-}
+TEST(variable_list_leading_comma) { EXPECT_URITEMPLATE_PARSE_ERROR("{,x}", 2); }
 
-TEST(URITemplate_parse_error, nested_open_brace) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{{var}", 2);
-}
+TEST(nested_open_brace) { EXPECT_URITEMPLATE_PARSE_ERROR("{{var}", 2); }
 
-TEST(URITemplate_parse_error, space_in_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var name}", 5);
-}
+TEST(space_in_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var name}", 5); }
 
-TEST(URITemplate_parse_error, space_before_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{ var}", 2);
-}
+TEST(space_before_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{ var}", 2); }
 
-TEST(URITemplate_parse_error, space_after_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var }", 5);
-}
+TEST(space_after_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var }", 5); }
 
-TEST(URITemplate_parse_error, percent_at_end_of_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var%}", 5);
-}
+TEST(percent_at_end_of_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var%}", 5); }
 
-TEST(URITemplate_parse_error, percent_one_hex_at_end) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var%3}", 5);
-}
+TEST(percent_one_hex_at_end) { EXPECT_URITEMPLATE_PARSE_ERROR("{var%3}", 5); }
 
-TEST(URITemplate_parse_error, double_explode) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var**}", 6);
-}
+TEST(double_explode) { EXPECT_URITEMPLATE_PARSE_ERROR("{var**}", 6); }
 
-TEST(URITemplate_parse_error, caret_in_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var^name}", 5);
-}
+TEST(caret_in_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var^name}", 5); }
 
-TEST(URITemplate_parse_error, backtick_in_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var`name}", 5);
-}
+TEST(backtick_in_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var`name}", 5); }
 
-TEST(URITemplate_parse_error, backslash_in_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var\\name}", 5);
-}
+TEST(backslash_in_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var\\name}", 5); }
 
-TEST(URITemplate_parse_error, bracket_in_varname) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{var[0]}", 5);
-}
+TEST(bracket_in_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{var[0]}", 5); }
 
-TEST(URITemplate_parse_error, dot_start_in_list) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{x,.y}", 4);
-}
+TEST(dot_start_in_list) { EXPECT_URITEMPLATE_PARSE_ERROR("{x,.y}", 4); }
 
-TEST(URITemplate_parse_error, label_expansion_empty) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{.}", 3);
-}
+TEST(label_expansion_empty) { EXPECT_URITEMPLATE_PARSE_ERROR("{.}", 3); }
 
-TEST(URITemplate_parse_error, path_expansion_empty) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{/}", 3);
-}
+TEST(path_expansion_empty) { EXPECT_URITEMPLATE_PARSE_ERROR("{/}", 3); }
 
-TEST(URITemplate_parse_error, path_parameter_expansion_empty) {
+TEST(path_parameter_expansion_empty) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{;}", 3);
 }
 
-TEST(URITemplate_parse_error, query_expansion_empty) {
-  EXPECT_URITEMPLATE_PARSE_ERROR("{?}", 3);
-}
+TEST(query_expansion_empty) { EXPECT_URITEMPLATE_PARSE_ERROR("{?}", 3); }
 
-TEST(URITemplate_parse_error, query_continuation_expansion_empty) {
+TEST(query_continuation_expansion_empty) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{&}", 3);
 }

--- a/test/uritemplate/uritemplate_parse_error_test.cc
+++ b/test/uritemplate/uritemplate_parse_error_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uritemplate.h>
 
 #define EXPECT_URITEMPLATE_PARSE_ERROR(input, expected_column)                 \

--- a/test/uritemplate/uritemplate_parse_test.cc
+++ b/test/uritemplate/uritemplate_parse_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uritemplate.h>
 
 #include "uritemplate_helpers.h"

--- a/test/uritemplate/uritemplate_parse_test.cc
+++ b/test/uritemplate/uritemplate_parse_test.cc
@@ -1,17 +1,17 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uritemplate.h>
 
 #include "uritemplate_helpers.h"
 
-TEST(URITemplate_parse, empty_string) {
+TEST(empty_string) {
   const sourcemeta::core::URITemplate uri_template{""};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(""));
   EXPECT_TRUE(uri_template.empty());
   EXPECT_EQ(uri_template.size(), 0);
 }
 
-TEST(URITemplate_parse, literal_only) {
+TEST(literal_only) {
   const sourcemeta::core::URITemplate uri_template{
       "http://example.com/path/to/resource"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
@@ -22,7 +22,7 @@ TEST(URITemplate_parse, literal_only) {
                              "http://example.com/path/to/resource");
 }
 
-TEST(URITemplate_parse, single_variable) {
+TEST(single_variable) {
   const sourcemeta::core::URITemplate uri_template{"{var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -31,7 +31,7 @@ TEST(URITemplate_parse, single_variable) {
                                "var", 0, false);
 }
 
-TEST(URITemplate_parse, variable_with_underscore) {
+TEST(variable_with_underscore) {
   const sourcemeta::core::URITemplate uri_template{"{my_var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{my_var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -39,7 +39,7 @@ TEST(URITemplate_parse, variable_with_underscore) {
                                "my_var", 0, false);
 }
 
-TEST(URITemplate_parse, variable_with_digits) {
+TEST(variable_with_digits) {
   const sourcemeta::core::URITemplate uri_template{"{var123}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{var123}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -47,7 +47,7 @@ TEST(URITemplate_parse, variable_with_digits) {
                                "var123", 0, false);
 }
 
-TEST(URITemplate_parse, variable_with_dot) {
+TEST(variable_with_dot) {
   const sourcemeta::core::URITemplate uri_template{"{foo.bar}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{foo.bar}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -55,7 +55,7 @@ TEST(URITemplate_parse, variable_with_dot) {
                                "foo.bar", 0, false);
 }
 
-TEST(URITemplate_parse, variable_with_multiple_dots) {
+TEST(variable_with_multiple_dots) {
   const sourcemeta::core::URITemplate uri_template{"{foo.bar.baz}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{foo.bar.baz}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -63,7 +63,7 @@ TEST(URITemplate_parse, variable_with_multiple_dots) {
                                "foo.bar.baz", 0, false);
 }
 
-TEST(URITemplate_parse, variable_with_percent_encoded) {
+TEST(variable_with_percent_encoded) {
   const sourcemeta::core::URITemplate uri_template{"{%3Bvar}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{%3Bvar}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -71,7 +71,7 @@ TEST(URITemplate_parse, variable_with_percent_encoded) {
                                "%3Bvar", 0, false);
 }
 
-TEST(URITemplate_parse, literal_then_variable) {
+TEST(literal_then_variable) {
   const sourcemeta::core::URITemplate uri_template{"http://example.com/{id}"};
   EXPECT_TRUE(
       sourcemeta::core::URITemplate::is_uritemplate("http://example.com/{id}"));
@@ -81,7 +81,7 @@ TEST(URITemplate_parse, literal_then_variable) {
                                "id", 0, false);
 }
 
-TEST(URITemplate_parse, variable_then_literal) {
+TEST(variable_then_literal) {
   const sourcemeta::core::URITemplate uri_template{"{id}/resource"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{id}/resource"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -90,7 +90,7 @@ TEST(URITemplate_parse, variable_then_literal) {
   EXPECT_URITEMPLATE_LITERAL(uri_template, 1, "/resource");
 }
 
-TEST(URITemplate_parse, literal_variable_literal) {
+TEST(literal_variable_literal) {
   const sourcemeta::core::URITemplate uri_template{
       "http://example.com/~{username}/"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
@@ -102,7 +102,7 @@ TEST(URITemplate_parse, literal_variable_literal) {
   EXPECT_URITEMPLATE_LITERAL(uri_template, 2, "/");
 }
 
-TEST(URITemplate_parse, multiple_variables) {
+TEST(multiple_variables) {
   const sourcemeta::core::URITemplate uri_template{
       "/users/{id}/posts/{postId}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
@@ -116,7 +116,7 @@ TEST(URITemplate_parse, multiple_variables) {
                                "postId", 0, false);
 }
 
-TEST(URITemplate_parse, adjacent_variables) {
+TEST(adjacent_variables) {
   const sourcemeta::core::URITemplate uri_template{"{x}{y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{x}{y}"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -126,7 +126,7 @@ TEST(URITemplate_parse, adjacent_variables) {
                                "y", 0, false);
 }
 
-TEST(URITemplate_parse, reserved_expansion) {
+TEST(reserved_expansion) {
   const sourcemeta::core::URITemplate uri_template{"{+var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{+var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -134,7 +134,7 @@ TEST(URITemplate_parse, reserved_expansion) {
       uri_template, 0, URITemplateTokenReservedExpansion, 0, "var", 0, false);
 }
 
-TEST(URITemplate_parse, reserved_expansion_with_dots) {
+TEST(reserved_expansion_with_dots) {
   const sourcemeta::core::URITemplate uri_template{"{+foo.bar}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{+foo.bar}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -143,7 +143,7 @@ TEST(URITemplate_parse, reserved_expansion_with_dots) {
                                0, false);
 }
 
-TEST(URITemplate_parse, reserved_expansion_with_literal) {
+TEST(reserved_expansion_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"http://example.com{+path}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
       "http://example.com{+path}"));
@@ -153,7 +153,7 @@ TEST(URITemplate_parse, reserved_expansion_with_literal) {
       uri_template, 1, URITemplateTokenReservedExpansion, 0, "path", 0, false);
 }
 
-TEST(URITemplate_parse, fragment_expansion) {
+TEST(fragment_expansion) {
   const sourcemeta::core::URITemplate uri_template{"{#var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{#var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -161,7 +161,7 @@ TEST(URITemplate_parse, fragment_expansion) {
       uri_template, 0, URITemplateTokenFragmentExpansion, 0, "var", 0, false);
 }
 
-TEST(URITemplate_parse, fragment_expansion_with_dots) {
+TEST(fragment_expansion_with_dots) {
   const sourcemeta::core::URITemplate uri_template{"{#foo.bar}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{#foo.bar}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -170,7 +170,7 @@ TEST(URITemplate_parse, fragment_expansion_with_dots) {
                                0, false);
 }
 
-TEST(URITemplate_parse, fragment_expansion_with_literal) {
+TEST(fragment_expansion_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"http://example.com{#frag}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
       "http://example.com{#frag}"));
@@ -180,7 +180,7 @@ TEST(URITemplate_parse, fragment_expansion_with_literal) {
       uri_template, 1, URITemplateTokenFragmentExpansion, 0, "frag", 0, false);
 }
 
-TEST(URITemplate_parse, mixed_level1_and_level2) {
+TEST(mixed_level1_and_level2) {
   const sourcemeta::core::URITemplate uri_template{
       "http://example.com{+path}{#frag}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
@@ -193,7 +193,7 @@ TEST(URITemplate_parse, mixed_level1_and_level2) {
       uri_template, 2, URITemplateTokenFragmentExpansion, 0, "frag", 0, false);
 }
 
-TEST(URITemplate_parse, variable_list_two) {
+TEST(variable_list_two) {
   const sourcemeta::core::URITemplate uri_template{"{x,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{x,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -203,7 +203,7 @@ TEST(URITemplate_parse, variable_list_two) {
                                "y", 0, false);
 }
 
-TEST(URITemplate_parse, variable_list_three) {
+TEST(variable_list_three) {
   const sourcemeta::core::URITemplate uri_template{"{x,hello,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{x,hello,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -215,7 +215,7 @@ TEST(URITemplate_parse, variable_list_three) {
                                "y", 0, false);
 }
 
-TEST(URITemplate_parse, variable_list_with_literal) {
+TEST(variable_list_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"map?{x,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("map?{x,y}"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -226,7 +226,7 @@ TEST(URITemplate_parse, variable_list_with_literal) {
                                "y", 0, false);
 }
 
-TEST(URITemplate_parse, reserved_expansion_variable_list) {
+TEST(reserved_expansion_variable_list) {
   const sourcemeta::core::URITemplate uri_template{"{+x,hello,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{+x,hello,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -238,7 +238,7 @@ TEST(URITemplate_parse, reserved_expansion_variable_list) {
       uri_template, 0, URITemplateTokenReservedExpansion, 2, "y", 0, false);
 }
 
-TEST(URITemplate_parse, reserved_expansion_variable_list_with_literal) {
+TEST(reserved_expansion_variable_list_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"{+path,x}/here"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{+path,x}/here"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -249,7 +249,7 @@ TEST(URITemplate_parse, reserved_expansion_variable_list_with_literal) {
   EXPECT_URITEMPLATE_LITERAL(uri_template, 1, "/here");
 }
 
-TEST(URITemplate_parse, fragment_expansion_variable_list) {
+TEST(fragment_expansion_variable_list) {
   const sourcemeta::core::URITemplate uri_template{"{#x,hello,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{#x,hello,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -261,7 +261,7 @@ TEST(URITemplate_parse, fragment_expansion_variable_list) {
       uri_template, 0, URITemplateTokenFragmentExpansion, 2, "y", 0, false);
 }
 
-TEST(URITemplate_parse, fragment_expansion_variable_list_with_literal) {
+TEST(fragment_expansion_variable_list_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"{#path,x}/here"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{#path,x}/here"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -272,7 +272,7 @@ TEST(URITemplate_parse, fragment_expansion_variable_list_with_literal) {
   EXPECT_URITEMPLATE_LITERAL(uri_template, 1, "/here");
 }
 
-TEST(URITemplate_parse, label_expansion_single) {
+TEST(label_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"{.var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{.var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -280,7 +280,7 @@ TEST(URITemplate_parse, label_expansion_single) {
                                0, "var", 0, false);
 }
 
-TEST(URITemplate_parse, label_expansion_multiple) {
+TEST(label_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{.x,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{.x,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -290,7 +290,7 @@ TEST(URITemplate_parse, label_expansion_multiple) {
                                1, "y", 0, false);
 }
 
-TEST(URITemplate_parse, label_expansion_with_literal) {
+TEST(label_expansion_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"X{.var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("X{.var}"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -299,7 +299,7 @@ TEST(URITemplate_parse, label_expansion_with_literal) {
                                0, "var", 0, false);
 }
 
-TEST(URITemplate_parse, path_expansion_single) {
+TEST(path_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"{/var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{/var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -307,7 +307,7 @@ TEST(URITemplate_parse, path_expansion_single) {
                                0, "var", 0, false);
 }
 
-TEST(URITemplate_parse, path_expansion_multiple) {
+TEST(path_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{/var,x}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{/var,x}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -317,7 +317,7 @@ TEST(URITemplate_parse, path_expansion_multiple) {
                                1, "x", 0, false);
 }
 
-TEST(URITemplate_parse, path_expansion_with_literal) {
+TEST(path_expansion_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"{/var,x}/here"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{/var,x}/here"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -328,7 +328,7 @@ TEST(URITemplate_parse, path_expansion_with_literal) {
   EXPECT_URITEMPLATE_LITERAL(uri_template, 1, "/here");
 }
 
-TEST(URITemplate_parse, path_parameter_expansion_single) {
+TEST(path_parameter_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"{;x}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{;x}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -337,7 +337,7 @@ TEST(URITemplate_parse, path_parameter_expansion_single) {
                                0, false);
 }
 
-TEST(URITemplate_parse, path_parameter_expansion_multiple) {
+TEST(path_parameter_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{;x,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{;x,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -349,7 +349,7 @@ TEST(URITemplate_parse, path_parameter_expansion_multiple) {
                                0, false);
 }
 
-TEST(URITemplate_parse, path_parameter_expansion_three) {
+TEST(path_parameter_expansion_three) {
   const sourcemeta::core::URITemplate uri_template{"{;x,y,empty}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{;x,y,empty}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -364,7 +364,7 @@ TEST(URITemplate_parse, path_parameter_expansion_three) {
                                "empty", 0, false);
 }
 
-TEST(URITemplate_parse, query_expansion_single) {
+TEST(query_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"{?x}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{?x}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -372,7 +372,7 @@ TEST(URITemplate_parse, query_expansion_single) {
                                0, "x", 0, false);
 }
 
-TEST(URITemplate_parse, query_expansion_multiple) {
+TEST(query_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{?x,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{?x,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -382,7 +382,7 @@ TEST(URITemplate_parse, query_expansion_multiple) {
                                1, "y", 0, false);
 }
 
-TEST(URITemplate_parse, query_expansion_three) {
+TEST(query_expansion_three) {
   const sourcemeta::core::URITemplate uri_template{"{?x,y,empty}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{?x,y,empty}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -394,7 +394,7 @@ TEST(URITemplate_parse, query_expansion_three) {
                                2, "empty", 0, false);
 }
 
-TEST(URITemplate_parse, query_continuation_expansion_single) {
+TEST(query_continuation_expansion_single) {
   const sourcemeta::core::URITemplate uri_template{"{&x}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{&x}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -403,7 +403,7 @@ TEST(URITemplate_parse, query_continuation_expansion_single) {
                                "x", 0, false);
 }
 
-TEST(URITemplate_parse, query_continuation_expansion_multiple) {
+TEST(query_continuation_expansion_multiple) {
   const sourcemeta::core::URITemplate uri_template{"{&x,y,empty}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{&x,y,empty}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -418,7 +418,7 @@ TEST(URITemplate_parse, query_continuation_expansion_multiple) {
                                "empty", 0, false);
 }
 
-TEST(URITemplate_parse, query_continuation_with_literal) {
+TEST(query_continuation_with_literal) {
   const sourcemeta::core::URITemplate uri_template{"?fixed=yes{&x}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("?fixed=yes{&x}"));
   EXPECT_EQ(uri_template.size(), 2);
@@ -428,7 +428,7 @@ TEST(URITemplate_parse, query_continuation_with_literal) {
                                "x", 0, false);
 }
 
-TEST(URITemplate_parse, prefix_modifier) {
+TEST(prefix_modifier) {
   const sourcemeta::core::URITemplate uri_template{"{var:3}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{var:3}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -436,7 +436,7 @@ TEST(URITemplate_parse, prefix_modifier) {
                                "var", 3, false);
 }
 
-TEST(URITemplate_parse, prefix_modifier_max) {
+TEST(prefix_modifier_max) {
   const sourcemeta::core::URITemplate uri_template{"{var:9999}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{var:9999}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -444,7 +444,7 @@ TEST(URITemplate_parse, prefix_modifier_max) {
                                "var", 9999, false);
 }
 
-TEST(URITemplate_parse, explode_modifier) {
+TEST(explode_modifier) {
   const sourcemeta::core::URITemplate uri_template{"{list*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{list*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -452,7 +452,7 @@ TEST(URITemplate_parse, explode_modifier) {
                                "list", 0, true);
 }
 
-TEST(URITemplate_parse, reserved_with_prefix) {
+TEST(reserved_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{+path:6}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{+path:6}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -460,7 +460,7 @@ TEST(URITemplate_parse, reserved_with_prefix) {
       uri_template, 0, URITemplateTokenReservedExpansion, 0, "path", 6, false);
 }
 
-TEST(URITemplate_parse, fragment_with_prefix) {
+TEST(fragment_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{#path:6}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{#path:6}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -468,7 +468,7 @@ TEST(URITemplate_parse, fragment_with_prefix) {
       uri_template, 0, URITemplateTokenFragmentExpansion, 0, "path", 6, false);
 }
 
-TEST(URITemplate_parse, label_with_prefix) {
+TEST(label_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{.var:3}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{.var:3}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -476,7 +476,7 @@ TEST(URITemplate_parse, label_with_prefix) {
                                0, "var", 3, false);
 }
 
-TEST(URITemplate_parse, path_with_explode) {
+TEST(path_with_explode) {
   const sourcemeta::core::URITemplate uri_template{"{/list*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{/list*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -484,7 +484,7 @@ TEST(URITemplate_parse, path_with_explode) {
                                0, "list", 0, true);
 }
 
-TEST(URITemplate_parse, query_with_prefix) {
+TEST(query_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{?var:3}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{?var:3}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -492,7 +492,7 @@ TEST(URITemplate_parse, query_with_prefix) {
                                0, "var", 3, false);
 }
 
-TEST(URITemplate_parse, mixed_modifiers_in_list) {
+TEST(mixed_modifiers_in_list) {
   const sourcemeta::core::URITemplate uri_template{"{/var:1,var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{/var:1,var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -502,7 +502,7 @@ TEST(URITemplate_parse, mixed_modifiers_in_list) {
                                1, "var", 0, false);
 }
 
-TEST(URITemplate_parse, variable_single_char) {
+TEST(variable_single_char) {
   const sourcemeta::core::URITemplate uri_template{"{x}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{x}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -510,7 +510,7 @@ TEST(URITemplate_parse, variable_single_char) {
                                "x", 0, false);
 }
 
-TEST(URITemplate_parse, variable_starting_with_digit) {
+TEST(variable_starting_with_digit) {
   const sourcemeta::core::URITemplate uri_template{"{1var}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{1var}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -518,7 +518,7 @@ TEST(URITemplate_parse, variable_starting_with_digit) {
                                "1var", 0, false);
 }
 
-TEST(URITemplate_parse, variable_only_digit) {
+TEST(variable_only_digit) {
   const sourcemeta::core::URITemplate uri_template{"{1}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{1}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -526,7 +526,7 @@ TEST(URITemplate_parse, variable_only_digit) {
                                "1", 0, false);
 }
 
-TEST(URITemplate_parse, variable_only_underscore) {
+TEST(variable_only_underscore) {
   const sourcemeta::core::URITemplate uri_template{"{_}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{_}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -534,7 +534,7 @@ TEST(URITemplate_parse, variable_only_underscore) {
                                "_", 0, false);
 }
 
-TEST(URITemplate_parse, variable_starting_with_underscore) {
+TEST(variable_starting_with_underscore) {
   const sourcemeta::core::URITemplate uri_template{"{_private}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{_private}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -542,7 +542,7 @@ TEST(URITemplate_parse, variable_starting_with_underscore) {
                                "_private", 0, false);
 }
 
-TEST(URITemplate_parse, variable_percent_encoded_start) {
+TEST(variable_percent_encoded_start) {
   const sourcemeta::core::URITemplate uri_template{"{%41bc}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{%41bc}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -550,7 +550,7 @@ TEST(URITemplate_parse, variable_percent_encoded_start) {
                                "%41bc", 0, false);
 }
 
-TEST(URITemplate_parse, variable_multiple_percent_encoded) {
+TEST(variable_multiple_percent_encoded) {
   const sourcemeta::core::URITemplate uri_template{"{%41%42%43}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{%41%42%43}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -558,7 +558,7 @@ TEST(URITemplate_parse, variable_multiple_percent_encoded) {
                                "%41%42%43", 0, false);
 }
 
-TEST(URITemplate_parse, variable_with_dot_and_digits) {
+TEST(variable_with_dot_and_digits) {
   const sourcemeta::core::URITemplate uri_template{"{a.1.b.2}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{a.1.b.2}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -566,7 +566,7 @@ TEST(URITemplate_parse, variable_with_dot_and_digits) {
                                "a.1.b.2", 0, false);
 }
 
-TEST(URITemplate_parse, prefix_single_digit) {
+TEST(prefix_single_digit) {
   const sourcemeta::core::URITemplate uri_template{"{var:1}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{var:1}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -574,7 +574,7 @@ TEST(URITemplate_parse, prefix_single_digit) {
                                "var", 1, false);
 }
 
-TEST(URITemplate_parse, prefix_four_digits) {
+TEST(prefix_four_digits) {
   const sourcemeta::core::URITemplate uri_template{"{var:1234}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{var:1234}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -582,7 +582,7 @@ TEST(URITemplate_parse, prefix_four_digits) {
                                "var", 1234, false);
 }
 
-TEST(URITemplate_parse, explode_with_reserved_expansion) {
+TEST(explode_with_reserved_expansion) {
   const sourcemeta::core::URITemplate uri_template{"{+list*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{+list*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -590,7 +590,7 @@ TEST(URITemplate_parse, explode_with_reserved_expansion) {
       uri_template, 0, URITemplateTokenReservedExpansion, 0, "list", 0, true);
 }
 
-TEST(URITemplate_parse, explode_with_fragment_expansion) {
+TEST(explode_with_fragment_expansion) {
   const sourcemeta::core::URITemplate uri_template{"{#keys*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{#keys*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -598,7 +598,7 @@ TEST(URITemplate_parse, explode_with_fragment_expansion) {
       uri_template, 0, URITemplateTokenFragmentExpansion, 0, "keys", 0, true);
 }
 
-TEST(URITemplate_parse, explode_with_label_expansion) {
+TEST(explode_with_label_expansion) {
   const sourcemeta::core::URITemplate uri_template{"{.list*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{.list*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -606,7 +606,7 @@ TEST(URITemplate_parse, explode_with_label_expansion) {
                                0, "list", 0, true);
 }
 
-TEST(URITemplate_parse, explode_with_path_parameter) {
+TEST(explode_with_path_parameter) {
   const sourcemeta::core::URITemplate uri_template{"{;keys*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{;keys*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -615,7 +615,7 @@ TEST(URITemplate_parse, explode_with_path_parameter) {
                                "keys", 0, true);
 }
 
-TEST(URITemplate_parse, explode_with_query_expansion) {
+TEST(explode_with_query_expansion) {
   const sourcemeta::core::URITemplate uri_template{"{?list*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{?list*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -623,7 +623,7 @@ TEST(URITemplate_parse, explode_with_query_expansion) {
                                0, "list", 0, true);
 }
 
-TEST(URITemplate_parse, explode_with_query_continuation) {
+TEST(explode_with_query_continuation) {
   const sourcemeta::core::URITemplate uri_template{"{&keys*}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{&keys*}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -632,7 +632,7 @@ TEST(URITemplate_parse, explode_with_query_continuation) {
                                "keys", 0, true);
 }
 
-TEST(URITemplate_parse, multiple_variables_with_explode) {
+TEST(multiple_variables_with_explode) {
   const sourcemeta::core::URITemplate uri_template{"{?x,list*,y}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{?x,list*,y}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -644,7 +644,7 @@ TEST(URITemplate_parse, multiple_variables_with_explode) {
                                2, "y", 0, false);
 }
 
-TEST(URITemplate_parse, multiple_variables_with_prefix) {
+TEST(multiple_variables_with_prefix) {
   const sourcemeta::core::URITemplate uri_template{"{x:3,y:5,z}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{x:3,y:5,z}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -656,7 +656,7 @@ TEST(URITemplate_parse, multiple_variables_with_prefix) {
                                "z", 0, false);
 }
 
-TEST(URITemplate_parse, long_variable_name) {
+TEST(long_variable_name) {
   const sourcemeta::core::URITemplate uri_template{
       "{abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate(
@@ -668,7 +668,7 @@ TEST(URITemplate_parse, long_variable_name) {
       false);
 }
 
-TEST(URITemplate_parse, variable_list_many) {
+TEST(variable_list_many) {
   const sourcemeta::core::URITemplate uri_template{"{a,b,c,d,e,f,g,h,i,j}"};
   EXPECT_TRUE(
       sourcemeta::core::URITemplate::is_uritemplate("{a,b,c,d,e,f,g,h,i,j}"));
@@ -695,7 +695,7 @@ TEST(URITemplate_parse, variable_list_many) {
                                "j", 0, false);
 }
 
-TEST(URITemplate_parse, lowercase_percent_encoding) {
+TEST(lowercase_percent_encoding) {
   const sourcemeta::core::URITemplate uri_template{"{%3avar}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{%3avar}"));
   EXPECT_EQ(uri_template.size(), 1);
@@ -703,7 +703,7 @@ TEST(URITemplate_parse, lowercase_percent_encoding) {
                                "%3avar", 0, false);
 }
 
-TEST(URITemplate_parse, mixed_case_percent_encoding) {
+TEST(mixed_case_percent_encoding) {
   const sourcemeta::core::URITemplate uri_template{"{%3Avar}"};
   EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{%3Avar}"));
   EXPECT_EQ(uri_template.size(), 1);

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uritemplate.h>
 
@@ -25,7 +25,7 @@
     FAIL();                                                                    \
   }
 
-TEST(URITemplateRouter, single_literal_route) {
+TEST(single_literal_route) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_2", 1);
@@ -33,7 +33,7 @@ TEST(URITemplateRouter, single_literal_route) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, single_literal_route_no_match) {
+TEST(single_literal_route_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_3", 1);
@@ -41,7 +41,7 @@ TEST(URITemplateRouter, single_literal_route_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, multi_segment_literal) {
+TEST(multi_segment_literal) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/list", "op_4", 1);
@@ -49,7 +49,7 @@ TEST(URITemplateRouter, multi_segment_literal) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, single_variable) {
+TEST(single_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{id}", "op_5", 1);
@@ -58,7 +58,7 @@ TEST(URITemplateRouter, single_variable) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
 }
 
-TEST(URITemplateRouter, multiple_variables) {
+TEST(multiple_variables) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{id}/posts/{post_id}", "op_6", 1);
@@ -68,7 +68,7 @@ TEST(URITemplateRouter, multiple_variables) {
   EXPECT_ROUTER_CAPTURE(captures, 1, "post_id", "99");
 }
 
-TEST(URITemplateRouter, literal_before_variable_precedence) {
+TEST(literal_before_variable_precedence) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/me", "op_7", 1);
@@ -77,7 +77,7 @@ TEST(URITemplateRouter, literal_before_variable_precedence) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, variable_fallback) {
+TEST(variable_fallback) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/me", "op_9", 1);
@@ -87,7 +87,7 @@ TEST(URITemplateRouter, variable_fallback) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
 }
 
-TEST(URITemplateRouter, multiple_routes_match_users) {
+TEST(multiple_routes_match_users) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_11", 1);
@@ -98,7 +98,7 @@ TEST(URITemplateRouter, multiple_routes_match_users) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, multiple_routes_match_users_id) {
+TEST(multiple_routes_match_users_id) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_15", 1);
@@ -110,7 +110,7 @@ TEST(URITemplateRouter, multiple_routes_match_users_id) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, multiple_routes_match_posts) {
+TEST(multiple_routes_match_posts) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_19", 1);
@@ -121,7 +121,7 @@ TEST(URITemplateRouter, multiple_routes_match_posts) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, multiple_routes_match_posts_id) {
+TEST(multiple_routes_match_posts_id) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_23", 1);
@@ -133,28 +133,28 @@ TEST(URITemplateRouter, multiple_routes_match_posts_id) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "99");
 }
 
-TEST(URITemplateRouter, no_match_partial_path) {
+TEST(no_match_partial_path) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{id}/posts", "op_27", 1);
   EXPECT_ROUTER_MATCH(router, "/users/123", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, no_match_extra_segments) {
+TEST(no_match_extra_segments) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_28", 1);
   EXPECT_ROUTER_MATCH(router, "/users/123", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, empty_path) {
+TEST(empty_path) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_29", 1);
   EXPECT_ROUTER_MATCH(router, "", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, root_template_matches_root) {
+TEST(root_template_matches_root) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/", "op_30", 1);
@@ -162,7 +162,7 @@ TEST(URITemplateRouter, root_template_matches_root) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, root_template_no_match_empty) {
+TEST(root_template_no_match_empty) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/", "op_31", 1);
@@ -170,7 +170,7 @@ TEST(URITemplateRouter, root_template_no_match_empty) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, root_template_no_match_path) {
+TEST(root_template_no_match_path) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/", "op_32", 1);
@@ -178,7 +178,7 @@ TEST(URITemplateRouter, root_template_no_match_path) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_template_matches_empty) {
+TEST(empty_template_matches_empty) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_33", 1);
@@ -186,7 +186,7 @@ TEST(URITemplateRouter, empty_template_matches_empty) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_template_no_match_root) {
+TEST(empty_template_no_match_root) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_34", 1);
@@ -194,7 +194,7 @@ TEST(URITemplateRouter, empty_template_no_match_root) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_template_no_match_path) {
+TEST(empty_template_no_match_path) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_35", 1);
@@ -202,7 +202,7 @@ TEST(URITemplateRouter, empty_template_no_match_path) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, root_and_other_routes_match_root) {
+TEST(root_and_other_routes_match_root) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/", "op_36", 1);
@@ -212,7 +212,7 @@ TEST(URITemplateRouter, root_and_other_routes_match_root) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, root_and_other_routes_match_users) {
+TEST(root_and_other_routes_match_users) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/", "op_39", 1);
@@ -222,7 +222,7 @@ TEST(URITemplateRouter, root_and_other_routes_match_users) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, root_and_other_routes_match_users_id) {
+TEST(root_and_other_routes_match_users_id) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/", "op_42", 1);
@@ -233,7 +233,7 @@ TEST(URITemplateRouter, root_and_other_routes_match_users_id) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
 }
 
-TEST(URITemplateRouter, empty_and_root_together_match_empty) {
+TEST(empty_and_root_together_match_empty) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_45", 1);
@@ -242,7 +242,7 @@ TEST(URITemplateRouter, empty_and_root_together_match_empty) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_and_root_together_match_root) {
+TEST(empty_and_root_together_match_root) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_47", 1);
@@ -251,7 +251,7 @@ TEST(URITemplateRouter, empty_and_root_together_match_root) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_and_root_together_no_match_path) {
+TEST(empty_and_root_together_no_match_path) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_49", 1);
@@ -260,7 +260,7 @@ TEST(URITemplateRouter, empty_and_root_together_no_match_path) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_and_root_and_others_match_empty) {
+TEST(empty_and_root_and_others_match_empty) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_51", 1);
@@ -271,7 +271,7 @@ TEST(URITemplateRouter, empty_and_root_and_others_match_empty) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_and_root_and_others_match_root) {
+TEST(empty_and_root_and_others_match_root) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_55", 1);
@@ -282,7 +282,7 @@ TEST(URITemplateRouter, empty_and_root_and_others_match_root) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_and_root_and_others_match_users) {
+TEST(empty_and_root_and_others_match_users) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_59", 1);
@@ -293,7 +293,7 @@ TEST(URITemplateRouter, empty_and_root_and_others_match_users) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, empty_and_root_and_others_match_users_id) {
+TEST(empty_and_root_and_others_match_users_id) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("", "op_63", 1);
@@ -305,7 +305,7 @@ TEST(URITemplateRouter, empty_and_root_and_others_match_users_id) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, binary_search_literals_gamma) {
+TEST(binary_search_literals_gamma) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/alpha", "op_67", 1);
@@ -317,7 +317,7 @@ TEST(URITemplateRouter, binary_search_literals_gamma) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, binary_search_literals_alpha) {
+TEST(binary_search_literals_alpha) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/alpha", "op_72", 1);
@@ -329,7 +329,7 @@ TEST(URITemplateRouter, binary_search_literals_alpha) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, binary_search_literals_epsilon) {
+TEST(binary_search_literals_epsilon) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/alpha", "op_77", 1);
@@ -341,7 +341,7 @@ TEST(URITemplateRouter, binary_search_literals_epsilon) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, conflicting_variable_names_throws) {
+TEST(conflicting_variable_names_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{user_id}/posts", "op_82", 1);
@@ -355,7 +355,7 @@ TEST(URITemplateRouter, conflicting_variable_names_throws) {
   }
 }
 
-TEST(URITemplateRouter, same_variable_names_allowed) {
+TEST(same_variable_names_allowed) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{id}/posts", "op_84", 1);
@@ -365,7 +365,7 @@ TEST(URITemplateRouter, same_variable_names_allowed) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
 }
 
-TEST(URITemplateRouter, conflicting_expansion_variable_names_throws) {
+TEST(conflicting_expansion_variable_names_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{id}", "op_86", 1);
@@ -379,7 +379,7 @@ TEST(URITemplateRouter, conflicting_expansion_variable_names_throws) {
   }
 }
 
-TEST(URITemplateRouter, reserved_expansion_catch_all) {
+TEST(reserved_expansion_catch_all) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_88", 1);
@@ -388,7 +388,7 @@ TEST(URITemplateRouter, reserved_expansion_catch_all) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/baz.txt");
 }
 
-TEST(URITemplateRouter, reserved_expansion_single_segment) {
+TEST(reserved_expansion_single_segment) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_89", 1);
@@ -397,7 +397,7 @@ TEST(URITemplateRouter, reserved_expansion_single_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "readme.md");
 }
 
-TEST(URITemplateRouter, reserved_expansion_with_literal_prefix) {
+TEST(reserved_expansion_with_literal_prefix) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/api/v1/proxy/{+url}", "op_90", 1);
@@ -407,7 +407,7 @@ TEST(URITemplateRouter, reserved_expansion_with_literal_prefix) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "url", "https://example.com/path");
 }
 
-TEST(URITemplateRouter, reserved_expansion_matches_single_segment) {
+TEST(reserved_expansion_matches_single_segment) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_91", 1);
@@ -416,7 +416,7 @@ TEST(URITemplateRouter, reserved_expansion_matches_single_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "123");
 }
 
-TEST(URITemplateRouter, reserved_expansion_matches_multi_segment) {
+TEST(reserved_expansion_matches_multi_segment) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_92", 1);
@@ -425,7 +425,7 @@ TEST(URITemplateRouter, reserved_expansion_matches_multi_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, expansion_takes_priority_over_variable) {
+TEST(expansion_takes_priority_over_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{path}", "op_93", 1);
@@ -435,7 +435,7 @@ TEST(URITemplateRouter, expansion_takes_priority_over_variable) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "readme.md");
 }
 
-TEST(URITemplateRouter, expansion_takes_priority_multi_segment) {
+TEST(expansion_takes_priority_multi_segment) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{path}", "op_95", 1);
@@ -445,7 +445,7 @@ TEST(URITemplateRouter, expansion_takes_priority_multi_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/baz");
 }
 
-TEST(URITemplateRouter, expansion_first_then_variable) {
+TEST(expansion_first_then_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_97", 1);
@@ -455,7 +455,7 @@ TEST(URITemplateRouter, expansion_first_then_variable) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "readme.md");
 }
 
-TEST(URITemplateRouter, literal_takes_priority_over_expansion) {
+TEST(literal_takes_priority_over_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_99", 1);
@@ -464,7 +464,7 @@ TEST(URITemplateRouter, literal_takes_priority_over_expansion) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, expansion_fallback_from_literal) {
+TEST(expansion_fallback_from_literal) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_101", 1);
@@ -474,230 +474,230 @@ TEST(URITemplateRouter, expansion_fallback_from_literal) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "other");
 }
 
-TEST(URITemplateRouter, literal_suffix_after_variable_throws) {
+TEST(literal_suffix_after_variable_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar}.json", 1, "{bar}.json");
 }
 
-TEST(URITemplateRouter, literal_prefix_before_variable_throws) {
+TEST(literal_prefix_before_variable_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/prefix{bar}", 1, "prefix{bar}");
 }
 
-TEST(URITemplateRouter, mixed_segment_variable_then_literal_suffix) {
+TEST(mixed_segment_variable_then_literal_suffix) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/{id}.html", 1, "{id}.html");
 }
 
-TEST(URITemplateRouter, mixed_segment_expansion_then_literal_suffix) {
+TEST(mixed_segment_expansion_then_literal_suffix) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/files/{+path}.bak", 1, "{+path}.bak");
 }
 
-TEST(URITemplateRouter, mixed_segment_prefix_before_expansion_throws) {
+TEST(mixed_segment_prefix_before_expansion_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/v1{+rest}", 1, "v1{+rest}");
 }
 
-TEST(URITemplateRouter, mixed_segment_suffix_in_middle) {
+TEST(mixed_segment_suffix_in_middle) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar}.json/baz", 1, "{bar}.json");
 }
 
-TEST(URITemplateRouter, mixed_segment_prefix_in_middle) {
+TEST(mixed_segment_prefix_in_middle) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/prefix{bar}/baz", 1, "prefix{bar}");
 }
 
-TEST(URITemplateRouter, mixed_segment_expansion_suffix_in_middle) {
+TEST(mixed_segment_expansion_suffix_in_middle) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/files/{+path}.txt/meta", 1,
                               "{+path}.txt");
 }
 
-TEST(URITemplateRouter, mixed_segment_expansion_prefix_in_middle) {
+TEST(mixed_segment_expansion_prefix_in_middle) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/v2{+path}/end", 1, "v2{+path}");
 }
 
-TEST(URITemplateRouter, error_unclosed_brace) {
+TEST(error_unclosed_brace) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar", 1, "{bar");
 }
 
-TEST(URITemplateRouter, error_unclosed_brace_at_end) {
+TEST(error_unclosed_brace_at_end) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/bar{", 1, "bar{");
 }
 
-TEST(URITemplateRouter, error_empty_variable) {
+TEST(error_empty_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{}", 1, "{}");
 }
 
-TEST(URITemplateRouter, error_empty_expansion) {
+TEST(error_empty_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{+}", 1, "{+}");
 }
 
-TEST(URITemplateRouter, error_nested_brace) {
+TEST(error_nested_brace) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{{bar}}", 1, "{{bar}}");
 }
 
-TEST(URITemplateRouter, error_unmatched_close_brace) {
+TEST(error_unmatched_close_brace) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/bar}", 1, "bar}");
 }
 
-TEST(URITemplateRouter, error_space_before_variable) {
+TEST(error_space_before_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{ bar}", 1, "{ bar}");
 }
 
-TEST(URITemplateRouter, error_space_after_variable) {
+TEST(error_space_after_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar }", 1, "{bar }");
 }
 
-TEST(URITemplateRouter, error_space_in_variable) {
+TEST(error_space_in_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar baz}", 1, "{bar baz}");
 }
 
-TEST(URITemplateRouter, error_invalid_variable_start) {
+TEST(error_invalid_variable_start) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{-bar}", 1, "{-bar}");
 }
 
-TEST(URITemplateRouter, error_invalid_character_in_variable) {
+TEST(error_invalid_character_in_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar!baz}", 1, "{bar!baz}");
 }
 
-TEST(URITemplateRouter, error_reserved_operator_equals) {
+TEST(error_reserved_operator_equals) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{=bar}", 1, "{=bar}");
 }
 
-TEST(URITemplateRouter, error_reserved_operator_pipe) {
+TEST(error_reserved_operator_pipe) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{|bar}", 1, "{|bar}");
 }
 
-TEST(URITemplateRouter, error_reserved_operator_exclamation) {
+TEST(error_reserved_operator_exclamation) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{!bar}", 1, "{!bar}");
 }
 
-TEST(URITemplateRouter, error_reserved_operator_at) {
+TEST(error_reserved_operator_at) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{@bar}", 1, "{@bar}");
 }
 
-TEST(URITemplateRouter, error_bracket_in_variable) {
+TEST(error_bracket_in_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar[0]}", 1, "{bar[0]}");
 }
 
-TEST(URITemplateRouter, error_multiple_variables) {
+TEST(error_multiple_variables) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar,baz}", 1, "{bar,baz}");
 }
 
-TEST(URITemplateRouter, error_prefix_modifier) {
+TEST(error_prefix_modifier) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar:3}", 1, "{bar:3}");
 }
 
-TEST(URITemplateRouter, error_explode_modifier) {
+TEST(error_explode_modifier) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{bar*}", 1, "{bar*}");
 }
 
-TEST(URITemplateRouter, error_unsupported_fragment_expansion) {
+TEST(error_unsupported_fragment_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{#bar}", 1, "{#bar}");
 }
 
-TEST(URITemplateRouter, error_unsupported_label_expansion) {
+TEST(error_unsupported_label_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{.bar}", 1, "{.bar}");
 }
 
-TEST(URITemplateRouter, error_unsupported_path_expansion) {
+TEST(error_unsupported_path_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{/bar}", 1, "{/bar}");
 }
 
-TEST(URITemplateRouter, error_unsupported_path_parameter_expansion) {
+TEST(error_unsupported_path_parameter_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{;bar}", 1, "{;bar}");
 }
 
-TEST(URITemplateRouter, error_unsupported_query_expansion) {
+TEST(error_unsupported_query_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{?bar}", 1, "{?bar}");
 }
 
-TEST(URITemplateRouter, error_unsupported_query_continuation_expansion) {
+TEST(error_unsupported_query_continuation_expansion) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{&bar}", 1, "{&bar}");
 }
 
-TEST(URITemplateRouter, error_expansion_not_last_segment_literal) {
+TEST(error_expansion_not_last_segment_literal) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{+bar}/baz", 1, "{+bar}");
 }
 
-TEST(URITemplateRouter, error_expansion_not_last_segment_variable) {
+TEST(error_expansion_not_last_segment_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{+bar}/{baz}", 1, "{+bar}");
 }
 
-TEST(URITemplateRouter, error_expansion_not_last_segment_trailing_slash) {
+TEST(error_expansion_not_last_segment_trailing_slash) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/foo/{+bar}/", 1, "{+bar}");
 }
 
-TEST(URITemplateRouter, trailing_slash_no_match) {
+TEST(trailing_slash_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_103", 1);
@@ -705,7 +705,7 @@ TEST(URITemplateRouter, trailing_slash_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, multiple_trailing_slashes_no_match) {
+TEST(multiple_trailing_slashes_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_104", 1);
@@ -713,7 +713,7 @@ TEST(URITemplateRouter, multiple_trailing_slashes_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, leading_double_slash_no_match) {
+TEST(leading_double_slash_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users", "op_105", 1);
@@ -721,7 +721,7 @@ TEST(URITemplateRouter, leading_double_slash_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, internal_double_slashes_no_match) {
+TEST(internal_double_slashes_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/posts", "op_106", 1);
@@ -729,7 +729,7 @@ TEST(URITemplateRouter, internal_double_slashes_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_with_variable_no_match) {
+TEST(trailing_slash_with_variable_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{id}", "op_107", 1);
@@ -738,7 +738,7 @@ TEST(URITemplateRouter, trailing_slash_with_variable_no_match) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
 }
 
-TEST(URITemplateRouter, internal_double_slash_with_variable_no_match) {
+TEST(internal_double_slash_with_variable_no_match) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/users/{id}/posts", "op_108", 1);
@@ -746,7 +746,7 @@ TEST(URITemplateRouter, internal_double_slash_with_variable_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, expansion_matches_trailing_slash) {
+TEST(expansion_matches_trailing_slash) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_109", 1);
@@ -755,7 +755,7 @@ TEST(URITemplateRouter, expansion_matches_trailing_slash) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/");
 }
 
-TEST(URITemplateRouter, expansion_matches_double_slashes) {
+TEST(expansion_matches_double_slashes) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/files/{+path}", "op_110", 1);
@@ -764,7 +764,7 @@ TEST(URITemplateRouter, expansion_matches_double_slashes) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo//bar");
 }
 
-TEST(URITemplateRouter, add_with_single_string_argument) {
+TEST(add_with_single_string_argument) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -784,7 +784,7 @@ TEST(URITemplateRouter, add_with_single_string_argument) {
   EXPECT_EQ(std::get<std::string_view>(collected[0].second), "some/path");
 }
 
-TEST(URITemplateRouter, add_with_single_integer_argument) {
+TEST(add_with_single_integer_argument) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -804,7 +804,7 @@ TEST(URITemplateRouter, add_with_single_integer_argument) {
   EXPECT_EQ(std::get<std::int64_t>(collected[0].second), 42);
 }
 
-TEST(URITemplateRouter, add_with_single_boolean_argument_true) {
+TEST(add_with_single_boolean_argument_true) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -824,7 +824,7 @@ TEST(URITemplateRouter, add_with_single_boolean_argument_true) {
   EXPECT_TRUE(std::get<bool>(collected[0].second));
 }
 
-TEST(URITemplateRouter, add_with_single_boolean_argument_false) {
+TEST(add_with_single_boolean_argument_false) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -844,7 +844,7 @@ TEST(URITemplateRouter, add_with_single_boolean_argument_false) {
   EXPECT_FALSE(std::get<bool>(collected[0].second));
 }
 
-TEST(URITemplateRouter, add_with_multiple_arguments) {
+TEST(add_with_multiple_arguments) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 3> arguments{
@@ -870,7 +870,7 @@ TEST(URITemplateRouter, add_with_multiple_arguments) {
   EXPECT_TRUE(std::get<bool>(collected[2].second));
 }
 
-TEST(URITemplateRouter, add_with_empty_arguments_span) {
+TEST(add_with_empty_arguments_span) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/test", "op_116", 1, 0,
@@ -886,7 +886,7 @@ TEST(URITemplateRouter, add_with_empty_arguments_span) {
   EXPECT_TRUE(collected.empty());
 }
 
-TEST(URITemplateRouter, add_without_arguments_parameter) {
+TEST(add_without_arguments_parameter) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   router.add("/test", "op_117", 1);
@@ -901,7 +901,7 @@ TEST(URITemplateRouter, add_without_arguments_parameter) {
   EXPECT_TRUE(collected.empty());
 }
 
-TEST(URITemplateRouter, add_multiple_routes_with_arguments) {
+TEST(add_multiple_routes_with_arguments) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1>
@@ -952,7 +952,7 @@ TEST(URITemplateRouter, add_multiple_routes_with_arguments) {
   EXPECT_FALSE(std::get<bool>(collected_three[0].second));
 }
 
-TEST(URITemplateRouter, add_arguments_negative_integer) {
+TEST(add_arguments_negative_integer) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -972,7 +972,7 @@ TEST(URITemplateRouter, add_arguments_negative_integer) {
   EXPECT_EQ(std::get<std::int64_t>(collected[0].second), INT64_MIN);
 }
 
-TEST(URITemplateRouter, add_arguments_zero_integer) {
+TEST(add_arguments_zero_integer) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -992,7 +992,7 @@ TEST(URITemplateRouter, add_arguments_zero_integer) {
   EXPECT_EQ(std::get<std::int64_t>(collected[0].second), 0);
 }
 
-TEST(URITemplateRouter, add_arguments_max_integer) {
+TEST(add_arguments_max_integer) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -1012,7 +1012,7 @@ TEST(URITemplateRouter, add_arguments_max_integer) {
   EXPECT_EQ(std::get<std::int64_t>(collected[0].second), INT64_MAX);
 }
 
-TEST(URITemplateRouter, add_arguments_empty_string_value) {
+TEST(add_arguments_empty_string_value) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -1032,7 +1032,7 @@ TEST(URITemplateRouter, add_arguments_empty_string_value) {
   EXPECT_EQ(std::get<std::string_view>(collected[0].second), "");
 }
 
-TEST(URITemplateRouter, add_arguments_empty_string_name) {
+TEST(add_arguments_empty_string_name) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -1052,7 +1052,7 @@ TEST(URITemplateRouter, add_arguments_empty_string_name) {
   EXPECT_EQ(std::get<std::string_view>(collected[0].second), "some_value");
 }
 
-TEST(URITemplateRouter, match_still_works_with_arguments) {
+TEST(match_still_works_with_arguments) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_path().empty());
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
@@ -1063,7 +1063,7 @@ TEST(URITemplateRouter, match_still_works_with_arguments) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, base_path_single_segment) {
+TEST(base_path_single_segment) {
   sourcemeta::core::URITemplateRouter router{"/prefix"};
   EXPECT_EQ(router.base_path(), "/prefix");
   router.add("/foo", "op_127", 1);
@@ -1071,7 +1071,7 @@ TEST(URITemplateRouter, base_path_single_segment) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_without_prefix_no_match) {
+TEST(base_path_without_prefix_no_match) {
   sourcemeta::core::URITemplateRouter router{"/prefix"};
   EXPECT_EQ(router.base_path(), "/prefix");
   router.add("/foo", "op_128", 1);
@@ -1079,7 +1079,7 @@ TEST(URITemplateRouter, base_path_without_prefix_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_multi_segment) {
+TEST(base_path_multi_segment) {
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   EXPECT_EQ(router.base_path(), "/v1/catalog");
   router.add("/api/list", "op_129", 1);
@@ -1091,7 +1091,7 @@ TEST(URITemplateRouter, base_path_multi_segment) {
   EXPECT_ROUTER_CAPTURE(captures_expansion, 0, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, base_path_with_variable) {
+TEST(base_path_with_variable) {
   sourcemeta::core::URITemplateRouter router{"/prefix"};
   EXPECT_EQ(router.base_path(), "/prefix");
   router.add("/users/{id}", "op_131", 1);
@@ -1100,7 +1100,7 @@ TEST(URITemplateRouter, base_path_with_variable) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, base_path_prefix_boundary_no_match) {
+TEST(base_path_prefix_boundary_no_match) {
   sourcemeta::core::URITemplateRouter router{"/prefix"};
   EXPECT_EQ(router.base_path(), "/prefix");
   router.add("/foo", "op_132", 1);
@@ -1108,7 +1108,7 @@ TEST(URITemplateRouter, base_path_prefix_boundary_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_with_empty_template) {
+TEST(base_path_with_empty_template) {
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   EXPECT_EQ(router.base_path(), "/v1/catalog");
   router.add("", "op_133", 1);
@@ -1116,7 +1116,7 @@ TEST(URITemplateRouter, base_path_with_empty_template) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_slash_only_is_no_base_path) {
+TEST(base_path_slash_only_is_no_base_path) {
   sourcemeta::core::URITemplateRouter router{"/"};
   EXPECT_TRUE(router.base_path().empty());
   router.add("/foo", "op_134", 1);
@@ -1124,7 +1124,7 @@ TEST(URITemplateRouter, base_path_slash_only_is_no_base_path) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_trailing_slash_normalized) {
+TEST(base_path_trailing_slash_normalized) {
   sourcemeta::core::URITemplateRouter router{"/prefix/"};
   EXPECT_EQ(router.base_path(), "/prefix");
   router.add("/foo", "op_135", 1);
@@ -1132,7 +1132,7 @@ TEST(URITemplateRouter, base_path_trailing_slash_normalized) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_multiple_trailing_slashes_normalized) {
+TEST(base_path_multiple_trailing_slashes_normalized) {
   sourcemeta::core::URITemplateRouter router{"/prefix///"};
   EXPECT_EQ(router.base_path(), "/prefix");
   router.add("/foo", "op_136", 1);
@@ -1140,7 +1140,7 @@ TEST(URITemplateRouter, base_path_multiple_trailing_slashes_normalized) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_expansion) {
+TEST(base_path_expansion) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   EXPECT_EQ(router.base_path(), "/api");
   router.add("/files/{+path}", "op_137", 1);
@@ -1149,14 +1149,14 @@ TEST(URITemplateRouter, base_path_expansion) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "a/b/c");
 }
 
-TEST(URITemplateRouter, base_path_trailing_slash_on_request_no_match) {
+TEST(base_path_trailing_slash_on_request_no_match) {
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   EXPECT_EQ(router.base_path(), "/v1/catalog");
   router.add("/foo", "op_138", 1);
   EXPECT_ROUTER_MATCH(router, "/v1/catalog/foo/", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, base_path_empty_string_is_no_base_path) {
+TEST(base_path_empty_string_is_no_base_path) {
   sourcemeta::core::URITemplateRouter router{""};
   EXPECT_TRUE(router.base_path().empty());
   router.add("/foo", "op_139", 1);
@@ -1164,7 +1164,7 @@ TEST(URITemplateRouter, base_path_empty_string_is_no_base_path) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_wrong_prefix_no_match) {
+TEST(base_path_wrong_prefix_no_match) {
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   EXPECT_EQ(router.base_path(), "/v1/catalog");
   router.add("/api/list", "op_140", 1);
@@ -1172,7 +1172,7 @@ TEST(URITemplateRouter, base_path_wrong_prefix_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_path_partial_prefix_no_match) {
+TEST(base_path_partial_prefix_no_match) {
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   EXPECT_EQ(router.base_path(), "/v1/catalog");
   router.add("/api/list", "op_141", 1);
@@ -1180,45 +1180,45 @@ TEST(URITemplateRouter, base_path_partial_prefix_no_match) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, base_url_empty_by_default) {
+TEST(base_url_empty_by_default) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_TRUE(router.base_url().empty());
 }
 
-TEST(URITemplateRouter, base_url_empty_when_only_base_path) {
+TEST(base_url_empty_when_only_base_path) {
   sourcemeta::core::URITemplateRouter router{"/prefix"};
   EXPECT_EQ(router.base_path(), "/prefix");
   EXPECT_TRUE(router.base_url().empty());
 }
 
-TEST(URITemplateRouter, base_url_set_with_base_path) {
+TEST(base_url_set_with_base_path) {
   sourcemeta::core::URITemplateRouter router{"/v1", "https://api.example.com"};
   EXPECT_EQ(router.base_path(), "/v1");
   EXPECT_EQ(router.base_url(), "https://api.example.com");
 }
 
-TEST(URITemplateRouter, base_url_set_without_base_path) {
+TEST(base_url_set_without_base_path) {
   sourcemeta::core::URITemplateRouter router{"", "https://api.example.com"};
   EXPECT_TRUE(router.base_path().empty());
   EXPECT_EQ(router.base_url(), "https://api.example.com");
 }
 
-TEST(URITemplateRouter, base_url_trailing_slash_normalized) {
+TEST(base_url_trailing_slash_normalized) {
   sourcemeta::core::URITemplateRouter router{"", "https://api.example.com/"};
   EXPECT_EQ(router.base_url(), "https://api.example.com");
 }
 
-TEST(URITemplateRouter, base_url_multiple_trailing_slashes_normalized) {
+TEST(base_url_multiple_trailing_slashes_normalized) {
   sourcemeta::core::URITemplateRouter router{"", "https://api.example.com///"};
   EXPECT_EQ(router.base_url(), "https://api.example.com");
 }
 
-TEST(URITemplateRouter, base_url_only_slash_collapses_to_empty) {
+TEST(base_url_only_slash_collapses_to_empty) {
   sourcemeta::core::URITemplateRouter router{"", "/"};
   EXPECT_TRUE(router.base_url().empty());
 }
 
-TEST(URITemplateRouter, base_url_not_used_for_matching) {
+TEST(base_url_not_used_for_matching) {
   sourcemeta::core::URITemplateRouter router{"/v1", "https://api.example.com"};
   router.add("/foo", "op_base_url_match", 1);
   EXPECT_ROUTER_MATCH(router, "/v1/foo", 1, 0, captures);
@@ -1228,14 +1228,14 @@ TEST(URITemplateRouter, base_url_not_used_for_matching) {
   EXPECT_EQ(captures_absolute.size(), 0);
 }
 
-TEST(URITemplateRouter, add_with_context_literal_route) {
+TEST(add_with_context_literal_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_142", 1, 7);
   EXPECT_ROUTER_MATCH(router, "/users", 1, 7, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, add_with_context_variable_route) {
+TEST(add_with_context_variable_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "op_143", 1, 42);
   EXPECT_ROUTER_MATCH(router, "/users/123", 1, 42, captures);
@@ -1243,14 +1243,14 @@ TEST(URITemplateRouter, add_with_context_variable_route) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "123");
 }
 
-TEST(URITemplateRouter, add_with_context_default_zero) {
+TEST(add_with_context_default_zero) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_144", 1);
   EXPECT_ROUTER_MATCH(router, "/users", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, add_multiple_routes_different_contexts) {
+TEST(add_multiple_routes_different_contexts) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_145", 1, 1);
   router.add("/posts", "op_146", 2, 2);
@@ -1264,7 +1264,7 @@ TEST(URITemplateRouter, add_multiple_routes_different_contexts) {
   }
 }
 
-TEST(URITemplateRouter, add_same_context_multiple_routes) {
+TEST(add_same_context_multiple_routes) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_147", 1, 99);
   router.add("/posts", "op_148", 2, 99);
@@ -1278,7 +1278,7 @@ TEST(URITemplateRouter, add_same_context_multiple_routes) {
   }
 }
 
-TEST(URITemplateRouter, add_with_context_and_arguments) {
+TEST(add_with_context_and_arguments) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 2> arguments{{
       {"schema", std::string_view{"schemas/health"}},
@@ -1303,15 +1303,15 @@ TEST(URITemplateRouter, add_with_context_and_arguments) {
         }
       });
 
-  ASSERT_EQ(seen_string.size(), 1);
+  EXPECT_EQ(seen_string.size(), 1);
   EXPECT_EQ(seen_string.at(0).first, "schema");
   EXPECT_EQ(seen_string.at(0).second, "schemas/health");
-  ASSERT_EQ(seen_bool.size(), 1);
+  EXPECT_EQ(seen_bool.size(), 1);
   EXPECT_EQ(seen_bool.at(0).first, "enabled");
   EXPECT_TRUE(seen_bool.at(0).second);
 }
 
-TEST(URITemplateRouter, add_context_expansion_route) {
+TEST(add_context_expansion_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/files/{+path}", "op_150", 1, 5);
   EXPECT_ROUTER_MATCH(router, "/files/a/b/c", 1, 5, captures);
@@ -1319,21 +1319,21 @@ TEST(URITemplateRouter, add_context_expansion_route) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "a/b/c");
 }
 
-TEST(URITemplateRouter, add_context_base_path) {
+TEST(add_context_base_path) {
   sourcemeta::core::URITemplateRouter router{"/v1/catalog"};
   router.add("/api/list", "op_151", 1, 33);
   EXPECT_ROUTER_MATCH(router, "/v1/catalog/api/list", 1, 33, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, add_with_context_no_match_returns_zero_pair) {
+TEST(add_with_context_no_match_returns_zero_pair) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_152", 1, 7);
   EXPECT_ROUTER_MATCH(router, "/posts", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, add_with_context_overwrites_previous_context) {
+TEST(add_with_context_overwrites_previous_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_153", 1, 10);
   router.add("/users", "op_154", 1, 20);
@@ -1341,18 +1341,18 @@ TEST(URITemplateRouter, add_with_context_overwrites_previous_context) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, size_empty_router) {
+TEST(size_empty_router) {
   const sourcemeta::core::URITemplateRouter router;
   EXPECT_EQ(router.size(), 0);
 }
 
-TEST(URITemplateRouter, size_single_route) {
+TEST(size_single_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_155", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, size_multiple_routes) {
+TEST(size_multiple_routes) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_156", 1);
   router.add("/users/{id}", "op_157", 2);
@@ -1361,46 +1361,46 @@ TEST(URITemplateRouter, size_multiple_routes) {
   EXPECT_EQ(router.size(), 4);
 }
 
-TEST(URITemplateRouter, size_duplicate_route_does_not_increase) {
+TEST(size_duplicate_route_does_not_increase) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_160", 1);
   router.add("/users", "op_161", 2);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, size_with_context_overwrite_does_not_increase) {
+TEST(size_with_context_overwrite_does_not_increase) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_162", 1, 10);
   router.add("/users", "op_163", 1, 20);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, size_root_template) {
+TEST(size_root_template) {
   sourcemeta::core::URITemplateRouter router;
   router.add("", "op_164", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, size_with_base_path) {
+TEST(size_with_base_path) {
   sourcemeta::core::URITemplateRouter router{"/v1"};
   router.add("/users", "op_165", 1);
   router.add("/posts", "op_166", 2);
   EXPECT_EQ(router.size(), 2);
 }
 
-TEST(URITemplateRouter, otherwise_default_is_zero_context) {
+TEST(otherwise_default_is_zero_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_167", 1);
   EXPECT_ROUTER_MATCH(router, "/unknown", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, otherwise_sets_context) {
+TEST(otherwise_sets_context) {
   sourcemeta::core::URITemplateRouter router;
   router.otherwise(42);
   EXPECT_ROUTER_MATCH(router, "/anything", 0, 42, captures);
 }
 
-TEST(URITemplateRouter, otherwise_returned_from_match_on_unknown_path) {
+TEST(otherwise_returned_from_match_on_unknown_path) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_168", 1, 5);
   router.otherwise(99);
@@ -1408,7 +1408,7 @@ TEST(URITemplateRouter, otherwise_returned_from_match_on_unknown_path) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, otherwise_not_returned_from_matching_route) {
+TEST(otherwise_not_returned_from_matching_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_169", 1, 5);
   router.otherwise(99);
@@ -1416,27 +1416,27 @@ TEST(URITemplateRouter, otherwise_not_returned_from_matching_route) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, otherwise_returned_for_empty_segment) {
+TEST(otherwise_returned_for_empty_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_170", 1);
   router.otherwise(77);
   EXPECT_ROUTER_MATCH(router, "/users//", 0, 77, captures);
 }
 
-TEST(URITemplateRouter, otherwise_returned_for_root_slash_no_match) {
+TEST(otherwise_returned_for_root_slash_no_match) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_171", 1);
   router.otherwise(88);
   EXPECT_ROUTER_MATCH(router, "/", 0, 88, captures);
 }
 
-TEST(URITemplateRouter, otherwise_without_registration_returns_zero_context) {
+TEST(otherwise_without_registration_returns_zero_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_172", 1);
   EXPECT_ROUTER_MATCH(router, "/unknown", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, otherwise_arguments_lookup) {
+TEST(otherwise_arguments_lookup) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 2> arguments{
       {{"status", std::int64_t{404}},
@@ -1462,14 +1462,14 @@ TEST(URITemplateRouter, otherwise_arguments_lookup) {
   EXPECT_EQ(std::get<std::string_view>(collected[1].second), "Not Found");
 }
 
-TEST(URITemplateRouter, otherwise_overwrite_context) {
+TEST(otherwise_overwrite_context) {
   sourcemeta::core::URITemplateRouter router;
   router.otherwise(10);
   router.otherwise(20);
   EXPECT_ROUTER_MATCH(router, "/nope", 0, 20, captures);
 }
 
-TEST(URITemplateRouter, otherwise_overwrite_arguments) {
+TEST(otherwise_overwrite_arguments) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> first{
       {{"version", std::int64_t{1}}}};
@@ -1493,7 +1493,7 @@ TEST(URITemplateRouter, otherwise_overwrite_arguments) {
   EXPECT_EQ(std::get<std::int64_t>(collected[0].second), 2);
 }
 
-TEST(URITemplateRouter, otherwise_overwrite_with_empty_clears_arguments) {
+TEST(otherwise_overwrite_with_empty_clears_arguments) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
       {{"key", std::string_view{"value"}}}};
@@ -1514,7 +1514,7 @@ TEST(URITemplateRouter, otherwise_overwrite_with_empty_clears_arguments) {
   EXPECT_ROUTER_MATCH(router, "/nope", 0, 2, captures);
 }
 
-TEST(URITemplateRouter, otherwise_boolean_argument) {
+TEST(otherwise_boolean_argument) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> arguments{
       {{"cached", true}}};
@@ -1535,7 +1535,7 @@ TEST(URITemplateRouter, otherwise_boolean_argument) {
   EXPECT_EQ(std::get<bool>(collected[0].second), true);
 }
 
-TEST(URITemplateRouter, otherwise_does_not_affect_other_arguments) {
+TEST(otherwise_does_not_affect_other_arguments) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> route_args{
       {{"schema", std::string_view{"user.json"}}}};
@@ -1570,28 +1570,28 @@ TEST(URITemplateRouter, otherwise_does_not_affect_other_arguments) {
   EXPECT_EQ(default_collected[0].first, "message");
 }
 
-TEST(URITemplateRouter, otherwise_does_not_count_as_route_in_size) {
+TEST(otherwise_does_not_count_as_route_in_size) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_174", 1);
   router.otherwise(99);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, otherwise_with_base_path_and_unmatched) {
+TEST(otherwise_with_base_path_and_unmatched) {
   sourcemeta::core::URITemplateRouter router{"/v1"};
   router.add("/users", "op_175", 1);
   router.otherwise(42);
   EXPECT_ROUTER_MATCH(router, "/v1/other", 0, 42, captures);
 }
 
-TEST(URITemplateRouter, otherwise_with_partial_trie_walk) {
+TEST(otherwise_with_partial_trie_walk) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}/posts", "op_176", 1);
   router.otherwise(42);
   EXPECT_ROUTER_MATCH(router, "/users/123", 0, 42, captures);
 }
 
-TEST(URITemplateRouter, listing_at_returns_identifiers_in_add_order) {
+TEST(listing_at_returns_identifiers_in_add_order) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_177", 7);
   router.add("/posts/{id}", "op_178", 3);
@@ -1602,7 +1602,7 @@ TEST(URITemplateRouter, listing_at_returns_identifiers_in_add_order) {
   EXPECT_EQ(router.at(2), 9);
 }
 
-TEST(URITemplateRouter, listing_context_returns_associated_context) {
+TEST(listing_context_returns_associated_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_180", 1, 100);
   router.add("/posts/{id}", "op_181", 2, 200);
@@ -1612,7 +1612,7 @@ TEST(URITemplateRouter, listing_context_returns_associated_context) {
   EXPECT_EQ(router.context(3), 300);
 }
 
-TEST(URITemplateRouter, listing_context_default_zero) {
+TEST(listing_context_default_zero) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_183", 1);
   router.add("/posts", "op_184", 2);
@@ -1620,55 +1620,55 @@ TEST(URITemplateRouter, listing_context_default_zero) {
   EXPECT_EQ(router.context(2), 0);
 }
 
-TEST(URITemplateRouter, listing_path_for_literal_route) {
+TEST(listing_path_for_literal_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_185", 1);
   EXPECT_EQ(router.path(1), "/users");
 }
 
-TEST(URITemplateRouter, listing_path_for_variable_route) {
+TEST(listing_path_for_variable_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "op_186", 1);
   EXPECT_EQ(router.path(1), "/users/{id}");
 }
 
-TEST(URITemplateRouter, listing_path_for_multi_variable_route) {
+TEST(listing_path_for_multi_variable_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}/posts/{post_id}", "op_187", 1);
   EXPECT_EQ(router.path(1), "/users/{id}/posts/{post_id}");
 }
 
-TEST(URITemplateRouter, listing_path_for_expansion_route) {
+TEST(listing_path_for_expansion_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/files/{+rest}", "op_188", 1);
   EXPECT_EQ(router.path(1), "/files/{+rest}");
 }
 
-TEST(URITemplateRouter, listing_path_for_root_route) {
+TEST(listing_path_for_root_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/", "op_189", 1);
   EXPECT_EQ(router.path(1), "/");
 }
 
-TEST(URITemplateRouter, listing_path_excludes_base_path) {
+TEST(listing_path_excludes_base_path) {
   sourcemeta::core::URITemplateRouter router{"/api/v1"};
   router.add("/users/{id}", "op_190", 1);
   EXPECT_EQ(router.path(1), "/users/{id}");
 }
 
-TEST(URITemplateRouter, listing_path_excludes_base_path_for_root_template) {
+TEST(listing_path_excludes_base_path_for_root_template) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   router.add("/", "op_191", 1);
   EXPECT_EQ(router.path(1), "/");
 }
 
-TEST(URITemplateRouter, listing_path_excludes_base_path_for_empty_template) {
+TEST(listing_path_excludes_base_path_for_empty_template) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   router.add("", "op_192", 1);
   EXPECT_EQ(router.path(1), "");
 }
 
-TEST(URITemplateRouter, listing_path_for_multiple_routes_each_correct) {
+TEST(listing_path_for_multiple_routes_each_correct) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_193", 1);
   router.add("/users/{id}", "op_194", 2);
@@ -1680,7 +1680,7 @@ TEST(URITemplateRouter, listing_path_for_multiple_routes_each_correct) {
   EXPECT_EQ(router.path(4), "/files/{+rest}");
 }
 
-TEST(URITemplateRouter, listing_size_does_not_count_otherwise) {
+TEST(listing_size_does_not_count_otherwise) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_197", 1);
   router.add("/posts", "op_198", 2);
@@ -1690,7 +1690,7 @@ TEST(URITemplateRouter, listing_size_does_not_count_otherwise) {
   EXPECT_EQ(router.at(1), 2);
 }
 
-TEST(URITemplateRouter, listing_path_returns_freshly_allocated_string) {
+TEST(listing_path_returns_freshly_allocated_string) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "op_199", 1);
   const auto first = router.path(1);
@@ -1699,7 +1699,7 @@ TEST(URITemplateRouter, listing_path_returns_freshly_allocated_string) {
   EXPECT_NE(first.data(), second.data());
 }
 
-TEST(URITemplateRouter, listing_iterate_via_size_and_at) {
+TEST(listing_iterate_via_size_and_at) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "op_200", 10);
   router.add("/b/{id}", "op_201", 20);
@@ -1710,13 +1710,13 @@ TEST(URITemplateRouter, listing_iterate_via_size_and_at) {
     seen.push_back(router.at(index));
   }
 
-  ASSERT_EQ(seen.size(), 3);
+  EXPECT_EQ(seen.size(), 3);
   EXPECT_EQ(seen[0], 10);
   EXPECT_EQ(seen[1], 20);
   EXPECT_EQ(seen[2], 30);
 }
 
-TEST(URITemplateRouter, listing_size_overwrite_does_not_grow) {
+TEST(listing_size_overwrite_does_not_grow) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_203", 1);
   EXPECT_EQ(router.size(), 1);
@@ -1726,7 +1726,7 @@ TEST(URITemplateRouter, listing_size_overwrite_does_not_grow) {
   EXPECT_EQ(router.path(2), "/users");
 }
 
-TEST(URITemplateRouter, operation_id_minimum_length) {
+TEST(operation_id_minimum_length) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "x", 1);
   const auto result = router.operation("x");
@@ -1734,7 +1734,7 @@ TEST(URITemplateRouter, operation_id_minimum_length) {
   EXPECT_EQ(result.second, 0);
 }
 
-TEST(URITemplateRouter, operation_id_maximum_length) {
+TEST(operation_id_maximum_length) {
   sourcemeta::core::URITemplateRouter router;
   const std::string operation_id(64, 'a');
   router.add("/a", operation_id, 1);
@@ -1743,7 +1743,7 @@ TEST(URITemplateRouter, operation_id_maximum_length) {
   EXPECT_EQ(result.second, 0);
 }
 
-TEST(URITemplateRouter, operation_id_full_character_set) {
+TEST(operation_id_full_character_set) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "aZ0_-", 7, 42);
   const auto result = router.operation("aZ0_-");
@@ -1751,7 +1751,7 @@ TEST(URITemplateRouter, operation_id_full_character_set) {
   EXPECT_EQ(result.second, 42);
 }
 
-TEST(URITemplateRouter, operation_id_reject_empty) {
+TEST(operation_id_reject_empty) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("/a", "", 1);
@@ -1762,7 +1762,7 @@ TEST(URITemplateRouter, operation_id_reject_empty) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_reject_too_long) {
+TEST(operation_id_reject_too_long) {
   sourcemeta::core::URITemplateRouter router;
   const std::string operation_id(65, 'a');
   try {
@@ -1776,7 +1776,7 @@ TEST(URITemplateRouter, operation_id_reject_too_long) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_reject_leading_digit) {
+TEST(operation_id_reject_leading_digit) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("/a", "1foo", 1);
@@ -1787,7 +1787,7 @@ TEST(URITemplateRouter, operation_id_reject_leading_digit) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_reject_leading_underscore) {
+TEST(operation_id_reject_leading_underscore) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("/a", "_foo", 1);
@@ -1798,7 +1798,7 @@ TEST(URITemplateRouter, operation_id_reject_leading_underscore) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_reject_leading_hyphen) {
+TEST(operation_id_reject_leading_hyphen) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("/a", "-foo", 1);
@@ -1809,7 +1809,7 @@ TEST(URITemplateRouter, operation_id_reject_leading_hyphen) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_reject_invalid_characters) {
+TEST(operation_id_reject_invalid_characters) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("/a", "foo.bar", 1);
@@ -1834,7 +1834,7 @@ TEST(URITemplateRouter, operation_id_reject_invalid_characters) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_duplicate_throws) {
+TEST(operation_id_duplicate_throws) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "listUsers", 1);
   try {
@@ -1848,7 +1848,7 @@ TEST(URITemplateRouter, operation_id_duplicate_throws) {
   }
 }
 
-TEST(URITemplateRouter, operation_unknown_returns_zero_zero) {
+TEST(operation_unknown_returns_zero_zero) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "listUsers", 1, 11);
   const auto result = router.operation("missing");
@@ -1856,7 +1856,7 @@ TEST(URITemplateRouter, operation_unknown_returns_zero_zero) {
   EXPECT_EQ(result.second, 0);
 }
 
-TEST(URITemplateRouter, operation_unknown_ignores_otherwise) {
+TEST(operation_unknown_ignores_otherwise) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "listUsers", 1, 11);
   router.otherwise(99);
@@ -1865,7 +1865,7 @@ TEST(URITemplateRouter, operation_unknown_ignores_otherwise) {
   EXPECT_EQ(result.second, 0);
 }
 
-TEST(URITemplateRouter, operation_returns_identifier_and_context) {
+TEST(operation_returns_identifier_and_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "alpha", 1, 11);
   router.add("/b", "beta", 2, 22);
@@ -1884,7 +1884,7 @@ TEST(URITemplateRouter, operation_returns_identifier_and_context) {
   EXPECT_EQ(gamma.second, 33);
 }
 
-TEST(URITemplateRouter, operation_id_not_reserved_when_add_throws) {
+TEST(operation_id_not_reserved_when_add_throws) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("/foo/{bar}.json", "listFoo", 1);
@@ -1898,7 +1898,7 @@ TEST(URITemplateRouter, operation_id_not_reserved_when_add_throws) {
   }
 }
 
-TEST(URITemplateRouter, operation_id_overwrite_removes_previous_mapping) {
+TEST(operation_id_overwrite_removes_previous_mapping) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "first", 1, 11);
   router.add("/users", "second", 2, 22);
@@ -1912,103 +1912,102 @@ TEST(URITemplateRouter, operation_id_overwrite_removes_previous_mapping) {
   EXPECT_EQ(live.second, 22);
 }
 
-TEST(URITemplateRouter, optional_expansion_accepted_simple) {
+TEST(optional_expansion_accepted_simple) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/list{/path*}", "op_oex_1", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, optional_expansion_accepted_with_explicit_slash) {
+TEST(optional_expansion_accepted_with_explicit_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list/{/path*}", "op_oex_2", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, optional_expansion_accepted_at_root) {
+TEST(optional_expansion_accepted_at_root) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/{/path*}", "op_oex_3", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, optional_expansion_accepted_with_deep_literal_prefix) {
+TEST(optional_expansion_accepted_with_deep_literal_prefix) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/v1/users/list{/path*}", "op_oex_4", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, optional_expansion_accepted_no_literal_prefix) {
+TEST(optional_expansion_accepted_no_literal_prefix) {
   sourcemeta::core::URITemplateRouter router;
   router.add("{/path*}", "op_oex_5", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_no_explode) {
+TEST(optional_expansion_reject_no_explode) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path}", 1, "{/path}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_no_explode_at_root) {
+TEST(optional_expansion_reject_no_explode_at_root) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "{/path}", 1, "{/path}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_empty_name) {
+TEST(optional_expansion_reject_empty_name) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/}", 1, "{/}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_empty_name_with_explode) {
+TEST(optional_expansion_reject_empty_name_with_explode) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/*}", 1, "{/*}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_unclosed) {
+TEST(optional_expansion_reject_unclosed) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*", 1, "{/path*");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_not_last_segment_literal) {
+TEST(optional_expansion_reject_not_last_segment_literal) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*}/more", 1, "{/path*}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_not_last_segment_variable) {
+TEST(optional_expansion_reject_not_last_segment_variable) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*}/{tail}", 1, "{/path*}");
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_reject_not_last_segment_trailing_slash) {
+TEST(optional_expansion_reject_not_last_segment_trailing_slash) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*}/", 1, "{/path*}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_extra_after_explode) {
+TEST(optional_expansion_reject_extra_after_explode) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*abc}", 1, "{/path*abc}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_comma_after_explode) {
+TEST(optional_expansion_reject_comma_after_explode) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/path*,more}", 1, "{/path*,more}");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_invalid_varname_char) {
+TEST(optional_expansion_reject_invalid_varname_char) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list{/pa-th*}", 1, "{/pa-th*}");
 }
 
-TEST(URITemplateRouter, simple_explode_still_rejected) {
+TEST(simple_explode_still_rejected) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list/{var*}", 1, "{var*}");
 }
 
-TEST(URITemplateRouter, reserved_explode_still_rejected) {
+TEST(reserved_explode_still_rejected) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/list/{+var*}", 1, "{+var*}");
 }
 
-TEST(URITemplateRouter, optional_expansion_dotted_varname_accepted) {
+TEST(optional_expansion_dotted_varname_accepted) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/list{/foo.bar*}", "op_oex_dot", 1);
   EXPECT_ROUTER_MATCH(router, "/list/x", 1, 0, captures);
@@ -2016,7 +2015,7 @@ TEST(URITemplateRouter, optional_expansion_dotted_varname_accepted) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "foo.bar", "x");
 }
 
-TEST(URITemplateRouter, literal_followed_by_path_segment_no_slash) {
+TEST(literal_followed_by_path_segment_no_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_join", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
@@ -2024,17 +2023,17 @@ TEST(URITemplateRouter, literal_followed_by_path_segment_no_slash) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
 }
 
-TEST(URITemplateRouter, literal_followed_by_non_path_segment_still_throws) {
+TEST(literal_followed_by_non_path_segment_still_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{path}", 1, "list{path}");
 }
 
-TEST(URITemplateRouter, literal_followed_by_reserved_expansion_still_throws) {
+TEST(literal_followed_by_reserved_expansion_still_throws) {
   sourcemeta::core::URITemplateRouter router;
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{+path}", 1, "list{+path}");
 }
 
-TEST(URITemplateRouter, optional_expansion_match_empty_capture) {
+TEST(optional_expansion_match_empty_capture) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m1", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list", 1, 0, captures);
@@ -2042,7 +2041,7 @@ TEST(URITemplateRouter, optional_expansion_match_empty_capture) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
 }
 
-TEST(URITemplateRouter, optional_expansion_match_single_segment) {
+TEST(optional_expansion_match_single_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m2", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
@@ -2050,7 +2049,7 @@ TEST(URITemplateRouter, optional_expansion_match_single_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
 }
 
-TEST(URITemplateRouter, optional_expansion_match_two_segments) {
+TEST(optional_expansion_match_two_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m3", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo/bar", 1, 0, captures);
@@ -2058,7 +2057,7 @@ TEST(URITemplateRouter, optional_expansion_match_two_segments) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, optional_expansion_match_many_segments) {
+TEST(optional_expansion_match_many_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m4", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo/bar/baz/qux", 1, 0, captures);
@@ -2066,7 +2065,7 @@ TEST(URITemplateRouter, optional_expansion_match_many_segments) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar/baz/qux");
 }
 
-TEST(URITemplateRouter, optional_expansion_match_percent_encoded_segment) {
+TEST(optional_expansion_match_percent_encoded_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m5", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo%2Fbar", 1, 0, captures);
@@ -2074,7 +2073,7 @@ TEST(URITemplateRouter, optional_expansion_match_percent_encoded_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo%2Fbar");
 }
 
-TEST(URITemplateRouter, optional_expansion_match_dot_segment) {
+TEST(optional_expansion_match_dot_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m6", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/.well-known/version", 1, 0, captures);
@@ -2082,55 +2081,55 @@ TEST(URITemplateRouter, optional_expansion_match_dot_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", ".well-known/version");
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_trailing_slash) {
+TEST(optional_expansion_reject_trailing_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m7", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_double_trailing_slash) {
+TEST(optional_expansion_reject_double_trailing_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m8", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list//", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_internal_empty_segment) {
+TEST(optional_expansion_reject_internal_empty_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m9", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list//foo", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_non_prefix) {
+TEST(optional_expansion_reject_non_prefix) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m10", 1);
   EXPECT_ROUTER_MATCH(router, "/api/listing", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_unrelated_root) {
+TEST(optional_expansion_reject_unrelated_root) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m11", 1);
   EXPECT_ROUTER_MATCH(router, "/other", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_empty_path) {
+TEST(optional_expansion_reject_empty_path) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m12", 1);
   EXPECT_ROUTER_MATCH(router, "", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_reject_root_path) {
+TEST(optional_expansion_reject_root_path) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_m13", 1);
   EXPECT_ROUTER_MATCH(router, "/", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_root_template_does_not_match_slash) {
+TEST(optional_expansion_root_template_does_not_match_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/{/path*}", "op_oex_m14", 1);
   EXPECT_ROUTER_MATCH(router, "/", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_root_template_matches_segment) {
+TEST(optional_expansion_root_template_matches_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/{/path*}", "op_oex_m15", 1);
   EXPECT_ROUTER_MATCH(router, "/foo", 1, 0, captures);
@@ -2138,8 +2137,7 @@ TEST(URITemplateRouter, optional_expansion_root_template_matches_segment) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_root_template_matches_multiple_segments) {
+TEST(optional_expansion_root_template_matches_multiple_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/{/path*}", "op_oex_m16", 1);
   EXPECT_ROUTER_MATCH(router, "/foo/bar", 1, 0, captures);
@@ -2147,7 +2145,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, optional_expansion_callback_index_zero) {
+TEST(optional_expansion_callback_index_zero) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_idx", 1);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 0, captures);
@@ -2155,7 +2153,7 @@ TEST(URITemplateRouter, optional_expansion_callback_index_zero) {
   EXPECT_EQ(std::get<0>(captures.at(0)), 0);
 }
 
-TEST(URITemplateRouter, optional_expansion_callback_index_after_variables) {
+TEST(optional_expansion_callback_index_after_variables) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/{namespace}/list{/path*}", "op_oex_idx2", 1);
   EXPECT_ROUTER_MATCH(router, "/api/users/list/foo/bar", 1, 0, captures);
@@ -2164,8 +2162,7 @@ TEST(URITemplateRouter, optional_expansion_callback_index_after_variables) {
   EXPECT_ROUTER_CAPTURE(captures, 1, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_empty_callback_index_after_variables) {
+TEST(optional_expansion_empty_callback_index_after_variables) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/{namespace}/list{/path*}", "op_oex_idx3", 1);
   EXPECT_ROUTER_MATCH(router, "/api/users/list", 1, 0, captures);
@@ -2174,7 +2171,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_CAPTURE(captures, 1, "path", "");
 }
 
-TEST(URITemplateRouter, optional_expansion_with_context) {
+TEST(optional_expansion_with_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_ctx", 1, 42);
   EXPECT_ROUTER_MATCH(router, "/api/list/foo", 1, 42, captures);
@@ -2182,7 +2179,7 @@ TEST(URITemplateRouter, optional_expansion_with_context) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
 }
 
-TEST(URITemplateRouter, optional_expansion_empty_with_context) {
+TEST(optional_expansion_empty_with_context) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_ctx2", 1, 42);
   EXPECT_ROUTER_MATCH(router, "/api/list", 1, 42, captures);
@@ -2190,7 +2187,7 @@ TEST(URITemplateRouter, optional_expansion_empty_with_context) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "");
 }
 
-TEST(URITemplateRouter, optional_expansion_literal_sibling_takes_priority) {
+TEST(optional_expansion_literal_sibling_takes_priority) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_p1", 1);
   router.add("/api/list/special", "op_oex_p2", 2);
@@ -2198,7 +2195,7 @@ TEST(URITemplateRouter, optional_expansion_literal_sibling_takes_priority) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, optional_expansion_literal_sibling_fallback) {
+TEST(optional_expansion_literal_sibling_fallback) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_p3", 1);
   router.add("/api/list/special", "op_oex_p4", 2);
@@ -2207,7 +2204,7 @@ TEST(URITemplateRouter, optional_expansion_literal_sibling_fallback) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "other");
 }
 
-TEST(URITemplateRouter, optional_expansion_literal_sibling_fallback_multi) {
+TEST(optional_expansion_literal_sibling_fallback_multi) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_p5", 1);
   router.add("/api/list/special", "op_oex_p6", 2);
@@ -2216,8 +2213,7 @@ TEST(URITemplateRouter, optional_expansion_literal_sibling_fallback_multi) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "other/nested");
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_literal_parent_route_takes_priority) {
+TEST(optional_expansion_literal_parent_route_takes_priority) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list", "op_oex_pp1", 1);
   router.add("/api/list{/path*}", "op_oex_pp2", 2);
@@ -2225,7 +2221,7 @@ TEST(URITemplateRouter,
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, optional_expansion_literal_parent_route_other_order) {
+TEST(optional_expansion_literal_parent_route_other_order) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_pp3", 2);
   router.add("/api/list", "op_oex_pp4", 1);
@@ -2233,7 +2229,7 @@ TEST(URITemplateRouter, optional_expansion_literal_parent_route_other_order) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, optional_expansion_with_literal_parent_match_nested) {
+TEST(optional_expansion_with_literal_parent_match_nested) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list", "op_oex_pn1", 1);
   router.add("/api/list{/path*}", "op_oex_pn2", 2);
@@ -2242,7 +2238,7 @@ TEST(URITemplateRouter, optional_expansion_with_literal_parent_match_nested) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, optional_expansion_versus_simple_variable_upgrade) {
+TEST(optional_expansion_versus_simple_variable_upgrade) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list/{path}", "op_oex_v1", 1);
   router.add("/api/list{/path*}", "op_oex_v2", 2);
@@ -2251,7 +2247,7 @@ TEST(URITemplateRouter, optional_expansion_versus_simple_variable_upgrade) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
 }
 
-TEST(URITemplateRouter, optional_expansion_versus_simple_variable_absorbs) {
+TEST(optional_expansion_versus_simple_variable_absorbs) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_v3", 1);
   router.add("/api/list/{path}", "op_oex_v4", 2);
@@ -2260,20 +2256,19 @@ TEST(URITemplateRouter, optional_expansion_versus_simple_variable_absorbs) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo");
 }
 
-TEST(URITemplateRouter, optional_expansion_conflicts_with_reserved_expansion) {
+TEST(optional_expansion_conflicts_with_reserved_expansion) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list/{+path}", "op_oex_c1", 1);
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list{/path*}", 2, "{/path*}");
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_conflicts_with_reserved_expansion_other_order) {
+TEST(optional_expansion_conflicts_with_reserved_expansion_other_order) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_c2", 1);
   EXPECT_ROUTER_SEGMENT_ERROR(router, "/api/list/{+path}", 2, "{+path}");
 }
 
-TEST(URITemplateRouter, optional_expansion_variable_name_mismatch) {
+TEST(optional_expansion_variable_name_mismatch) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list/{id}", "op_oex_mm1", 1);
   try {
@@ -2286,8 +2281,7 @@ TEST(URITemplateRouter, optional_expansion_variable_name_mismatch) {
   }
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_variable_name_mismatch_with_expansion) {
+TEST(optional_expansion_variable_name_mismatch_with_expansion) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list/{+abc}", "op_oex_mm3", 1);
   try {
@@ -2300,8 +2294,7 @@ TEST(URITemplateRouter,
   }
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_distinct_parents_independent_registration) {
+TEST(optional_expansion_distinct_parents_independent_registration) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/a{/x*}", "op_oex_d1", 1);
   router.add("/api/b{/y*}", "op_oex_d2", 2);
@@ -2313,7 +2306,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "bar");
 }
 
-TEST(URITemplateRouter, optional_expansion_distinct_parents_both_empty) {
+TEST(optional_expansion_distinct_parents_both_empty) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/a{/x*}", "op_oex_d3", 1);
   router.add("/api/b{/y*}", "op_oex_d4", 2);
@@ -2325,7 +2318,7 @@ TEST(URITemplateRouter, optional_expansion_distinct_parents_both_empty) {
   EXPECT_ROUTER_CAPTURE(captures_b, 0, "y", "");
 }
 
-TEST(URITemplateRouter, optional_expansion_otherwise_fallback) {
+TEST(optional_expansion_otherwise_fallback) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_o1", 1);
   router.otherwise(99);
@@ -2333,7 +2326,7 @@ TEST(URITemplateRouter, optional_expansion_otherwise_fallback) {
   EXPECT_ROUTER_MATCH(router, "/api/listing", 0, 99, no_captures);
 }
 
-TEST(URITemplateRouter, optional_expansion_under_intermediate_variable) {
+TEST(optional_expansion_under_intermediate_variable) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/{tenant}{/path*}", "op_oex_iv1", 1);
   EXPECT_ROUTER_MATCH(router, "/api/acme", 1, 0, captures);
@@ -2342,8 +2335,7 @@ TEST(URITemplateRouter, optional_expansion_under_intermediate_variable) {
   EXPECT_ROUTER_CAPTURE(captures, 1, "path", "");
 }
 
-TEST(URITemplateRouter,
-     optional_expansion_under_intermediate_variable_with_payload) {
+TEST(optional_expansion_under_intermediate_variable_with_payload) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/{tenant}{/path*}", "op_oex_iv2", 1);
   EXPECT_ROUTER_MATCH(router, "/api/acme/foo/bar", 1, 0, captures);
@@ -2352,13 +2344,13 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_CAPTURE(captures, 1, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, optional_expansion_path_method_round_trips) {
+TEST(optional_expansion_path_method_round_trips) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_pth", 1);
   EXPECT_EQ(router.path(1), "/api/list{/path*}");
 }
 
-TEST(URITemplateRouter, optional_expansion_operation_lookup) {
+TEST(optional_expansion_operation_lookup) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "list_directory", 1, 42);
   const auto result = router.operation("list_directory");
@@ -2366,20 +2358,20 @@ TEST(URITemplateRouter, optional_expansion_operation_lookup) {
   EXPECT_EQ(result.second, 42);
 }
 
-TEST(URITemplateRouter, optional_expansion_size_counts_one) {
+TEST(optional_expansion_size_counts_one) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_sz", 1);
   EXPECT_EQ(router.size(), 1);
 }
 
-TEST(URITemplateRouter, optional_expansion_size_counts_with_sibling_literal) {
+TEST(optional_expansion_size_counts_with_sibling_literal) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list", "op_oex_sz1", 1);
   router.add("/api/list{/path*}", "op_oex_sz2", 2);
   EXPECT_EQ(router.size(), 2);
 }
 
-TEST(URITemplateRouter, optional_expansion_with_arguments) {
+TEST(optional_expansion_with_arguments) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 2> arguments{
       {{"max", std::int64_t{10}}, {"flag", true}}};
@@ -2400,7 +2392,7 @@ TEST(URITemplateRouter, optional_expansion_with_arguments) {
   EXPECT_EQ(std::get<bool>(collected[1].second), true);
 }
 
-TEST(URITemplateRouter, optional_expansion_with_base_path) {
+TEST(optional_expansion_with_base_path) {
   sourcemeta::core::URITemplateRouter router{"/v1"};
   router.add("/api/list{/path*}", "op_oex_bp", 1);
   EXPECT_ROUTER_MATCH(router, "/v1/api/list", 1, 0, captures_empty);
@@ -2414,7 +2406,7 @@ TEST(URITemplateRouter, optional_expansion_with_base_path) {
   EXPECT_ROUTER_CAPTURE(captures_two, 0, "path", "foo/bar");
 }
 
-TEST(URITemplateRouter, optional_expansion_matches_after_variable_segment) {
+TEST(optional_expansion_matches_after_variable_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}/files{/path*}", "op_oex_uf", 1);
   EXPECT_ROUTER_MATCH(router, "/users/42/files", 1, 0, captures_empty);
@@ -2427,7 +2419,7 @@ TEST(URITemplateRouter, optional_expansion_matches_after_variable_segment) {
   EXPECT_ROUTER_CAPTURE(captures_one, 1, "path", "readme.md");
 }
 
-TEST(URITemplateRouter, optional_expansion_motivating_use_case) {
+TEST(optional_expansion_motivating_use_case) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/self/v1/api/list{/path*}", "list_directory", 1, 7);
   EXPECT_ROUTER_MATCH(router, "/self/v1/api/list", 1, 7, captures_root);
@@ -2445,7 +2437,7 @@ TEST(URITemplateRouter, optional_expansion_motivating_use_case) {
   EXPECT_ROUTER_MATCH(router, "/self/v1/api/list/", 0, 0, captures_trailing);
 }
 
-TEST(URITemplateRouter, optional_expansion_listing_does_not_count_node) {
+TEST(optional_expansion_listing_does_not_count_node) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "op_oex_lc", 1);
   EXPECT_EQ(router.size(), 1);
@@ -2454,7 +2446,7 @@ TEST(URITemplateRouter, optional_expansion_listing_does_not_count_node) {
   EXPECT_EQ(router.context(1), 0);
 }
 
-TEST(URITemplateRouter, optional_expansion_overwrite_replaces_identifier) {
+TEST(optional_expansion_overwrite_replaces_identifier) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/api/list{/path*}", "first", 1, 11);
   router.add("/api/list{/path*}", "second", 2, 22);
@@ -2471,26 +2463,26 @@ TEST(URITemplateRouter, optional_expansion_overwrite_replaces_identifier) {
   EXPECT_EQ(live.second, 22);
 }
 
-TEST(URITemplateRouter, variable_does_not_consume_multiple_segments) {
+TEST(variable_does_not_consume_multiple_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "var_no_consume_1", 1);
   EXPECT_ROUTER_MATCH(router, "/users/42/extra", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, variable_does_not_consume_with_literal_suffix) {
+TEST(variable_does_not_consume_with_literal_suffix) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}/posts", "var_no_consume_2", 1);
   EXPECT_ROUTER_MATCH(router, "/users/42/extra/posts", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, variable_segment_does_not_match_empty_capture) {
+TEST(variable_segment_does_not_match_empty_capture) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "var_no_empty", 1);
   EXPECT_ROUTER_MATCH(router, "/users", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, expansion_consumes_unlike_plain_variable) {
+TEST(expansion_consumes_unlike_plain_variable) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a/{x}", "plain_var", 1);
   router.add("/b/{+y}", "reserved_exp", 2);
@@ -2504,13 +2496,13 @@ TEST(URITemplateRouter, expansion_consumes_unlike_plain_variable) {
   EXPECT_ROUTER_CAPTURE(captures_c, 0, "z", "one/two");
 }
 
-TEST(URITemplateRouter, operation_id_round_trip_single_route) {
+TEST(operation_id_round_trip_single_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "list_users", 1);
   EXPECT_EQ(router.operation_id(1), "list_users");
 }
 
-TEST(URITemplateRouter, operation_id_round_trip_multiple_routes) {
+TEST(operation_id_round_trip_multiple_routes) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "list_users", 1, 11);
   router.add("/posts/{id}", "show_post", 2, 22);
@@ -2520,7 +2512,7 @@ TEST(URITemplateRouter, operation_id_round_trip_multiple_routes) {
   EXPECT_EQ(router.operation_id(3), "fetch_files");
 }
 
-TEST(URITemplateRouter, operation_id_inverse_of_operation) {
+TEST(operation_id_inverse_of_operation) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "alpha", 1, 11);
   router.add("/b", "beta", 2, 22);
@@ -2543,19 +2535,19 @@ TEST(URITemplateRouter, operation_id_inverse_of_operation) {
   EXPECT_EQ(resolved_gamma.second, 33);
 }
 
-TEST(URITemplateRouter, operation_id_zero_returns_empty) {
+TEST(operation_id_zero_returns_empty) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "list_users", 1);
   EXPECT_TRUE(router.operation_id(0).empty());
 }
 
-TEST(URITemplateRouter, operation_id_unregistered_returns_empty) {
+TEST(operation_id_unregistered_returns_empty) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "list_users", 1);
   EXPECT_TRUE(router.operation_id(99).empty());
 }
 
-TEST(URITemplateRouter, operation_id_after_overwrite) {
+TEST(operation_id_after_overwrite) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "list_users", 1);
   router.add("/users", "list_users_v2", 2);
@@ -2563,35 +2555,35 @@ TEST(URITemplateRouter, operation_id_after_overwrite) {
   EXPECT_EQ(router.operation_id(2), "list_users_v2");
 }
 
-TEST(URITemplateRouter, trailing_slash_distinct_from_bare_match_bare) {
+TEST(trailing_slash_distinct_from_bare_match_bare) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_700", 1);
   EXPECT_ROUTER_MATCH(router, "/foo", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_distinct_from_bare_no_match_slashed) {
+TEST(trailing_slash_distinct_from_bare_no_match_slashed) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_701", 1);
   EXPECT_ROUTER_MATCH(router, "/foo/", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_only_registration_matches_slashed) {
+TEST(trailing_slash_only_registration_matches_slashed) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/", "op_702", 1);
   EXPECT_ROUTER_MATCH(router, "/foo/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_only_registration_no_match_bare) {
+TEST(trailing_slash_only_registration_no_match_bare) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/", "op_703", 1);
   EXPECT_ROUTER_MATCH(router, "/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_both_forms_registered_match_bare) {
+TEST(trailing_slash_both_forms_registered_match_bare) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_704", 1);
   router.add("/foo/", "op_705", 2);
@@ -2599,7 +2591,7 @@ TEST(URITemplateRouter, trailing_slash_both_forms_registered_match_bare) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_both_forms_registered_match_slashed) {
+TEST(trailing_slash_both_forms_registered_match_slashed) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_706", 1);
   router.add("/foo/", "op_707", 2);
@@ -2607,15 +2599,14 @@ TEST(URITemplateRouter, trailing_slash_both_forms_registered_match_slashed) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_both_forms_registered_size_is_two) {
+TEST(trailing_slash_both_forms_registered_size_is_two) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_708", 1);
   router.add("/foo/", "op_709", 2);
   EXPECT_EQ(router.size(), 2);
 }
 
-TEST(URITemplateRouter,
-     trailing_slash_both_forms_registered_lookup_by_operation_id) {
+TEST(trailing_slash_both_forms_registered_lookup_by_operation_id) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_710", 1);
   router.add("/foo/", "op_711", 2);
@@ -2625,8 +2616,7 @@ TEST(URITemplateRouter,
   EXPECT_EQ(slashed.first, 2);
 }
 
-TEST(URITemplateRouter,
-     trailing_slash_both_forms_registered_path_reconstruction) {
+TEST(trailing_slash_both_forms_registered_path_reconstruction) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo", "op_712", 1);
   router.add("/foo/", "op_713", 2);
@@ -2634,21 +2624,21 @@ TEST(URITemplateRouter,
   EXPECT_EQ(router.path(2), "/foo/");
 }
 
-TEST(URITemplateRouter, trailing_slash_multi_segment_match_slashed) {
+TEST(trailing_slash_multi_segment_match_slashed) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/bar/", "op_714", 1);
   EXPECT_ROUTER_MATCH(router, "/foo/bar/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_multi_segment_no_match_bare) {
+TEST(trailing_slash_multi_segment_no_match_bare) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/bar/", "op_715", 1);
   EXPECT_ROUTER_MATCH(router, "/foo/bar", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_after_variable_match_slashed) {
+TEST(trailing_slash_after_variable_match_slashed) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}/", "op_716", 1);
   EXPECT_ROUTER_MATCH(router, "/users/42/", 1, 0, captures);
@@ -2656,13 +2646,13 @@ TEST(URITemplateRouter, trailing_slash_after_variable_match_slashed) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, trailing_slash_after_variable_no_match_bare) {
+TEST(trailing_slash_after_variable_no_match_bare) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}/", "op_717", 1);
   EXPECT_ROUTER_MATCH(router, "/users/42", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, trailing_slash_both_forms_with_variable) {
+TEST(trailing_slash_both_forms_with_variable) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "op_718", 1);
   router.add("/users/{id}/", "op_719", 2);
@@ -2674,28 +2664,28 @@ TEST(URITemplateRouter, trailing_slash_both_forms_with_variable) {
   EXPECT_ROUTER_CAPTURE(captures_slashed, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, trailing_slash_does_not_relax_internal_double_slash) {
+TEST(trailing_slash_does_not_relax_internal_double_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/bar", "op_720", 1);
   EXPECT_ROUTER_MATCH(router, "/foo//bar", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_with_base_path_match_slashed) {
+TEST(trailing_slash_with_base_path_match_slashed) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   router.add("/foo/", "op_721", 1);
   EXPECT_ROUTER_MATCH(router, "/api/foo/", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_with_base_path_no_match_bare) {
+TEST(trailing_slash_with_base_path_no_match_bare) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   router.add("/foo/", "op_722", 1);
   EXPECT_ROUTER_MATCH(router, "/api/foo", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_with_base_path_both_forms) {
+TEST(trailing_slash_with_base_path_both_forms) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   router.add("/foo", "op_723", 1);
   router.add("/foo/", "op_724", 2);
@@ -2705,15 +2695,14 @@ TEST(URITemplateRouter, trailing_slash_with_base_path_both_forms) {
   EXPECT_EQ(captures_slashed.size(), 0);
 }
 
-TEST(URITemplateRouter,
-     trailing_slash_multiple_trailing_slashes_in_request_no_match) {
+TEST(trailing_slash_multiple_trailing_slashes_in_request_no_match) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/", "op_726", 1);
   EXPECT_ROUTER_MATCH(router, "/foo//", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, trailing_slash_both_forms_each_has_distinct_arguments) {
+TEST(trailing_slash_both_forms_each_has_distinct_arguments) {
   sourcemeta::core::URITemplateRouter router;
   const std::array<sourcemeta::core::URITemplateRouter::Argument, 1> bare_args{
       {sourcemeta::core::URITemplateRouter::Argument{
@@ -2743,8 +2732,7 @@ TEST(URITemplateRouter, trailing_slash_both_forms_each_has_distinct_arguments) {
   EXPECT_EQ(slashed_kind, "slashed");
 }
 
-TEST(URITemplateRouter,
-     strict_internal_double_slash_registers_and_matches_only_itself) {
+TEST(strict_internal_double_slash_registers_and_matches_only_itself) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo//bar", "op_800", 1);
   EXPECT_ROUTER_MATCH(router, "/foo//bar", 1, 0, captures_verbatim);
@@ -2752,8 +2740,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_MATCH(router, "/foo/bar", 0, 0, captures_canonical);
 }
 
-TEST(URITemplateRouter,
-     strict_only_slashes_template_registers_four_empty_segments) {
+TEST(strict_only_slashes_template_registers_four_empty_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("////", "op_801", 1);
   EXPECT_EQ(router.size(), 1);
@@ -2763,8 +2750,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_MATCH(router, "/////", 0, 0, captures_long);
 }
 
-TEST(URITemplateRouter,
-     strict_three_slashes_template_registers_three_empty_segments) {
+TEST(strict_three_slashes_template_registers_three_empty_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("///", "op_802", 1);
   EXPECT_ROUTER_MATCH(router, "///", 1, 0, captures_match);
@@ -2773,8 +2759,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_MATCH(router, "////", 0, 0, captures_long);
 }
 
-TEST(URITemplateRouter,
-     strict_double_slash_template_registers_two_empty_segments) {
+TEST(strict_double_slash_template_registers_two_empty_segments) {
   sourcemeta::core::URITemplateRouter router;
   router.add("//", "op_803", 1);
   EXPECT_ROUTER_MATCH(router, "//", 1, 0, captures_match);
@@ -2782,7 +2767,7 @@ TEST(URITemplateRouter,
   EXPECT_ROUTER_MATCH(router, "/", 0, 0, captures_short);
 }
 
-TEST(URITemplateRouter, strict_internal_empty_with_variable_after) {
+TEST(strict_internal_empty_with_variable_after) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo//{id}", "op_804", 1);
   EXPECT_ROUTER_MATCH(router, "/foo//42", 1, 0, captures);
@@ -2790,13 +2775,13 @@ TEST(URITemplateRouter, strict_internal_empty_with_variable_after) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "id", "42");
 }
 
-TEST(URITemplateRouter, strict_variable_does_not_bind_empty_segment) {
+TEST(strict_variable_does_not_bind_empty_segment) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/{id}", "op_805", 1);
   EXPECT_ROUTER_MATCH(router, "/users/", 0, 0, captures);
 }
 
-TEST(URITemplateRouter, strict_missing_leading_slash_throws) {
+TEST(strict_missing_leading_slash_throws) {
   sourcemeta::core::URITemplateRouter router;
   try {
     router.add("foo", "op_806", 1);
@@ -2807,14 +2792,14 @@ TEST(URITemplateRouter, strict_missing_leading_slash_throws) {
   }
 }
 
-TEST(URITemplateRouter, strict_empty_template_still_special) {
+TEST(strict_empty_template_still_special) {
   sourcemeta::core::URITemplateRouter router;
   router.add("", "op_807", 1);
   EXPECT_ROUTER_MATCH(router, "", 1, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouter, strict_internal_empty_then_literal) {
+TEST(strict_internal_empty_then_literal) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/a", "op_810", 1);
   router.add("/a//b", "op_811", 2);
@@ -2826,7 +2811,7 @@ TEST(URITemplateRouter, strict_internal_empty_then_literal) {
   EXPECT_ROUTER_MATCH(router, "/a/", 0, 0, captures_a_slash);
 }
 
-TEST(URITemplateRouter, strict_root_template_still_works) {
+TEST(strict_root_template_still_works) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/", "op_812", 1);
   EXPECT_ROUTER_MATCH(router, "/", 1, 0, captures_match);
@@ -2835,7 +2820,7 @@ TEST(URITemplateRouter, strict_root_template_still_works) {
   EXPECT_ROUTER_MATCH(router, "//", 0, 0, captures_double);
 }
 
-TEST(URITemplateRouter, strict_path_reconstruction_preserves_input) {
+TEST(strict_path_reconstruction_preserves_input) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo//bar", "op_813", 1);
   router.add("////", "op_814", 2);
@@ -2843,7 +2828,7 @@ TEST(URITemplateRouter, strict_path_reconstruction_preserves_input) {
   EXPECT_EQ(router.path(2), "////");
 }
 
-TEST(URITemplateRouter, describes_worked_example_table) {
+TEST(describes_worked_example_table) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/self/v1/api/schemas/health/{+schema}", "op_815", 1);
   router.add("/self/v1/api/{+any}", "op_816", 2);
@@ -2864,7 +2849,7 @@ TEST(URITemplateRouter, describes_worked_example_table) {
   EXPECT_TRUE(router.describes("/"));
 }
 
-TEST(URITemplateRouter, describes_intermediate_prefixes) {
+TEST(describes_intermediate_prefixes) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/self/v1/mcp", "op_820", 1);
   router.otherwise(0);
@@ -2877,7 +2862,7 @@ TEST(URITemplateRouter, describes_intermediate_prefixes) {
   EXPECT_FALSE(router.describes("/other"));
 }
 
-TEST(URITemplateRouter, describes_expansion_capture) {
+TEST(describes_expansion_capture) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/files/{+path}", "op_821", 1);
   router.otherwise(0);
@@ -2889,7 +2874,7 @@ TEST(URITemplateRouter, describes_expansion_capture) {
   EXPECT_FALSE(router.describes("/filesx"));
 }
 
-TEST(URITemplateRouter, describes_optional_expansion_capture) {
+TEST(describes_optional_expansion_capture) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/docs/{/rest*}", "op_822", 1);
   router.otherwise(0);
@@ -2901,8 +2886,7 @@ TEST(URITemplateRouter, describes_optional_expansion_capture) {
   EXPECT_FALSE(router.describes("/docsx"));
 }
 
-TEST(URITemplateRouter,
-     describes_single_segment_variable_does_not_over_absorb) {
+TEST(describes_single_segment_variable_does_not_over_absorb) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/foo/{bar}/baz", "op_823", 1);
   router.otherwise(0);
@@ -2914,7 +2898,7 @@ TEST(URITemplateRouter,
   EXPECT_FALSE(router.describes("/foo/anything/baz/extra"));
 }
 
-TEST(URITemplateRouter, describes_whole_segment_discipline) {
+TEST(describes_whole_segment_discipline) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/internalish", "op_824", 1);
   router.otherwise(0);
@@ -2924,7 +2908,7 @@ TEST(URITemplateRouter, describes_whole_segment_discipline) {
   EXPECT_FALSE(router.describes("/internalisher"));
 }
 
-TEST(URITemplateRouter, describes_excludes_otherwise_fallback) {
+TEST(describes_excludes_otherwise_fallback) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/known", "op_825", 1);
   router.otherwise(7);
@@ -2934,7 +2918,7 @@ TEST(URITemplateRouter, describes_excludes_otherwise_fallback) {
   EXPECT_FALSE(router.describes("/known/deeper"));
 }
 
-TEST(URITemplateRouter, describes_empty_router_describes_nothing) {
+TEST(describes_empty_router_describes_nothing) {
   sourcemeta::core::URITemplateRouter router;
   router.otherwise(3);
 
@@ -2943,7 +2927,7 @@ TEST(URITemplateRouter, describes_empty_router_describes_nothing) {
   EXPECT_FALSE(router.describes("/anything"));
 }
 
-TEST(URITemplateRouter, describes_root_and_empty_path) {
+TEST(describes_root_and_empty_path) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_826", 1);
   router.otherwise(0);
@@ -2952,7 +2936,7 @@ TEST(URITemplateRouter, describes_root_and_empty_path) {
   EXPECT_TRUE(router.describes(""));
 }
 
-TEST(URITemplateRouter, describes_requires_leading_slash) {
+TEST(describes_requires_leading_slash) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users", "op_827", 1);
   router.otherwise(0);
@@ -2961,7 +2945,7 @@ TEST(URITemplateRouter, describes_requires_leading_slash) {
   EXPECT_FALSE(router.describes("users/list"));
 }
 
-TEST(URITemplateRouter, describes_with_base_path) {
+TEST(describes_with_base_path) {
   sourcemeta::core::URITemplateRouter router{"/api"};
   router.add("/foo", "op_828", 1);
   router.otherwise(0);
@@ -2972,7 +2956,7 @@ TEST(URITemplateRouter, describes_with_base_path) {
   EXPECT_FALSE(router.describes("/api/bar"));
 }
 
-TEST(URITemplateRouter, describes_literal_preferred_over_variable) {
+TEST(describes_literal_preferred_over_variable) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/users/me", "op_829", 1);
   router.add("/users/{id}/posts", "op_830", 2);
@@ -2985,7 +2969,7 @@ TEST(URITemplateRouter, describes_literal_preferred_over_variable) {
   EXPECT_FALSE(router.describes("/users/me/posts"));
 }
 
-TEST(URITemplateRouter, describes_empty_template_root_route) {
+TEST(describes_empty_template_root_route) {
   sourcemeta::core::URITemplateRouter router;
   router.add("", "op_831", 1);
   router.otherwise(0);
@@ -2995,7 +2979,7 @@ TEST(URITemplateRouter, describes_empty_template_root_route) {
   EXPECT_FALSE(router.describes("/foo"));
 }
 
-TEST(URITemplateRouter, describes_with_base_argument_equivalent_to_concat) {
+TEST(describes_with_base_argument_equivalent_to_concat) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/self/v1/api/{+any}", "op_832", 1);
   router.add("/self/v1/mcp", "op_833", 2);
@@ -3009,7 +2993,7 @@ TEST(URITemplateRouter, describes_with_base_argument_equivalent_to_concat) {
   EXPECT_FALSE(router.describes("/api", "/self/v2"));
 }
 
-TEST(URITemplateRouter, describes_with_base_argument_prefix_and_capture) {
+TEST(describes_with_base_argument_prefix_and_capture) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/files/{+path}", "op_834", 1);
   router.otherwise(0);
@@ -3022,7 +3006,7 @@ TEST(URITemplateRouter, describes_with_base_argument_prefix_and_capture) {
   EXPECT_FALSE(router.describes("/a/b", "/file"));
 }
 
-TEST(URITemplateRouter, describes_with_base_argument_captured_in_base) {
+TEST(describes_with_base_argument_captured_in_base) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/files/{+path}", "op_835", 1);
   router.otherwise(0);
@@ -3030,7 +3014,7 @@ TEST(URITemplateRouter, describes_with_base_argument_captured_in_base) {
   EXPECT_TRUE(router.describes("/anything", "/files/already"));
 }
 
-TEST(URITemplateRouter, describes_with_base_argument_base_mismatch) {
+TEST(describes_with_base_argument_base_mismatch) {
   sourcemeta::core::URITemplateRouter router;
   router.add("/self/v1/mcp", "op_836", 1);
   router.otherwise(0);
@@ -3039,7 +3023,7 @@ TEST(URITemplateRouter, describes_with_base_argument_base_mismatch) {
   EXPECT_FALSE(router.describes("/mcp", "/self/v2"));
 }
 
-TEST(URITemplateRouter, describes_with_router_base_path_split_argument) {
+TEST(describes_with_router_base_path_split_argument) {
   sourcemeta::core::URITemplateRouter router{"/prefix"};
   router.add("/foo", "op_837", 1);
   router.otherwise(0);
@@ -3050,7 +3034,7 @@ TEST(URITemplateRouter, describes_with_router_base_path_split_argument) {
   EXPECT_FALSE(router.describes("/bar", "/prefix"));
 }
 
-TEST(URITemplateRouter, describes_with_base_argument_empty_router) {
+TEST(describes_with_base_argument_empty_router) {
   sourcemeta::core::URITemplateRouter router;
   router.otherwise(0);
 

--- a/test/uritemplate/uritemplate_router_test.cc
+++ b/test/uritemplate/uritemplate_router_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uritemplate.h>
 
 #include "uritemplate_helpers.h"

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uritemplate.h>
 
 #include "uritemplate_helpers.h"

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uritemplate.h>
 
@@ -12,14 +12,18 @@
 #include <fstream>    // std::ifstream
 #include <span>       // std::span
 #include <string>     // std::string
-#include <string_view> // std::string_view
-#include <utility>     // std::pair
-#include <variant>     // std::holds_alternative, std::get
-#include <vector>      // std::vector
+#include <string_view>  // std::string_view
+#include <system_error> // std::error_code
+#include <utility>      // std::pair
+#include <variant>      // std::holds_alternative, std::get
+#include <vector>       // std::vector
 
-class URITemplateRouterViewTest : public ::testing::Test {
+class URITemplateRouterViewTest {
 protected:
-  void TearDown() override { std::filesystem::remove(this->path); }
+  ~URITemplateRouterViewTest() {
+    std::error_code error;
+    std::filesystem::remove(this->path, error);
+  }
   // The tests are always sequential, so using the same path is safe
   std::filesystem::path path{std::filesystem::temp_directory_path() /
                              "sourcemeta_core_uritemplate_router_test.bin"};
@@ -710,20 +714,20 @@ TEST_F(URITemplateRouterViewTest, expansion_matches_double_slashes) {
   EXPECT_ROUTER_CAPTURE(captures, 0, "path", "foo//bar");
 }
 
-TEST(URITemplateRouterView, corrupt_empty_data) {
+TEST(corrupt_empty_data) {
   const sourcemeta::core::URITemplateRouterView view{nullptr, 0};
   EXPECT_ROUTER_MATCH(view, "/users", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_too_small_for_header) {
+TEST(corrupt_too_small_for_header) {
   const std::uint8_t data[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03};
   const sourcemeta::core::URITemplateRouterView view{data, sizeof(data)};
   EXPECT_ROUTER_MATCH(view, "/users", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_wrong_magic) {
+TEST(corrupt_wrong_magic) {
   const std::uint32_t data[] = {0xDEADBEEF, 5, 1, 64, 64, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
       reinterpret_cast<const std::uint8_t *>(data), sizeof(data)};
@@ -731,7 +735,7 @@ TEST(URITemplateRouterView, corrupt_wrong_magic) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_wrong_version) {
+TEST(corrupt_wrong_version) {
   const std::uint32_t data[] = {0x52544552, 99, 1, 64, 64, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
       reinterpret_cast<const std::uint8_t *>(data), sizeof(data)};
@@ -739,7 +743,7 @@ TEST(URITemplateRouterView, corrupt_wrong_version) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_node_count_exceeds_file) {
+TEST(corrupt_node_count_exceeds_file) {
   const std::uint32_t data[] = {0x52544552, 5, 10, 32, 32, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
       reinterpret_cast<const std::uint8_t *>(data), sizeof(data)};
@@ -747,7 +751,7 @@ TEST(URITemplateRouterView, corrupt_node_count_exceeds_file) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_literal_child_out_of_bounds) {
+TEST(corrupt_literal_child_out_of_bounds) {
   const std::uint32_t data[] = {0x52544552, 5, 1,   64, 64,         0, 0, 0,
                                 0,          0, 999, 1,  0xFFFFFFFF, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
@@ -756,7 +760,7 @@ TEST(URITemplateRouterView, corrupt_literal_child_out_of_bounds) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_variable_child_out_of_bounds) {
+TEST(corrupt_variable_child_out_of_bounds) {
   const std::uint32_t data[] = {0x52544552, 5, 1,          64, 64,  0, 0, 0,
                                 0,          0, 0xFFFFFFFF, 0,  500, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
@@ -765,7 +769,7 @@ TEST(URITemplateRouterView, corrupt_variable_child_out_of_bounds) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_string_offset_out_of_bounds) {
+TEST(corrupt_string_offset_out_of_bounds) {
   const std::uint32_t data[] = {
       0x52544552, 5, 2, 96, 96,   0, 0,          0, 0,          0, 0, 1, 1,
       0xFFFFFFFF, 0, 0, 0,  9999, 5, 0xFFFFFFFF, 0, 0xFFFFFFFF, 0, 0, 0};
@@ -775,7 +779,7 @@ TEST(URITemplateRouterView, corrupt_string_offset_out_of_bounds) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_variable_string_offset_out_of_bounds) {
+TEST(corrupt_variable_string_offset_out_of_bounds) {
   const std::uint32_t data[] = {
       0x52544552, 5,   2,          96, 96,         0,          0, 0,
       0,          0,   0xFFFFFFFF, 0,  1,          0,          0, 0,
@@ -786,14 +790,14 @@ TEST(URITemplateRouterView, corrupt_variable_string_offset_out_of_bounds) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_all_zeroes) {
+TEST(corrupt_all_zeroes) {
   const std::uint8_t data[128] = {};
   const sourcemeta::core::URITemplateRouterView view{data, sizeof(data)};
   EXPECT_ROUTER_MATCH(view, "/users", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_all_ones) {
+TEST(corrupt_all_ones) {
   std::uint8_t data[128];
   std::memset(data, 0xFF, sizeof(data));
   const sourcemeta::core::URITemplateRouterView view{data, sizeof(data)};
@@ -801,7 +805,7 @@ TEST(URITemplateRouterView, corrupt_all_ones) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_string_table_offset_overlaps_header) {
+TEST(corrupt_string_table_offset_overlaps_header) {
   const std::uint32_t data[] = {0x52544552, 5, 1,          4, 64, 0, 0, 0, 0, 0,
                                 0xFFFFFFFF, 0, 0xFFFFFFFF, 0, 0,  0};
   const sourcemeta::core::URITemplateRouterView view{
@@ -810,7 +814,7 @@ TEST(URITemplateRouterView, corrupt_string_table_offset_overlaps_header) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_string_table_offset_past_end) {
+TEST(corrupt_string_table_offset_past_end) {
   const std::uint32_t data[] = {0x52544552, 5, 1, 99999, 99999,      0,
                                 0,          0, 0, 0,     0xFFFFFFFF, 0,
                                 0xFFFFFFFF, 0, 0, 0};
@@ -820,7 +824,7 @@ TEST(URITemplateRouterView, corrupt_string_table_offset_past_end) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_zero_node_count) {
+TEST(corrupt_zero_node_count) {
   const std::uint32_t data[] = {0x52544552, 5, 0, 32, 32, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
       reinterpret_cast<const std::uint8_t *>(data), sizeof(data)};
@@ -828,19 +832,19 @@ TEST(URITemplateRouterView, corrupt_zero_node_count) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_empty_data_match_empty_path) {
+TEST(corrupt_empty_data_match_empty_path) {
   const sourcemeta::core::URITemplateRouterView view{nullptr, 0};
   EXPECT_ROUTER_MATCH(view, "", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_empty_data_match_root) {
+TEST(corrupt_empty_data_match_root) {
   const sourcemeta::core::URITemplateRouterView view{nullptr, 0};
   EXPECT_ROUTER_MATCH(view, "/", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_literal_child_count_overflow) {
+TEST(corrupt_literal_child_count_overflow) {
   const std::uint32_t data[] = {
       0x52544552, 5, 2, 96, 96, 0, 0,          0, 0,          0, 1, 0xFFFFFFFF,
       0xFFFFFFFF, 0, 0, 0,  0,  0, 0xFFFFFFFF, 0, 0xFFFFFFFF, 0, 0, 0};
@@ -850,7 +854,7 @@ TEST(URITemplateRouterView, corrupt_literal_child_count_overflow) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_root_literal_child_oob_match_root) {
+TEST(corrupt_root_literal_child_oob_match_root) {
   const std::uint32_t data[] = {0x52544552, 5, 1,   64, 64,         0, 0, 0,
                                 0,          0, 999, 1,  0xFFFFFFFF, 0, 0, 0};
   const sourcemeta::core::URITemplateRouterView view{
@@ -859,7 +863,7 @@ TEST(URITemplateRouterView, corrupt_root_literal_child_oob_match_root) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_deep_node_variable_child_oob) {
+TEST(corrupt_deep_node_variable_child_oob) {
   std::vector<std::uint8_t> data;
   const std::uint32_t header[] = {0x52544552, 5, 2, 96, 101, 0, 0, 0};
   const std::uint32_t root[] = {0, 0, 1, 1, 0xFFFFFFFF, 0, 0, 0};
@@ -877,7 +881,7 @@ TEST(URITemplateRouterView, corrupt_deep_node_variable_child_oob) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_expansion_string_oob) {
+TEST(corrupt_expansion_string_oob) {
   const std::uint32_t data[] = {
       0x52544552, 5,   2,          96, 96,         0,          0, 0,
       0,          0,   0xFFFFFFFF, 0,  1,          0,          0, 0,
@@ -888,7 +892,7 @@ TEST(URITemplateRouterView, corrupt_expansion_string_oob) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_empty_string_table_with_string_ref) {
+TEST(corrupt_empty_string_table_with_string_ref) {
   const std::uint32_t data[] = {
       0x52544552, 5, 2, 96, 96, 0,  0,          0, 0,          0, 1, 1,
       0xFFFFFFFF, 0, 0, 0,  0,  10, 0xFFFFFFFF, 0, 0xFFFFFFFF, 0, 0, 0};
@@ -898,7 +902,7 @@ TEST(URITemplateRouterView, corrupt_empty_string_table_with_string_ref) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_node_count_max_uint32) {
+TEST(corrupt_node_count_max_uint32) {
   const std::uint32_t data[] = {0x52544552, 5, 0xFFFFFFFF, 44, 44, 0,
                                 0,          0, 0,          0,  0};
   const sourcemeta::core::URITemplateRouterView view{
@@ -907,7 +911,7 @@ TEST(URITemplateRouterView, corrupt_node_count_max_uint32) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView, corrupt_string_offset_plus_length_overflow) {
+TEST(corrupt_string_offset_plus_length_overflow) {
   const std::uint32_t data[] = {
       0x52544552, 5,          2,          96, 96,         0,          0, 0,
       0,          0,          0xFFFFFFFF, 0,  1,          0,          0, 0,
@@ -918,8 +922,7 @@ TEST(URITemplateRouterView, corrupt_string_offset_plus_length_overflow) {
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView,
-     corrupt_string_offset_plus_length_overflow_with_data) {
+TEST(corrupt_string_offset_plus_length_overflow_with_data) {
   std::vector<std::uint8_t> data;
   const std::uint32_t header[] = {0x52544552, 5, 2, 96, 97, 0, 0, 0};
   const std::uint32_t root[] = {0, 0, 0xFFFFFFFF, 0, 1, 0, 0, 0};
@@ -939,8 +942,7 @@ TEST(URITemplateRouterView,
   EXPECT_EQ(captures.size(), 0);
 }
 
-TEST(URITemplateRouterView,
-     corrupt_literal_string_offset_plus_length_overflow) {
+TEST(corrupt_literal_string_offset_plus_length_overflow) {
   std::vector<std::uint8_t> data;
   const std::uint32_t header[] = {0x52544552, 5, 2, 96, 97, 0, 0, 0};
   const std::uint32_t root[] = {0, 0, 1, 1, 0xFFFFFFFF, 0, 0, 0};
@@ -2243,7 +2245,7 @@ TEST_F(URITemplateRouterViewTest, base_url_arguments_still_resolve) {
                             std::string{std::get<std::string_view>(value)});
         }
       });
-  ASSERT_EQ(seen.size(), 1);
+  EXPECT_EQ(seen.size(), 1);
   EXPECT_EQ(seen.at(0).first, "schema");
   EXPECT_EQ(seen.at(0).second, "schemas/health");
 }
@@ -2354,10 +2356,10 @@ TEST_F(URITemplateRouterViewTest, add_with_context_and_arguments) {
         }
       });
 
-  ASSERT_EQ(seen_string.size(), 1);
+  EXPECT_EQ(seen_string.size(), 1);
   EXPECT_EQ(seen_string.at(0).first, "schema");
   EXPECT_EQ(seen_string.at(0).second, "schemas/health");
-  ASSERT_EQ(seen_bool.size(), 1);
+  EXPECT_EQ(seen_bool.size(), 1);
   EXPECT_EQ(seen_bool.at(0).first, "enabled");
   EXPECT_TRUE(seen_bool.at(0).second);
 }

--- a/test/uritemplate/uritemplate_test.cc
+++ b/test/uritemplate/uritemplate_test.cc
@@ -1,4 +1,4 @@
-#include <gtest/gtest.h>
+#include <sourcemeta/core/test.h>
 
 #include <sourcemeta/core/uritemplate.h>
 
@@ -6,7 +6,7 @@
 
 #include <utility> // std::move
 
-TEST(URITemplate, iterator) {
+TEST(iterator) {
   const sourcemeta::core::URITemplate uri_template{"/{a}/{b}"};
   EXPECT_EQ(uri_template.size(), 4);
 
@@ -50,7 +50,7 @@ TEST(URITemplate, iterator) {
   EXPECT_EQ(iterator, uri_template.end());
 }
 
-TEST(URITemplate, copy_constructor) {
+TEST(copy_constructor) {
   const sourcemeta::core::URITemplate original{"http://example.com/{id}"};
   const sourcemeta::core::URITemplate copy{original};
 
@@ -60,7 +60,7 @@ TEST(URITemplate, copy_constructor) {
                                false);
 }
 
-TEST(URITemplate, move_constructor) {
+TEST(move_constructor) {
   sourcemeta::core::URITemplate original{"http://example.com/{id}"};
   const sourcemeta::core::URITemplate moved{std::move(original)};
 
@@ -70,7 +70,7 @@ TEST(URITemplate, move_constructor) {
                                false);
 }
 
-TEST(URITemplate, copy_assignment) {
+TEST(copy_assignment) {
   const sourcemeta::core::URITemplate original{"http://example.com/{id}"};
   sourcemeta::core::URITemplate copy{""};
 
@@ -88,7 +88,7 @@ TEST(URITemplate, copy_assignment) {
                                false);
 }
 
-TEST(URITemplate, move_assignment) {
+TEST(move_assignment) {
   sourcemeta::core::URITemplate original{"http://example.com/{id}"};
   sourcemeta::core::URITemplate moved{""};
 
@@ -101,7 +101,7 @@ TEST(URITemplate, move_assignment) {
                                false);
 }
 
-TEST(URITemplate, at_const_lvalue) {
+TEST(at_const_lvalue) {
   const sourcemeta::core::URITemplate uri_template{"/{id}"};
   const auto &token = uri_template.at(1);
   EXPECT_TRUE(
@@ -113,7 +113,7 @@ TEST(URITemplate, at_const_lvalue) {
   EXPECT_EQ(variable.variables[0].name, "id");
 }
 
-TEST(URITemplate, at_rvalue_move) {
+TEST(at_rvalue_move) {
   sourcemeta::core::URITemplate uri_template{"/{id}"};
   auto token = std::move(uri_template).at(1);
   EXPECT_TRUE(
@@ -124,7 +124,7 @@ TEST(URITemplate, at_rvalue_move) {
   EXPECT_EQ(variable.variables[0].name, "id");
 }
 
-TEST(URITemplate, at_rvalue_move_multiple) {
+TEST(at_rvalue_move_multiple) {
   sourcemeta::core::URITemplate uri_template{"/users/{id}/posts/{post_id}"};
   EXPECT_EQ(uri_template.size(), 4);
 

--- a/test/uritemplate/uritemplate_test.cc
+++ b/test/uritemplate/uritemplate_test.cc
@@ -1,5 +1,4 @@
 #include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/uritemplate.h>
 
 #include "uritemplate_helpers.h"

--- a/test/yaml/yaml_parse_callback_test.cc
+++ b/test/yaml/yaml_parse_callback_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/yaml.h>
 
 #include <tuple>

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -1,7 +1,6 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/yaml.h>
 
 #include <sstream>

--- a/test/yaml/yaml_roundtrip_test.cc
+++ b/test/yaml/yaml_roundtrip_test.cc
@@ -1,6 +1,5 @@
-#include <sourcemeta/core/test.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/yaml.h>
 
 #include <sstream> // std::ostringstream


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

