### PR TITLE
Add URI escaping/unescaping utilities

### DIFF
--- a/src/core/uri/CMakeLists.txt
+++ b/src/core/uri/CMakeLists.txt
@@ -1,8 +1,8 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME uri
   PRIVATE_HEADERS error.h
   SOURCES uri.cc parse.cc accessors.cc setters.cc recompose.cc canonicalize.cc
-          resolution.cc filesystem.cc query.cc path.cc escaping.h normalize.h
-          grammar.h)
+          resolution.cc filesystem.cc query.cc path.cc escape.cc escaping.h
+          normalize.h grammar.h)
 
 if(SOURCEMETA_CORE_INSTALL)
   sourcemeta_library_install(NAMESPACE sourcemeta PROJECT core NAME uri)

--- a/src/core/uri/escape.cc
+++ b/src/core/uri/escape.cc
@@ -1,0 +1,40 @@
+#include <sourcemeta/core/uri.h>
+
+#include "escaping.h"
+#include "grammar.h"
+
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto URI::escape(const std::string_view input, std::string &output) -> void {
+  output.reserve(output.size() + input.size());
+  for (const auto character : input) {
+    if (uri_is_unreserved(character)) {
+      output += character;
+      continue;
+    }
+
+    const auto byte{static_cast<unsigned char>(character)};
+    const auto high{(byte >> 4) & 0x0F};
+    const auto low{byte & 0x0F};
+    output += URI_PERCENT;
+    output += static_cast<char>(high < 10 ? '0' + high : 'A' + high - 10);
+    output += static_cast<char>(low < 10 ? '0' + low : 'A' + low - 10);
+  }
+}
+
+auto URI::escape(const std::string_view input) -> std::string {
+  std::string result;
+  URI::escape(input, result);
+  return result;
+}
+
+auto URI::unescape(const std::string_view input) -> std::string {
+  std::string result{input};
+  uri_unescape_all_inplace(result);
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/uri/escape.cc
+++ b/src/core/uri/escape.cc
@@ -9,7 +9,7 @@
 namespace sourcemeta::core {
 
 auto URI::escape(const std::string_view input, std::string &output) -> void {
-  output.reserve(output.size() + input.size());
+  output.reserve(output.size() + input.size() * 3);
   for (const auto character : input) {
     if (uri_is_unreserved(character)) {
       output += character;

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -737,6 +737,43 @@ public:
   /// ```
   static auto canonicalize(std::string_view input) -> std::string;
 
+  /// Percent-encode a string per RFC 3986, escaping every octet outside the
+  /// unreserved set. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// assert(sourcemeta::core::URI::escape("foo bar/baz") == "foo%20bar%2Fbaz");
+  /// ```
+  [[nodiscard]] static auto escape(std::string_view input) -> std::string;
+
+  /// Percent-encode a string per RFC 3986, appending the result to an existing
+  /// string rather than allocating a new one. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  /// #include <string>
+  ///
+  /// std::string output{"key="};
+  /// sourcemeta::core::URI::escape("foo bar", output);
+  /// assert(output == "key=foo%20bar");
+  /// ```
+  static auto escape(std::string_view input, std::string &output) -> void;
+
+  /// Percent-decode every escape sequence in a string per RFC 3986, leaving
+  /// malformed sequences untouched. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// assert(sourcemeta::core::URI::unescape("foo%20bar%2Fbaz") == "foo
+  /// bar/baz");
+  /// ```
+  [[nodiscard]] static auto unescape(std::string_view input) -> std::string;
+
   /// Check if the given string is a valid URI scheme per RFC 3986
   /// (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`). For example:
   ///

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -749,7 +749,8 @@ public:
   [[nodiscard]] static auto escape(std::string_view input) -> std::string;
 
   /// Percent-encode a string per RFC 3986, appending the result to an existing
-  /// string rather than allocating a new one. For example:
+  /// string rather than allocating a new one. The output must not alias the
+  /// input. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>
@@ -769,8 +770,8 @@ public:
   /// #include <sourcemeta/core/uri.h>
   /// #include <cassert>
   ///
-  /// assert(sourcemeta::core::URI::unescape("foo%20bar%2Fbaz") == "foo
-  /// bar/baz");
+  /// const auto decoded{sourcemeta::core::URI::unescape("foo%20bar%2Fbaz")};
+  /// assert(decoded == "foo bar/baz");
   /// ```
   [[nodiscard]] static auto unescape(std::string_view input) -> std::string;
 

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -29,6 +29,8 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_recompose_relative_test.cc
     uri_has_same_authority_test.cc
     uri_canonicalize_test.cc
+    uri_escape_test.cc
+    uri_unescape_test.cc
     uri_resolve_from_test.cc
     uri_relative_to_test.cc
     uri_extension_test.cc

--- a/test/uri/uri_escape_test.cc
+++ b/test/uri/uri_escape_test.cc
@@ -1,0 +1,69 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+TEST(unreserved_characters_pass_through) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("ABCabc0123456789-._~"),
+            "ABCabc0123456789-._~");
+}
+
+TEST(space) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("foo bar"), "foo%20bar");
+}
+
+TEST(slash_is_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("path/to/key"), "path%2Fto%2Fkey");
+}
+
+TEST(percent_is_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("100%"), "100%25");
+}
+
+TEST(sub_delimiters_are_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("a=b&c"), "a%3Db%26c");
+}
+
+TEST(plus_sign_is_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("a+b"), "a%2Bb");
+}
+
+TEST(generic_delimiters_are_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape(":?#[]@"), "%3A%3F%23%5B%5D%40");
+}
+
+TEST(hex_output_is_uppercase) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("\xff"), "%FF");
+}
+
+TEST(utf8_multibyte) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("\xc3\xa9"), "%C3%A9");
+}
+
+TEST(embedded_nul_byte) {
+  EXPECT_EQ(sourcemeta::core::URI::escape(std::string_view{"a\x00"
+                                                           "b",
+                                                           3}),
+            "a%00b");
+}
+
+TEST(empty) { EXPECT_EQ(sourcemeta::core::URI::escape(""), ""); }
+
+TEST(append_preserves_existing_output) {
+  std::string output{"prefix="};
+  sourcemeta::core::URI::escape("a b/c", output);
+  EXPECT_EQ(output, "prefix=a%20b%2Fc");
+}
+
+TEST(append_matches_returning_form) {
+  std::string output;
+  sourcemeta::core::URI::escape(":?#[]@", output);
+  EXPECT_EQ(output, sourcemeta::core::URI::escape(":?#[]@"));
+}
+
+TEST(append_empty_leaves_output_untouched) {
+  std::string output{"unchanged"};
+  sourcemeta::core::URI::escape("", output);
+  EXPECT_EQ(output, "unchanged");
+}

--- a/test/uri/uri_unescape_test.cc
+++ b/test/uri/uri_unescape_test.cc
@@ -1,0 +1,48 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+#include <string> // std::string
+
+TEST(space) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("foo%20bar"), "foo bar");
+}
+
+TEST(slash) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("path%2Fto%2Fkey"), "path/to/key");
+}
+
+TEST(percent) { EXPECT_EQ(sourcemeta::core::URI::unescape("100%25"), "100%"); }
+
+TEST(uppercase_hex) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("%C3%A9"), "\xc3\xa9");
+}
+
+TEST(lowercase_hex) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("%c3%a9"), "\xc3\xa9");
+}
+
+TEST(unreserved_characters_pass_through) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("ABCabc0123-._~"),
+            "ABCabc0123-._~");
+}
+
+TEST(trailing_percent_is_literal) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("100%"), "100%");
+}
+
+TEST(incomplete_sequence_is_literal) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("a%2"), "a%2");
+}
+
+TEST(invalid_hex_is_literal) {
+  EXPECT_EQ(sourcemeta::core::URI::unescape("a%2Gb"), "a%2Gb");
+}
+
+TEST(empty) { EXPECT_EQ(sourcemeta::core::URI::unescape(""), ""); }
+
+TEST(round_trip_with_escape) {
+  const std::string original{"a b/c%d?e=f&g:h@i"};
+  EXPECT_EQ(
+      sourcemeta::core::URI::unescape(sourcemeta::core::URI::escape(original)),
+      original);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

