### PR TITLE
Extend `HTTPSystemRequest` with header getters

### DIFF
--- a/src/core/http/include/sourcemeta/core/http_system.h
+++ b/src/core/http/include/sourcemeta/core/http_system.h
@@ -7,14 +7,16 @@
 
 #include <sourcemeta/core/http_method.h>
 #include <sourcemeta/core/http_status.h>
+#include <sourcemeta/core/text.h>
 
-#include <chrono>    // std::chrono::milliseconds, std::chrono::seconds
-#include <cstddef>   // std::size_t
-#include <optional>  // std::optional
-#include <stdexcept> // std::runtime_error
-#include <string>    // std::string
-#include <utility>   // std::move, std::pair
-#include <vector>    // std::vector
+#include <chrono>      // std::chrono::milliseconds, std::chrono::seconds
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional
+#include <stdexcept>   // std::runtime_error
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::move, std::pair
+#include <vector>      // std::vector
 
 namespace sourcemeta::core {
 
@@ -121,6 +123,33 @@ public:
   auto header(std::string name, std::string value) -> HTTPSystemRequest & {
     this->headers_.emplace_back(std::move(name), std::move(value));
     return *this;
+  }
+
+  /// Get the value of the first header with the given name, compared case
+  /// insensitively, or no value when no such header was added. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/http.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  /// request.header("Accept", "application/json");
+  /// assert(request.header("accept") == "application/json");
+  /// ```
+  [[nodiscard]] auto header(const std::string_view name) const
+      -> std::optional<std::string_view> {
+    for (const auto &[key, value] : this->headers_) {
+      if (equals_ignore_case(key, name)) {
+        return value;
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  /// Get the request headers configured so far, in the order they were added
+  [[nodiscard]] auto headers() const noexcept -> const auto & {
+    return this->headers_;
   }
 
   /// Set the request body, sent along with the given `Content-Type` header

--- a/src/core/http/include/sourcemeta/core/http_system.h
+++ b/src/core/http/include/sourcemeta/core/http_system.h
@@ -134,7 +134,7 @@ public:
   ///
   /// sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
   /// request.header("Accept", "application/json");
-  /// assert(request.header("accept") == "application/json");
+  /// assert(request.header("accept").value() == "application/json");
   /// ```
   [[nodiscard]] auto header(const std::string_view name) const
       -> std::optional<std::string_view> {

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -10,7 +10,8 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_header_find_test.cc http_error_test.cc
           http_parse_bearer_test.cc http_cache_control_max_age_test.cc
           http_serialize_cookie_test.cc http_parse_cookies_test.cc
-          http_cookie_valid_test.cc http_aws_sigv4_test.cc)
+          http_cookie_valid_test.cc http_aws_sigv4_test.cc
+          http_system_request_test.cc)
 
 target_link_libraries(sourcemeta_core_http_unit
   PRIVATE sourcemeta::core::http)

--- a/test/http/http_system_request_test.cc
+++ b/test/http/http_system_request_test.cc
@@ -1,0 +1,44 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+TEST(headers_empty_by_default) {
+  const sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  EXPECT_TRUE(request.headers().empty());
+}
+
+TEST(headers_returns_added_headers_in_order) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("Accept", "application/json");
+  request.header("X-Custom", "value");
+  EXPECT_EQ(request.headers().size(), 2);
+  EXPECT_EQ(request.headers().at(0).first, "Accept");
+  EXPECT_EQ(request.headers().at(0).second, "application/json");
+  EXPECT_EQ(request.headers().at(1).first, "X-Custom");
+  EXPECT_EQ(request.headers().at(1).second, "value");
+}
+
+TEST(header_lookup_present) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("Accept", "application/json");
+  EXPECT_TRUE(request.header("Accept").has_value());
+  EXPECT_EQ(request.header("Accept").value(), "application/json");
+}
+
+TEST(header_lookup_case_insensitive) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("Content-Type", "text/plain");
+  EXPECT_EQ(request.header("content-type").value(), "text/plain");
+  EXPECT_EQ(request.header("CONTENT-TYPE").value(), "text/plain");
+}
+
+TEST(header_lookup_absent) {
+  const sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  EXPECT_FALSE(request.header("Accept").has_value());
+}
+
+TEST(header_lookup_returns_first_of_repeated) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("X-Repeated", "first");
+  request.header("X-Repeated", "second");
+  EXPECT_EQ(request.header("X-Repeated").value(), "first");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

