### PR TITLE
Support dynamic test suites in `src/lang/test`

### DIFF
--- a/cmake/common/targets/test.cmake
+++ b/cmake/common/targets/test.cmake
@@ -22,7 +22,7 @@ endfunction()
 
 function(sourcemeta_test)
   cmake_parse_arguments(SOURCEMETA_TEST ""
-    "NAMESPACE;PROJECT;NAME;VARIANT" "SOURCES" ${ARGN})
+    "NAMESPACE;PROJECT;NAME;VARIANT;MAIN" "SOURCES" ${ARGN})
 
   if(SOURCEMETA_TEST_VARIANT)
     set(TARGET_VARIANT "${SOURCEMETA_TEST_VARIANT}_unit")
@@ -30,14 +30,20 @@ function(sourcemeta_test)
     set(TARGET_VARIANT "unit")
   endif()
 
-  sourcemeta_test_main(GENERATED_MAIN)
+  # Dynamic suites provide their own entry point that registers cases at runtime,
+  # so they opt out of the generated one with MAIN OFF
+  if(NOT DEFINED SOURCEMETA_TEST_MAIN OR SOURCEMETA_TEST_MAIN)
+    sourcemeta_test_main(GENERATED_MAIN)
+  else()
+    set(GENERATED_MAIN "")
+  endif()
 
   sourcemeta_executable(
     NAMESPACE "${SOURCEMETA_TEST_NAMESPACE}"
     PROJECT "${SOURCEMETA_TEST_PROJECT}"
     NAME "${SOURCEMETA_TEST_NAME}"
     VARIANT "${TARGET_VARIANT}"
-    SOURCES "${SOURCEMETA_TEST_SOURCES}" "${GENERATED_MAIN}"
+    SOURCES "${SOURCEMETA_TEST_SOURCES}" ${GENERATED_MAIN}
     OUTPUT TARGET_NAME)
 
   target_link_libraries("${TARGET_NAME}"

--- a/cmake/common/targets/test.cmake
+++ b/cmake/common/targets/test.cmake
@@ -30,12 +30,13 @@ function(sourcemeta_test)
     set(TARGET_VARIANT "unit")
   endif()
 
+  set(TARGET_SOURCES "${SOURCEMETA_TEST_SOURCES}")
+
   # Dynamic suites provide their own entry point that registers cases at runtime,
   # so they opt out of the generated one with MAIN OFF
   if(NOT DEFINED SOURCEMETA_TEST_MAIN OR SOURCEMETA_TEST_MAIN)
     sourcemeta_test_main(GENERATED_MAIN)
-  else()
-    set(GENERATED_MAIN "")
+    list(APPEND TARGET_SOURCES "${GENERATED_MAIN}")
   endif()
 
   sourcemeta_executable(
@@ -43,7 +44,7 @@ function(sourcemeta_test)
     PROJECT "${SOURCEMETA_TEST_PROJECT}"
     NAME "${SOURCEMETA_TEST_NAME}"
     VARIANT "${TARGET_VARIANT}"
-    SOURCES "${SOURCEMETA_TEST_SOURCES}" ${GENERATED_MAIN}
+    SOURCES "${TARGET_SOURCES}"
     OUTPUT TARGET_NAME)
 
   target_link_libraries("${TARGET_NAME}"

--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -7,11 +7,12 @@
 
 #include <sourcemeta/core/numeric_util.h>
 
-#include <functional>  // std::function
-#include <ostream>     // std::ostream
-#include <sstream>     // std::ostringstream
-#include <string>      // std::string
-#include <string_view> // std::string_view
+#include <functional>      // std::function
+#include <ostream>         // std::ostream
+#include <source_location> // std::source_location
+#include <sstream>         // std::ostringstream
+#include <string>          // std::string
+#include <string_view>     // std::string_view
 #include <type_traits> // std::is_integral_v, std::is_same_v, std::remove_cv_t
 #include <utility> // std::cmp_equal, std::cmp_not_equal, std::cmp_less, std::cmp_greater, std::cmp_less_equal, std::cmp_greater_equal
 
@@ -50,6 +51,15 @@ SOURCEMETA_CORE_TEST_EXPORT
 auto test_register(std::string_view suite, std::string_view name,
                    std::string_view file, int line, std::function<void()> body)
     -> int;
+
+/// @ingroup test
+///
+/// Register a test case whose suite and source location are taken from the call
+/// site. Intended for suites that discover their cases at runtime.
+SOURCEMETA_CORE_TEST_EXPORT
+auto test_register(
+    std::string_view name, std::function<void()> body,
+    std::source_location location = std::source_location::current()) -> int;
 
 /// @ingroup test
 ///

--- a/src/lang/test/test.cc
+++ b/src/lang/test/test.cc
@@ -2,15 +2,16 @@
 #include <sourcemeta/core/stacktrace.h>
 #include <sourcemeta/core/test.h>
 
-#include <cstddef>    // std::size_t
-#include <cstdlib>    // EXIT_SUCCESS, EXIT_FAILURE
-#include <exception>  // std::exception
-#include <filesystem> // std::filesystem::path
-#include <functional> // std::function
-#include <iostream>   // std::cout
-#include <string>     // std::string
-#include <utility>    // std::move
-#include <vector>     // std::vector
+#include <cstddef>         // std::size_t
+#include <cstdlib>         // EXIT_SUCCESS, EXIT_FAILURE
+#include <exception>       // std::exception
+#include <filesystem>      // std::filesystem::path
+#include <functional>      // std::function
+#include <iostream>        // std::cout
+#include <source_location> // std::source_location
+#include <string>          // std::string
+#include <utility>         // std::move
+#include <vector>          // std::vector
 
 namespace {
 
@@ -70,6 +71,13 @@ auto test_register(std::string_view suite, std::string_view name,
                         .line = line,
                         .body = std::move(body)});
   return 0;
+}
+
+auto test_register(std::string_view name, std::function<void()> body,
+                   std::source_location location) -> int {
+  return test_register(test_suite_from_path(location.file_name()), name,
+                       location.file_name(), static_cast<int>(location.line()),
+                       std::move(body));
 }
 
 [[noreturn]] auto test_report_failure(std::string_view file, int line,

--- a/test/json/CMakeLists.txt
+++ b/test/json/CMakeLists.txt
@@ -32,7 +32,7 @@ target_compile_definitions(sourcemeta_core_json_unit
 
 # JSON Test Suite
 # See https://github.com/nst/JSONTestSuite
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsontestsuite
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsontestsuite MAIN OFF
   SOURCES jsontestsuite.cc)
 target_compile_definitions(sourcemeta_core_jsontestsuite_unit
   PRIVATE JSONTESTSUITE_PATH="${PROJECT_SOURCE_DIR}/vendor/jsontestsuite")

--- a/test/json/jsontestsuite.cc
+++ b/test/json/jsontestsuite.cc
@@ -1,78 +1,65 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 
 #include <exception>  // std::exception
 #include <filesystem> // std::filesystem
 #include <fstream>    // std::ifstream
+#include <ios>        // std::ios::binary, std::ios_base::badbit
 #include <string>     // std::string, std::char_traits
 
+namespace {
 enum class JSONTestType { Accept, Reject };
 
-class JSONTest : public testing::Test {
-public:
-  explicit JSONTest(const std::filesystem::path path,
-                    const JSONTestType category)
-      : test_path{path}, type{category} {}
-
-  void TestBody() override {
-    std::ifstream stream{this->test_path, std::ios::binary};
-    stream.exceptions(std::ios_base::badbit);
-    if (this->type == JSONTestType::Accept) {
-      sourcemeta::core::parse_json(stream);
-      // Core consumes up to the end of a valid document
-      // in the stream. Force it continue until the end to cover
-      // certain test cases.
-      while (stream.peek() != std::char_traits<char>::eof()) {
-        switch (stream.get()) {
-          case '\r':
-          case '\t':
-          case '\n':
-          case ' ':
-            break;
-          default:
-            FAIL() << "Unexpected character";
-        }
+auto run_json_test_case(const std::filesystem::path &path,
+                        const JSONTestType type) -> void {
+  std::ifstream stream{path, std::ios::binary};
+  stream.exceptions(std::ios_base::badbit);
+  if (type == JSONTestType::Accept) {
+    sourcemeta::core::parse_json(stream);
+    // Core consumes up to the end of a valid document in the stream. Force it
+    // to continue until the end to cover certain test cases.
+    while (stream.peek() != std::char_traits<char>::eof()) {
+      switch (stream.get()) {
+        case '\r':
+        case '\t':
+        case '\n':
+        case ' ':
+          break;
+        default:
+          FAIL();
       }
-    } else if (this->type == JSONTestType::Reject) {
-      try {
-        // Core consumes up to the end of a valid document
-        // in the stream. Force it continue until the end to cover
-        // certain test cases.
-        while (!stream.eof()) {
-          sourcemeta::core::parse_json(stream);
-        }
-      } catch (const sourcemeta::core::JSONParseError &) {
-        SUCCEED();
-      } catch (const std::exception &) {
-        FAIL() << "The parse function threw an unexpected error";
+    }
+  } else {
+    // Core consumes up to the end of a valid document in the stream. Force it
+    // to continue until the end to cover certain test cases.
+    try {
+      while (!stream.eof()) {
+        sourcemeta::core::parse_json(stream);
       }
-    } else {
-      FAIL() << "Invalid test type";
+      FAIL();
+    } catch (const sourcemeta::core::JSONParseError &) {
+      // A malformed document is expected to be rejected
+    } catch (...) {
+      FAIL();
     }
   }
+}
+} // namespace
 
-private:
-  const std::filesystem::path test_path;
-  const JSONTestType type;
-};
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
-  const std::filesystem::path test_parsing_path =
-      std::filesystem::path{JSONTESTSUITE_PATH} / "test_parsing";
+auto main(int argc, char **argv) -> int {
+  const std::filesystem::path test_parsing_path{
+      std::filesystem::path{JSONTESTSUITE_PATH} / "test_parsing"};
   for (const std::filesystem::directory_entry &entry :
-       std::filesystem::directory_iterator(test_parsing_path)) {
+       std::filesystem::directory_iterator{test_parsing_path}) {
     const std::filesystem::path test_path{entry.path()};
-    const char front = test_path.filename().string().front();
-
-    JSONTestType type = front == 'n' || front == 'i' ? JSONTestType::Reject
-                                                     : JSONTestType::Accept;
-    testing::RegisterTest(
-        "JSONTestSuite", test_path.filename().string().c_str(), nullptr,
-        nullptr, __FILE__, __LINE__,
-        [=]() -> JSONTest * { return new JSONTest(test_path, type); });
+    const char front{test_path.filename().string().front()};
+    const JSONTestType type{front == 'n' || front == 'i'
+                                ? JSONTestType::Reject
+                                : JSONTestType::Accept};
+    sourcemeta::core::test_register(
+        test_path.filename().string(),
+        [test_path, type]() -> void { run_json_test_case(test_path, type); });
   }
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/json/jsontestsuite.cc
+++ b/test/json/jsontestsuite.cc
@@ -1,7 +1,6 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/test.h>
 
-#include <exception>  // std::exception
 #include <filesystem> // std::filesystem
 #include <fstream>    // std::ifstream
 #include <ios>        // std::ios::binary, std::ios_base::badbit
@@ -39,8 +38,6 @@ auto run_json_test_case(const std::filesystem::path &path,
       FAIL();
     } catch (const sourcemeta::core::JSONParseError &) {
       // A malformed document is expected to be rejected
-    } catch (...) {
-      FAIL();
     }
   }
 }

--- a/test/test/CMakeLists.txt
+++ b/test/test/CMakeLists.txt
@@ -25,6 +25,13 @@ add_executable(sourcemeta_core_test_fixture
 target_link_libraries(sourcemeta_core_test_fixture
   PRIVATE sourcemeta::core::test)
 
+# This suite registers its cases at runtime, so it provides its own entry point
+# rather than the generated one
+add_executable(sourcemeta_core_test_dynamic
+  test_dynamic.cc)
+target_link_libraries(sourcemeta_core_test_dynamic
+  PRIVATE sourcemeta::core::test)
+
 if(WIN32)
   set(SOURCEMETA_CORE_TEST_RUNNER powershell -ExecutionPolicy Bypass -File
     "${CMAKE_CURRENT_SOURCE_DIR}/test_runner.ps1")
@@ -63,3 +70,7 @@ add_test(NAME core.test.filter_none COMMAND ${SOURCEMETA_CORE_TEST_RUNNER}
 add_test(NAME core.test.fixture COMMAND ${SOURCEMETA_CORE_TEST_RUNNER}
   "$<TARGET_FILE:sourcemeta_core_test_fixture>" 0
   "${CMAKE_CURRENT_SOURCE_DIR}/test_fixture.txt")
+
+add_test(NAME core.test.dynamic COMMAND ${SOURCEMETA_CORE_TEST_RUNNER}
+  "$<TARGET_FILE:sourcemeta_core_test_dynamic>" 0
+  "${CMAKE_CURRENT_SOURCE_DIR}/test_dynamic.txt")

--- a/test/test/test_dynamic.cc
+++ b/test/test/test_dynamic.cc
@@ -1,0 +1,26 @@
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace {
+auto expect_length(const std::string_view value, const std::size_t length)
+    -> void {
+  EXPECT_EQ(value.size(), length);
+}
+} // namespace
+
+auto main(int argc, char **argv) -> int {
+  constexpr std::array<std::string_view, 3> values{"a", "bb", "ccc"};
+  std::size_t index{0};
+  for (const std::string_view value : values) {
+    index += 1;
+    sourcemeta::core::test_register(
+        "length_" + std::to_string(index),
+        [value]() -> void { expect_length(value, value.size()); });
+  }
+
+  return sourcemeta::core::test_run(argc, argv);
+}

--- a/test/test/test_dynamic.cc
+++ b/test/test/test_dynamic.cc
@@ -13,13 +13,13 @@ auto expect_length(const std::string_view value, const std::size_t length)
 } // namespace
 
 auto main(int argc, char **argv) -> int {
-  constexpr std::array<std::string_view, 3> values{"a", "bb", "ccc"};
+  constexpr std::array<std::string_view, 3> values{{"a", "bb", "ccc"}};
   std::size_t index{0};
   for (const std::string_view value : values) {
     index += 1;
     sourcemeta::core::test_register(
         "length_" + std::to_string(index),
-        [value]() -> void { expect_length(value, value.size()); });
+        [value, index]() -> void { expect_length(value, index); });
   }
 
   return sourcemeta::core::test_run(argc, argv);

--- a/test/test/test_dynamic.txt
+++ b/test/test/test_dynamic.txt
@@ -1,0 +1,6 @@
+TAP version 14
+1..3
+ok 1 - test_dynamic.length_1
+ok 2 - test_dynamic.length_2
+ok 3 - test_dynamic.length_3
+# 3 passed, 0 failed


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

