### PR TITLE
Implement the AWS SigV4 protocol in `src/core/http`

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -10,10 +10,11 @@ endif()
 
 sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
   PRIVATE_HEADERS problem.h status.h method.h message.h error.h system.h
+    aws_sigv4.h
   SOURCES helpers.h problem.cc match_accept.cc match_accept_language.cc
           negotiate_encoding.cc from_date.cc format_link.cc field_list.cc
           accept_includes_all.cc content_type_matches.cc parse_bearer.cc
-          cache_control_max_age.cc serialize_cookie.cc
+          cache_control_max_age.cc serialize_cookie.cc aws_sigv4.cc
           ${SOURCEMETA_CORE_HTTP_CLIENT_SOURCE})
 
 if(SOURCEMETA_CORE_INSTALL)
@@ -24,6 +25,8 @@ target_link_libraries(sourcemeta_core_http PUBLIC sourcemeta::core::json)
 target_link_libraries(sourcemeta_core_http PUBLIC sourcemeta::core::text)
 target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::time)
 target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::dns)
+target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::crypto)
+target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::uri)
 
 if(SOURCEMETA_CORE_HTTP_USE_SYSTEM_CURL)
   find_package(CURL REQUIRED)

--- a/src/core/http/aws_sigv4.cc
+++ b/src/core/http/aws_sigv4.cc
@@ -1,0 +1,250 @@
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/http_aws_sigv4.h>
+#include <sourcemeta/core/text.h>
+#include <sourcemeta/core/uri.h>
+
+#include "helpers.h"
+
+#include <algorithm>   // std::sort, std::stable_sort
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair, std::move
+#include <vector>      // std::vector
+
+namespace {
+
+auto digest_view(const std::array<std::uint8_t, 32> &bytes)
+    -> std::string_view {
+  return {reinterpret_cast<const char *>(bytes.data()), bytes.size()};
+}
+
+auto sorted_headers(
+    const std::span<const std::pair<std::string_view, std::string_view>>
+        headers) -> std::vector<std::pair<std::string_view, std::string_view>> {
+  std::vector<std::pair<std::string_view, std::string_view>> entries;
+  entries.reserve(headers.size());
+  for (const auto &[name, value] : headers) {
+    entries.emplace_back(name,
+                         sourcemeta::core::http_trim_trailing_ows(
+                             sourcemeta::core::http_trim_leading_ows(value)));
+  }
+
+  std::ranges::stable_sort(
+      entries, sourcemeta::core::less_ignore_case,
+      &std::pair<std::string_view, std::string_view>::first);
+  return entries;
+}
+
+auto append_lowercased(std::string &output, const std::string_view name)
+    -> void {
+  for (const auto character : name) {
+    output.push_back(sourcemeta::core::to_lowercase(character));
+  }
+}
+
+auto append_canonical_headers(
+    std::string &output,
+    const std::vector<std::pair<std::string_view, std::string_view>> &entries)
+    -> void {
+  std::size_t index{0};
+  while (index < entries.size()) {
+    const auto name{entries[index].first};
+    append_lowercased(output, name);
+    output.push_back(':');
+    bool first{true};
+    while (index < entries.size() &&
+           sourcemeta::core::equals_ignore_case(entries[index].first, name)) {
+      if (!first) {
+        output.push_back(',');
+      }
+
+      sourcemeta::core::squeeze(entries[index].second, ' ', output);
+      first = false;
+      ++index;
+    }
+
+    output.push_back('\n');
+  }
+}
+
+auto append_signed_headers(
+    std::string &output,
+    const std::vector<std::pair<std::string_view, std::string_view>> &entries)
+    -> void {
+  std::string_view previous;
+  bool first{true};
+  for (const auto &[name, value] : entries) {
+    if (!first && sourcemeta::core::equals_ignore_case(name, previous)) {
+      continue;
+    }
+
+    if (!first) {
+      output.push_back(';');
+    }
+
+    append_lowercased(output, name);
+    previous = name;
+    first = false;
+  }
+}
+
+auto append_canonical_uri(std::string &output, std::string_view path,
+                          const bool normalize) -> void {
+  std::string normalized;
+  if (normalize) {
+    // Beyond RFC 3986 dot-segment removal, the default canonicalization also
+    // collapses redundant slashes, which Amazon S3 does not
+    normalized = sourcemeta::core::URI::normalize_path(
+        sourcemeta::core::squeeze(path, '/'));
+    path = normalized;
+  }
+
+  if (path.empty()) {
+    output.push_back('/');
+    return;
+  }
+
+  std::size_t start{0};
+  while (true) {
+    const auto slash{path.find('/', start)};
+    if (slash == std::string_view::npos) {
+      sourcemeta::core::URI::escape(path.substr(start), output);
+      break;
+    }
+
+    sourcemeta::core::URI::escape(path.substr(start, slash - start), output);
+    output.push_back('/');
+    start = slash + 1;
+  }
+}
+
+auto append_canonical_query(std::string &output, const std::string_view query)
+    -> void {
+  if (query.empty()) {
+    return;
+  }
+
+  std::vector<std::pair<std::string, std::string>> parameters;
+  for (const auto &[name, value] : sourcemeta::core::URI::Query{query}) {
+    std::string encoded_name;
+    std::string encoded_value;
+    sourcemeta::core::URI::escape(name, encoded_name);
+    sourcemeta::core::URI::escape(value, encoded_value);
+    parameters.emplace_back(std::move(encoded_name), std::move(encoded_value));
+  }
+
+  std::ranges::sort(parameters);
+  bool first{true};
+  for (const auto &[key, value] : parameters) {
+    if (!first) {
+      output.push_back('&');
+    }
+
+    output.append(key);
+    output.push_back('=');
+    output.append(value);
+    first = false;
+  }
+}
+
+} // namespace
+
+namespace sourcemeta::core {
+
+auto http_aws_sigv4_canonical_request(
+    const std::string_view method, const std::string_view path,
+    const std::string_view query,
+    const std::span<const std::pair<std::string_view, std::string_view>>
+        headers,
+    const std::string_view payload_hash, const bool normalize) -> std::string {
+  const auto entries{sorted_headers(headers)};
+  std::string result;
+  result.append(method);
+  result.push_back('\n');
+  append_canonical_uri(result, path, normalize);
+  result.push_back('\n');
+  append_canonical_query(result, query);
+  result.push_back('\n');
+  append_canonical_headers(result, entries);
+  result.push_back('\n');
+  append_signed_headers(result, entries);
+  result.push_back('\n');
+  result.append(payload_hash);
+  return result;
+}
+
+auto http_aws_sigv4_signed_headers(
+    const std::span<const std::pair<std::string_view, std::string_view>>
+        headers) -> std::string {
+  std::string result;
+  append_signed_headers(result, sorted_headers(headers));
+  return result;
+}
+
+auto http_aws_sigv4_credential_scope(const std::string_view date,
+                                     const std::string_view region,
+                                     const std::string_view service)
+    -> std::string {
+  std::string result;
+  result.append(date);
+  result.push_back('/');
+  result.append(region);
+  result.push_back('/');
+  result.append(service);
+  result.append("/aws4_request");
+  return result;
+}
+
+auto http_aws_sigv4_string_to_sign(const std::string_view amz_date,
+                                   const std::string_view scope,
+                                   const std::string_view canonical_request)
+    -> std::string {
+  std::string result{"AWS4-HMAC-SHA256\n"};
+  result.append(amz_date);
+  result.push_back('\n');
+  result.append(scope);
+  result.push_back('\n');
+  result.append(sha256(canonical_request));
+  return result;
+}
+
+auto http_aws_sigv4_signing_key(const std::string_view secret,
+                                const std::string_view date,
+                                const std::string_view region,
+                                const std::string_view service)
+    -> std::array<std::uint8_t, 32> {
+  std::string initial{"AWS4"};
+  initial.append(secret);
+  const auto key_date{hmac_sha256_digest(initial, date)};
+  const auto key_region{hmac_sha256_digest(digest_view(key_date), region)};
+  const auto key_service{hmac_sha256_digest(digest_view(key_region), service)};
+  return hmac_sha256_digest(digest_view(key_service), "aws4_request");
+}
+
+auto http_aws_sigv4_signature(const std::array<std::uint8_t, 32> &signing_key,
+                              const std::string_view string_to_sign)
+    -> std::string {
+  return hmac_sha256(digest_view(signing_key), string_to_sign);
+}
+
+auto http_aws_sigv4_authorization(const std::string_view access_key_id,
+                                  const std::string_view scope,
+                                  const std::string_view signed_headers,
+                                  const std::string_view signature)
+    -> std::string {
+  std::string result{"AWS4-HMAC-SHA256 Credential="};
+  result.append(access_key_id);
+  result.push_back('/');
+  result.append(scope);
+  result.append(", SignedHeaders=");
+  result.append(signed_headers);
+  result.append(", Signature=");
+  result.append(signature);
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -6,6 +6,7 @@
 #endif
 
 // NOLINTBEGIN(misc-include-cleaner)
+#include <sourcemeta/core/http_aws_sigv4.h>
 #include <sourcemeta/core/http_error.h>
 #include <sourcemeta/core/http_message.h>
 #include <sourcemeta/core/http_method.h>

--- a/src/core/http/include/sourcemeta/core/http_aws_sigv4.h
+++ b/src/core/http/include/sourcemeta/core/http_aws_sigv4.h
@@ -1,0 +1,156 @@
+#ifndef SOURCEMETA_CORE_HTTP_AWS_SIGV4_H_
+#define SOURCEMETA_CORE_HTTP_AWS_SIGV4_H_
+
+#ifndef SOURCEMETA_CORE_HTTP_EXPORT
+#include <sourcemeta/core/http_export.h>
+#endif
+
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair
+
+namespace sourcemeta::core {
+
+/// @ingroup http
+/// Compute the AWS Signature Version 4 canonical request from a request method,
+/// path, query, headers, and payload hash. The path and query are percent-
+/// encoded during canonicalization, so they must be provided in decoded form.
+/// When `normalize` is set the path is normalised by collapsing sequential
+/// slashes and removing dot segments, which every service except Amazon S3
+/// requires. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+/// #include <string_view>
+/// #include <utility>
+/// #include <vector>
+///
+/// const std::vector<std::pair<std::string_view, std::string_view>> headers{
+///     {"Host", "example.amazonaws.com"}, {"X-Amz-Date", "20150830T123600Z"}};
+/// const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+///     "GET", "/", "", headers,
+///     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")};
+/// assert(canonical.starts_with("GET\n/\n"));
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT http_aws_sigv4_canonical_request(
+    const std::string_view method, const std::string_view path,
+    const std::string_view query,
+    const std::span<const std::pair<std::string_view, std::string_view>>
+        headers,
+    const std::string_view payload_hash, const bool normalize = true)
+    -> std::string;
+
+/// @ingroup http
+/// Compute the AWS Signature Version 4 signed headers list, the lowercased
+/// header names sorted and joined with a semicolon. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+/// #include <string_view>
+/// #include <utility>
+/// #include <vector>
+///
+/// const std::vector<std::pair<std::string_view, std::string_view>> headers{
+///     {"Host", "example.amazonaws.com"}, {"X-Amz-Date", "20150830T123600Z"}};
+/// assert(sourcemeta::core::http_aws_sigv4_signed_headers(headers) ==
+///        "host;x-amz-date");
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT http_aws_sigv4_signed_headers(
+    const std::span<const std::pair<std::string_view, std::string_view>>
+        headers) -> std::string;
+
+/// @ingroup http
+/// Compute the AWS Signature Version 4 credential scope from a date, region,
+/// and service. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_aws_sigv4_credential_scope(
+///            "20150830", "us-east-1", "service") ==
+///        "20150830/us-east-1/service/aws4_request");
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT http_aws_sigv4_credential_scope(
+    const std::string_view date, const std::string_view region,
+    const std::string_view service) -> std::string;
+
+/// @ingroup http
+/// Compute the AWS Signature Version 4 string to sign from a timestamp, a
+/// credential scope, and a canonical request. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const auto result{sourcemeta::core::http_aws_sigv4_string_to_sign(
+///     "20150830T123600Z", "20150830/us-east-1/service/aws4_request",
+///     "canonical request")};
+/// assert(result.starts_with("AWS4-HMAC-SHA256\n20150830T123600Z\n"));
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT http_aws_sigv4_string_to_sign(
+    const std::string_view amz_date, const std::string_view scope,
+    const std::string_view canonical_request) -> std::string;
+
+/// @ingroup http
+/// Derive the AWS Signature Version 4 signing key from a secret access key,
+/// date, region, and service. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const auto key{sourcemeta::core::http_aws_sigv4_signing_key(
+///     "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1",
+///     "service")};
+/// assert(key.size() == 32);
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT http_aws_sigv4_signing_key(
+    const std::string_view secret, const std::string_view date,
+    const std::string_view region, const std::string_view service)
+    -> std::array<std::uint8_t, 32>;
+
+/// @ingroup http
+/// Compute the AWS Signature Version 4 hex signature from a signing key and a
+/// string to sign. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const auto key{sourcemeta::core::http_aws_sigv4_signing_key(
+///     "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1",
+///     "service")};
+/// assert(sourcemeta::core::http_aws_sigv4_signature(key, "string to sign")
+///            .size() == 64);
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT
+http_aws_sigv4_signature(const std::array<std::uint8_t, 32> &signing_key,
+                         const std::string_view string_to_sign) -> std::string;
+
+/// @ingroup http
+/// Assemble the AWS Signature Version 4 `Authorization` header value from an
+/// access key, credential scope, signed headers, and signature. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// const auto header{sourcemeta::core::http_aws_sigv4_authorization(
+///     "AKIDEXAMPLE", "20150830/us-east-1/service/aws4_request",
+///     "host;x-amz-date", "signature")};
+/// assert(header.starts_with("AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/"));
+/// ```
+auto SOURCEMETA_CORE_HTTP_EXPORT http_aws_sigv4_authorization(
+    const std::string_view access_key_id, const std::string_view scope,
+    const std::string_view signed_headers, const std::string_view signature)
+    -> std::string;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -10,7 +10,22 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_header_find_test.cc http_error_test.cc
           http_parse_bearer_test.cc http_cache_control_max_age_test.cc
           http_serialize_cookie_test.cc http_parse_cookies_test.cc
-          http_cookie_valid_test.cc)
+          http_cookie_valid_test.cc http_aws_sigv4_test.cc)
 
 target_link_libraries(sourcemeta_core_http_unit
   PRIVATE sourcemeta::core::http)
+
+# Official AWS Signature Version 4 Test Suite
+# See https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
+sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME aws_sigv4_suite
+  SOURCES aws_sigv4_suite_test.cc)
+target_compile_definitions(sourcemeta_core_aws_sigv4_suite_unit
+  PRIVATE AWS_SIGV4_TEST_SUITE_PATH="${PROJECT_SOURCE_DIR}/vendor/aws-sig-v4-test-suite/raw/aws-sig-v4-test-suite")
+target_link_libraries(sourcemeta_core_aws_sigv4_suite_unit
+  PRIVATE sourcemeta::core::http)
+target_link_libraries(sourcemeta_core_aws_sigv4_suite_unit
+  PRIVATE sourcemeta::core::crypto)
+target_link_libraries(sourcemeta_core_aws_sigv4_suite_unit
+  PRIVATE sourcemeta::core::io)
+target_link_libraries(sourcemeta_core_aws_sigv4_suite_unit
+  PRIVATE sourcemeta::core::text)

--- a/test/http/aws_sigv4_suite_test.cc
+++ b/test/http/aws_sigv4_suite_test.cc
@@ -1,0 +1,192 @@
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/io.h>
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/text.h>
+
+#include <cstddef>     // std::size_t
+#include <filesystem>  // std::filesystem
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair
+#include <vector>      // std::vector
+
+namespace {
+
+// The fixed inputs every case in the suite shares
+constexpr std::string_view ACCESS_KEY_ID{"AKIDEXAMPLE"};
+constexpr std::string_view SECRET_ACCESS_KEY{
+    "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"};
+constexpr std::string_view REGION{"us-east-1"};
+constexpr std::string_view SERVICE{"service"};
+
+// Every field borrows from the request content that produced it
+struct ParsedRequest {
+  std::string_view method;
+  std::string_view path;
+  std::string_view query;
+  std::string_view body;
+  std::vector<std::pair<std::string_view, std::string_view>> headers;
+};
+
+auto parse_request(const std::string_view content) -> ParsedRequest {
+  ParsedRequest request;
+
+  // The header block and the body are separated by a blank line, and a request
+  // without a body has no such separator
+  std::string_view header_block{content};
+  const auto separator{content.find("\n\n")};
+  if (separator != std::string_view::npos) {
+    header_block = content.substr(0, separator);
+    request.body = content.substr(separator + 2);
+  }
+
+  std::size_t line_start{0};
+  bool is_request_line{true};
+  std::string_view last_name;
+  while (line_start <= header_block.size()) {
+    const auto line_end{header_block.find('\n', line_start)};
+    const auto line{
+        header_block.substr(line_start, line_end == std::string_view::npos
+                                            ? std::string_view::npos
+                                            : line_end - line_start)};
+
+    if (line.empty()) {
+      // A blank line, such as a trailing newline at the end of the file
+    } else if (is_request_line) {
+      // "<METHOD> <TARGET> HTTP/1.1", where the target may contain spaces
+      request.method = sourcemeta::core::take_until(line, ' ');
+      const auto rest{line.substr(request.method.size() + 1)};
+      const auto target{rest.substr(0, rest.rfind(' '))};
+      const auto split{sourcemeta::core::split_once(target, '?')};
+      if (split.has_value()) {
+        request.path = split->first;
+        request.query = split->second;
+      } else {
+        request.path = target;
+      }
+
+      is_request_line = false;
+    } else if (line.front() == ' ' || line.front() == '\t') {
+      // A folded continuation line is signed as a separate value of the
+      // previous header
+      request.headers.emplace_back(last_name, line);
+    } else if (const auto field{sourcemeta::core::split_once(line, ':')};
+               field.has_value()) {
+      last_name = field->first;
+      request.headers.emplace_back(field->first, field->second);
+    }
+
+    if (line_end == std::string_view::npos) {
+      break;
+    }
+
+    line_start = line_end + 1;
+  }
+
+  return request;
+}
+
+auto find_amz_date(
+    const std::span<const std::pair<std::string_view, std::string_view>>
+        headers) -> std::string_view {
+  for (const auto &[name, value] : headers) {
+    if (sourcemeta::core::equals_ignore_case(name, "x-amz-date")) {
+      return sourcemeta::core::trim(value);
+    }
+  }
+
+  return {};
+}
+
+auto run_case(const std::string_view content,
+              const std::string_view expected_canonical,
+              const std::string_view expected_string_to_sign,
+              const std::string_view expected_authorization) -> void {
+  const auto request{parse_request(content)};
+  const auto payload_hash{sourcemeta::core::sha256(request.body)};
+  const auto amz_date{find_amz_date(request.headers)};
+  const auto date{amz_date.substr(0, 8)};
+
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      request.method, request.path, request.query, request.headers,
+      payload_hash)};
+  EXPECT_EQ(canonical, expected_canonical);
+
+  const auto scope{
+      sourcemeta::core::http_aws_sigv4_credential_scope(date, REGION, SERVICE)};
+  const auto string_to_sign{sourcemeta::core::http_aws_sigv4_string_to_sign(
+      amz_date, scope, canonical)};
+  EXPECT_EQ(string_to_sign, expected_string_to_sign);
+
+  const auto signed_headers{
+      sourcemeta::core::http_aws_sigv4_signed_headers(request.headers)};
+  const auto key{sourcemeta::core::http_aws_sigv4_signing_key(
+      SECRET_ACCESS_KEY, date, REGION, SERVICE)};
+  const auto signature{
+      sourcemeta::core::http_aws_sigv4_signature(key, string_to_sign)};
+  const auto authorization{sourcemeta::core::http_aws_sigv4_authorization(
+      ACCESS_KEY_ID, scope, signed_headers, signature)};
+  EXPECT_EQ(authorization, expected_authorization);
+}
+
+auto register_suite_case(const std::filesystem::path &request_path) -> void {
+  const auto name{request_path.stem().string()};
+  const auto content{sourcemeta::core::read_file_to_string(request_path)};
+  const auto expected_canonical{sourcemeta::core::read_file_to_string(
+      std::filesystem::path{request_path}.replace_extension(".creq"))};
+  const auto expected_string_to_sign{sourcemeta::core::read_file_to_string(
+      std::filesystem::path{request_path}.replace_extension(".sts"))};
+  const auto expected_authorization{sourcemeta::core::read_file_to_string(
+      std::filesystem::path{request_path}.replace_extension(".authz"))};
+
+  sourcemeta::core::test_register(
+      "AWS_SigV4." + name, [content, expected_canonical,
+                            expected_string_to_sign, expected_authorization]() {
+        run_case(content, expected_canonical, expected_string_to_sign,
+                 expected_authorization);
+      });
+}
+
+} // namespace
+
+TEST(parse_request_basic) {
+  const std::string content{
+      "POST /path?a=b HTTP/1.1\nHost:example.com\n\nbody"};
+  const auto request{parse_request(content)};
+  EXPECT_EQ(request.method, "POST");
+  EXPECT_EQ(request.path, "/path");
+  EXPECT_EQ(request.query, "a=b");
+  EXPECT_EQ(request.body, "body");
+  EXPECT_EQ(request.headers.size(), 1);
+}
+
+TEST(parse_request_tolerates_trailing_newline) {
+  const std::string content{"GET / HTTP/1.1\nHost:example.amazonaws.com\n"
+                            "X-Amz-Date:20150830T123600Z\n"};
+  const auto request{parse_request(content)};
+  EXPECT_EQ(request.method, "GET");
+  EXPECT_EQ(request.path, "/");
+  EXPECT_EQ(request.headers.size(), 2);
+}
+
+TEST(parse_request_ignores_line_without_colon) {
+  const std::string content{"GET / HTTP/1.1\nHost:example.amazonaws.com\n"
+                            "garbage-without-a-colon\n"
+                            "X-Amz-Date:20150830T123600Z"};
+  const auto request{parse_request(content)};
+  EXPECT_EQ(request.headers.size(), 2);
+}
+
+auto main(int argc, char **argv) -> int {
+  const std::filesystem::path base{AWS_SIGV4_TEST_SUITE_PATH};
+  for (const auto &entry :
+       std::filesystem::recursive_directory_iterator{base}) {
+    if (entry.is_regular_file() && entry.path().extension() == ".req") {
+      register_suite_case(entry.path());
+    }
+  }
+
+  return sourcemeta::core::test_run(argc, argv);
+}

--- a/test/http/http_aws_sigv4_test.cc
+++ b/test/http/http_aws_sigv4_test.cc
@@ -1,0 +1,86 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::pair
+#include <vector>      // std::vector
+
+TEST(credential_scope) {
+  EXPECT_EQ(sourcemeta::core::http_aws_sigv4_credential_scope(
+                "20150830", "us-east-1", "service"),
+            "20150830/us-east-1/service/aws4_request");
+}
+
+TEST(canonical_request_empty_path_becomes_root) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"Host", "example.amazonaws.com"}};
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      "GET", "", "", headers,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")};
+  EXPECT_TRUE(canonical.starts_with("GET\n/\n"));
+}
+
+TEST(canonical_request_default_normalizes_path) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"Host", "example.amazonaws.com"}};
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      "GET", "/foo/../bar", "", headers,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")};
+  EXPECT_TRUE(canonical.starts_with("GET\n/bar\n"));
+}
+
+TEST(canonical_request_s3_preserves_dot_segments) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"Host", "example.amazonaws.com"}};
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      "GET", "/foo/../bar", "", headers,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      false)};
+  EXPECT_TRUE(canonical.starts_with("GET\n/foo/../bar\n"));
+}
+
+TEST(signed_headers_lowercases_and_sorts) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"X-Amz-Date", "20150830T123600Z"}, {"Host", "example.amazonaws.com"}};
+  EXPECT_EQ(sourcemeta::core::http_aws_sigv4_signed_headers(headers),
+            "host;x-amz-date");
+}
+
+TEST(authorization_format) {
+  EXPECT_EQ(
+      sourcemeta::core::http_aws_sigv4_authorization(
+          "AKIDEXAMPLE", "20150830/us-east-1/service/aws4_request",
+          "host;x-amz-date", "abc123"),
+      "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/"
+      "aws4_request, SignedHeaders=host;x-amz-date, Signature=abc123");
+}
+
+TEST(string_to_sign_format) {
+  EXPECT_EQ(
+      sourcemeta::core::http_aws_sigv4_string_to_sign(
+          "20150830T123600Z", "20150830/us-east-1/service/aws4_request", ""),
+      "AWS4-HMAC-SHA256\n20150830T123600Z\n"
+      "20150830/us-east-1/service/aws4_request\n"
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+TEST(signing_key_size) {
+  const auto key{sourcemeta::core::http_aws_sigv4_signing_key(
+      "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1",
+      "service")};
+  EXPECT_EQ(key.size(), 32);
+}
+
+// The signing key and signature for the suite's get-vanilla string to sign
+TEST(signature_known_vector) {
+  const std::string string_to_sign{
+      "AWS4-HMAC-SHA256\n20150830T123600Z\n"
+      "20150830/us-east-1/service/aws4_request\n"
+      "bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63"};
+  const auto key{sourcemeta::core::http_aws_sigv4_signing_key(
+      "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20150830", "us-east-1",
+      "service")};
+  EXPECT_EQ(sourcemeta::core::http_aws_sigv4_signature(key, string_to_sign),
+            "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

