### PR TITLE
Add a UTS #46 variant of `is_idn_email`

### DIFF
--- a/src/core/email/email.cc
+++ b/src/core/email/email.cc
@@ -8,8 +8,10 @@
 namespace sourcemeta::core {
 
 // RFC 5321 §4.1.2 Mailbox grammar. When AllowUtf8 is true, RFC 6531 §3.3
-// extends atext, qtextSMTP, and sub-domain with UTF8-non-ascii alternatives
-template <bool AllowUtf8>
+// extends atext, qtextSMTP, and sub-domain with UTF8-non-ascii alternatives.
+// When UseUts46 is also true, the domain is validated under UTS #46 processing
+// rather than strict IDNA 2008.
+template <bool AllowUtf8, bool UseUts46 = false>
 static auto is_mailbox(const std::string_view value) -> bool {
   if (value.empty()) {
     return false;
@@ -116,7 +118,11 @@ static auto is_mailbox(const std::string_view value) -> bool {
 
   if constexpr (AllowUtf8) {
     // RFC 6531 §3.3: sub-domain =/ U-label
-    return is_idn_hostname(domain);
+    if constexpr (UseUts46) {
+      return is_idn_hostname_uts46(domain);
+    } else {
+      return is_idn_hostname(domain);
+    }
   } else {
     // RFC 5321 §4.1.2 Domain matches is_hostname (RFC 1123 §2.1) by
     // grammar, by 63-octet label cap (RFC 1035 §2.3.4), and by
@@ -131,6 +137,10 @@ auto is_email(const std::string_view value) -> bool {
 
 auto is_idn_email(const std::string_view value) -> bool {
   return is_mailbox<true>(value);
+}
+
+auto is_idn_email_uts46(const std::string_view value) -> bool {
+  return is_mailbox<true, true>(value);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -56,6 +56,29 @@ auto is_email(const std::string_view value) -> bool;
 SOURCEMETA_CORE_EMAIL_EXPORT
 auto is_idn_email(const std::string_view value) -> bool;
 
+/// @ingroup email
+/// Check whether the given string is a valid internationalized `Mailbox` per
+/// RFC 6531 Section 3.3, validating the domain under UTS #46 processing rather
+/// than strict IDNA 2008. The domain is mapped and NFC-normalised before
+/// validation, so human-typed forms such as uppercase, fullwidth characters,
+/// and non-normalised (non-NFC) labels are accepted rather than rejected. The
+/// local part carries no normalisation requirement (RFC 6531) and is validated
+/// as-is. See https://www.unicode.org/reports/tr46/ for the algorithm. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/email.h>
+///
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::is_idn_email_uts46("joe.bloggs@example.com"));
+/// // Uppercase and fullwidth domains are mapped before validation
+/// assert(sourcemeta::core::is_idn_email_uts46("user@EXAMPLE.COM"));
+/// assert(!sourcemeta::core::is_idn_email_uts46("2962"));
+/// ```
+SOURCEMETA_CORE_EMAIL_EXPORT
+auto is_idn_email_uts46(const std::string_view value) -> bool;
+
 } // namespace sourcemeta::core
 
 #endif

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -59,12 +59,13 @@ auto is_idn_email(const std::string_view value) -> bool;
 /// @ingroup email
 /// Check whether the given string is a valid internationalized `Mailbox` per
 /// RFC 6531 Section 3.3, validating the domain under UTS #46 processing rather
-/// than strict IDNA 2008. The domain is mapped and NFC-normalised before
-/// validation, so human-typed forms such as uppercase, fullwidth characters,
-/// and non-normalised (non-NFC) labels are accepted rather than rejected. The
-/// local part carries no normalisation requirement (RFC 6531) and is validated
-/// as-is. See https://www.unicode.org/reports/tr46/ for the algorithm. For
-/// example:
+/// than strict IDNA 2008. The domain is mapped (case folding, compatibility
+/// mappings such as fullwidth to ASCII, and removal of ignorable characters)
+/// and NFC-normalised before validation, so forms that strict validation
+/// rejects, such as fullwidth characters and non-normalised (non-NFC) labels,
+/// are accepted. The local part carries no normalisation requirement
+/// (RFC 6531) and is validated as-is. See https://www.unicode.org/reports/tr46/
+/// for the algorithm. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/email.h>
@@ -72,8 +73,10 @@ auto is_idn_email(const std::string_view value) -> bool;
 /// #include <cassert>
 ///
 /// assert(sourcemeta::core::is_idn_email_uts46("joe.bloggs@example.com"));
-/// // Uppercase and fullwidth domains are mapped before validation
-/// assert(sourcemeta::core::is_idn_email_uts46("user@EXAMPLE.COM"));
+/// // The fullwidth domain U+FF41 U+FF42 U+FF43 maps to "abc" and is accepted,
+/// // whereas strict IDNA 2008 validation rejects it
+/// assert(sourcemeta::core::is_idn_email_uts46(
+///     "user@\xef\xbd\x81\xef\xbd\x82\xef\xbd\x83"));
 /// assert(!sourcemeta::core::is_idn_email_uts46("2962"));
 /// ```
 SOURCEMETA_CORE_EMAIL_EXPORT

--- a/test/email/CMakeLists.txt
+++ b/test/email/CMakeLists.txt
@@ -1,5 +1,5 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME email
-  SOURCES email_test.cc idn_email_test.cc)
+  SOURCES email_test.cc idn_email_test.cc idn_email_uts46_test.cc)
 
 target_link_libraries(sourcemeta_core_email_unit
   PRIVATE sourcemeta::core::email)

--- a/test/email/idn_email_uts46_test.cc
+++ b/test/email/idn_email_uts46_test.cc
@@ -1,0 +1,165 @@
+#include <sourcemeta/core/email.h>
+#include <sourcemeta/core/test.h>
+
+#include <string> // std::string
+
+// The lookup variant accepts everything the strict variant accepts
+TEST(valid_ascii_parity) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("joe.bloggs@example.com"));
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("joe.bloggs@example.com"));
+}
+
+TEST(valid_single_letter_parity) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("a@b"));
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("a@b"));
+}
+
+// RFC 5890 §2.3.2.3: Hangul local part and domain
+TEST(valid_utf8_local_and_domain) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46(
+      "\xec\x8b\xa4\xeb\xa1\x80@"
+      "\xec\x8b\xa4\xeb\xa1\x80.\xed\x85\x8c\xec\x8a\xa4\xed\x8a\xb8"));
+}
+
+TEST(valid_quoted_local) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("\"a b\"@example.com"));
+}
+
+TEST(valid_uppercase_local) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("ABC@b"));
+}
+
+// RFC 6532 §3.1: a UTF-8 local part (Greek alpha U+03B1)
+TEST(valid_utf8_local_part) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("\xce\xb1@b"));
+}
+
+// Address literals are unaffected by UTS #46 domain processing
+TEST(valid_ipv4_address_literal) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("user@[192.168.1.1]"));
+}
+
+TEST(invalid_bad_ipv4_address_literal) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@[999.0.0.1]"));
+}
+
+// RFC 5890 §2.3.2.1 states the domain U-label NFC requirement as a SHOULD, so
+// the lookup profile must not reject a non-NFC domain. The mapping normalises
+// it; the strict variant rejects it. Domain is "caf" + "e" + U+0301 ("cafe"
+// decomposed).
+TEST(non_nfc_domain_accepted_by_uts46_rejected_by_strict) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("user@cafe\xcc\x81"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@cafe\xcc\x81"));
+}
+
+// RFC 6531 sets no normalisation requirement on the local part, so a non-NFC
+// local part is accepted by both variants
+TEST(non_nfc_local_part_accepted_by_both) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("cafe\xcc\x81@example.com"));
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("cafe\xcc\x81@example.com"));
+}
+
+// Fullwidth Latin letters U+FF21..U+FF23 in the domain map to "abc"; the strict
+// variant rejects them as DISALLOWED
+TEST(fullwidth_domain_accepted_by_uts46_rejected_by_strict) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46(
+      "user@\xef\xbc\xa1\xef\xbc\xa2\xef\xbc\xa3"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email(
+      "user@\xef\xbc\xa1\xef\xbc\xa2\xef\xbc\xa3"));
+}
+
+// Soft hyphen (U+00AD) in the domain is ignored by the mapping; the strict
+// variant rejects it as DISALLOWED
+TEST(soft_hyphen_domain_accepted_by_uts46_rejected_by_strict) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("user@ab\xc2\xad"
+                                                   "c"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@ab\xc2\xad"
+                                              "c"));
+}
+
+// Uppercase ASCII domains are case-insensitive (RFC 1123) and accepted by both
+TEST(uppercase_ascii_domain_accepted_by_both) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("user@EXAMPLE.COM"));
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("user@EXAMPLE.COM"));
+}
+
+// UTS #46 §4 step 1: the ideographic full stop U+3002 maps to a label separator
+TEST(ideographic_full_stop_domain_separator) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("user@a\xe3\x80\x82"
+                                                   "b"));
+}
+
+// Nontransitional Processing: the deviation character sharp s (U+00DF) is kept
+// and forms a valid domain label
+TEST(deviation_sharp_s_domain) {
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46("user@fa\xc3\x9f"));
+}
+
+TEST(invalid_empty) { EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("")); }
+
+TEST(invalid_no_at) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("2962"));
+}
+
+TEST(invalid_missing_domain) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@"));
+}
+
+TEST(invalid_missing_local) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("@example.com"));
+}
+
+TEST(invalid_leading_dot_local) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46(".user@example.com"));
+}
+
+TEST(invalid_trailing_dot_local) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user.@example.com"));
+}
+
+TEST(invalid_consecutive_dots_local) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("a..b@example.com"));
+}
+
+// RFC 5321 §4.5.3.1.1: local part limit is 64 octets
+TEST(valid_local_part_at_64) {
+  const std::string local(64, 'a');
+  EXPECT_TRUE(sourcemeta::core::is_idn_email_uts46(local + "@b"));
+}
+
+TEST(invalid_local_part_over_64) {
+  const std::string local(65, 'a');
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46(local + "@b"));
+}
+
+// The mapping does not rescue a structurally invalid domain
+TEST(invalid_leading_hyphen_domain) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@-bad"));
+}
+
+TEST(invalid_trailing_dot_domain) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@example."));
+}
+
+// A disallowed codepoint (U+0080 control) in the domain is preserved by the
+// mapping and rejected by the per-label validity check
+TEST(invalid_disallowed_domain_codepoint) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@a\xc2\x80"
+                                                    "b"));
+}
+
+// RFC 5893 §2: a digit-first label in a Bidi domain is invalid. Domain is
+// "0" + Hebrew letter Alef (U+05D0)
+TEST(invalid_bidi_domain) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@0\xd7\x90"));
+}
+
+// Malformed UTF-8 in the domain is rejected before mapping
+TEST(invalid_utf8_domain) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("user@\xc0\x80"));
+}
+
+// Malformed UTF-8 in the local part is rejected
+TEST(invalid_utf8_local) {
+  EXPECT_FALSE(sourcemeta::core::is_idn_email_uts46("\xc0\x80@b"));
+}


### PR DESCRIPTION
See: https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/945
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

