### PR TITLE
Mitigate ClangFormat max argument size

### DIFF
--- a/cmake/common/targets/clang-format.cmake
+++ b/cmake/common/targets/clang-format.cmake
@@ -110,18 +110,47 @@ function(sourcemeta_target_clang_format)
 
   if(CLANG_FORMAT_BIN)
     message(STATUS "Using `clang-format` from ${CLANG_FORMAT_BIN}")
+
+    # Invoke `clang-format` over the files in batches so that the full command
+    # never exceeds the operating system command-line length limit (notably the
+    # Windows `CreateProcess` limit) as the number of sources grows
+    set(SOURCEMETA_CLANG_FORMAT_BATCH_SIZE 100)
+    set(SOURCEMETA_CLANG_FORMAT_COMMANDS)
+    set(SOURCEMETA_CLANG_FORMAT_TEST_COMMANDS)
+    set(SOURCEMETA_CLANG_FORMAT_BATCH)
+    foreach(SOURCEMETA_CLANG_FORMAT_FILE IN LISTS
+        SOURCEMETA_TARGET_CLANG_FORMAT_FILES)
+      list(APPEND SOURCEMETA_CLANG_FORMAT_BATCH "${SOURCEMETA_CLANG_FORMAT_FILE}")
+      list(LENGTH SOURCEMETA_CLANG_FORMAT_BATCH SOURCEMETA_CLANG_FORMAT_LENGTH)
+      if(SOURCEMETA_CLANG_FORMAT_LENGTH GREATER_EQUAL
+          SOURCEMETA_CLANG_FORMAT_BATCH_SIZE)
+        list(APPEND SOURCEMETA_CLANG_FORMAT_COMMANDS
+          COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
+            -i ${SOURCEMETA_CLANG_FORMAT_BATCH})
+        list(APPEND SOURCEMETA_CLANG_FORMAT_TEST_COMMANDS
+          COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
+            --dry-run -Werror -i ${SOURCEMETA_CLANG_FORMAT_BATCH})
+        set(SOURCEMETA_CLANG_FORMAT_BATCH)
+      endif()
+    endforeach()
+    if(SOURCEMETA_CLANG_FORMAT_BATCH)
+      list(APPEND SOURCEMETA_CLANG_FORMAT_COMMANDS
+        COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
+          -i ${SOURCEMETA_CLANG_FORMAT_BATCH})
+      list(APPEND SOURCEMETA_CLANG_FORMAT_TEST_COMMANDS
+        COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
+          --dry-run -Werror -i ${SOURCEMETA_CLANG_FORMAT_BATCH})
+    endif()
+
     add_custom_target(clang_format
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
       VERBATIM
-      COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
-        -i ${SOURCEMETA_TARGET_CLANG_FORMAT_FILES}
+      ${SOURCEMETA_CLANG_FORMAT_COMMANDS}
       COMMENT "Formatting sources using ClangFormat")
     add_custom_target(clang_format_test
       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
       VERBATIM
-      COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
-        --dry-run -Werror
-        -i ${SOURCEMETA_TARGET_CLANG_FORMAT_FILES}
+      ${SOURCEMETA_CLANG_FORMAT_TEST_COMMANDS}
       COMMENT "Checking for ClangFormat compliance")
   else()
     add_custom_target(clang_format

--- a/cmake/common/targets/clang-format.cmake
+++ b/cmake/common/targets/clang-format.cmake
@@ -101,6 +101,12 @@ function(sourcemeta_target_clang_format)
   file(GLOB_RECURSE SOURCEMETA_TARGET_CLANG_FORMAT_FILES
     ${SOURCEMETA_TARGET_CLANG_FORMAT_SOURCES})
 
+  # Fail fast rather than silently skipping formatting, since batching an empty
+  # file list would otherwise produce targets that do nothing but succeed
+  if(NOT SOURCEMETA_TARGET_CLANG_FORMAT_FILES)
+    message(FATAL_ERROR "The ClangFormat file globs did not match any files")
+  endif()
+
   set(CLANG_FORMAT_CONFIG "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/clang-format.json")
   if(CMAKE_SYSTEM_NAME STREQUAL "MSYS")
     # Because `clang-format` is typically a Windows `.exe`, transform the path accordingly
@@ -111,19 +117,26 @@ function(sourcemeta_target_clang_format)
   if(CLANG_FORMAT_BIN)
     message(STATUS "Using `clang-format` from ${CLANG_FORMAT_BIN}")
 
-    # Invoke `clang-format` over the files in batches so that the full command
-    # never exceeds the operating system command-line length limit (notably the
-    # Windows `CreateProcess` limit) as the number of sources grows
-    set(SOURCEMETA_CLANG_FORMAT_BATCH_SIZE 100)
+    # Invoke `clang-format` over the files in batches whose combined argument
+    # length is bounded well below the operating system command-line length
+    # limit (notably the Windows `CreateProcess` limit of around 32767
+    # characters), so the command stays runnable however many sources exist and
+    # however long their paths are
+    set(SOURCEMETA_CLANG_FORMAT_BATCH_LIMIT 8000)
     set(SOURCEMETA_CLANG_FORMAT_COMMANDS)
     set(SOURCEMETA_CLANG_FORMAT_TEST_COMMANDS)
     set(SOURCEMETA_CLANG_FORMAT_BATCH)
+    set(SOURCEMETA_CLANG_FORMAT_BATCH_LENGTH 0)
     foreach(SOURCEMETA_CLANG_FORMAT_FILE IN LISTS
         SOURCEMETA_TARGET_CLANG_FORMAT_FILES)
-      list(APPEND SOURCEMETA_CLANG_FORMAT_BATCH "${SOURCEMETA_CLANG_FORMAT_FILE}")
-      list(LENGTH SOURCEMETA_CLANG_FORMAT_BATCH SOURCEMETA_CLANG_FORMAT_LENGTH)
-      if(SOURCEMETA_CLANG_FORMAT_LENGTH GREATER_EQUAL
-          SOURCEMETA_CLANG_FORMAT_BATCH_SIZE)
+      string(LENGTH "${SOURCEMETA_CLANG_FORMAT_FILE}"
+        SOURCEMETA_CLANG_FORMAT_FILE_LENGTH)
+      math(EXPR SOURCEMETA_CLANG_FORMAT_NEXT_LENGTH
+        "${SOURCEMETA_CLANG_FORMAT_BATCH_LENGTH} + ${SOURCEMETA_CLANG_FORMAT_FILE_LENGTH} + 1")
+      # Flush the current batch before it would cross the bound, keeping at
+      # least one file per batch so an unusually long path still makes progress
+      if(SOURCEMETA_CLANG_FORMAT_BATCH AND SOURCEMETA_CLANG_FORMAT_NEXT_LENGTH
+          GREATER SOURCEMETA_CLANG_FORMAT_BATCH_LIMIT)
         list(APPEND SOURCEMETA_CLANG_FORMAT_COMMANDS
           COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
             -i ${SOURCEMETA_CLANG_FORMAT_BATCH})
@@ -131,7 +144,11 @@ function(sourcemeta_target_clang_format)
           COMMAND "${CLANG_FORMAT_BIN}" "--style=file:${CLANG_FORMAT_CONFIG}"
             --dry-run -Werror -i ${SOURCEMETA_CLANG_FORMAT_BATCH})
         set(SOURCEMETA_CLANG_FORMAT_BATCH)
+        set(SOURCEMETA_CLANG_FORMAT_BATCH_LENGTH 0)
       endif()
+      list(APPEND SOURCEMETA_CLANG_FORMAT_BATCH "${SOURCEMETA_CLANG_FORMAT_FILE}")
+      math(EXPR SOURCEMETA_CLANG_FORMAT_BATCH_LENGTH
+        "${SOURCEMETA_CLANG_FORMAT_BATCH_LENGTH} + ${SOURCEMETA_CLANG_FORMAT_FILE_LENGTH} + 1")
     endforeach()
     if(SOURCEMETA_CLANG_FORMAT_BATCH)
       list(APPEND SOURCEMETA_CLANG_FORMAT_COMMANDS


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

