### PR TITLE
Add a URI escaping `maybe_encoded` flag

### DIFF
--- a/src/core/uri/escape.cc
+++ b/src/core/uri/escape.cc
@@ -1,33 +1,63 @@
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include "escaping.h"
 #include "grammar.h"
 
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::int8_t
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
-auto URI::escape(const std::string_view input, std::string &output) -> void {
+auto URI::escape(const std::string_view input, std::string &output,
+                 const bool maybe_encoded) -> void {
   output.reserve(output.size() + input.size() * 3);
-  for (const auto character : input) {
-    if (uri_is_unreserved(character)) {
-      output += character;
-      continue;
+  if (!maybe_encoded) {
+    for (const auto character : input) {
+      if (uri_is_unreserved(character)) {
+        output += character;
+      } else {
+        uri_percent_encode_byte(output, static_cast<unsigned char>(character));
+      }
     }
 
-    const auto byte{static_cast<unsigned char>(character)};
-    const auto high{(byte >> 4) & 0x0F};
-    const auto low{byte & 0x0F};
-    output += URI_PERCENT;
-    output += static_cast<char>(high < 10 ? '0' + high : 'A' + high - 10);
-    output += static_cast<char>(low < 10 ? '0' + low : 'A' + low - 10);
+    return;
+  }
+
+  // Treat the input as possibly already encoded, decoding each octet before
+  // re-encoding so that a valid escape survives and a needlessly encoded
+  // unreserved octet is decoded
+  for (std::size_t position = 0; position < input.size();) {
+    const auto high{input[position] == URI_PERCENT &&
+                            position + 2 < input.size()
+                        ? hex_digit_value(input[position + 1])
+                        : static_cast<std::int8_t>(-1)};
+    const auto low{high < 0 ? static_cast<std::int8_t>(-1)
+                            : hex_digit_value(input[position + 2])};
+
+    unsigned char byte{};
+    if (low < 0) {
+      byte = static_cast<unsigned char>(input[position]);
+      position += 1;
+    } else {
+      byte = static_cast<unsigned char>((high << 4) | low);
+      position += 3;
+    }
+
+    if (uri_is_unreserved(static_cast<char>(byte))) {
+      output += static_cast<char>(byte);
+    } else {
+      uri_percent_encode_byte(output, byte);
+    }
   }
 }
 
-auto URI::escape(const std::string_view input) -> std::string {
+auto URI::escape(const std::string_view input, const bool maybe_encoded)
+    -> std::string {
   std::string result;
-  URI::escape(input, result);
+  URI::escape(input, result, maybe_encoded);
   return result;
 }
 

--- a/src/core/uri/escaping.h
+++ b/src/core/uri/escaping.h
@@ -35,6 +35,15 @@ enum class URIEscapeMode : std::uint8_t {
   UserInfo
 };
 
+inline auto uri_percent_encode_byte(std::string &output,
+                                    const unsigned char byte) -> void {
+  const auto high{(byte >> 4) & 0x0F};
+  const auto low{byte & 0x0F};
+  output += URI_PERCENT;
+  output += static_cast<char>(high < 10 ? '0' + high : 'A' + high - 10);
+  output += static_cast<char>(low < 10 ? '0' + low : 'A' + low - 10);
+}
+
 inline auto uri_is_percent_encoded(const std::string &input,
                                    std::string::size_type position) -> bool {
   return position < input.size() && input[position] == URI_PERCENT &&

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -738,19 +738,25 @@ public:
   static auto canonicalize(std::string_view input) -> std::string;
 
   /// Percent-encode a string per RFC 3986, escaping every octet outside the
-  /// unreserved set. For example:
+  /// unreserved set. The input can optionally be treated as possibly already
+  /// encoded, preserving valid escapes and decoding needlessly encoded
+  /// unreserved octets so the result is stable under repeated application. For
+  /// example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>
   /// #include <cassert>
   ///
   /// assert(sourcemeta::core::URI::escape("foo bar/baz") == "foo%20bar%2Fbaz");
+  /// assert(sourcemeta::core::URI::escape("a b%2Fc", true) == "a%20b%2Fc");
   /// ```
-  [[nodiscard]] static auto escape(std::string_view input) -> std::string;
+  [[nodiscard]] static auto escape(std::string_view input,
+                                   bool maybe_encoded = false) -> std::string;
 
   /// Percent-encode a string per RFC 3986, appending the result to an existing
-  /// string rather than allocating a new one. The output must not alias the
-  /// input. For example:
+  /// string rather than allocating a new one, optionally treating the input as
+  /// possibly already encoded. The output must not alias the input. For
+  /// example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>
@@ -761,7 +767,8 @@ public:
   /// sourcemeta::core::URI::escape("foo bar", output);
   /// assert(output == "key=foo%20bar");
   /// ```
-  static auto escape(std::string_view input, std::string &output) -> void;
+  static auto escape(std::string_view input, std::string &output,
+                     bool maybe_encoded = false) -> void;
 
   /// Percent-decode every escape sequence in a string per RFC 3986, leaving
   /// malformed sequences untouched. For example:

--- a/test/uri/uri_escape_test.cc
+++ b/test/uri/uri_escape_test.cc
@@ -67,3 +67,54 @@ TEST(append_empty_leaves_output_untouched) {
   sourcemeta::core::URI::escape("", output);
   EXPECT_EQ(output, "unchanged");
 }
+
+TEST(normalized_raw_characters_are_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("a=b&c", true), "a%3Db%26c");
+}
+
+TEST(normalized_existing_escape_is_preserved) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("a%20b", true), "a%20b");
+}
+
+TEST(normalized_existing_encoded_delimiter_is_preserved) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("path%2Fto", true), "path%2Fto");
+}
+
+TEST(normalized_needlessly_encoded_unreserved_is_decoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("%41%42", true), "AB");
+}
+
+TEST(normalized_lowercase_escape_is_uppercased) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("a%2fb", true), "a%2Fb");
+}
+
+TEST(normalized_mixed_raw_and_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("a b%2Fc", true), "a%20b%2Fc");
+}
+
+TEST(normalized_lone_percent_is_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("100%", true), "100%25");
+}
+
+TEST(normalized_percent_without_hex_is_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("%zz", true), "%25zz");
+}
+
+TEST(normalized_percent_with_single_trailing_hex_is_encoded) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("%a", true), "%25a");
+}
+
+TEST(normalized_utf8_multibyte_encoded_is_preserved) {
+  EXPECT_EQ(sourcemeta::core::URI::escape("%C3%A9", true), "%C3%A9");
+}
+
+TEST(normalized_is_idempotent_under_repeated_application) {
+  const auto once{sourcemeta::core::URI::escape("a b%2Fc&d", true)};
+  EXPECT_EQ(sourcemeta::core::URI::escape(once, true), once);
+}
+
+TEST(normalized_append_preserves_existing_output) {
+  std::string output{"prefix="};
+  sourcemeta::core::URI::escape("a b%2Fc", output, true);
+  EXPECT_EQ(output, "prefix=a%20b%2Fc");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

