### PR TITLE
Implement a `URI::authority` helper getter

### DIFF
--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -227,6 +227,20 @@ public:
   /// ```
   [[nodiscard]] auto port() const -> std::optional<std::uint32_t>;
 
+  /// Get the recomposed authority component of the URI, if any, in the RFC 3986
+  /// form `[ userinfo "@" ] host [ ":" port ]`, with IPv6 hosts wrapped in
+  /// brackets. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::URI uri{"https://example.com:8443/foo"};
+  /// assert(uri.authority().has_value());
+  /// assert(uri.authority().value() == "example.com:8443");
+  /// ```
+  [[nodiscard]] auto authority() const -> std::optional<std::string>;
+
   /// Get the path part of the URI, if any. For example:
   ///
   /// ```cpp

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -229,7 +229,9 @@ public:
 
   /// Get the recomposed authority component of the URI, if any, in the RFC 3986
   /// form `[ userinfo "@" ] host [ ":" port ]`, with IPv6 hosts wrapped in
-  /// brackets. For example:
+  /// brackets. A URI with an empty authority, such as `file:///path`, returns a
+  /// present but empty value, so a caller must not treat a present value as
+  /// necessarily non-empty. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>
@@ -238,6 +240,10 @@ public:
   /// const sourcemeta::core::URI uri{"https://example.com:8443/foo"};
   /// assert(uri.authority().has_value());
   /// assert(uri.authority().value() == "example.com:8443");
+  ///
+  /// const sourcemeta::core::URI file{"file:///path"};
+  /// assert(file.authority().has_value());
+  /// assert(file.authority().value().empty());
   /// ```
   [[nodiscard]] auto authority() const -> std::optional<std::string>;
 

--- a/src/core/uri/recompose.cc
+++ b/src/core/uri/recompose.cc
@@ -4,13 +4,14 @@
 
 #include "escaping.h"
 
-#include <array>    // std::array
-#include <charconv> // std::to_chars
-#include <cstdint>  // std::uint32_t
-#include <iomanip>  // std::hex, std::uppercase
-#include <optional> // std::optional
-#include <sstream>  // std::ostringstream
-#include <string>   // std::string
+#include <array>       // std::array
+#include <charconv>    // std::to_chars
+#include <cstdint>     // std::uint32_t
+#include <iomanip>     // std::hex, std::uppercase
+#include <optional>    // std::optional
+#include <sstream>     // std::ostringstream
+#include <string>      // std::string
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
@@ -96,6 +97,38 @@ auto escape_component_to_string(std::string &output, std::string_view input,
   }
 }
 
+auto recompose_authority(std::string &output,
+                         const std::optional<std::string_view> user_info,
+                         const std::optional<std::string_view> host,
+                         const std::optional<std::uint32_t> port,
+                         const bool ip_literal, const bool iri) -> void {
+  if (user_info.has_value()) {
+    escape_component_to_string(output, user_info.value(),
+                               URIEscapeMode::UserInfo, iri);
+    output += '@';
+  }
+
+  if (host.has_value()) {
+    if (ip_literal) {
+      output += '[';
+      output += host.value();
+      output += ']';
+    } else {
+      escape_component_to_string(output, host.value(),
+                                 URIEscapeMode::SkipSubDelims, iri);
+    }
+  }
+
+  if (port.has_value()) {
+    output += ':';
+    std::array<char, 20> port_buffer{};
+    const auto [end_pointer, error_code] =
+        std::to_chars(port_buffer.data(),
+                      port_buffer.data() + port_buffer.size(), port.value());
+    output.append(port_buffer.data(), end_pointer);
+  }
+}
+
 } // namespace
 
 auto URI::recompose() const -> std::string {
@@ -178,6 +211,18 @@ auto URI::recompose_relative() const -> std::string {
   return result;
 }
 
+auto URI::authority() const -> std::optional<std::string> {
+  if (!this->userinfo().has_value() && !this->host().has_value() &&
+      !this->port().has_value()) {
+    return std::nullopt;
+  }
+
+  std::string result;
+  recompose_authority(result, this->userinfo(), this->host(), this->port(),
+                      this->ip_literal_, this->iri_);
+  return result;
+}
+
 auto URI::recompose_without_fragment() const -> std::optional<std::string> {
   std::string result;
   result.reserve(256);
@@ -190,43 +235,11 @@ auto URI::recompose_without_fragment() const -> std::optional<std::string> {
   }
 
   // Authority
-  const auto user_info{this->userinfo()};
-  const auto result_host{this->host()};
-  const auto result_port{this->port()};
-  const bool has_authority{user_info.has_value() || result_host.has_value() ||
-                           result_port.has_value()};
-
-  // Add "//" prefix when we have authority (with or without scheme)
-  if (has_authority) {
+  if (this->userinfo().has_value() || this->host().has_value() ||
+      this->port().has_value()) {
     result += "//";
-  }
-
-  if (user_info.has_value()) {
-    escape_component_to_string(result, user_info.value(),
-                               URIEscapeMode::UserInfo, this->iri_);
-    result += '@';
-  }
-
-  // Host
-  if (result_host.has_value()) {
-    if (this->ip_literal_) {
-      result += '[';
-      result += result_host.value();
-      result += ']';
-    } else {
-      escape_component_to_string(result, result_host.value(),
-                                 URIEscapeMode::SkipSubDelims, this->iri_);
-    }
-  }
-
-  // Port
-  if (result_port.has_value()) {
-    result += ':';
-    std::array<char, 20> port_buffer{};
-    const auto [end_pointer, error_code] = std::to_chars(
-        port_buffer.data(), port_buffer.data() + port_buffer.size(),
-        result_port.value());
-    result.append(port_buffer.data(), end_pointer);
+    recompose_authority(result, this->userinfo(), this->host(), this->port(),
+                        this->ip_literal_, this->iri_);
   }
 
   // Path

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -4,6 +4,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_fragment_test.cc
     uri_empty_test.cc
     uri_host_test.cc
+    uri_authority_test.cc
     uri_path_test.cc
     uri_from_path_test.cc
     uri_to_path_test.cc

--- a/test/uri/uri_authority_test.cc
+++ b/test/uri/uri_authority_test.cc
@@ -1,0 +1,108 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(host_only) {
+  const sourcemeta::core::URI uri{"https://example.com/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com");
+}
+
+TEST(host_without_path) {
+  const sourcemeta::core::URI uri{"https://example.com"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com");
+}
+
+TEST(host_with_non_default_port) {
+  const sourcemeta::core::URI uri{"https://example.com:8443/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com:8443");
+}
+
+TEST(host_with_http_port) {
+  const sourcemeta::core::URI uri{"http://example.com:8000/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com:8000");
+}
+
+TEST(explicit_default_port_is_kept_verbatim) {
+  const sourcemeta::core::URI uri{"https://example.com:443/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com:443");
+}
+
+TEST(canonicalize_drops_the_default_port) {
+  sourcemeta::core::URI uri{"https://example.com:443/foo"};
+  uri.canonicalize();
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com");
+}
+
+TEST(canonicalize_keeps_a_non_default_port) {
+  sourcemeta::core::URI uri{"https://example.com:8443/foo"};
+  uri.canonicalize();
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "example.com:8443");
+}
+
+TEST(ipv6_host_is_bracketed) {
+  const sourcemeta::core::URI uri{"https://[::1]/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "[::1]");
+}
+
+TEST(ipv6_host_with_port) {
+  const sourcemeta::core::URI uri{"https://[2001:db8::1]:8443/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "[2001:db8::1]:8443");
+}
+
+TEST(ipv4_host) {
+  const sourcemeta::core::URI uri{"http://192.168.1.1:8080/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "192.168.1.1:8080");
+}
+
+TEST(userinfo_and_host) {
+  const sourcemeta::core::URI uri{"https://user@example.com/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "user@example.com");
+}
+
+TEST(userinfo_host_and_port) {
+  const sourcemeta::core::URI uri{"https://user@example.com:8443/foo"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "user@example.com:8443");
+}
+
+TEST(relative_reference_has_no_authority) {
+  const sourcemeta::core::URI uri{"../foo/bar"};
+  EXPECT_FALSE(uri.authority().has_value());
+}
+
+TEST(path_only_absolute_has_no_authority) {
+  const sourcemeta::core::URI uri{"/foo/bar"};
+  EXPECT_FALSE(uri.authority().has_value());
+}
+
+TEST(urn_has_no_authority) {
+  const sourcemeta::core::URI uri{"urn:example:schema"};
+  EXPECT_FALSE(uri.authority().has_value());
+}
+
+TEST(mailto_has_no_authority) {
+  const sourcemeta::core::URI uri{"mailto:joe@example.com"};
+  EXPECT_FALSE(uri.authority().has_value());
+}
+
+TEST(fragment_only_has_no_authority) {
+  const sourcemeta::core::URI uri{"#section"};
+  EXPECT_FALSE(uri.authority().has_value());
+}
+
+TEST(matches_recompose_authority_component) {
+  const sourcemeta::core::URI uri{"https://user@example.com:8443/foo?x=1#y"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.recompose(),
+            "https://" + uri.authority().value() + "/foo?x=1#y");
+}

--- a/test/uri/uri_authority_test.cc
+++ b/test/uri/uri_authority_test.cc
@@ -100,6 +100,18 @@ TEST(fragment_only_has_no_authority) {
   EXPECT_FALSE(uri.authority().has_value());
 }
 
+TEST(empty_authority_is_present_but_empty) {
+  const sourcemeta::core::URI uri{"file:///path/to/file"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "");
+}
+
+TEST(file_url_with_host) {
+  const sourcemeta::core::URI uri{"file://host/path/to/file"};
+  EXPECT_TRUE(uri.authority().has_value());
+  EXPECT_EQ(uri.authority().value(), "host");
+}
+
 TEST(matches_recompose_authority_component) {
   const sourcemeta::core::URI uri{"https://user@example.com:8443/foo?x=1#y"};
   EXPECT_TRUE(uri.authority().has_value());


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

