### PR TITLE
Fix `http_aws_sigv4_canonical_request` URI encoding

### DIFF
--- a/src/core/http/aws_sigv4.cc
+++ b/src/core/http/aws_sigv4.cc
@@ -108,15 +108,18 @@ auto append_canonical_uri(std::string &output, std::string_view path,
     return;
   }
 
+  // Each segment is normalised in place, so a segment that arrives already
+  // percent-encoded is not encoded a second time
   std::size_t start{0};
   while (true) {
     const auto slash{path.find('/', start)};
     if (slash == std::string_view::npos) {
-      sourcemeta::core::URI::escape(path.substr(start), output);
+      sourcemeta::core::URI::escape(path.substr(start), output, true);
       break;
     }
 
-    sourcemeta::core::URI::escape(path.substr(start, slash - start), output);
+    sourcemeta::core::URI::escape(path.substr(start, slash - start), output,
+                                  true);
     output.push_back('/');
     start = slash + 1;
   }
@@ -128,12 +131,15 @@ auto append_canonical_query(std::string &output, const std::string_view query)
     return;
   }
 
+  // Each parameter is split off the encoded query, where delimiters are
+  // unambiguous, then normalised so that an encoded delimiter inside a value
+  // survives intact
   std::vector<std::pair<std::string, std::string>> parameters;
   for (const auto &[name, value] : sourcemeta::core::URI::Query{query}) {
     std::string encoded_name;
     std::string encoded_value;
-    sourcemeta::core::URI::escape(name, encoded_name);
-    sourcemeta::core::URI::escape(value, encoded_value);
+    sourcemeta::core::URI::escape(name, encoded_name, true);
+    sourcemeta::core::URI::escape(value, encoded_value, true);
     parameters.emplace_back(std::move(encoded_name), std::move(encoded_value));
   }
 

--- a/src/core/http/include/sourcemeta/core/http_aws_sigv4.h
+++ b/src/core/http/include/sourcemeta/core/http_aws_sigv4.h
@@ -16,11 +16,11 @@ namespace sourcemeta::core {
 
 /// @ingroup http
 /// Compute the AWS Signature Version 4 canonical request from a request method,
-/// path, query, headers, and payload hash. The path and query are percent-
-/// encoded during canonicalization, so they must be provided in decoded form.
-/// When `normalize` is set the path is normalised by collapsing sequential
-/// slashes and removing dot segments, which every service except Amazon S3
-/// requires. For example:
+/// path, query, headers, and payload hash. Each path segment and query
+/// parameter is decoded and re-encoded into canonical form, so the path and
+/// query may be passed exactly as they appear in the request target. The path
+/// is optionally normalised by collapsing sequential slashes and removing dot
+/// segments, which every service except Amazon S3 requires. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/http.h>

--- a/test/http/http_aws_sigv4_test.cc
+++ b/test/http/http_aws_sigv4_test.cc
@@ -40,6 +40,33 @@ TEST(canonical_request_s3_preserves_dot_segments) {
   EXPECT_TRUE(canonical.starts_with("GET\n/foo/../bar\n"));
 }
 
+TEST(canonical_request_preserves_encoded_query_delimiter) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"Host", "example.amazonaws.com"}};
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      "GET", "/", "a=b%26c&x=y", headers,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")};
+  EXPECT_TRUE(canonical.find("\na=b%26c&x=y\n") != std::string::npos);
+}
+
+TEST(canonical_request_does_not_double_encode_query) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"Host", "example.amazonaws.com"}};
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      "GET", "/", "a=b%20c", headers,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")};
+  EXPECT_TRUE(canonical.find("\na=b%20c\n") != std::string::npos);
+}
+
+TEST(canonical_request_preserves_encoded_path_slash) {
+  const std::vector<std::pair<std::string_view, std::string_view>> headers{
+      {"Host", "example.amazonaws.com"}};
+  const auto canonical{sourcemeta::core::http_aws_sigv4_canonical_request(
+      "GET", "/foo%2Fbar", "", headers,
+      "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")};
+  EXPECT_TRUE(canonical.starts_with("GET\n/foo%2Fbar\n"));
+}
+
 TEST(signed_headers_lowercases_and_sorts) {
   const std::vector<std::pair<std::string_view, std::string_view>> headers{
       {"X-Amz-Date", "20150830T123600Z"}, {"Host", "example.amazonaws.com"}};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

