### PR TITLE
Implement a `URI::normalize_path` static method

### DIFF
--- a/src/core/uri/canonicalize.cc
+++ b/src/core/uri/canonicalize.cc
@@ -118,7 +118,7 @@ auto URI::canonicalize() -> URI & {
   // Canonicalize path by removing "." and ".." segments
   if (this->path_.has_value() && !this->path_.value().empty()) {
     auto &current_path{this->path_.value()};
-    normalize_path(current_path);
+    sourcemeta::core::normalize_path(current_path);
     if (current_path.empty()) {
       this->path_ = std::nullopt;
     }

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -776,7 +776,7 @@ public:
   [[nodiscard]] static auto unescape(std::string_view input) -> std::string;
 
   /// Remove the "." and ".." segments from a URI path per RFC 3986 Section
-  /// 5.2.4. For example:
+  /// 5.2.4, preserving leading ".." segments in a relative path. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -775,6 +775,19 @@ public:
   /// ```
   [[nodiscard]] static auto unescape(std::string_view input) -> std::string;
 
+  /// Remove the "." and ".." segments from a URI path per RFC 3986 Section
+  /// 5.2.4. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// assert(sourcemeta::core::URI::normalize_path("/foo/bar/../baz") ==
+  ///        "/foo/baz");
+  /// ```
+  [[nodiscard]] static auto normalize_path(std::string_view path)
+      -> std::string;
+
   /// Check if the given string is a valid URI scheme per RFC 3986
   /// (`ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`). For example:
   ///

--- a/src/core/uri/normalize.h
+++ b/src/core/uri/normalize.h
@@ -13,11 +13,9 @@ namespace sourcemeta::core {
 // extension because the spec algorithm assumes a path that has already been
 // merged with an absolute base; applied to a stand-alone relative path it
 // would discard semantic intent that is needed at later resolution time.
-inline auto normalize_path(std::string &path) -> void {
-  const std::string buffer{std::move(path)};
-  std::string_view input{buffer};
+inline auto normalize_path(std::string_view input) -> std::string {
   std::string output;
-  output.reserve(buffer.size());
+  output.reserve(input.size());
   const bool is_absolute{!input.empty() && input.front() == '/'};
 
   while (!input.empty()) {
@@ -71,7 +69,12 @@ inline auto normalize_path(std::string &path) -> void {
     }
   }
 
-  path = std::move(output);
+  return output;
+}
+
+// Remove "." and ".." segments from a URI path in place
+inline auto normalize_path(std::string &path) -> void {
+  path = normalize_path(std::string_view{path});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/uri/normalize.h
+++ b/src/core/uri/normalize.h
@@ -13,7 +13,8 @@ namespace sourcemeta::core {
 // extension because the spec algorithm assumes a path that has already been
 // merged with an absolute base; applied to a stand-alone relative path it
 // would discard semantic intent that is needed at later resolution time.
-inline auto normalize_path(std::string_view input) -> std::string {
+[[nodiscard]] inline auto normalize_path(std::string_view input)
+    -> std::string {
   std::string output;
   output.reserve(input.size());
   const bool is_absolute{!input.empty() && input.front() == '/'};

--- a/src/core/uri/path.cc
+++ b/src/core/uri/path.cc
@@ -109,4 +109,10 @@ auto URI::rebase_path(const std::string_view path,
   return result;
 }
 
+auto URI::normalize_path(const std::string_view path) -> std::string {
+  std::string result{path};
+  sourcemeta::core::normalize_path(result);
+  return result;
+}
+
 } // namespace sourcemeta::core

--- a/src/core/uri/path.cc
+++ b/src/core/uri/path.cc
@@ -110,9 +110,7 @@ auto URI::rebase_path(const std::string_view path,
 }
 
 auto URI::normalize_path(const std::string_view path) -> std::string {
-  std::string result{path};
-  sourcemeta::core::normalize_path(result);
-  return result;
+  return sourcemeta::core::normalize_path(path);
 }
 
 } // namespace sourcemeta::core

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -31,6 +31,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_canonicalize_test.cc
     uri_escape_test.cc
     uri_unescape_test.cc
+    uri_normalize_path_test.cc
     uri_resolve_from_test.cc
     uri_relative_to_test.cc
     uri_extension_test.cc

--- a/test/uri/uri_normalize_path_test.cc
+++ b/test/uri/uri_normalize_path_test.cc
@@ -76,8 +76,16 @@ TEST(relative_leading_single_dot) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("./foo"), "foo");
 }
 
+TEST(relative_interior_single_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("a/./b"), "a/b");
+}
+
 TEST(relative_interior_double_dot) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("a/b/../c"), "a/c");
+}
+
+TEST(relative_double_dot_removes_prior_segment) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("a/../b"), "b");
 }
 
 TEST(relative_double_dot_consumes_segment) {

--- a/test/uri/uri_normalize_path_test.cc
+++ b/test/uri/uri_normalize_path_test.cc
@@ -9,12 +9,24 @@ TEST(no_dot_segments) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar"), "/foo/bar");
 }
 
-TEST(single_dot) {
+TEST(trailing_slash_is_preserved) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar/"), "/foo/bar/");
+}
+
+TEST(single_dot_slash) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("/./"), "/");
+}
+
+TEST(single_dot_at_end) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/."), "/");
 }
 
 TEST(interior_single_dot) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/./bar"), "/foo/bar");
+}
+
+TEST(interior_single_dot_with_trailing) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar/./"), "/foo/bar/");
 }
 
 TEST(double_dot) {
@@ -22,8 +34,16 @@ TEST(double_dot) {
             "/foo/baz");
 }
 
-TEST(trailing_double_dot) {
+TEST(double_dot_at_end) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar/.."), "/foo/");
+}
+
+TEST(double_dot_at_end_exact) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/.."), "/");
+}
+
+TEST(interleaved_dot_and_double_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/a/./b/../c"), "/a/c");
 }
 
 TEST(collapse_to_root) {
@@ -33,4 +53,47 @@ TEST(collapse_to_root) {
 
 TEST(double_dot_past_root_stays_at_root) {
   EXPECT_EQ(sourcemeta::core::URI::normalize_path("/../"), "/");
+}
+
+// Only "." and ".." segments are removed, so sequential slashes are preserved
+TEST(sequential_slashes_are_not_collapsed) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/a//b"), "/a//b");
+}
+
+TEST(double_slash_is_not_collapsed) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("//"), "//");
+}
+
+TEST(relative_no_dot_segments) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("foo"), "foo");
+}
+
+TEST(relative_multi_segment) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("foo/bar"), "foo/bar");
+}
+
+TEST(relative_leading_single_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("./foo"), "foo");
+}
+
+TEST(relative_interior_double_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("a/b/../c"), "a/c");
+}
+
+TEST(relative_double_dot_consumes_segment) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("a/.."), "");
+}
+
+TEST(relative_single_dot_only) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("."), "");
+}
+
+// Leading ".." blocks are preserved for stand-alone relative paths, since the
+// specification assumes a path already merged with an absolute base
+TEST(relative_leading_double_dot_is_preserved) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("../foo"), "../foo");
+}
+
+TEST(relative_multiple_leading_double_dots_are_preserved) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("../../foo"), "../../foo");
 }

--- a/test/uri/uri_normalize_path_test.cc
+++ b/test/uri/uri_normalize_path_test.cc
@@ -1,0 +1,36 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(empty) { EXPECT_EQ(sourcemeta::core::URI::normalize_path(""), ""); }
+
+TEST(root) { EXPECT_EQ(sourcemeta::core::URI::normalize_path("/"), "/"); }
+
+TEST(no_dot_segments) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar"), "/foo/bar");
+}
+
+TEST(single_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/./"), "/");
+}
+
+TEST(interior_single_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/./bar"), "/foo/bar");
+}
+
+TEST(double_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar/../baz"),
+            "/foo/baz");
+}
+
+TEST(trailing_double_dot) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/foo/bar/.."), "/foo/");
+}
+
+TEST(collapse_to_root) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/example1/example2/../.."),
+            "/");
+}
+
+TEST(double_dot_past_root_stays_at_root) {
+  EXPECT_EQ(sourcemeta::core::URI::normalize_path("/../"), "/");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

