### PR TITLE
Use the new test runner in all dynamic suites

### DIFF
--- a/test/crypto/CMakeLists.txt
+++ b/test/crypto/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(sourcemeta_core_crypto_unit
 
 # pyca/cryptography Test Vectors
 # See https://github.com/pyca/cryptography
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME pyca_cryptography
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME pyca_cryptography
   SOURCES pyca_cryptography_test.cc)
 target_compile_definitions(sourcemeta_core_pyca_cryptography_unit
   PRIVATE PYCA_CRYPTOGRAPHY_PATH="${PROJECT_SOURCE_DIR}/vendor/pyca-cryptography/vectors/cryptography_vectors")
@@ -36,7 +36,7 @@ target_link_libraries(sourcemeta_core_pyca_cryptography_unit
 
 # Project Wycheproof Test Vectors
 # See https://github.com/C2SP/wycheproof
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME wycheproof
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME wycheproof
   SOURCES wycheproof_test.cc)
 target_compile_definitions(sourcemeta_core_wycheproof_unit
   PRIVATE WYCHEPROOF_PATH="${PROJECT_SOURCE_DIR}/vendor/wycheproof")

--- a/test/crypto/pyca_cryptography_test.cc
+++ b/test/crypto/pyca_cryptography_test.cc
@@ -1,7 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <cstddef>     // std::size_t
@@ -13,11 +12,12 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move
 
+namespace {
 // Every NIST CAVP response file ignores blank lines and "#" comments, leaving
 // section headers and "Key = Value" records
 template <typename Callback>
-static auto for_each_vector_line(const std::filesystem::path &path,
-                                 Callback callback) -> void {
+auto for_each_vector_line(const std::filesystem::path &path, Callback callback)
+    -> void {
   auto stream{sourcemeta::core::read_file(path)};
   sourcemeta::core::for_each_line(stream,
                                   [&callback](const std::string_view line) {
@@ -29,7 +29,7 @@ static auto for_each_vector_line(const std::filesystem::path &path,
                                   });
 }
 
-static auto to_signature_hash_function(const std::string_view name)
+auto to_signature_hash_function(const std::string_view name)
     -> std::optional<sourcemeta::core::SignatureHashFunction> {
   if (name == "SHA256" || name == "SHA-256") {
     return sourcemeta::core::SignatureHashFunction::SHA256;
@@ -47,8 +47,7 @@ struct CurveParameters {
   std::size_t coordinate_bytes;
 };
 
-static auto to_curve(const std::string_view name)
-    -> std::optional<CurveParameters> {
+auto to_curve(const std::string_view name) -> std::optional<CurveParameters> {
   if (name == "P-256") {
     return CurveParameters{sourcemeta::core::EllipticCurve::P256, 32};
   } else if (name == "P-384") {
@@ -65,73 +64,63 @@ static auto to_curve(const std::string_view name)
 using DigestFunction = auto (*)(const std::string_view) -> std::string;
 
 // Every vector in this file reduces to running a closure that asserts on data
-// captured at registration time, so a single fixture carrying that closure
+// captured at registration time, so a single runner carrying that closure
 // stands in for every mechanism
-class PyCA_Cryptography_Test : public testing::Test {
-public:
-  explicit PyCA_Cryptography_Test(std::function<void()> input_assertion)
-      : assertion{std::move(input_assertion)} {}
+auto run_pyca_test_case(const std::function<void()> &assertion) -> void {
+  assertion();
+}
 
-  auto TestBody() -> void override { this->assertion(); }
-
-private:
-  const std::function<void()> assertion;
-};
-
-static auto verify_pkcs1(const sourcemeta::core::SignatureHashFunction hash,
-                         const std::string_view modulus,
-                         const std::string_view exponent,
-                         const std::string_view message,
-                         const std::string_view signature) -> bool {
+auto verify_pkcs1(const sourcemeta::core::SignatureHashFunction hash,
+                  const std::string_view modulus,
+                  const std::string_view exponent,
+                  const std::string_view message,
+                  const std::string_view signature) -> bool {
   const auto key{sourcemeta::core::make_rsa_public_key(modulus, exponent)};
   return key.has_value() && sourcemeta::core::rsassa_pkcs1_v15_verify(
                                 key.value(), hash, message, signature);
 }
 
-static auto verify_pss(const sourcemeta::core::SignatureHashFunction hash,
-                       const std::string_view modulus,
-                       const std::string_view exponent,
-                       const std::string_view message,
-                       const std::string_view signature) -> bool {
+auto verify_pss(const sourcemeta::core::SignatureHashFunction hash,
+                const std::string_view modulus, const std::string_view exponent,
+                const std::string_view message,
+                const std::string_view signature) -> bool {
   const auto key{sourcemeta::core::make_rsa_public_key(modulus, exponent)};
   return key.has_value() && sourcemeta::core::rsassa_pss_verify(
                                 key.value(), hash, message, signature);
 }
 
-static auto verify_ecdsa(const sourcemeta::core::EllipticCurve curve,
-                         const sourcemeta::core::SignatureHashFunction hash,
-                         const std::string_view coordinate_x,
-                         const std::string_view coordinate_y,
-                         const std::string_view message,
-                         const std::string_view signature) -> bool {
+auto verify_ecdsa(const sourcemeta::core::EllipticCurve curve,
+                  const sourcemeta::core::SignatureHashFunction hash,
+                  const std::string_view coordinate_x,
+                  const std::string_view coordinate_y,
+                  const std::string_view message,
+                  const std::string_view signature) -> bool {
   const auto key{
       sourcemeta::core::make_ec_public_key(curve, coordinate_x, coordinate_y)};
   return key.has_value() &&
          sourcemeta::core::ecdsa_verify(key.value(), hash, message, signature);
 }
 
-static auto verify_eddsa(const sourcemeta::core::EdwardsCurve curve,
-                         const std::string_view public_key,
-                         const std::string_view message,
-                         const std::string_view signature) -> bool {
+auto verify_eddsa(const sourcemeta::core::EdwardsCurve curve,
+                  const std::string_view public_key,
+                  const std::string_view message,
+                  const std::string_view signature) -> bool {
   const auto key{sourcemeta::core::make_eddsa_public_key(curve, public_key)};
   return key.has_value() &&
          sourcemeta::core::eddsa_verify(key.value(), message, signature);
 }
 
-static auto register_case(const std::string &suite_name,
-                          const std::string &test_name,
-                          std::function<void()> assertion) -> void {
-  testing::RegisterTest(
-      suite_name.c_str(), test_name.c_str(), nullptr, nullptr, __FILE__,
-      __LINE__, [assertion = std::move(assertion)]() -> testing::Test * {
-        return new PyCA_Cryptography_Test(assertion);
-      });
+auto register_case(const std::string &suite_name, const std::string &test_name,
+                   std::function<void()> assertion) -> void {
+  sourcemeta::core::test_register(suite_name + "." + test_name,
+                                  [assertion = std::move(assertion)]() -> void {
+                                    run_pyca_test_case(assertion);
+                                  });
 }
 
-static auto register_sha_msg_tests(const std::filesystem::path &file_path,
-                                   const std::string &suite_name,
-                                   const DigestFunction digest) -> void {
+auto register_sha_msg_tests(const std::filesystem::path &file_path,
+                            const std::string &suite_name,
+                            const DigestFunction digest) -> void {
   std::string current_length;
   std::string current_message_hex;
 
@@ -166,9 +155,9 @@ static auto register_sha_msg_tests(const std::filesystem::path &file_path,
   });
 }
 
-static auto register_sha_monte_tests(const std::filesystem::path &file_path,
-                                     const std::string &suite_name,
-                                     const DigestFunction digest) -> void {
+auto register_sha_monte_tests(const std::filesystem::path &file_path,
+                              const std::string &suite_name,
+                              const DigestFunction digest) -> void {
   std::string seed;
   std::string current_count;
 
@@ -218,9 +207,9 @@ static auto register_sha_monte_tests(const std::filesystem::path &file_path,
   });
 }
 
-static auto register_sha_tests(const std::filesystem::path &directory,
-                               const std::string &name,
-                               const DigestFunction digest) -> void {
+auto register_sha_tests(const std::filesystem::path &directory,
+                        const std::string &name, const DigestFunction digest)
+    -> void {
   register_sha_msg_tests(directory / (name + "ShortMsg.rsp"),
                          "PyCA_Cryptography_" + name + "_ShortMsg", digest);
   register_sha_msg_tests(directory / (name + "LongMsg.rsp"),
@@ -239,8 +228,8 @@ struct RSAVector {
 };
 
 template <typename Callback>
-static auto for_each_rsa_case(const std::filesystem::path &file_path,
-                              Callback callback) -> void {
+auto for_each_rsa_case(const std::filesystem::path &file_path,
+                       Callback callback) -> void {
   RSAVector vector;
   std::uint64_t case_count{0};
 
@@ -281,7 +270,7 @@ static auto for_each_rsa_case(const std::filesystem::path &file_path,
   });
 }
 
-static auto register_rsa_sigver15_tests(const std::filesystem::path &file_path)
+auto register_rsa_sigver15_tests(const std::filesystem::path &file_path)
     -> void {
   for_each_rsa_case(file_path, [](const RSAVector &vector,
                                   const std::string_view result,
@@ -311,7 +300,7 @@ static auto register_rsa_sigver15_tests(const std::filesystem::path &file_path)
   });
 }
 
-static auto register_rsa_sigverpss_tests(const std::filesystem::path &file_path)
+auto register_rsa_sigverpss_tests(const std::filesystem::path &file_path)
     -> void {
   // Every case in this suite uses a 10-byte salt, while RFC 7518 Section 3.5
   // fixes the salt size to the hash function output ("The size of the salt
@@ -344,7 +333,7 @@ static auto register_rsa_sigverpss_tests(const std::filesystem::path &file_path)
   });
 }
 
-static auto register_ecdsa_sigver_tests(const std::filesystem::path &file_path)
+auto register_ecdsa_sigver_tests(const std::filesystem::path &file_path)
     -> void {
   std::optional<CurveParameters> current_curve;
   std::optional<sourcemeta::core::SignatureHashFunction> current_hash;
@@ -424,7 +413,7 @@ static auto register_ecdsa_sigver_tests(const std::filesystem::path &file_path)
   });
 }
 
-static auto register_eddsa_25519_tests(const std::filesystem::path &file_path)
+auto register_eddsa_25519_tests(const std::filesystem::path &file_path)
     -> void {
   std::uint64_t case_count{0};
 
@@ -462,8 +451,7 @@ static auto register_eddsa_25519_tests(const std::filesystem::path &file_path)
   });
 }
 
-static auto register_eddsa_448_tests(const std::filesystem::path &file_path)
-    -> void {
+auto register_eddsa_448_tests(const std::filesystem::path &file_path) -> void {
   std::string current_count;
   std::string public_key_hex;
   std::string message_hex;
@@ -519,9 +507,9 @@ static auto register_eddsa_448_tests(const std::filesystem::path &file_path)
     }
   });
 }
+} // namespace
 
 auto main(int argc, char **argv) -> int {
-  testing::InitGoogleTest(&argc, argv);
   const std::filesystem::path suite_path{PYCA_CRYPTOGRAPHY_PATH};
   const auto hashes_path{suite_path / "hashes"};
 
@@ -546,5 +534,5 @@ auto main(int argc, char **argv) -> int {
 
   register_eddsa_448_tests(suite_path / "asymmetric" / "Ed448" / "rfc8032.txt");
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/crypto/wycheproof_test.cc
+++ b/test/crypto/wycheproof_test.cc
@@ -1,8 +1,7 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <array>       // std::array
@@ -14,7 +13,8 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move
 
-static auto to_signature_hash_function(const std::string_view name)
+namespace {
+auto to_signature_hash_function(const std::string_view name)
     -> std::optional<sourcemeta::core::SignatureHashFunction> {
   if (name == "SHA-256") {
     return sourcemeta::core::SignatureHashFunction::SHA256;
@@ -32,8 +32,7 @@ struct CurveParameters {
   std::size_t coordinate_bytes;
 };
 
-static auto to_curve(const std::string_view name)
-    -> std::optional<CurveParameters> {
+auto to_curve(const std::string_view name) -> std::optional<CurveParameters> {
   if (name == "secp256r1") {
     return CurveParameters{sourcemeta::core::EllipticCurve::P256, 32};
   } else if (name == "secp384r1") {
@@ -46,70 +45,60 @@ static auto to_curve(const std::string_view name)
 }
 
 // Each vector reduces to a closure that asserts on data captured at
-// registration time, so a single fixture carrying that closure stands in for
+// registration time, so a single runner carrying that closure stands in for
 // every mechanism, matching the pyca-cryptography harness
-class Wycheproof_Test : public testing::Test {
-public:
-  explicit Wycheproof_Test(std::function<void()> input_assertion)
-      : assertion{std::move(input_assertion)} {}
-
-  auto TestBody() -> void override { this->assertion(); }
-
-private:
-  const std::function<void()> assertion;
-};
-
-static auto register_case(const std::string &suite_name,
-                          const std::string &test_name,
-                          std::function<void()> assertion) -> void {
-  testing::RegisterTest(
-      suite_name.c_str(), test_name.c_str(), nullptr, nullptr, __FILE__,
-      __LINE__, [assertion = std::move(assertion)]() -> testing::Test * {
-        return new Wycheproof_Test(assertion);
-      });
+auto run_wycheproof_test_case(const std::function<void()> &assertion) -> void {
+  assertion();
 }
 
-static auto load(const std::filesystem::path &path) -> sourcemeta::core::JSON {
+auto register_case(const std::string &suite_name, const std::string &test_name,
+                   std::function<void()> assertion) -> void {
+  sourcemeta::core::test_register(suite_name + "." + test_name,
+                                  [assertion = std::move(assertion)]() -> void {
+                                    run_wycheproof_test_case(assertion);
+                                  });
+}
+
+auto load(const std::filesystem::path &path) -> sourcemeta::core::JSON {
   auto stream{sourcemeta::core::read_file(path)};
   return sourcemeta::core::parse_json(stream);
 }
 
-static auto verify_pkcs1(const sourcemeta::core::SignatureHashFunction hash,
-                         const std::string_view modulus,
-                         const std::string_view exponent,
-                         const std::string_view message,
-                         const std::string_view signature) -> bool {
+auto verify_pkcs1(const sourcemeta::core::SignatureHashFunction hash,
+                  const std::string_view modulus,
+                  const std::string_view exponent,
+                  const std::string_view message,
+                  const std::string_view signature) -> bool {
   const auto key{sourcemeta::core::make_rsa_public_key(modulus, exponent)};
   return key.has_value() && sourcemeta::core::rsassa_pkcs1_v15_verify(
                                 key.value(), hash, message, signature);
 }
 
-static auto verify_pss(const sourcemeta::core::SignatureHashFunction hash,
-                       const std::string_view modulus,
-                       const std::string_view exponent,
-                       const std::string_view message,
-                       const std::string_view signature) -> bool {
+auto verify_pss(const sourcemeta::core::SignatureHashFunction hash,
+                const std::string_view modulus, const std::string_view exponent,
+                const std::string_view message,
+                const std::string_view signature) -> bool {
   const auto key{sourcemeta::core::make_rsa_public_key(modulus, exponent)};
   return key.has_value() && sourcemeta::core::rsassa_pss_verify(
                                 key.value(), hash, message, signature);
 }
 
-static auto verify_ecdsa(const sourcemeta::core::EllipticCurve curve,
-                         const sourcemeta::core::SignatureHashFunction hash,
-                         const std::string_view coordinate_x,
-                         const std::string_view coordinate_y,
-                         const std::string_view message,
-                         const std::string_view signature) -> bool {
+auto verify_ecdsa(const sourcemeta::core::EllipticCurve curve,
+                  const sourcemeta::core::SignatureHashFunction hash,
+                  const std::string_view coordinate_x,
+                  const std::string_view coordinate_y,
+                  const std::string_view message,
+                  const std::string_view signature) -> bool {
   const auto key{
       sourcemeta::core::make_ec_public_key(curve, coordinate_x, coordinate_y)};
   return key.has_value() &&
          sourcemeta::core::ecdsa_verify(key.value(), hash, message, signature);
 }
 
-static auto verify_eddsa(const sourcemeta::core::EdwardsCurve curve,
-                         const std::string_view public_key,
-                         const std::string_view message,
-                         const std::string_view signature) -> bool {
+auto verify_eddsa(const sourcemeta::core::EdwardsCurve curve,
+                  const std::string_view public_key,
+                  const std::string_view message,
+                  const std::string_view signature) -> bool {
   const auto key{sourcemeta::core::make_eddsa_public_key(curve, public_key)};
   return key.has_value() &&
          sourcemeta::core::eddsa_verify(key.value(), message, signature);
@@ -120,9 +109,9 @@ using RsaVerify = auto (*)(const sourcemeta::core::SignatureHashFunction,
                            const std::string_view, const std::string_view)
     -> bool;
 
-static auto register_rsa_tests(const std::filesystem::path &path,
-                               const std::string &suite_name,
-                               const RsaVerify verify) -> void {
+auto register_rsa_tests(const std::filesystem::path &path,
+                        const std::string &suite_name, const RsaVerify verify)
+    -> void {
   const auto document{load(path)};
   const auto stem{path.stem().string()};
   for (const auto &group : document.at("testGroups").as_array()) {
@@ -167,8 +156,8 @@ static auto register_rsa_tests(const std::filesystem::path &path,
   }
 }
 
-static auto register_ecdsa_tests(const std::filesystem::path &path,
-                                 const std::string &suite_name) -> void {
+auto register_ecdsa_tests(const std::filesystem::path &path,
+                          const std::string &suite_name) -> void {
   const auto document{load(path)};
   const auto stem{path.stem().string()};
   for (const auto &group : document.at("testGroups").as_array()) {
@@ -214,10 +203,9 @@ static auto register_ecdsa_tests(const std::filesystem::path &path,
   }
 }
 
-static auto register_eddsa_tests(const std::filesystem::path &path,
-                                 const std::string &suite_name,
-                                 const sourcemeta::core::EdwardsCurve curve)
-    -> void {
+auto register_eddsa_tests(const std::filesystem::path &path,
+                          const std::string &suite_name,
+                          const sourcemeta::core::EdwardsCurve curve) -> void {
   const auto document{load(path)};
   const auto stem{path.stem().string()};
   for (const auto &group : document.at("testGroups").as_array()) {
@@ -248,9 +236,9 @@ static auto register_eddsa_tests(const std::filesystem::path &path,
     }
   }
 }
+} // namespace
 
 auto main(int argc, char **argv) -> int {
-  testing::InitGoogleTest(&argc, argv);
   const std::filesystem::path base{WYCHEPROOF_PATH};
   const auto vectors{base / "testvectors_v1"};
 
@@ -288,5 +276,5 @@ auto main(int argc, char **argv) -> int {
   register_eddsa_tests(vectors / "ed448_test.json", "Wycheproof_EdDSA",
                        sourcemeta::core::EdwardsCurve::Ed448);
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/jsonld/CMakeLists.txt
+++ b/test/jsonld/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(sourcemeta_core_jsonld_unit
 
 # W3C JSON-LD Test Suite
 # See https://github.com/w3c/json-ld-api
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME jsonld_suite
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonld_suite
   SOURCES jsonld_suite.cc)
 target_compile_definitions(sourcemeta_core_jsonld_suite_unit
   PRIVATE JSONLD_SUITE_PATH="${PROJECT_SOURCE_DIR}/vendor/w3c-json-ld/tests")

--- a/test/jsonld/jsonld_suite.cc
+++ b/test/jsonld/jsonld_suite.cc
@@ -1,7 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/text.h>
 
 #include <filesystem>  // std::filesystem
@@ -73,69 +72,58 @@ auto produces_valid_expanded_output(const std::string_view identifier) -> bool {
          identifier != "#t0122";
 }
 
-class JSONLDExpandTest : public testing::Test {
-public:
-  explicit JSONLDExpandTest(JSONLDExpandCase test_case)
-      : test_case_{std::move(test_case)} {}
+auto run_expand_case(const JSONLDExpandCase &test_case) -> void {
+  const auto resolver{
+      suite_resolver(test_case.suite_root, test_case.base_prefix)};
 
-  auto TestBody() -> void override {
-    const auto &test_case{this->test_case_};
-    const auto resolver{
-        suite_resolver(test_case.suite_root, test_case.base_prefix)};
+  const auto input{sourcemeta::core::read_json(test_case.input)};
 
-    const auto input{sourcemeta::core::read_json(test_case.input)};
-
-    if (test_case.negative) {
-      try {
-        if (test_case.expand_context.has_value()) {
-          const auto context{
-              sourcemeta::core::read_json(test_case.expand_context.value())};
-          [[maybe_unused]] const auto result{sourcemeta::core::jsonld_expand(
-              input, context, test_case.base_iri, resolver, test_case.version)};
-        } else {
-          [[maybe_unused]] const auto result{sourcemeta::core::jsonld_expand(
-              input, test_case.base_iri, resolver, test_case.version)};
-        }
-        FAIL() << "Expected error code: " << test_case.error_code;
-      } catch (const sourcemeta::core::JSONLDError &error) {
-        // The implementation capitalises the first letter of every error code,
-        // whereas the upstream suite expresses them in lower case.
-        std::string actual_code{error.what()};
-        if (!actual_code.empty()) {
-          actual_code.front() =
-              sourcemeta::core::to_lowercase(actual_code.front());
-        }
-        EXPECT_EQ(static_cast<std::string_view>(test_case.error_code),
-                  actual_code);
-      }
-    } else {
-      const auto expected{sourcemeta::core::read_json(test_case.expect)};
-      const auto actual{
-          test_case.expand_context.has_value()
-              ? sourcemeta::core::jsonld_expand(
-                    input,
-                    sourcemeta::core::read_json(
-                        test_case.expand_context.value()),
-                    test_case.base_iri, resolver, test_case.version)
-              : sourcemeta::core::jsonld_expand(input, test_case.base_iri,
-                                                resolver, test_case.version)};
-      EXPECT_EQ(actual, expected);
-      // Every expansion output, and every expected fixture, is by definition a
-      // valid expanded document, save for the few that are correct output yet
-      // not valid documents, which the validator must reject instead.
-      if (test_case.valid_expanded_output) {
-        EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(actual));
-        EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(expected));
+  if (test_case.negative) {
+    try {
+      if (test_case.expand_context.has_value()) {
+        const auto context{
+            sourcemeta::core::read_json(test_case.expand_context.value())};
+        [[maybe_unused]] const auto result{sourcemeta::core::jsonld_expand(
+            input, context, test_case.base_iri, resolver, test_case.version)};
       } else {
-        EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(actual));
-        EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(expected));
+        [[maybe_unused]] const auto result{sourcemeta::core::jsonld_expand(
+            input, test_case.base_iri, resolver, test_case.version)};
       }
+      FAIL();
+    } catch (const sourcemeta::core::JSONLDError &error) {
+      // The implementation capitalises the first letter of every error code,
+      // whereas the upstream suite expresses them in lower case.
+      std::string actual_code{error.what()};
+      if (!actual_code.empty()) {
+        actual_code.front() =
+            sourcemeta::core::to_lowercase(actual_code.front());
+      }
+      EXPECT_EQ(static_cast<std::string_view>(test_case.error_code),
+                actual_code);
+    }
+  } else {
+    const auto expected{sourcemeta::core::read_json(test_case.expect)};
+    const auto actual{
+        test_case.expand_context.has_value()
+            ? sourcemeta::core::jsonld_expand(
+                  input,
+                  sourcemeta::core::read_json(test_case.expand_context.value()),
+                  test_case.base_iri, resolver, test_case.version)
+            : sourcemeta::core::jsonld_expand(input, test_case.base_iri,
+                                              resolver, test_case.version)};
+    EXPECT_EQ(actual, expected);
+    // Every expansion output, and every expected fixture, is by definition a
+    // valid expanded document, save for the few that are correct output yet
+    // not valid documents, which the validator must reject instead.
+    if (test_case.valid_expanded_output) {
+      EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(actual));
+      EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(expected));
+    } else {
+      EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(actual));
+      EXPECT_FALSE(sourcemeta::core::jsonld_is_expanded(expected));
     }
   }
-
-private:
-  JSONLDExpandCase test_case_;
-};
+}
 
 auto register_expand_case(const sourcemeta::core::JSON &entry,
                           const std::filesystem::path &suite_root,
@@ -183,11 +171,9 @@ auto register_expand_case(const sourcemeta::core::JSON &entry,
     test_case.expect = suite_root / entry.at("expect").to_string();
   }
 
-  testing::RegisterTest(
-      "JSONLD_expand", suite_test_name(entry.at("@id").to_string()).c_str(),
-      nullptr, nullptr, __FILE__, __LINE__, [test_case]() -> testing::Test * {
-        return new JSONLDExpandTest(test_case);
-      });
+  sourcemeta::core::test_register(
+      "JSONLD_expand", suite_test_name(entry.at("@id").to_string()), __FILE__,
+      __LINE__, [test_case]() -> void { run_expand_case(test_case); });
 }
 
 struct JSONLDCompactCase {
@@ -204,49 +190,39 @@ struct JSONLDCompactCase {
   bool compact_to_relative;
 };
 
-class JSONLDCompactTest : public testing::Test {
-public:
-  explicit JSONLDCompactTest(JSONLDCompactCase test_case)
-      : test_case_{std::move(test_case)} {}
+auto run_compact_case(const JSONLDCompactCase &test_case) -> void {
+  const auto resolver{
+      suite_resolver(test_case.suite_root, test_case.base_prefix)};
 
-  auto TestBody() -> void override {
-    const auto &test_case{this->test_case_};
-    const auto resolver{
-        suite_resolver(test_case.suite_root, test_case.base_prefix)};
+  const auto input{sourcemeta::core::read_json(test_case.input)};
+  const auto context{sourcemeta::core::read_json(test_case.context)};
 
-    const auto input{sourcemeta::core::read_json(test_case.input)};
-    const auto context{sourcemeta::core::read_json(test_case.context)};
-
-    if (test_case.negative) {
-      try {
-        const auto expanded{sourcemeta::core::jsonld_expand(
-            input, test_case.base_iri, resolver, test_case.version)};
-        [[maybe_unused]] const auto result{sourcemeta::core::jsonld_compact(
-            expanded, context, test_case.base_iri, resolver, test_case.version,
-            test_case.compact_arrays, test_case.compact_to_relative)};
-        FAIL() << "Expected error code: " << test_case.error_code;
-      } catch (const sourcemeta::core::JSONLDError &error) {
-        std::string actual_code{error.what()};
-        sourcemeta::core::to_lowercase(actual_code);
-        std::string expected_code{test_case.error_code};
-        sourcemeta::core::to_lowercase(expected_code);
-        EXPECT_EQ(expected_code, actual_code);
-      }
-    } else {
+  if (test_case.negative) {
+    try {
       const auto expanded{sourcemeta::core::jsonld_expand(
           input, test_case.base_iri, resolver, test_case.version)};
-      const auto expected{sourcemeta::core::read_json(test_case.expect)};
-      EXPECT_EQ(sourcemeta::core::jsonld_compact(
-                    expanded, context, test_case.base_iri, resolver,
-                    test_case.version, test_case.compact_arrays,
-                    test_case.compact_to_relative),
-                expected);
+      [[maybe_unused]] const auto result{sourcemeta::core::jsonld_compact(
+          expanded, context, test_case.base_iri, resolver, test_case.version,
+          test_case.compact_arrays, test_case.compact_to_relative)};
+      FAIL();
+    } catch (const sourcemeta::core::JSONLDError &error) {
+      std::string actual_code{error.what()};
+      sourcemeta::core::to_lowercase(actual_code);
+      std::string expected_code{test_case.error_code};
+      sourcemeta::core::to_lowercase(expected_code);
+      EXPECT_EQ(expected_code, actual_code);
     }
+  } else {
+    const auto expanded{sourcemeta::core::jsonld_expand(
+        input, test_case.base_iri, resolver, test_case.version)};
+    const auto expected{sourcemeta::core::read_json(test_case.expect)};
+    EXPECT_EQ(sourcemeta::core::jsonld_compact(
+                  expanded, context, test_case.base_iri, resolver,
+                  test_case.version, test_case.compact_arrays,
+                  test_case.compact_to_relative),
+              expected);
   }
-
-private:
-  JSONLDCompactCase test_case_;
-};
+}
 
 auto register_compact_case(const sourcemeta::core::JSON &entry,
                            const std::filesystem::path &suite_root,
@@ -318,11 +294,9 @@ auto register_compact_case(const sourcemeta::core::JSON &entry,
     test_case.expect = suite_root / entry.at("expect").to_string();
   }
 
-  testing::RegisterTest(
-      "JSONLD_compact", suite_test_name(entry.at("@id").to_string()).c_str(),
-      nullptr, nullptr, __FILE__, __LINE__, [test_case]() -> testing::Test * {
-        return new JSONLDCompactTest(test_case);
-      });
+  sourcemeta::core::test_register(
+      "JSONLD_compact", suite_test_name(entry.at("@id").to_string()), __FILE__,
+      __LINE__, [test_case]() -> void { run_compact_case(test_case); });
 }
 
 struct JSONLDFlattenCase {
@@ -354,41 +328,31 @@ auto run_flatten(const JSONLDFlattenCase &test_case,
   return sourcemeta::core::jsonld_flatten(expanded);
 }
 
-class JSONLDFlattenTest : public testing::Test {
-public:
-  explicit JSONLDFlattenTest(JSONLDFlattenCase test_case)
-      : test_case_{std::move(test_case)} {}
+auto run_flatten_case(const JSONLDFlattenCase &test_case) -> void {
+  const auto resolver{
+      suite_resolver(test_case.suite_root, test_case.base_prefix)};
 
-  auto TestBody() -> void override {
-    const auto &test_case{this->test_case_};
-    const auto resolver{
-        suite_resolver(test_case.suite_root, test_case.base_prefix)};
+  const auto input{sourcemeta::core::read_json(test_case.input)};
+  const auto expanded{sourcemeta::core::jsonld_expand(
+      input, test_case.base_iri, resolver, test_case.version)};
 
-    const auto input{sourcemeta::core::read_json(test_case.input)};
-    const auto expanded{sourcemeta::core::jsonld_expand(
-        input, test_case.base_iri, resolver, test_case.version)};
-
-    if (test_case.negative) {
-      try {
-        [[maybe_unused]] const auto result{
-            run_flatten(test_case, expanded, resolver)};
-        FAIL() << "Expected error code: " << test_case.error_code;
-      } catch (const sourcemeta::core::JSONLDError &error) {
-        std::string actual_code{error.what()};
-        sourcemeta::core::to_lowercase(actual_code);
-        std::string expected_code{test_case.error_code};
-        sourcemeta::core::to_lowercase(expected_code);
-        EXPECT_EQ(expected_code, actual_code);
-      }
-    } else {
-      const auto expected{sourcemeta::core::read_json(test_case.expect)};
-      EXPECT_EQ(run_flatten(test_case, expanded, resolver), expected);
+  if (test_case.negative) {
+    try {
+      [[maybe_unused]] const auto result{
+          run_flatten(test_case, expanded, resolver)};
+      FAIL();
+    } catch (const sourcemeta::core::JSONLDError &error) {
+      std::string actual_code{error.what()};
+      sourcemeta::core::to_lowercase(actual_code);
+      std::string expected_code{test_case.error_code};
+      sourcemeta::core::to_lowercase(expected_code);
+      EXPECT_EQ(expected_code, actual_code);
     }
+  } else {
+    const auto expected{sourcemeta::core::read_json(test_case.expect)};
+    EXPECT_EQ(run_flatten(test_case, expanded, resolver), expected);
   }
-
-private:
-  JSONLDFlattenCase test_case_;
-};
+}
 
 auto register_flatten_case(const sourcemeta::core::JSON &entry,
                            const std::filesystem::path &suite_root,
@@ -447,11 +411,9 @@ auto register_flatten_case(const sourcemeta::core::JSON &entry,
     test_case.expect = suite_root / entry.at("expect").to_string();
   }
 
-  testing::RegisterTest(
-      "JSONLD_flatten", suite_test_name(entry.at("@id").to_string()).c_str(),
-      nullptr, nullptr, __FILE__, __LINE__, [test_case]() -> testing::Test * {
-        return new JSONLDFlattenTest(test_case);
-      });
+  sourcemeta::core::test_register(
+      "JSONLD_flatten", suite_test_name(entry.at("@id").to_string()), __FILE__,
+      __LINE__, [test_case]() -> void { run_flatten_case(test_case); });
 }
 
 auto register_suite(const std::filesystem::path &suite_root,
@@ -470,12 +432,10 @@ auto register_suite(const std::filesystem::path &suite_root,
 } // namespace
 
 auto main(int argc, char **argv) -> int {
-  testing::InitGoogleTest(&argc, argv);
-
   const std::filesystem::path suite_root{JSONLD_SUITE_PATH};
   register_suite(suite_root, "expand-manifest.jsonld", register_expand_case);
   register_suite(suite_root, "compact-manifest.jsonld", register_compact_case);
   register_suite(suite_root, "flatten-manifest.jsonld", register_flatten_case);
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/numeric/CMakeLists.txt
+++ b/test/numeric/CMakeLists.txt
@@ -7,7 +7,7 @@ target_link_libraries(sourcemeta_core_numeric_unit
 
 # IBM General Decimal Arithmetic Test Suite
 # See https://speleotrove.com/decimal/
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME ibm_dectest
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME ibm_dectest
   SOURCES decimal_ibm_dectest.cc)
 target_compile_definitions(sourcemeta_core_ibm_dectest_unit
   PRIVATE DECTEST_PATH="${CMAKE_CURRENT_SOURCE_DIR}/dectest")

--- a/test/numeric/decimal_ibm_dectest.cc
+++ b/test/numeric/decimal_ibm_dectest.cc
@@ -1,7 +1,6 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/io.h>
 #include <sourcemeta/core/numeric.h>
+#include <sourcemeta/core/test.h>
 
 #include <algorithm>   // std::transform, std::any_of
 #include <cctype>      // std::tolower, std::isalnum
@@ -154,255 +153,242 @@ static auto expect_decimal_eq(const sourcemeta::core::Decimal &result,
   }
 }
 
-class DecTest : public testing::Test {
-public:
-  explicit DecTest(DecTestCase test_case) : test_case_{std::move(test_case)} {}
+static auto run_comparison(const DecTestCase &test_case, bool signal_on_nan)
+    -> void {
+  const auto left{make_decimal(test_case.operand1)};
+  const auto right{make_decimal(test_case.operand2)};
 
-  auto TestBody() -> void override {
-    const auto operation{to_lower(this->test_case_.operation)};
+  if (signal_on_nan &&
+      has_condition(test_case.conditions, "invalid_operation")) {
+    EXPECT_TRUE(make_decimal(test_case.expected).is_nan());
+    return;
+  }
 
-    if (operation == "compare" || operation == "comparesig") {
-      this->run_comparison(operation == "comparesig");
-    } else if (operation == "add") {
-      this->run_binary(
-          [](const auto &left, const auto &right) { return left + right; });
-    } else if (operation == "subtract") {
-      this->run_binary(
-          [](const auto &left, const auto &right) { return left - right; });
-    } else if (operation == "multiply") {
-      this->run_binary(
-          [](const auto &left, const auto &right) { return left * right; });
-    } else if (operation == "divide") {
-      this->run_binary(
-          [](const auto &left, const auto &right) { return left / right; });
-    } else if (operation == "remainder") {
-      this->run_binary(
-          [](const auto &left, const auto &right) { return left % right; });
-    } else if (operation == "minus" || operation == "copynegate") {
-      this->run_unary([](const auto &value) { return -value; });
-    } else if (operation == "plus") {
-      this->run_unary([](const auto &value) { return +value; });
-    } else if (operation == "abs" || operation == "copyabs") {
-      this->run_unary([](const auto &value) { return decimal_abs(value); });
-    } else if (operation == "tointegral" || operation == "tointegralx") {
-      this->run_unary([](const auto &value) { return value.to_integral(); });
-    } else if (operation == "tosci" || operation == "toeng") {
-      this->run_conversion();
-    } else if (operation == "copy") {
-      this->run_unary([](const auto &value) { return value; });
-    } else if (operation == "copysign") {
-      this->run_copysign();
-    } else if (operation == "comparetotal") {
-      this->run_binary([](const auto &left, const auto &right) {
-        return left.compare_total(right);
-      });
-    } else if (operation == "comparetotmag") {
-      this->run_binary([](const auto &left, const auto &right) {
-        return decimal_abs(left).compare_total(decimal_abs(right));
-      });
-    } else if (operation == "max") {
-      this->run_max_min(true, false);
-    } else if (operation == "min") {
-      this->run_max_min(false, false);
-    } else if (operation == "maxmag") {
-      this->run_max_min(true, true);
-    } else if (operation == "minmag") {
-      this->run_max_min(false, true);
-    } else if (operation == "divideint") {
-      this->run_binary([](const auto &left, const auto &right) {
-        return left.divide_integer(right);
-      });
-    } else if (operation == "samequantum") {
-      this->run_binary([](const auto &left, const auto &right) {
-        return sourcemeta::core::Decimal{left.same_quantum(right) ? 1 : 0};
-      });
-    } else if (operation == "logb") {
-      this->run_logb();
-    } else if (operation == "scaleb") {
-      this->run_binary([](const auto &left, const auto &right) {
-        return left.scale_by(right);
-      });
-    } else if (operation == "reduce" || operation == "trim") {
-      this->run_unary([](const auto &value) { return value.reduce(); });
-    } else {
+  const auto expected{strip_quotes(test_case.expected)};
+  EXPECT_TRUE(expect_comparison_result(left, right, expected));
+}
+
+template <typename Operation>
+static auto run_binary(const DecTestCase &test_case, Operation op) -> void {
+  const auto has_invalid{
+      has_condition(test_case.conditions, "invalid_operation") ||
+      has_condition(test_case.conditions, "division_undefined")};
+  const auto has_divzero{
+      has_condition(test_case.conditions, "division_by_zero")};
+
+  if (has_invalid) {
+    try {
+      const auto result{op(make_decimal(test_case.operand1),
+                           make_decimal(test_case.operand2))};
+      EXPECT_TRUE(result.is_nan());
+    } catch (const sourcemeta::core::NumericInvalidOperationError &) {
+    } catch (const sourcemeta::core::NumericDivisionByZeroError &) {
+    }
+    return;
+  }
+
+  if (has_divzero) {
+    try {
+      const auto result{op(make_decimal(test_case.operand1),
+                           make_decimal(test_case.operand2))};
+      const auto expected_value{make_decimal(test_case.expected)};
+      if (expected_value.is_infinite() && result.is_infinite()) {
+        EXPECT_EQ(result.is_signed(), expected_value.is_signed());
+      } else {
+        FAIL();
+      }
+    } catch (const sourcemeta::core::NumericDivisionByZeroError &) {
+    }
+    return;
+  }
+
+  const auto expected_value{make_decimal(test_case.expected)};
+  const auto result{
+      op(make_decimal(test_case.operand1), make_decimal(test_case.operand2))};
+  expect_decimal_eq(result, expected_value);
+}
+
+template <typename Operation>
+static auto run_unary(const DecTestCase &test_case, Operation op) -> void {
+  if (has_condition(test_case.conditions, "invalid_operation")) {
+    try {
+      EXPECT_TRUE(op(make_decimal(test_case.operand1)).is_nan());
+    } catch (const sourcemeta::core::NumericInvalidOperationError &) {
+    }
+    return;
+  }
+
+  expect_decimal_eq(op(make_decimal(test_case.operand1)),
+                    make_decimal(test_case.expected));
+}
+
+// TODO: Our to_scientific_string() always uses exponential form
+// (e.g. "1.0e+1" instead of "10"), which differs from the spec's
+// to-scientific-string. Our to_string() has the same issue with
+// to-engineering-string. We compare parsed values instead of strings.
+static auto run_conversion(const DecTestCase &test_case) -> void {
+  const auto input{strip_quotes(test_case.operand1)};
+
+  if (has_condition(test_case.conditions, "conversion_syntax")) {
+    try {
+      const auto result{sourcemeta::core::Decimal{input}};
+      EXPECT_TRUE(result.is_nan());
+    } catch (const sourcemeta::core::DecimalParseError &) {
+    }
+    return;
+  }
+
+  expect_decimal_eq(sourcemeta::core::Decimal{input},
+                    make_decimal(test_case.expected));
+}
+
+static auto run_copysign(const DecTestCase &test_case) -> void {
+  const auto left{make_decimal(test_case.operand1)};
+  const auto right{make_decimal(test_case.operand2)};
+  auto result = decimal_abs(left);
+  if (right.is_signed()) {
+    result = -decimal_abs(result);
+  }
+
+  expect_decimal_eq(result, make_decimal(test_case.expected));
+}
+
+static auto run_logb(const DecTestCase &test_case) -> void {
+  if (has_condition(test_case.conditions, "division_by_zero")) {
+    try {
+      auto result = make_decimal(test_case.operand1).logb();
+      static_cast<void>(result);
       FAIL();
+    } catch (const sourcemeta::core::NumericDivisionByZeroError &) {
     }
+    return;
   }
 
-private:
-  auto run_comparison(bool signal_on_nan) -> void {
-    const auto left{make_decimal(this->test_case_.operand1)};
-    const auto right{make_decimal(this->test_case_.operand2)};
+  run_unary(test_case, [](const auto &value) { return value.logb(); });
+}
 
-    if (signal_on_nan &&
-        has_condition(this->test_case_.conditions, "invalid_operation")) {
-      EXPECT_TRUE(make_decimal(this->test_case_.expected).is_nan());
-      return;
-    }
+static auto run_max_min(const DecTestCase &test_case, bool is_max,
+                        bool by_magnitude) -> void {
+  const auto left{make_decimal(test_case.operand1)};
+  const auto right{make_decimal(test_case.operand2)};
+  const auto expected{make_decimal(test_case.expected)};
 
-    const auto expected{strip_quotes(this->test_case_.expected)};
-    // TODO: The decTest spec defines compare(NaN, x) = NaN, but our
-    // comparison operators return bool, so we cannot represent a NaN
-    // comparison result
-    if (to_lower(expected).find("nan") != std::string::npos) {
-      GTEST_SKIP() << "NaN comparison result";
-      return;
-    }
-
-    EXPECT_TRUE(expect_comparison_result(left, right, expected));
+  if (left.is_snan() || right.is_snan()) {
+    EXPECT_TRUE(expected.is_nan());
+    return;
   }
 
-  template <typename Operation> auto run_binary(Operation op) -> void {
-    const auto has_invalid{
-        has_condition(this->test_case_.conditions, "invalid_operation") ||
-        has_condition(this->test_case_.conditions, "division_undefined")};
-    const auto has_divzero{
-        has_condition(this->test_case_.conditions, "division_by_zero")};
-
-    if (has_invalid) {
-      try {
-        const auto result{op(make_decimal(this->test_case_.operand1),
-                             make_decimal(this->test_case_.operand2))};
-        EXPECT_TRUE(result.is_nan());
-      } catch (const sourcemeta::core::NumericInvalidOperationError &) {
-        SUCCEED();
-      } catch (const sourcemeta::core::NumericDivisionByZeroError &) {
-        SUCCEED();
-      }
-      return;
-    }
-
-    if (has_divzero) {
-      try {
-        const auto result{op(make_decimal(this->test_case_.operand1),
-                             make_decimal(this->test_case_.operand2))};
-        const auto expected_value{make_decimal(this->test_case_.expected)};
-        if (expected_value.is_infinite() && result.is_infinite()) {
-          EXPECT_EQ(result.is_signed(), expected_value.is_signed());
-        } else {
-          FAIL();
-        }
-      } catch (const sourcemeta::core::NumericDivisionByZeroError &) {
-        SUCCEED();
-      }
-      return;
-    }
-
-    const auto expected_value{make_decimal(this->test_case_.expected)};
-    const auto result{op(make_decimal(this->test_case_.operand1),
-                         make_decimal(this->test_case_.operand2))};
-    expect_decimal_eq(result, expected_value);
+  if (left.is_qnan() && right.is_qnan()) {
+    EXPECT_TRUE(expected.is_nan());
+    return;
   }
 
-  template <typename Operation> auto run_unary(Operation op) -> void {
-    if (has_condition(this->test_case_.conditions, "invalid_operation")) {
-      try {
-        EXPECT_TRUE(op(make_decimal(this->test_case_.operand1)).is_nan());
-      } catch (const sourcemeta::core::NumericInvalidOperationError &) {
-        SUCCEED();
-      }
-      return;
-    }
-
-    expect_decimal_eq(op(make_decimal(this->test_case_.operand1)),
-                      make_decimal(this->test_case_.expected));
+  if (left.is_qnan()) {
+    expect_decimal_eq(right, expected);
+    return;
   }
 
-  // TODO: Our to_scientific_string() always uses exponential form
-  // (e.g. "1.0e+1" instead of "10"), which differs from the spec's
-  // to-scientific-string. Our to_string() has the same issue with
-  // to-engineering-string. We compare parsed values instead of strings.
-  auto run_conversion() -> void {
-    const auto input{strip_quotes(this->test_case_.operand1)};
-
-    if (has_condition(this->test_case_.conditions, "conversion_syntax")) {
-      try {
-        const auto result{sourcemeta::core::Decimal{input}};
-        EXPECT_TRUE(result.is_nan());
-      } catch (const sourcemeta::core::DecimalParseError &) {
-        SUCCEED();
-      }
-      return;
-    }
-
-    expect_decimal_eq(sourcemeta::core::Decimal{input},
-                      make_decimal(this->test_case_.expected));
+  if (right.is_qnan()) {
+    expect_decimal_eq(left, expected);
+    return;
   }
 
-  auto run_copysign() -> void {
-    const auto left{make_decimal(this->test_case_.operand1)};
-    const auto right{make_decimal(this->test_case_.operand2)};
-    auto result = decimal_abs(left);
-    if (right.is_signed()) {
-      result = -decimal_abs(result);
-    }
-
-    expect_decimal_eq(result, make_decimal(this->test_case_.expected));
+  int comparison;
+  if (by_magnitude) {
+    auto abs_left = decimal_abs(left);
+    auto abs_right = decimal_abs(right);
+    comparison = abs_left < abs_right ? -1 : (abs_left > abs_right ? 1 : 0);
+  } else {
+    comparison = left < right ? -1 : (left > right ? 1 : 0);
   }
 
-  auto run_logb() -> void {
-    if (has_condition(this->test_case_.conditions, "division_by_zero")) {
-      try {
-        auto result = make_decimal(this->test_case_.operand1).logb();
-        static_cast<void>(result);
-        FAIL() << "Expected division_by_zero";
-      } catch (const sourcemeta::core::NumericDivisionByZeroError &) {
-        SUCCEED();
-      }
-      return;
-    }
-
-    this->run_unary([](const auto &value) { return value.logb(); });
+  sourcemeta::core::Decimal result{0};
+  if (comparison != 0) {
+    result = (is_max == (comparison > 0)) ? left : right;
+  } else {
+    auto total_cmp = left.compare_total(right);
+    result =
+        (is_max == (total_cmp > sourcemeta::core::Decimal{0})) ? left : right;
   }
 
-  auto run_max_min(bool is_max, bool by_magnitude) -> void {
-    const auto left{make_decimal(this->test_case_.operand1)};
-    const auto right{make_decimal(this->test_case_.operand2)};
-    const auto expected{make_decimal(this->test_case_.expected)};
+  expect_decimal_eq(result, expected);
+}
 
-    if (left.is_snan() || right.is_snan()) {
-      EXPECT_TRUE(expected.is_nan());
-      return;
-    }
+static auto run_dectest_case(const DecTestCase &test_case) -> void {
+  const auto operation{to_lower(test_case.operation)};
 
-    if (left.is_qnan() && right.is_qnan()) {
-      EXPECT_TRUE(expected.is_nan());
-      return;
-    }
-
-    if (left.is_qnan()) {
-      expect_decimal_eq(right, expected);
-      return;
-    }
-
-    if (right.is_qnan()) {
-      expect_decimal_eq(left, expected);
-      return;
-    }
-
-    int comparison;
-    if (by_magnitude) {
-      auto abs_left = decimal_abs(left);
-      auto abs_right = decimal_abs(right);
-      comparison = abs_left < abs_right ? -1 : (abs_left > abs_right ? 1 : 0);
-    } else {
-      comparison = left < right ? -1 : (left > right ? 1 : 0);
-    }
-
-    sourcemeta::core::Decimal result{0};
-    if (comparison != 0) {
-      result = (is_max == (comparison > 0)) ? left : right;
-    } else {
-      auto total_cmp = left.compare_total(right);
-      result =
-          (is_max == (total_cmp > sourcemeta::core::Decimal{0})) ? left : right;
-    }
-
-    expect_decimal_eq(result, expected);
+  if (operation == "compare" || operation == "comparesig") {
+    run_comparison(test_case, operation == "comparesig");
+  } else if (operation == "add") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left + right;
+    });
+  } else if (operation == "subtract") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left - right;
+    });
+  } else if (operation == "multiply") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left * right;
+    });
+  } else if (operation == "divide") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left / right;
+    });
+  } else if (operation == "remainder") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left % right;
+    });
+  } else if (operation == "minus" || operation == "copynegate") {
+    run_unary(test_case, [](const auto &value) { return -value; });
+  } else if (operation == "plus") {
+    run_unary(test_case, [](const auto &value) { return +value; });
+  } else if (operation == "abs" || operation == "copyabs") {
+    run_unary(test_case, [](const auto &value) { return decimal_abs(value); });
+  } else if (operation == "tointegral" || operation == "tointegralx") {
+    run_unary(test_case, [](const auto &value) { return value.to_integral(); });
+  } else if (operation == "tosci" || operation == "toeng") {
+    run_conversion(test_case);
+  } else if (operation == "copy") {
+    run_unary(test_case, [](const auto &value) { return value; });
+  } else if (operation == "copysign") {
+    run_copysign(test_case);
+  } else if (operation == "comparetotal") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left.compare_total(right);
+    });
+  } else if (operation == "comparetotmag") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return decimal_abs(left).compare_total(decimal_abs(right));
+    });
+  } else if (operation == "max") {
+    run_max_min(test_case, true, false);
+  } else if (operation == "min") {
+    run_max_min(test_case, false, false);
+  } else if (operation == "maxmag") {
+    run_max_min(test_case, true, true);
+  } else if (operation == "minmag") {
+    run_max_min(test_case, false, true);
+  } else if (operation == "divideint") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left.divide_integer(right);
+    });
+  } else if (operation == "samequantum") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return sourcemeta::core::Decimal{left.same_quantum(right) ? 1 : 0};
+    });
+  } else if (operation == "logb") {
+    run_logb(test_case);
+  } else if (operation == "scaleb") {
+    run_binary(test_case, [](const auto &left, const auto &right) {
+      return left.scale_by(right);
+    });
+  } else if (operation == "reduce" || operation == "trim") {
+    run_unary(test_case, [](const auto &value) { return value.reduce(); });
+  } else {
+    FAIL();
   }
-
-  DecTestCase test_case_;
-};
+}
 
 // ---------------------------------------------------------------------------
 // Parsing
@@ -549,6 +535,21 @@ static auto should_skip_test(const DecTestCase &test_case,
     return true;
   }
 
+  // The decTest spec defines compare(NaN, x) = NaN, but our comparison
+  // operators return bool, so a NaN comparison result cannot be represented.
+  // The signalling case that carries an invalid_operation condition is kept, as
+  // it only asserts that the expected result parses as NaN.
+  if (operation == "compare" || operation == "comparesig") {
+    const auto signalling_nan{
+        operation == "comparesig" &&
+        has_condition(test_case.conditions, "invalid_operation")};
+    if (!signalling_nan &&
+        to_lower(strip_quotes(test_case.expected)).find("nan") !=
+            std::string::npos) {
+      return true;
+    }
+  }
+
   if (operation == "compare" || operation == "comparetotal" ||
       operation == "comparetotmag" || operation == "comparesig" ||
       operation == "copy" || operation == "copyabs" ||
@@ -606,7 +607,6 @@ static auto sanitize_test_name(const std::string &name) -> std::string {
 }
 
 auto main(int argc, char **argv) -> int {
-  testing::InitGoogleTest(&argc, argv);
   const std::filesystem::path dectest_path{DECTEST_PATH};
 
   std::size_t total_registered{0};
@@ -658,11 +658,11 @@ auto main(int argc, char **argv) -> int {
       }
 
       const auto test_name{sanitize_test_name(test_case.id)};
-      testing::RegisterTest(suite_name.c_str(), test_name.c_str(), nullptr,
-                            nullptr, __FILE__, __LINE__,
-                            [test_case = std::move(test_case)]() -> DecTest * {
-                              return new DecTest(test_case);
-                            });
+      sourcemeta::core::test_register(
+          suite_name, test_name, __FILE__, __LINE__,
+          [test_case = std::move(test_case)]() -> void {
+            run_dectest_case(test_case);
+          });
       total_registered++;
     }
   }
@@ -675,5 +675,5 @@ auto main(int argc, char **argv) -> int {
     return 1;
   }
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/unicode/CMakeLists.txt
+++ b/test/unicode/CMakeLists.txt
@@ -28,7 +28,7 @@ target_link_libraries(sourcemeta_core_unicode_unit
   PRIVATE sourcemeta::core::unicode)
 
 # UAX #15 NormalizationTest.txt conformance pass
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core
   NAME unicode_normalization_suite
   SOURCES unicode_normalization_suite.cc)
 target_compile_definitions(sourcemeta_core_unicode_normalization_suite_unit

--- a/test/unicode/unicode_normalization_suite.cc
+++ b/test/unicode/unicode_normalization_suite.cc
@@ -1,6 +1,5 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/unicode.h>
 
 #include <array>       // std::array
@@ -49,65 +48,55 @@ auto parse_codepoint_sequence(const std::string_view field) -> std::u32string {
   return result;
 }
 
-class NormalizationTest : public testing::Test {
-public:
-  explicit NormalizationTest(const std::string_view raw_line)
-      : raw_line_{raw_line} {}
-
-  auto TestBody() -> void override {
-    auto data{this->raw_line_};
-    const auto hash{data.find('#')};
-    if (hash != std::string_view::npos) {
-      data = data.substr(0, hash);
-    }
-
-    std::array<std::u32string, 5> fields;
-    std::size_t start{0};
-    std::size_t field_index{0};
-    while (field_index < fields.size()) {
-      const auto separator{data.find(';', start)};
-      const auto end{separator == std::string_view::npos ? data.size()
-                                                         : separator};
-      fields[field_index] =
-          parse_codepoint_sequence(data.substr(start, end - start));
-      field_index += 1;
-      if (separator == std::string_view::npos) {
-        break;
-      }
-      start = separator + 1;
-    }
-    ASSERT_EQ(field_index, fields.size())
-        << "Expected 5 semicolon-separated columns, got " << field_index;
-
-    // Per the NormalizationTest.txt header, the NFC invariants over the
-    // five columns are:
-    //
-    //   c2 == toNFC(c1) == toNFC(c2) == toNFC(c3)
-    //   c4 == toNFC(c4) == toNFC(c5)
-    //
-    // and a codepoint is in NFC iff its NFC form equals itself.
-    const auto &c1{fields[0]};
-    const auto &c2{fields[1]};
-    const auto &c3{fields[2]};
-    const auto &c4{fields[3]};
-    const auto &c5{fields[4]};
-
-    EXPECT_EQ(sourcemeta::core::nfc(c1), c2);
-    EXPECT_EQ(sourcemeta::core::nfc(c2), c2);
-    EXPECT_EQ(sourcemeta::core::nfc(c3), c2);
-    EXPECT_EQ(sourcemeta::core::nfc(c4), c4);
-    EXPECT_EQ(sourcemeta::core::nfc(c5), c4);
-
-    EXPECT_TRUE(sourcemeta::core::is_nfc(c2));
-    EXPECT_TRUE(sourcemeta::core::is_nfc(c4));
-    EXPECT_EQ(sourcemeta::core::is_nfc(c1), c1 == c2);
-    EXPECT_EQ(sourcemeta::core::is_nfc(c3), c3 == c2);
-    EXPECT_EQ(sourcemeta::core::is_nfc(c5), c5 == c4);
+auto run_normalization_test_case(const std::string_view raw_line) -> void {
+  auto data{raw_line};
+  const auto hash{data.find('#')};
+  if (hash != std::string_view::npos) {
+    data = data.substr(0, hash);
   }
 
-private:
-  std::string_view raw_line_;
-};
+  std::array<std::u32string, 5> fields;
+  std::size_t start{0};
+  std::size_t field_index{0};
+  while (field_index < fields.size()) {
+    const auto separator{data.find(';', start)};
+    const auto end{separator == std::string_view::npos ? data.size()
+                                                       : separator};
+    fields[field_index] =
+        parse_codepoint_sequence(data.substr(start, end - start));
+    field_index += 1;
+    if (separator == std::string_view::npos) {
+      break;
+    }
+    start = separator + 1;
+  }
+  EXPECT_EQ(field_index, fields.size());
+
+  // Per the NormalizationTest.txt header, the NFC invariants over the
+  // five columns are:
+  //
+  //   c2 == toNFC(c1) == toNFC(c2) == toNFC(c3)
+  //   c4 == toNFC(c4) == toNFC(c5)
+  //
+  // and a codepoint is in NFC iff its NFC form equals itself.
+  const auto &c1{fields[0]};
+  const auto &c2{fields[1]};
+  const auto &c3{fields[2]};
+  const auto &c4{fields[3]};
+  const auto &c5{fields[4]};
+
+  EXPECT_EQ(sourcemeta::core::nfc(c1), c2);
+  EXPECT_EQ(sourcemeta::core::nfc(c2), c2);
+  EXPECT_EQ(sourcemeta::core::nfc(c3), c2);
+  EXPECT_EQ(sourcemeta::core::nfc(c4), c4);
+  EXPECT_EQ(sourcemeta::core::nfc(c5), c4);
+
+  EXPECT_TRUE(sourcemeta::core::is_nfc(c2));
+  EXPECT_TRUE(sourcemeta::core::is_nfc(c4));
+  EXPECT_EQ(sourcemeta::core::is_nfc(c1), c1 == c2);
+  EXPECT_EQ(sourcemeta::core::is_nfc(c3), c3 == c2);
+  EXPECT_EQ(sourcemeta::core::is_nfc(c5), c5 == c4);
+}
 
 auto register_tests(const std::string_view contents) -> void {
   std::size_t position{0};
@@ -146,22 +135,17 @@ auto register_tests(const std::string_view contents) -> void {
 
     std::ostringstream test_name;
     test_name << "Part" << current_part << "_line_" << line_number;
-    const auto test_name_string{test_name.str()};
-
-    testing::RegisterTest("UnicodeNormalizationTestSuite",
-                          test_name_string.c_str(), nullptr, nullptr, __FILE__,
-                          __LINE__, [line]() -> NormalizationTest * {
-                            return new NormalizationTest{line};
-                          });
+    sourcemeta::core::test_register(test_name.str(), [line]() -> void {
+      run_normalization_test_case(line);
+    });
   }
 }
 
 } // namespace
 
 auto main(int argc, char **argv) -> int {
-  testing::InitGoogleTest(&argc, argv);
   const auto contents{sourcemeta::core::read_file_to_string(
       std::filesystem::path{NORMALIZATIONTEST_PATH})};
   register_tests(contents);
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/uritemplate/CMakeLists.txt
+++ b/test/uritemplate/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(sourcemeta_core_uritemplate_unit
 
 # URI Template Test Suite
 # See https://github.com/uri-templates/uritemplate-test
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME uritemplate_suite
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uritemplate_suite
   SOURCES uritemplate_suite.cc)
 target_compile_definitions(sourcemeta_core_uritemplate_suite_unit
   PRIVATE URITEMPLATE_SUITE_PATH="${PROJECT_SOURCE_DIR}/vendor/uritemplate-test")

--- a/test/uritemplate/uritemplate_suite.cc
+++ b/test/uritemplate/uritemplate_suite.cc
@@ -1,6 +1,5 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/uritemplate.h>
 
 #include <cassert>       // assert
@@ -15,6 +14,7 @@
 #include <unordered_set> // std::unordered_set
 #include <variant>       // std::variant, std::get
 
+namespace {
 class JSONExpander {
 public:
   using CacheEntry =
@@ -90,46 +90,31 @@ private:
   std::unordered_map<std::string_view, CacheEntry> cache_;
 };
 
-class URITemplateTest : public testing::Test {
-public:
-  URITemplateTest(const std::string_view template_source,
-                  const std::unordered_set<std::string_view> &expected_results,
-                  const sourcemeta::core::JSON &variables)
-      : template_{template_source}, expected_{expected_results},
-        variables_{variables} {}
-
-  auto TestBody() -> void override {
-    try {
-      const sourcemeta::core::URITemplate uri_template{this->template_};
-      const auto result{uri_template.expand(JSONExpander{this->variables_})};
-      if (this->expected_.empty()) {
-        FAIL();
-      } else {
-        EXPECT_TRUE(this->expected_.contains(result));
-      }
-    } catch (const sourcemeta::core::URITemplateParseError &) {
-      if (this->expected_.empty()) {
-        SUCCEED();
-      } else {
-        throw;
-      }
-    } catch (const sourcemeta::core::URITemplateExpansionError &) {
-      if (this->expected_.empty()) {
-        SUCCEED();
-      } else {
-        throw;
-      }
+auto run_uritemplate_test_case(
+    const std::string_view template_source,
+    const std::unordered_set<std::string_view> &expected_results,
+    const sourcemeta::core::JSON &variables) -> void {
+  try {
+    const sourcemeta::core::URITemplate uri_template{template_source};
+    const auto result{uri_template.expand(JSONExpander{variables})};
+    if (expected_results.empty()) {
+      FAIL();
+    } else {
+      EXPECT_TRUE(expected_results.contains(result));
+    }
+  } catch (const sourcemeta::core::URITemplateParseError &) {
+    if (!expected_results.empty()) {
+      throw;
+    }
+  } catch (const sourcemeta::core::URITemplateExpansionError &) {
+    if (!expected_results.empty()) {
+      throw;
     }
   }
+}
 
-private:
-  const std::string_view template_;
-  const std::unordered_set<std::string_view> &expected_;
-  const sourcemeta::core::JSON &variables_;
-};
-
-static auto register_tests(const sourcemeta::core::JSON &document,
-                           const std::string_view prefix) -> void {
+auto register_tests(const sourcemeta::core::JSON &document,
+                    const std::string_view prefix) -> void {
   for (const auto &entry : document.as_object()) {
     const auto &section{entry.second};
     if (!section.is_object()) {
@@ -164,22 +149,21 @@ static auto register_tests(const sourcemeta::core::JSON &document,
 
       test_name << "_testcase_" << index;
 
-      testing::RegisterTest(
-          "URITemplateSuite", test_name.str().c_str(), nullptr, nullptr,
-          __FILE__, __LINE__,
-          [&template_value, expected_results, &section]() -> testing::Test * {
-            return new URITemplateTest(template_value.to_string(),
-                                       expected_results,
-                                       section.at("variables"));
+      sourcemeta::core::test_register(
+          test_name.str(),
+          [&template_value, expected_results, &section]() -> void {
+            run_uritemplate_test_case(template_value.to_string(),
+                                      expected_results,
+                                      section.at("variables"));
           });
 
       index += 1;
     }
   }
 }
+} // namespace
 
 auto main(int argc, char **argv) -> int {
-  testing::InitGoogleTest(&argc, argv);
   const std::filesystem::path suite_path{URITEMPLATE_SUITE_PATH};
 
   const auto spec_examples{
@@ -194,5 +178,5 @@ auto main(int argc, char **argv) -> int {
       sourcemeta::core::read_json(suite_path / "negative-tests.json")};
   register_tests(negative_tests, "negative_tests");
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }

--- a/test/yaml/CMakeLists.txt
+++ b/test/yaml/CMakeLists.txt
@@ -17,7 +17,7 @@ target_compile_definitions(sourcemeta_core_yaml_unit
 
 # YAML Test Suite
 # See https://github.com/yaml/yaml-test-suite
-sourcemeta_googletest(NAMESPACE sourcemeta PROJECT core NAME yamltestsuite
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME yamltestsuite
   SOURCES yamltestsuite.cc)
 target_compile_definitions(sourcemeta_core_yamltestsuite_unit
   PRIVATE YAMLTESTSUITE_PATH="${PROJECT_SOURCE_DIR}/vendor/yaml-test-suite")

--- a/test/yaml/yamltestsuite.cc
+++ b/test/yaml/yamltestsuite.cc
@@ -1,82 +1,67 @@
-#include <gtest/gtest.h>
-
 #include <sourcemeta/core/json.h>
+#include <sourcemeta/core/test.h>
 #include <sourcemeta/core/yaml.h>
 
 #include <algorithm>  // std::min
-#include <exception>  // std::exception
 #include <filesystem> // std::filesystem
 #include <fstream>    // std::ifstream
 #include <string>     // std::string
 #include <vector>     // std::vector
 
+namespace {
 enum class YAMLTestType { Success, Error };
 
-class YAMLTest : public testing::Test {
-public:
-  explicit YAMLTest(std::filesystem::path directory,
-                    const YAMLTestType category)
-      : test_directory{std::move(directory)}, type{category} {}
+auto run_yaml_test_case(const std::filesystem::path &test_directory,
+                        const YAMLTestType type) -> void {
+  const auto yaml_path{test_directory / "in.yaml"};
 
-  auto TestBody() -> void override {
-    const auto yaml_path{this->test_directory / "in.yaml"};
+  if (type == YAMLTestType::Success) {
+    const auto json_path{test_directory / "in.json"};
 
-    if (this->type == YAMLTestType::Success) {
-      const auto json_path{this->test_directory / "in.json"};
+    std::ifstream yaml_stream{yaml_path, std::ios::binary};
+    std::ifstream json_stream{json_path, std::ios::binary};
+    yaml_stream.exceptions(std::ios_base::badbit);
+    json_stream.exceptions(std::ios_base::badbit);
 
-      std::ifstream yaml_stream{yaml_path, std::ios::binary};
-      std::ifstream json_stream{json_path, std::ios::binary};
-      yaml_stream.exceptions(std::ios_base::badbit);
-      json_stream.exceptions(std::ios_base::badbit);
+    std::vector<sourcemeta::core::JSON> yaml_documents;
+    std::vector<sourcemeta::core::JSON> json_documents;
 
-      std::vector<sourcemeta::core::JSON> yaml_documents;
-      std::vector<sourcemeta::core::JSON> json_documents;
-
-      // Parse all YAML documents from the stream
-      while (yaml_stream.peek() != EOF) {
-        try {
-          yaml_documents.push_back(sourcemeta::core::parse_yaml(yaml_stream));
-        } catch (const sourcemeta::core::YAMLParseError &) {
-          break;
-        }
-      }
-
-      // Parse all JSON documents from the stream
-      while (json_stream.peek() != EOF) {
-        try {
-          json_documents.push_back(sourcemeta::core::parse_json(json_stream));
-        } catch (const sourcemeta::core::JSONParseError &) {
-          break;
-        }
-      }
-
-      EXPECT_EQ(yaml_documents.size(), json_documents.size());
-      const auto compare_count{
-          std::min(yaml_documents.size(), json_documents.size())};
-      for (std::size_t index = 0; index < compare_count; index++) {
-        EXPECT_EQ(yaml_documents[index], json_documents[index]);
-      }
-    } else if (this->type == YAMLTestType::Error) {
+    // Parse all YAML documents from the stream
+    while (yaml_stream.peek() != EOF) {
       try {
-        sourcemeta::core::read_yaml(yaml_path);
-        FAIL() << "Expected a YAML parse error but parsing succeeded";
+        yaml_documents.push_back(sourcemeta::core::parse_yaml(yaml_stream));
       } catch (const sourcemeta::core::YAMLParseError &) {
-        SUCCEED();
-      } catch (const std::exception &error) {
-        FAIL() << "Expected a YAML parse error but got: " << error.what();
+        break;
       }
-    } else {
-      FAIL() << "Invalid test type";
+    }
+
+    // Parse all JSON documents from the stream
+    while (json_stream.peek() != EOF) {
+      try {
+        json_documents.push_back(sourcemeta::core::parse_json(json_stream));
+      } catch (const sourcemeta::core::JSONParseError &) {
+        break;
+      }
+    }
+
+    EXPECT_EQ(yaml_documents.size(), json_documents.size());
+    const auto compare_count{
+        std::min(yaml_documents.size(), json_documents.size())};
+    for (std::size_t index = 0; index < compare_count; index++) {
+      EXPECT_EQ(yaml_documents[index], json_documents[index]);
+    }
+  } else {
+    try {
+      sourcemeta::core::read_yaml(yaml_path);
+      FAIL();
+    } catch (const sourcemeta::core::YAMLParseError &) {
+      // A malformed document is expected to be rejected
     }
   }
+}
+} // namespace
 
-private:
-  const std::filesystem::path test_directory;
-  const YAMLTestType type;
-};
-
-int main(int argc, char **argv) {
-  testing::InitGoogleTest(&argc, argv);
+auto main(int argc, char **argv) -> int {
   const std::filesystem::path test_suite_path{YAMLTESTSUITE_PATH};
 
   for (const auto &entry :
@@ -100,11 +85,11 @@ int main(int argc, char **argv) {
       continue;
     }
 
-    testing::RegisterTest("YAMLTestSuite", test_name.c_str(), nullptr, nullptr,
-                          __FILE__, __LINE__, [=]() -> YAMLTest * {
-                            return new YAMLTest(test_directory, type);
-                          });
+    sourcemeta::core::test_register(test_name,
+                                    [test_directory, type]() -> void {
+                                      run_yaml_test_case(test_directory, type);
+                                    });
   }
 
-  return RUN_ALL_TESTS();
+  return sourcemeta::core::test_run(argc, argv);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

