### PR TITLE
Enable Doxygen warnings as errors

### DIFF
--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -9,15 +9,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      DOXYGEN_VERSION: "1.13.2"
+    # Fedora provides a modern Doxygen out of the box
+    container: fedora:44
     steps:
+      - name: Install dependencies
+        run: dnf install --assumeyes doxygen cmake gcc-c++ graphviz git
       - uses: actions/checkout@v4
-      - name: Install Doxygen
-        run: |
-          wget -q "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" -O /tmp/doxygen.tar.gz
-          tar xzf /tmp/doxygen.tar.gz -C /tmp
-          echo "/tmp/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
       - run: >
           cmake -S . -B ./build
           -DCMAKE_BUILD_TYPE:STRING=Release

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -9,10 +9,15 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOXYGEN_VERSION: "1.13.2"
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt update
-      - run: sudo apt install -y doxygen
+      - name: Install Doxygen
+        run: |
+          wget -q "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" -O /tmp/doxygen.tar.gz
+          tar xzf /tmp/doxygen.tar.gz -C /tmp
+          echo "/tmp/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
       - run: >
           cmake -S . -B ./build
           -DCMAKE_BUILD_TYPE:STRING=Release

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Fedora provides a modern Doxygen out of the box
-    container: fedora:44
+    container: fedora:latest
     steps:
       - name: Install dependencies
         run: dnf install --assumeyes doxygen cmake gcc-c++ graphviz git

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     # Fedora provides a modern Doxygen out of the box
-    container: fedora:44
+    container: fedora:latest
     steps:
       - name: Install dependencies
         run: dnf install --assumeyes doxygen cmake gcc-c++ graphviz git

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -19,10 +19,15 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    env:
+      DOXYGEN_VERSION: "1.13.2"
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt update
-      - run: sudo apt install -y doxygen
+      - name: Install Doxygen
+        run: |
+          wget -q "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" -O /tmp/doxygen.tar.gz
+          tar xzf /tmp/doxygen.tar.gz -C /tmp
+          echo "/tmp/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
       - run: >
           cmake -S . -B ./build
           -DCMAKE_BUILD_TYPE:STRING=Release

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -19,15 +19,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    env:
-      DOXYGEN_VERSION: "1.13.2"
+    # Fedora provides a modern Doxygen out of the box
+    container: fedora:44
     steps:
+      - name: Install dependencies
+        run: dnf install --assumeyes doxygen cmake gcc-c++ graphviz git
       - uses: actions/checkout@v4
-      - name: Install Doxygen
-        run: |
-          wget -q "https://github.com/doxygen/doxygen/releases/download/Release_${DOXYGEN_VERSION//./_}/doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz" -O /tmp/doxygen.tar.gz
-          tar xzf /tmp/doxygen.tar.gz -C /tmp
-          echo "/tmp/doxygen-${DOXYGEN_VERSION}/bin" >> "$GITHUB_PATH"
       - run: >
           cmake -S . -B ./build
           -DCMAKE_BUILD_TYPE:STRING=Release

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -1023,6 +1023,10 @@ EXCLUDE_PATTERNS       =
 # wildcard * is used, a substring. Examples: ANamespace, AClass,
 # ANamespace::AClass, ANamespace::*Test
 
+# These are self-descriptive boilerplate that the codebase leaves undocumented by
+# convention. Excluding them keeps the undocumented-symbol gate meaningful without
+# forcing filler comments. The `*` in `operator*` is a substring wildcard, so it
+# intentionally covers every operator overload, not just dereference.
 EXCLUDE_SYMBOLS        = operator* \
                          what \
                          begin end cbegin cend rbegin rend crbegin crend \

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -885,7 +885,7 @@ WARN_NO_PARAMDOC       = NO
 # will automatically be disabled.
 # The default value is: NO.
 
-WARN_IF_UNDOC_ENUM_VAL = NO
+WARN_IF_UNDOC_ENUM_VAL = YES
 
 # If the WARN_AS_ERROR tag is set to YES then doxygen will immediately stop when
 # a warning is encountered. If the WARN_AS_ERROR tag is set to FAIL_ON_WARNINGS
@@ -2317,6 +2317,17 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             += DOXYGEN
+
+# The Unicode and IDNA character-database enumerators are generated from X-macro
+# lists, so their values have no source lines to attach documentation to. Expand
+# these lists to nothing for the documentation preprocessor only, keeping the
+# enum types and their descriptions while omitting the generated values.
+PREDEFINED             += SOURCEMETA_CORE_JOINING_TYPE_LIST(x)=
+PREDEFINED             += SOURCEMETA_CORE_BIDI_CLASS_LIST(x)=
+PREDEFINED             += SOURCEMETA_CORE_NFC_QUICK_CHECK_LIST(x)=
+PREDEFINED             += SOURCEMETA_CORE_UNICODE_SCRIPT_LIST(x)=
+PREDEFINED             += SOURCEMETA_CORE_IDNA_PROPERTY_LIST(x)=
+PREDEFINED             += SOURCEMETA_CORE_IDNA_MAPPING_STATUS_LIST(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -901,7 +901,7 @@ WARN_IF_UNDOC_ENUM_VAL = NO
 # Possible values are: NO, YES, FAIL_ON_WARNINGS and FAIL_ON_WARNINGS_PRINT.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -1023,7 +1023,14 @@ EXCLUDE_PATTERNS       =
 # wildcard * is used, a substring. Examples: ANamespace, AClass,
 # ANamespace::AClass, ANamespace::*Test
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = operator* \
+                         what \
+                         begin end cbegin cend rbegin rend crbegin crend \
+                         value_type const_reference reference const_pointer \
+                         pointer difference_type size_type iterator \
+                         const_iterator reverse_iterator const_reverse_iterator \
+                         iterator_category allocator_type mapped_type key_type \
+                         pair_value_type underlying_type is_transparent hash_type
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -1049,7 +1056,7 @@ EXAMPLE_RECURSIVE      = NO
 # that contain images that are to be included in the documentation (see the
 # \image command).
 
-IMAGE_PATH             = @PROJECT_SOURCE_DIR@/assets
+IMAGE_PATH             =
 
 # The INPUT_FILTER tag can be used to specify a program that doxygen should
 # invoke to filter for each input file. Doxygen will invoke the filter program
@@ -2681,15 +2688,6 @@ DOT_GRAPH_MAX_NODES    = 50
 # This tag requires that the tag HAVE_DOT is set to YES.
 
 MAX_DOT_GRAPH_DEPTH    = 0
-
-# Set the DOT_MULTI_TARGETS tag to YES to allow dot to generate multiple output
-# files in one run (i.e. multiple -o and -T options on the command line). This
-# makes dot run faster, but since only newer versions of dot (>1.8.10) support
-# this, this feature is disabled by default.
-# The default value is: NO.
-# This tag requires that the tag HAVE_DOT is set to YES.
-
-DOT_MULTI_TARGETS      = NO
 
 # If the GENERATE_LEGEND tag is set to YES doxygen will generate a legend page
 # explaining the meaning of the various boxes and arrows in the dot generated

--- a/doxygen/Doxyfile.in
+++ b/doxygen/Doxyfile.in
@@ -2318,17 +2318,6 @@ INCLUDE_FILE_PATTERNS  =
 
 PREDEFINED             += DOXYGEN
 
-# The Unicode and IDNA character-database enumerators are generated from X-macro
-# lists, so their values have no source lines to attach documentation to. Expand
-# these lists to nothing for the documentation preprocessor only, keeping the
-# enum types and their descriptions while omitting the generated values.
-PREDEFINED             += SOURCEMETA_CORE_JOINING_TYPE_LIST(x)=
-PREDEFINED             += SOURCEMETA_CORE_BIDI_CLASS_LIST(x)=
-PREDEFINED             += SOURCEMETA_CORE_NFC_QUICK_CHECK_LIST(x)=
-PREDEFINED             += SOURCEMETA_CORE_UNICODE_SCRIPT_LIST(x)=
-PREDEFINED             += SOURCEMETA_CORE_IDNA_PROPERTY_LIST(x)=
-PREDEFINED             += SOURCEMETA_CORE_IDNA_MAPPING_STATUS_LIST(x)=
-
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The
 # macro definition that is found in the sources will be used. Use the PREDEFINED

--- a/src/core/crypto/include/sourcemeta/core/crypto_sign.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_sign.h
@@ -36,6 +36,7 @@ public:
   enum class Type : std::uint8_t { RSA, EllipticCurve, Edwards };
 
   ~PrivateKey();
+  /// Move constructor
   PrivateKey(PrivateKey &&other) noexcept;
   auto operator=(PrivateKey &&other) noexcept -> PrivateKey &;
   PrivateKey(const PrivateKey &) = delete;

--- a/src/core/crypto/include/sourcemeta/core/crypto_sign.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_sign.h
@@ -33,7 +33,14 @@ namespace sourcemeta::core {
 class SOURCEMETA_CORE_CRYPTO_EXPORT PrivateKey {
 public:
   /// The kind of key, which fixes the signature schemes it can produce.
-  enum class Type : std::uint8_t { RSA, EllipticCurve, Edwards };
+  enum class Type : std::uint8_t {
+    /// The RSA key type.
+    RSA,
+    /// The elliptic-curve key type.
+    EllipticCurve,
+    /// The Edwards-curve key type.
+    Edwards
+  };
 
   ~PrivateKey();
   /// Move constructor

--- a/src/core/crypto/include/sourcemeta/core/crypto_verify.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_verify.h
@@ -13,15 +13,34 @@ namespace sourcemeta::core {
 
 /// @ingroup crypto
 /// The hash functions supported by signature verification.
-enum class SignatureHashFunction : std::uint8_t { SHA256, SHA384, SHA512 };
+enum class SignatureHashFunction : std::uint8_t {
+  /// The SHA-256 hash function.
+  SHA256,
+  /// The SHA-384 hash function.
+  SHA384,
+  /// The SHA-512 hash function.
+  SHA512
+};
 
 /// @ingroup crypto
 /// The NIST elliptic curves supported by signature verification.
-enum class EllipticCurve : std::uint8_t { P256, P384, P521 };
+enum class EllipticCurve : std::uint8_t {
+  /// The NIST P-256 elliptic curve.
+  P256,
+  /// The NIST P-384 elliptic curve.
+  P384,
+  /// The NIST P-521 elliptic curve.
+  P521
+};
 
 /// @ingroup crypto
 /// The Edwards curves supported by signature verification.
-enum class EdwardsCurve : std::uint8_t { Ed25519, Ed448 };
+enum class EdwardsCurve : std::uint8_t {
+  /// The Ed25519 Edwards curve.
+  Ed25519,
+  /// The Ed448 Edwards curve.
+  Ed448
+};
 
 /// @ingroup crypto
 /// A parsed public key that holds the native key, so that the same key can
@@ -42,7 +61,14 @@ enum class EdwardsCurve : std::uint8_t { Ed25519, Ed448 };
 class SOURCEMETA_CORE_CRYPTO_EXPORT PublicKey {
 public:
   /// The kind of key, which fixes the signature schemes it can verify.
-  enum class Type : std::uint8_t { RSA, EllipticCurve, Edwards };
+  enum class Type : std::uint8_t {
+    /// The RSA key type.
+    RSA,
+    /// The elliptic-curve key type.
+    EllipticCurve,
+    /// The Edwards-curve key type.
+    Edwards
+  };
 
   ~PublicKey();
   /// Move constructor

--- a/src/core/crypto/include/sourcemeta/core/crypto_verify.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_verify.h
@@ -45,6 +45,7 @@ public:
   enum class Type : std::uint8_t { RSA, EllipticCurve, Edwards };
 
   ~PublicKey();
+  /// Move constructor
   PublicKey(PublicKey &&other) noexcept;
   auto operator=(PublicKey &&other) noexcept -> PublicKey &;
   PublicKey(const PublicKey &) = delete;

--- a/src/core/gzip/include/sourcemeta/core/gzip_error.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip_error.h
@@ -22,6 +22,7 @@ namespace sourcemeta::core {
 /// An error that represents a GZIP compression or decompression failure
 class SOURCEMETA_CORE_GZIP_EXPORT GZIPError : public std::exception {
 public:
+  /// Construct an error with the given message
   GZIPError(const char *message) : message_{message} {}
   GZIPError(std::string message) = delete;
   GZIPError(std::string &&message) = delete;

--- a/src/core/gzip/include/sourcemeta/core/gzip_streambuf.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip_streambuf.h
@@ -16,6 +16,7 @@ namespace sourcemeta::core {
 /// an input stream.
 class SOURCEMETA_CORE_GZIP_EXPORT GZIPStreamBuffer : public std::streambuf {
 public:
+  /// Construct a stream buffer over a compressed input stream.
   GZIPStreamBuffer(std::istream &compressed_stream);
   ~GZIPStreamBuffer() override;
 
@@ -25,6 +26,7 @@ public:
   auto operator=(GZIPStreamBuffer &&) -> GZIPStreamBuffer & = delete;
 
 protected:
+  /// Refill the buffer with more decompressed data.
   auto underflow() -> int_type override;
 
 private:

--- a/src/core/html/include/sourcemeta/core/html_buffer.h
+++ b/src/core/html/include/sourcemeta/core/html_buffer.h
@@ -24,12 +24,14 @@ public:
   HTMLBuffer(HTMLBuffer &&) = delete;
   auto operator=(HTMLBuffer &&) -> HTMLBuffer & = delete;
 
+  /// Reserve a number of bytes of capacity up front
   SOURCEMETA_FORCEINLINE inline auto reserve(const std::size_t bytes) -> void {
     this->buffer_.resize(bytes);
     this->cursor_ = this->buffer_.data();
     this->end_ = this->cursor_ + bytes;
   }
 
+  /// Append a single character to the buffer
   SOURCEMETA_FORCEINLINE inline auto append(const char character) -> void {
     if (!this->cursor_ || this->cursor_ >= this->end_) [[unlikely]] {
       this->grow(1);
@@ -39,6 +41,7 @@ public:
     ++this->cursor_;
   }
 
+  /// Append a sequence of characters to the buffer
   SOURCEMETA_FORCEINLINE inline auto append(const std::string_view data)
       -> void {
     const auto length{data.size()};
@@ -57,6 +60,7 @@ public:
     this->cursor_ += length;
   }
 
+  /// Get the accumulated contents of the buffer
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto str()
       -> const std::string & {
     if (this->cursor_) {
@@ -69,6 +73,7 @@ public:
     return this->buffer_;
   }
 
+  /// Write the accumulated contents to an output stream
   auto write(std::ostream &stream) -> void;
 
 private:

--- a/src/core/html/include/sourcemeta/core/html_escape.h
+++ b/src/core/html/include/sourcemeta/core/html_escape.h
@@ -29,9 +29,9 @@ namespace sourcemeta::core {
 /// #include <sourcemeta/core/html.h>
 /// #include <cassert>
 ///
-/// std::string text{"<script>alert('xss')</script>"};
+/// std::string text{"1 < 2 & 3 > 0 'x' \"y\""};
 /// sourcemeta::core::html_escape(text);
-/// assert(text == "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+/// assert(text == "1 &lt; 2 &amp; 3 &gt; 0 &#39;x&#39; &quot;y&quot;");
 /// ```
 SOURCEMETA_CORE_HTML_EXPORT
 auto html_escape(std::string &text) -> void;

--- a/src/core/html/include/sourcemeta/core/html_escape.h
+++ b/src/core/html/include/sourcemeta/core/html_escape.h
@@ -16,12 +16,9 @@ namespace sourcemeta::core {
 /// HTML character escaping implementation per HTML Living Standard.
 /// See: https://html.spec.whatwg.org/multipage/parsing.html#escapingString
 ///
-/// This function escapes the five HTML special characters in-place:
-/// - `&` becomes `&amp;`
-/// - `<` becomes `&lt;`
-/// - `>` becomes `&gt;`
-/// - `"` becomes `&quot;`
-/// - `'` becomes `&#39;`
+/// This function escapes the five HTML special characters in-place: the
+/// ampersand, less-than sign, greater-than sign, double quote, and apostrophe
+/// each become their corresponding HTML entity.
 ///
 /// For example:
 ///

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -180,8 +180,11 @@ auto http_cache_control_max_age(const std::string_view cache_control) noexcept
 /// every field, must URI-escape `target`, and must ensure parameter values are
 /// valid `quoted-string` content.
 struct HTTPLink {
+  /// The link target reference
   std::string_view target;
+  /// The link relation type
   std::string_view rel;
+  /// The additional target attributes of the link
   std::span<const std::pair<std::string_view, std::string_view>> parameters{};
 };
 
@@ -265,13 +268,21 @@ enum class HTTPCookieSameSite : std::uint8_t { Strict, Lax, None };
 /// §4.1.1 cookie-octets. RFC 6265bis §5.7 requires a cookie with a same-site
 /// mode of none to also be secure.
 struct HTTPCookie {
+  /// The cookie name
   std::string_view name{};
+  /// The cookie value
   std::string_view value{};
+  /// The path the cookie is scoped to
   std::optional<std::string_view> path{};
+  /// The host the cookie is scoped to
   std::optional<std::string_view> domain{};
+  /// The cookie lifetime
   std::optional<std::chrono::seconds> max_age{};
+  /// Whether the cookie is withheld from scripts
   bool http_only{false};
+  /// Whether the cookie is only sent over secure channels
   bool secure{false};
+  /// The cross-site request policy for the cookie
   std::optional<HTTPCookieSameSite> same_site{};
 };
 

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -39,7 +39,9 @@ namespace sourcemeta::core {
 /// @ingroup http
 /// A content coding supported by this implementation.
 enum class HTTPContentEncoding : std::uint8_t {
+  /// The identity coding that applies no transformation.
   Identity,
+  /// The gzip coding per RFC 9110 §8.4.1.3.
   GZIP,
 };
 
@@ -259,7 +261,14 @@ auto http_format_links(std::span<const HTTPLink> links) -> std::string;
 
 /// @ingroup http
 /// The `SameSite` attribute of a cookie per RFC 6265bis §5.2.
-enum class HTTPCookieSameSite : std::uint8_t { Strict, Lax, None };
+enum class HTTPCookieSameSite : std::uint8_t {
+  /// The cookie is withheld from every cross-site request.
+  Strict,
+  /// The cookie is sent on top-level cross-site navigations only.
+  Lax,
+  /// The cookie is sent on every cross-site request.
+  None
+};
 
 /// @ingroup http
 /// A cookie to serialise into an RFC 6265 §4.1 `Set-Cookie` response header

--- a/src/core/http/include/sourcemeta/core/http_aws_sigv4.h
+++ b/src/core/http/include/sourcemeta/core/http_aws_sigv4.h
@@ -18,8 +18,11 @@ namespace sourcemeta::core {
 /// The credentials used to sign a request with AWS Signature Version 4. The
 /// session token is left empty when using long-term credentials.
 struct HTTPAWSCredentials {
+  /// The access key identifier
   std::string_view access_key_id;
+  /// The secret access key
   std::string_view secret_access_key;
+  /// The temporary session token used with short-term credentials
   std::string_view session_token;
 };
 

--- a/src/core/http/include/sourcemeta/core/http_error.h
+++ b/src/core/http/include/sourcemeta/core/http_error.h
@@ -38,6 +38,7 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_HTTP_EXPORT HTTPError : public std::runtime_error {
 public:
+  /// Construct an error from the request method, URL, and a message
   HTTPError(const HTTPMethod method, std::string url,
             const std::string &message)
       : std::runtime_error{message}, method_{method}, url_{std::move(url)} {}
@@ -72,6 +73,8 @@ private:
 /// ```
 class SOURCEMETA_CORE_HTTP_EXPORT HTTPStatusError : public HTTPError {
 public:
+  /// Construct an error from the request method, URL, and the unsuccessful
+  /// response status
   HTTPStatusError(const HTTPMethod method, std::string url,
                   const HTTPStatus &status)
       : HTTPError{method, std::move(url), "Unsuccessful HTTP response"},

--- a/src/core/http/include/sourcemeta/core/http_method.h
+++ b/src/core/http/include/sourcemeta/core/http_method.h
@@ -10,14 +10,23 @@ namespace sourcemeta::core {
 /// @ingroup http
 /// A request method per RFC 9110 §9.3 and RFC 5789 §2.
 enum class HTTPMethod : std::uint8_t {
+  /// Transfer a current representation of the target resource.
   GET,
+  /// Identical to a retrieval but without transferring the response content.
   HEAD,
+  /// Process the enclosed representation according to the resource semantics.
   POST,
+  /// Replace the target resource with the enclosed representation.
   PUT,
+  /// Remove the association between the target resource and its function.
   DELETE,
+  /// Establish a tunnel to the server identified by the target resource.
   CONNECT,
+  /// Describe the communication options available for the target resource.
   OPTIONS,
+  /// Perform a message loop-back test along the path to the target resource.
   TRACE,
+  /// Apply a partial modification to the target resource per RFC 5789 §2.
   PATCH
 };
 

--- a/src/core/http/include/sourcemeta/core/http_problem.h
+++ b/src/core/http/include/sourcemeta/core/http_problem.h
@@ -13,10 +13,15 @@ namespace sourcemeta::core {
 /// @ingroup http
 /// Fields of an RFC 9457 §3.1 Problem Details object.
 struct HTTPProblemDetails {
+  /// The HTTP status code for this occurrence of the problem
   HTTPStatus status;
+  /// The identifier for the problem type
   JSON::StringView type{"about:blank"};
+  /// The short human-readable summary of the problem type
   JSON::StringView title{};
+  /// The human-readable explanation specific to this occurrence
   JSON::StringView detail{};
+  /// The identifier for this specific occurrence of the problem
   JSON::StringView instance{};
 };
 

--- a/src/core/http/include/sourcemeta/core/http_status.h
+++ b/src/core/http/include/sourcemeta/core/http_status.h
@@ -18,8 +18,11 @@ namespace sourcemeta::core {
 /// assert(sourcemeta::core::HTTP_STATUS_OK.wire == "200 OK");
 /// ```
 struct HTTPStatus {
+  /// The numeric status code
   std::uint16_t code;
+  /// The reason phrase
   std::string_view phrase;
+  /// The status code and reason phrase in their wire form
   std::string_view wire;
 
   constexpr auto operator==(const HTTPStatus &) const -> bool = default;

--- a/src/core/http/include/sourcemeta/core/http_system.h
+++ b/src/core/http/include/sourcemeta/core/http_system.h
@@ -70,6 +70,8 @@ struct HTTPResponse {
 class SOURCEMETA_CORE_HTTP_EXPORT HTTPSystemBackendError
     : public std::runtime_error {
 public:
+  /// Construct an error from a message, the environment variable that overrides
+  /// the backend path, and the paths that were searched
   HTTPSystemBackendError(const std::string &message, std::string variable,
                          std::vector<std::string> paths)
       : std::runtime_error{message}, variable_{std::move(variable)},
@@ -110,6 +112,7 @@ private:
 /// ```
 class SOURCEMETA_CORE_HTTP_EXPORT HTTPSystemRequest {
 public:
+  /// Construct a request for the given URL and method
   explicit HTTPSystemRequest(std::string url,
                              const HTTPMethod method = HTTPMethod::GET)
       : url_{std::move(url)}, method_{method} {}

--- a/src/core/idna/include/sourcemeta/core/idna_ucd.h
+++ b/src/core/idna/include/sourcemeta/core/idna_ucd.h
@@ -18,9 +18,11 @@ namespace sourcemeta::core {
 /// The RFC 5892 derived property of a Unicode codepoint. See
 /// https://www.rfc-editor.org/rfc/rfc5892 for the property's definition.
 enum class IDNAProperty : std::uint8_t {
+#if !defined(DOXYGEN)
 #define SOURCEMETA_CORE_IDNA_ENUM_ENTRY(name, alias) name,
   SOURCEMETA_CORE_IDNA_PROPERTY_LIST(SOURCEMETA_CORE_IDNA_ENUM_ENTRY)
 #undef SOURCEMETA_CORE_IDNA_ENUM_ENTRY
+#endif
 };
 
 /// @ingroup idna
@@ -37,10 +39,12 @@ enum class IDNAProperty : std::uint8_t {
 /// The UTS #46 status of a Unicode codepoint in the mapping table. See
 /// https://www.unicode.org/reports/tr46/ for the status definitions.
 enum class IDNAMappingStatus : std::uint8_t {
+#if !defined(DOXYGEN)
 #define SOURCEMETA_CORE_IDNA_MAPPING_ENUM_ENTRY(name, alias) name,
   SOURCEMETA_CORE_IDNA_MAPPING_STATUS_LIST(
       SOURCEMETA_CORE_IDNA_MAPPING_ENUM_ENTRY)
 #undef SOURCEMETA_CORE_IDNA_MAPPING_ENUM_ENTRY
+#endif
 };
 
 } // namespace sourcemeta::core

--- a/src/core/jose/include/sourcemeta/core/jose_algorithm.h
+++ b/src/core/jose/include/sourcemeta/core/jose_algorithm.h
@@ -17,15 +17,25 @@ namespace sourcemeta::core {
 /// family and the null algorithm are intentionally absent, which makes
 /// algorithm confusion attacks unrepresentable in the type system.
 enum class JWSAlgorithm : std::uint8_t {
+  /// RSASSA-PKCS1-v1_5 using SHA-256.
   RS256,
+  /// RSASSA-PKCS1-v1_5 using SHA-384.
   RS384,
+  /// RSASSA-PKCS1-v1_5 using SHA-512.
   RS512,
+  /// RSASSA-PSS using SHA-256 and MGF1 with SHA-256.
   PS256,
+  /// RSASSA-PSS using SHA-384 and MGF1 with SHA-384.
   PS384,
+  /// RSASSA-PSS using SHA-512 and MGF1 with SHA-512.
   PS512,
+  /// ECDSA using the NIST P-256 curve and SHA-256.
   ES256,
+  /// ECDSA using the NIST P-384 curve and SHA-384.
   ES384,
+  /// ECDSA using the NIST P-521 curve and SHA-512.
   ES512,
+  /// Edwards-curve Digital Signature Algorithm.
   EdDSA
 };
 

--- a/src/core/jose/include/sourcemeta/core/jose_jwk.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwk.h
@@ -38,6 +38,7 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_JOSE_EXPORT JWK {
 public:
+  /// The family of key material a key holds.
   enum class Type : std::uint8_t { RSA, EllipticCurve, OctetKeyPair };
 
   /// Parse a JSON Web Key from a JSON value, throwing on invalid input.
@@ -60,8 +61,10 @@ public:
   /// input.
   [[nodiscard]] static auto from(JSON &&value) -> std::optional<JWK>;
 
+  /// The family of key material this key holds.
   [[nodiscard]] auto type() const noexcept -> Type { return this->type_; }
 
+  /// The key identifier used to select this key, if present.
   [[nodiscard]] auto key_id() const noexcept
       -> std::optional<std::string_view> {
     if (this->key_id_.has_value()) {
@@ -71,6 +74,7 @@ public:
     return std::nullopt;
   }
 
+  /// The algorithm this key is intended for, if present.
   [[nodiscard]] auto algorithm() const noexcept -> std::optional<JWSAlgorithm> {
     return this->algorithm_;
   }
@@ -78,6 +82,7 @@ public:
   // Elliptic curve keys (RFC 7518 Section 6.2) and octet key pairs (RFC 8037
   // Section 2) carry a curve name, which the elliptic curve algorithms pin to
   // exactly one curve
+  /// The curve this key is pinned to, empty when it carries none.
   [[nodiscard]] auto curve() const noexcept -> std::string_view {
     return this->curve_;
   }
@@ -85,6 +90,8 @@ public:
   // The parsed platform key, built once from the decoded material so that
   // verification reuses it rather than reconstructing it per signature. It is
   // null when the material could not be turned into a key
+  /// The parsed platform key, null when the material could not be turned into
+  /// one.
   [[nodiscard]] auto public_key() const noexcept -> const PublicKey * {
     return this->public_key_.has_value() ? &*this->public_key_ : nullptr;
   }

--- a/src/core/jose/include/sourcemeta/core/jose_jwk.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwk.h
@@ -39,7 +39,14 @@ namespace sourcemeta::core {
 class SOURCEMETA_CORE_JOSE_EXPORT JWK {
 public:
   /// The family of key material a key holds.
-  enum class Type : std::uint8_t { RSA, EllipticCurve, OctetKeyPair };
+  enum class Type : std::uint8_t {
+    /// The RSA key type.
+    RSA,
+    /// The elliptic-curve key type.
+    EllipticCurve,
+    /// The Edwards-curve octet key pair type.
+    OctetKeyPair
+  };
 
   /// Parse a JSON Web Key from a JSON value, throwing on invalid input.
   explicit JWK(const JSON &value);

--- a/src/core/jose/include/sourcemeta/core/jose_jwk_private.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwk_private.h
@@ -33,7 +33,15 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_JOSE_EXPORT JWKPrivate {
 public:
-  enum class Type : std::uint8_t { RSA, EllipticCurve, OctetKeyPair };
+  /// The family of key material a key holds.
+  enum class Type : std::uint8_t {
+    /// The RSA key type.
+    RSA,
+    /// The elliptic-curve key type.
+    EllipticCurve,
+    /// The Edwards-curve octet key pair type.
+    OctetKeyPair
+  };
 
   /// A key exclusively owns its parsed private key, so it is move-only.
   JWKPrivate(JWKPrivate &&other) noexcept = default;
@@ -58,8 +66,10 @@ public:
   [[nodiscard]] static auto from_pem(const std::string_view pem)
       -> std::optional<JWKPrivate>;
 
+  /// The family of key material this key holds.
   [[nodiscard]] auto type() const noexcept -> Type { return this->type_; }
 
+  /// The key identifier used to select this key, if present.
   [[nodiscard]] auto key_id() const noexcept
       -> std::optional<std::string_view> {
     if (this->key_id_.has_value()) {
@@ -69,6 +79,7 @@ public:
     return std::nullopt;
   }
 
+  /// The algorithm this key is intended for, if present.
   [[nodiscard]] auto algorithm() const noexcept -> std::optional<JWSAlgorithm> {
     return this->algorithm_;
   }
@@ -76,6 +87,7 @@ public:
   // Elliptic curve keys (RFC 7518 Section 6.2) and octet key pairs (RFC 8037
   // Section 2) carry a curve name, which the elliptic curve algorithms pin to
   // exactly one curve. It is empty for keys parsed from a PEM document
+  /// The curve this key is pinned to, empty when it carries none.
   [[nodiscard]] auto curve() const noexcept -> std::string_view {
     return this->curve_;
   }
@@ -83,6 +95,7 @@ public:
   // The parsed platform key, built once from the decoded material so that
   // signing reuses it rather than reconstructing it per signature. It is null
   // when the material could not be turned into a key
+  /// The parsed private key, or null when the material could not be decoded.
   [[nodiscard]] auto private_key() const noexcept -> const PrivateKey * {
     return this->private_key_.has_value() ? &*this->private_key_ : nullptr;
   }

--- a/src/core/jose/include/sourcemeta/core/jose_jwks.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwks.h
@@ -42,6 +42,8 @@ public:
   /// Parse a JSON Web Key Set from a JSON value, throwing a `JWKSParseError`
   /// on invalid input.
   explicit JWKS(const JSON &value);
+  /// Parse a JSON Web Key Set from a JSON value, throwing a `JWKSParseError`
+  /// on invalid input.
   explicit JWKS(JSON &&value);
 
   /// A key set exclusively owns its keys, so it is move-only.
@@ -53,6 +55,8 @@ public:
   /// Parse a JSON Web Key Set from a JSON value, returning no value on invalid
   /// input.
   [[nodiscard]] static auto from(const JSON &value) -> std::optional<JWKS>;
+  /// Parse a JSON Web Key Set from a JSON value, returning no value on invalid
+  /// input.
   [[nodiscard]] static auto from(JSON &&value) -> std::optional<JWKS>;
 
   /// Look up a key by its identifier (RFC 7515 Section 4.1.4), returning no
@@ -60,10 +64,12 @@ public:
   [[nodiscard]] auto find(const std::string_view key_id) const noexcept
       -> const JWK *;
 
+  /// The number of keys in the set.
   [[nodiscard]] auto size() const noexcept -> std::size_t {
     return this->keys_.size();
   }
 
+  /// Whether the set holds no keys.
   [[nodiscard]] auto empty() const noexcept -> bool {
     return this->keys_.empty();
   }

--- a/src/core/jose/include/sourcemeta/core/jose_jwks_provider.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwks_provider.h
@@ -71,7 +71,7 @@ public:
   };
 
   /// Construct a provider for a concrete key set URL with an injected
-  /// transport, optionally overriding the policy and the clock.
+  /// transport, using the default policy and the system clock.
   JWKSProvider(std::string jwks_uri, Fetcher fetcher);
   /// Construct a provider for a concrete key set URL with an injected
   /// transport, overriding the caching and verification policy.

--- a/src/core/jose/include/sourcemeta/core/jose_jwks_provider.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwks_provider.h
@@ -36,7 +36,9 @@ public:
   /// the caching response header. An absent hint means no lifetime was
   /// advertised, which is distinct from an advertised lifetime of zero.
   struct FetchResult {
+    /// The raw key set bytes.
     std::string body;
+    /// The advertised freshness lifetime, absent when none was given.
     std::optional<std::chrono::seconds> max_age;
   };
 
@@ -55,17 +57,27 @@ public:
 
   /// Tunables for the caching and verification policy.
   struct Options {
+    /// The lifetime to assume when the transport advertises none.
     std::chrono::seconds fallback_ttl{std::chrono::hours{1}};
+    /// The shortest lifetime honored, clamping smaller advertised values up.
     std::chrono::seconds minimum_ttl{std::chrono::minutes{5}};
+    /// The longest lifetime honored, clamping larger advertised values down.
     std::chrono::seconds maximum_ttl{std::chrono::hours{24}};
+    /// The wait before another refetch is allowed after an unknown key
+    /// identifier.
     std::chrono::seconds unknown_kid_cooldown{std::chrono::minutes{5}};
+    /// The tolerance applied to time-based claims.
     std::chrono::seconds clock_skew{0};
   };
 
   /// Construct a provider for a concrete key set URL with an injected
   /// transport, optionally overriding the policy and the clock.
   JWKSProvider(std::string jwks_uri, Fetcher fetcher);
+  /// Construct a provider for a concrete key set URL with an injected
+  /// transport, overriding the caching and verification policy.
   JWKSProvider(std::string jwks_uri, Fetcher fetcher, Options options);
+  /// Construct a provider for a concrete key set URL with an injected
+  /// transport, overriding the policy and the clock.
   JWKSProvider(std::string jwks_uri, Fetcher fetcher, Options options,
                Clock clock);
 

--- a/src/core/jose/include/sourcemeta/core/jose_jwt.h
+++ b/src/core/jose/include/sourcemeta/core/jose_jwt.h
@@ -48,50 +48,64 @@ public:
 
   // Header (RFC 7515 Section 4)
 
+  /// The signing algorithm declared in the token header, if present.
   [[nodiscard]] auto algorithm() const noexcept -> std::optional<JWSAlgorithm> {
     return this->algorithm_;
   }
 
+  /// The key identifier from the token header, if present.
   [[nodiscard]] auto key_id() const noexcept -> std::optional<std::string_view>;
 
+  /// The token type declared in the header, if present.
   [[nodiscard]] auto type() const noexcept -> std::optional<std::string_view>;
 
+  /// The decoded token header.
   [[nodiscard]] auto header() const noexcept -> const JSON & {
     return this->header_;
   }
 
   // Registered claims (RFC 7519 Section 4.1)
 
+  /// The issuer that created the token, if present.
   [[nodiscard]] auto issuer() const noexcept -> std::optional<std::string_view>;
 
+  /// The subject the token is about, if present.
   [[nodiscard]] auto subject() const noexcept
       -> std::optional<std::string_view>;
 
+  /// Whether the token is intended for the given audience.
   [[nodiscard]] auto
   has_audience(const std::string_view audience) const noexcept -> bool;
 
+  /// The time after which the token is no longer valid, if present.
   [[nodiscard]] auto expires_at() const
       -> std::optional<std::chrono::system_clock::time_point>;
 
+  /// The time before which the token is not yet valid, if present.
   [[nodiscard]] auto not_before() const
       -> std::optional<std::chrono::system_clock::time_point>;
 
+  /// The time at which the token was issued, if present.
   [[nodiscard]] auto issued_at() const
       -> std::optional<std::chrono::system_clock::time_point>;
 
+  /// The unique identifier of the token, if present.
   [[nodiscard]] auto token_id() const noexcept
       -> std::optional<std::string_view>;
 
+  /// The decoded token payload.
   [[nodiscard]] auto payload() const noexcept -> const JSON & {
     return this->payload_;
   }
 
   // The exact wire bytes the signature is computed over, never re-serialized
   // (RFC 7515 Section 5.1)
+  /// The exact wire bytes the signature is computed over.
   [[nodiscard]] auto signing_input() const noexcept -> std::string_view {
     return this->signing_input_;
   }
 
+  /// The raw token signature.
   [[nodiscard]] auto signature() const noexcept -> std::string_view {
     return this->signature_;
   }

--- a/src/core/jose/include/sourcemeta/core/jose_verify.h
+++ b/src/core/jose/include/sourcemeta/core/jose_verify.h
@@ -24,11 +24,17 @@ namespace sourcemeta::core {
 /// The claim validation errors that claim checking can return, one per check
 /// performed rather than an exhaustive list of registered claims.
 enum class JWTClaimError : std::uint8_t {
+  /// The issuer claim is missing or does not match the expected value.
   Issuer,
+  /// The subject claim is missing or does not match the expected value.
   Subject,
+  /// The audience claim is missing or does not contain the expected value.
   Audience,
+  /// The expiration time claim is missing or the token has expired.
   Expiration,
+  /// The not-before time claim is malformed or lies in the future.
   NotBefore,
+  /// The issued-at time claim is malformed or lies in the future.
   IssuedAt
 };
 
@@ -120,15 +126,25 @@ auto jwt_verify_signature(const JWT &token, const JWK &key) -> bool;
 /// The steps of full token verification that can fail, in the order they are
 /// evaluated.
 enum class JWTVerificationError : std::uint8_t {
+  /// The token's algorithm is missing or absent from the allow-list.
   AlgorithmNotAllowed,
+  /// No key in the set could be selected or verified the signature.
   UnknownKey,
+  /// The named key was found but its signature did not verify.
   Signature,
+  /// The token type does not match the expected media type.
   Type,
+  /// The issuer claim is missing or does not match the expected value.
   Issuer,
+  /// The subject claim is missing or does not match the expected value.
   Subject,
+  /// The audience claim is missing or does not contain the expected value.
   Audience,
+  /// The expiration time claim is missing or the token has expired.
   Expiration,
+  /// The not-before time claim is malformed or lies in the future.
   NotBefore,
+  /// The issued-at time claim is malformed or lies in the future.
   IssuedAt
 };
 

--- a/src/core/json/include/sourcemeta/core/json.h
+++ b/src/core/json/include/sourcemeta/core/json.h
@@ -328,6 +328,7 @@ make_set(std::initializer_list<JSON::Type> types) -> JSON::TypeSet {
 
 } // namespace sourcemeta::core
 
+/// @cond
 template <> struct std::formatter<sourcemeta::core::JSON> {
   constexpr auto parse(std::format_parse_context &context)
       -> decltype(context.begin()) {
@@ -355,5 +356,6 @@ template <> struct std::formatter<sourcemeta::core::JSON::Type> {
     return std::format_to(context.out(), "{}", stream.str());
   }
 };
+/// @endcond
 
 #endif

--- a/src/core/json/include/sourcemeta/core/json_array.h
+++ b/src/core/json/include/sourcemeta/core/json_array.h
@@ -7,12 +7,15 @@
 namespace sourcemeta::core {
 
 /// @ingroup json
+/// An ordered sequence of JSON values
 template <typename Value> class JSONArray {
 public:
   // Constructors
+  /// The underlying container type that holds the array elements
   using Container =
       std::vector<Value, typename Value::template Allocator<Value>>;
   JSONArray() : data{} {}
+  /// Construct an array from a list of values
   JSONArray(std::initializer_list<Value> values) : data{values} {}
 
   // Operators

--- a/src/core/json/include/sourcemeta/core/json_auto.h
+++ b/src/core/json/include/sourcemeta/core/json_auto.h
@@ -240,6 +240,7 @@ auto to_json(const T &value) -> JSON {
 }
 
 /// @ingroup json
+/// Convert a file time point into JSON
 template <typename T>
   requires std::is_same_v<T, std::filesystem::file_time_type>
 auto to_json(const T value) -> JSON {
@@ -356,6 +357,7 @@ auto from_json(const JSON &value) -> std::optional<T> {
 }
 
 /// @ingroup json
+/// Convert an optional value into JSON, using null when empty
 template <typename T> auto to_json(const std::optional<T> &value) -> JSON {
   return value.has_value() ? to_json(value.value()) : JSON{nullptr};
 }
@@ -379,6 +381,7 @@ auto from_json(const JSON &value) -> std::optional<T> {
 }
 
 /// @ingroup json
+/// Convert a range of list-like elements into a JSON array
 template <json_auto_list_like T>
 auto to_json(typename T::const_iterator begin, typename T::const_iterator end)
     -> JSON {
@@ -397,6 +400,8 @@ auto to_json(typename T::const_iterator begin, typename T::const_iterator end)
 }
 
 /// @ingroup json
+/// Convert a range of list-like elements into a JSON array using a custom
+/// callback
 template <json_auto_list_like T,
           std::invocable<const typename T::value_type &> F>
 auto to_json(typename T::const_iterator begin, typename T::const_iterator end,
@@ -421,6 +426,7 @@ template <json_auto_list_like T> auto to_json(const T &value) -> JSON {
 }
 
 /// @ingroup json
+/// Convert a list-like value into a JSON array using a custom callback
 template <json_auto_list_like T,
           std::invocable<const typename T::value_type &> F>
 auto to_json(const T &value, const F &callback) -> JSON {
@@ -457,6 +463,7 @@ auto from_json(const JSON &value) -> std::optional<T> {
 }
 
 /// @ingroup json
+/// Convert a JSON array into a list-like value using a custom callback
 template <json_auto_list_like T>
 auto from_json(
     const JSON &value,
@@ -539,6 +546,7 @@ auto from_json(const JSON &value) -> std::optional<T> {
 }
 
 /// @ingroup json
+/// Convert a JSON object into a map-like value using a custom callback
 template <json_auto_map_like T>
 auto from_json(
     const JSON &value,
@@ -569,6 +577,7 @@ auto to_json(const T &value, const F &callback) -> JSON {
 }
 
 /// @ingroup json
+/// Convert a pair into a JSON array of two elements
 template <typename L, typename R>
 auto to_json(const std::pair<L, R> &value) -> JSON {
   auto tuple{JSON::make_array()};

--- a/src/core/json/include/sourcemeta/core/json_error.h
+++ b/src/core/json/include/sourcemeta/core/json_error.h
@@ -50,7 +50,7 @@ public:
     return this->line_;
   }
 
-  // Get the column number of the error
+  /// Get the column number of the error
   [[nodiscard]] auto column() const noexcept -> std::uint64_t {
     return this->column_;
   }

--- a/src/core/json/include/sourcemeta/core/json_hash.h
+++ b/src/core/json/include/sourcemeta/core/json_hash.h
@@ -10,6 +10,7 @@
 namespace sourcemeta::core {
 
 /// @ingroup json
+/// A hash function object for JSON values
 template <typename T> struct HashJSON {
   using hash_type = std::uint64_t;
 
@@ -21,6 +22,7 @@ template <typename T> struct HashJSON {
     }
   }
 
+  /// Check whether the given hash is a perfect hash
   [[nodiscard]]
   inline auto is_perfect(const hash_type) const noexcept -> bool {
     return false;
@@ -28,6 +30,7 @@ template <typename T> struct HashJSON {
 };
 
 /// @ingroup json
+/// A hash function object for JSON object property keys
 template <typename T> struct PropertyHashJSON {
   struct hash_type {
     using type = sourcemeta::core::uint128_t;
@@ -37,6 +40,7 @@ template <typename T> struct PropertyHashJSON {
     auto operator==(const hash_type &) const noexcept -> bool = default;
   };
 
+  /// Compute a perfect hash from raw data
   [[nodiscard]]
   inline auto perfect(const char *data, const std::size_t size) const noexcept
       -> hash_type {
@@ -211,6 +215,7 @@ template <typename T> struct PropertyHashJSON {
     }
   }
 
+  /// Check whether the given hash is a perfect hash
   [[nodiscard]]
   inline auto is_perfect(const hash_type &hash) const noexcept -> bool {
     // If there is anything written past the first byte,

--- a/src/core/json/include/sourcemeta/core/json_object.h
+++ b/src/core/json/include/sourcemeta/core/json_object.h
@@ -15,6 +15,7 @@
 namespace sourcemeta::core {
 
 /// @ingroup json
+/// A JSON object mapping property keys to values
 template <typename Key, typename Value, typename Hash> class JSONObject {
 public:
   JSONObject() = default;
@@ -23,9 +24,11 @@ public:
   using mapped_type = Value;
   using hash_type = typename Hash::hash_type;
   using pair_value_type = std::pair<key_type, mapped_type>;
+  /// The string view type used to look up object keys
   using KeyView = std::basic_string_view<typename Key::value_type,
                                          typename Key::traits_type>;
 
+  /// Construct an object from a list of key and value pairs
   JSONObject(std::initializer_list<pair_value_type> entries) : data{} {
     this->data.reserve(entries.size());
     for (auto &&entry : entries) {
@@ -33,9 +36,13 @@ public:
     }
   }
 
+  /// A single object property entry
   struct Entry {
+    /// The property key
     key_type first;
+    /// The property value
     mapped_type second;
+    /// The precomputed hash of the property key
     hash_type hash;
 
     /// Check whether this entry's key equals the given key, comparing the

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -34,6 +34,7 @@
 namespace sourcemeta::core {
 
 /// @ingroup json
+/// This class represents a JSON document.
 class SOURCEMETA_CORE_JSON_EXPORT JSON {
 public:
   /// The character type used by the JSON document.
@@ -122,6 +123,7 @@ public:
   explicit JSON(const int value);
 
   // On some systems, `std::int64_t` might be equal to `long`
+  /// This constructor creates a JSON document from an integer type.
   template <typename T = std::int64_t>
   explicit JSON(const long value)
     requires(!std::is_same_v<T, std::int64_t>)
@@ -250,6 +252,7 @@ public:
 
   /// Misc constructors
   JSON(const JSON &);
+  /// A move constructor.
   JSON(JSON &&) noexcept;
   auto operator=(const JSON &) -> JSON &;
   auto operator=(JSON &&) noexcept -> JSON &;
@@ -1330,6 +1333,7 @@ public:
   /// const auto result = document.try_at("foo");
   /// EXPECT_TRUE(result);
   /// EXPECT_EQ(result->to_integer(), 1);
+  /// ```
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
   try_at(const String &key) const -> const JSON * {
     assert(this->is_object());
@@ -1362,6 +1366,7 @@ public:
   ///   document.as_object().hash("foo"));
   /// EXPECT_TRUE(result);
   /// EXPECT_EQ(result->to_integer(), 1);
+  /// ```
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
   try_at(const String &key, const typename Object::hash_type hash) const
       -> const JSON * {

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -56,18 +56,31 @@ public:
   /// The object type used by the JSON document.
   using Object = JSONObject<String, JSON, PropertyHashJSON<JSON::String>>;
   /// The parsing phase of a JSON document.
-  enum class ParsePhase : std::uint8_t { Pre, Post };
+  enum class ParsePhase : std::uint8_t {
+    /// The phase before a value is parsed.
+    Pre,
+    /// The phase after a value is parsed.
+    Post
+  };
 
   // The enumeration indexes must stay in sync with the internal variant
   /// The different types of a JSON instance.
   enum class Type : std::uint8_t {
+    /// The JSON null type.
     Null = 0,
+    /// The JSON boolean type.
     Boolean = 1,
+    /// The JSON integer type.
     Integer = 2,
+    /// The JSON real number type.
     Real = 3,
+    /// The JSON string type.
     String = 4,
+    /// The JSON array type.
     Array = 5,
+    /// The JSON object type.
     Object = 6,
+    /// The JSON decimal type.
     Decimal = 7
   };
 
@@ -75,7 +88,14 @@ public:
   using TypeSet = std::bitset<8>;
 
   /// The context type for parse callbacks
-  enum class ParseContext : std::uint8_t { Root, Property, Index };
+  enum class ParseContext : std::uint8_t {
+    /// The root value of the document
+    Root,
+    /// An object property value
+    Property,
+    /// An array element value
+    Index
+  };
 
   /// An optional callback that can be passed to parsing functions to obtain
   /// metadata during the parsing process

--- a/src/core/jsonl/include/sourcemeta/core/jsonl.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl.h
@@ -30,6 +30,7 @@
 namespace sourcemeta::core {
 
 /// @ingroup jsonl
+/// A range over the JSON documents contained in a JSON Lines stream.
 class SOURCEMETA_CORE_JSONL_EXPORT JSONL {
 public:
   /// The mode of operation for the JSONL parser

--- a/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
+++ b/src/core/jsonl/include/sourcemeta/core/jsonl_iterator.h
@@ -19,6 +19,7 @@ namespace sourcemeta::core {
 /// A forward iterator to parse JSON documents out of a JSON Lines stream.
 class SOURCEMETA_CORE_JSONL_EXPORT ConstJSONLIterator {
 public:
+  /// Construct an iterator over the JSON documents in a stream.
   ConstJSONLIterator(std::basic_istream<JSON::Char, JSON::CharTraits> *stream);
   ~ConstJSONLIterator();
   using iterator_category = std::forward_iterator_tag;

--- a/src/core/jsonld/include/sourcemeta/core/jsonld.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld.h
@@ -33,7 +33,12 @@ using JSONLDResolver = std::function<std::optional<JSON>(JSON::StringView)>;
 
 /// @ingroup jsonld
 /// The JSON-LD processing mode
-enum class JSONLDVersion : std::uint8_t { V1_0, V1_1 };
+enum class JSONLDVersion : std::uint8_t {
+  /// The JSON-LD 1.0 processing mode
+  V1_0,
+  /// The JSON-LD 1.1 processing mode
+  V1_1
+};
 
 /// @ingroup jsonld
 ///

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_error.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_error.h
@@ -27,15 +27,16 @@ namespace sourcemeta::core {
 /// pointer locates the offending position in the input document
 class SOURCEMETA_CORE_JSONLD_EXPORT JSONLDError : public std::exception {
 public:
+  /// Locate the error at an owned pointer.
   JSONLDError(const char *code, Pointer pointer)
       : code_{code}, pointer_{std::move(pointer)} {}
 
-  // Locate the error at a weak pointer, materialising an owned pointer.
+  /// Locate the error at a weak pointer, materialising an owned pointer.
   JSONLDError(const char *code, const WeakPointer &pointer)
       : code_{code}, pointer_{to_pointer(pointer)} {}
 
-  // Locate the error at a weak pointer extended with the given trailing
-  // property tokens.
+  /// Locate the error at a weak pointer extended with the given trailing
+  /// property tokens.
   JSONLDError(const char *code, const WeakPointer &pointer,
               const std::initializer_list<JSON::StringView> children)
       : code_{code}, pointer_{to_pointer(pointer)} {

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
@@ -28,7 +28,12 @@ struct JSONLDEdge {
 
 /// @ingroup jsonld
 /// The base direction of a language-tagged string
-enum class JSONLDDirection : std::uint8_t { LTR, RTL };
+enum class JSONLDDirection : std::uint8_t {
+  /// The left-to-right base direction
+  LTR,
+  /// The right-to-left base direction
+  RTL
+};
 
 /// @ingroup jsonld
 /// A position that is an object. An absent identifier means a fresh blank node,
@@ -70,7 +75,16 @@ struct JSONLDReference {
 /// @ingroup jsonld
 /// The container form of a collection position. List and Set range over an
 /// array; Language and Index range over an object.
-enum class JSONLDContainer : std::uint8_t { List, Set, Language, Index };
+enum class JSONLDContainer : std::uint8_t {
+  /// An ordered RDF list ranging over an array
+  List,
+  /// An unordered set ranging over an array
+  Set,
+  /// A map of language tag to string ranging over an object
+  Language,
+  /// A map of index labels carrying no RDF ranging over an object
+  Index
+};
 
 /// @ingroup jsonld
 /// A position that is a collection. A List is asserted as an RDF list and a Set

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
@@ -20,7 +20,9 @@ namespace sourcemeta::core {
 /// How a position connects to its parent. The position is the object of the
 /// edge, asserted in reverse when the flag is set.
 struct JSONLDEdge {
+  /// The predicate that connects the position to its parent.
   JSON::String predicate{};
+  /// Whether the edge is asserted in reverse.
   bool reverse{false};
 };
 
@@ -33,8 +35,11 @@ enum class JSONLDDirection : std::uint8_t { LTR, RTL };
 /// and the graph flag asserts the node's descendants in the named graph the
 /// identifier denotes.
 struct JSONLDNode {
+  /// The node identifier, absent for a fresh blank node.
   std::optional<JSON::String> id{};
+  /// The types of the node.
   std::vector<JSON::String> types{};
+  /// Whether the node's descendants are asserted in the named graph it denotes.
   bool graph{false};
 };
 
@@ -43,16 +48,22 @@ struct JSONLDNode {
 /// JSON value, a language may carry a direction, and the JSON flag preserves an
 /// opaque JSON literal verbatim.
 struct JSONLDLiteral {
+  /// The literal datatype, defaulting to the native type of the value.
   std::optional<JSON::String> datatype{};
+  /// The language tag of the literal.
   std::optional<JSON::String> language{};
+  /// The base direction of the literal.
   std::optional<JSONLDDirection> direction{};
+  /// Whether the literal is preserved as an opaque JSON literal.
   bool json{false};
 };
 
 /// @ingroup jsonld
 /// A scalar promoted to an identified node
 struct JSONLDReference {
+  /// The identifier of the promoted node.
   JSON::String id{};
+  /// The types of the promoted node.
   std::vector<JSON::String> types{};
 };
 
@@ -67,6 +78,7 @@ enum class JSONLDContainer : std::uint8_t { List, Set, Language, Index };
 /// object of language tag to string, and an Index container over an object
 /// whose keys are index labels that carry no RDF.
 struct JSONLDCollection {
+  /// The container form of the collection.
   JSONLDContainer container{JSONLDContainer::Set};
 };
 
@@ -74,7 +86,9 @@ struct JSONLDCollection {
 /// The semantics of a single instance position: how it connects to its parent
 /// and what it is
 struct JSONLDDescriptor {
+  /// How the position connects to its parent.
   std::vector<JSONLDEdge> edges{};
+  /// What the position is.
   std::variant<JSONLDNode, JSONLDLiteral, JSONLDReference, JSONLDCollection>
       value{};
 };

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer.h
@@ -35,9 +35,12 @@
 namespace sourcemeta::core {
 
 /// @ingroup jsonpointer
+/// A JSON Pointer whose object property tokens own their string values.
 using Pointer = GenericPointer<JSON::String, PropertyHashJSON<JSON::String>>;
 
 /// @ingroup jsonpointer
+/// A JSON Pointer whose object property tokens reference externally owned
+/// strings.
 using WeakPointer = GenericPointer<
     // We use this instead of a string view as the latter occupies more memory
     std::reference_wrapper<const std::string>, PropertyHashJSON<JSON::String>>;
@@ -616,14 +619,19 @@ SOURCEMETA_CORE_JSONPOINTER_EXPORT
 auto to_uri(const Pointer &pointer, const URI &base) -> URI;
 
 /// @ingroup jsonpointer
+/// Stringify the input JSON Pointer into a properly escaped URI fragment.
 SOURCEMETA_CORE_JSONPOINTER_EXPORT
 auto to_uri(const WeakPointer &pointer) -> URI;
 
 /// @ingroup jsonpointer
+/// Stringify the input JSON Pointer into a properly escaped URI fragment
+/// alongside a base URI.
 SOURCEMETA_CORE_JSONPOINTER_EXPORT
 auto to_uri(const WeakPointer &pointer, const URI &base) -> URI;
 
 /// @ingroup jsonpointer
+/// Stringify the input JSON Pointer into a properly escaped URI fragment
+/// alongside a base URI.
 SOURCEMETA_CORE_JSONPOINTER_EXPORT
 auto to_uri(const WeakPointer &pointer, const std::string_view base) -> URI;
 

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -20,10 +20,15 @@
 namespace sourcemeta::core {
 
 /// @ingroup jsonpointer
+/// A sequence of reference tokens that identifies a location within a JSON
+/// document.
 template <typename PropertyT, typename Hash> class GenericPointer {
 public:
+  /// A single reference token within this pointer
   using Token = GenericToken<PropertyT, Hash>;
+  /// The JSON value type used for serialisation
   using Value = typename Token::Value;
+  /// The underlying sequence container of tokens
   using Container = std::vector<Token>;
 
   /// This constructor creates an empty JSON Pointer. For example:

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -45,16 +45,21 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_JSONPOINTER_EXPORT PointerPositionTracker {
 public:
+  /// The pointer type used to look up positions
   using Pointer = GenericPointer<JSON::String, PropertyHashJSON<JSON::String>>;
+  /// The start and end line and column numbers of a value
   using Position =
       std::tuple<std::uint64_t, std::uint64_t, std::uint64_t, std::uint64_t>;
   auto operator()(const JSON::ParsePhase phase, const JSON::Type,
                   const std::uint64_t line, const std::uint64_t column,
                   const JSON::ParseContext context, const std::size_t index,
                   const JSON::String &property) -> void;
+  /// Get the position of the value at a given pointer
   [[nodiscard]] auto get(const Pointer &pointer) const
       -> std::optional<Position>;
+  /// Get the number of tracked positions
   [[nodiscard]] auto size() const -> std::size_t;
+  /// Serialise the tracked positions as a JSON document
   [[nodiscard]] auto to_json() const -> JSON;
 
 private:

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_token.h
@@ -8,10 +8,15 @@
 namespace sourcemeta::core {
 
 /// @ingroup jsonpointer
+/// A single reference token of a JSON Pointer, holding either an object
+/// property or an array index.
 template <typename PropertyT, typename Hash> class GenericToken {
 public:
+  /// The JSON value type these tokens convert to
   using Value = JSON;
+  /// The stored type of an object property token
   using Property = PropertyT;
+  /// The stored type of an array index token
   using Index = typename Value::Array::size_type;
 
   /// This constructor creates an JSON Pointer token from a string given its

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
@@ -16,6 +16,7 @@ private:
   using internal = typename std::vector<PointerT>;
 
 public:
+  /// Construct a walker over every location in a JSON document
   GenericPointerWalker(const JSON &document) {
     PointerT accumulator;
     this->walk(document, accumulator);

--- a/src/core/mcp/include/sourcemeta/core/mcp.h
+++ b/src/core/mcp/include/sourcemeta/core/mcp.h
@@ -27,8 +27,11 @@ namespace sourcemeta::core {
 /// @ingroup mcp
 /// The supported MCP protocol revisions.
 enum class MCPProtocolVersion : std::uint8_t {
+  /// The MCP 2025-03-26 protocol revision.
   V_2025_03_26,
+  /// The MCP 2025-06-18 protocol revision.
   V_2025_06_18,
+  /// The MCP 2025-11-25 protocol revision.
   V_2025_11_25,
 };
 

--- a/src/core/punycode/include/sourcemeta/core/punycode_error.h
+++ b/src/core/punycode/include/sourcemeta/core/punycode_error.h
@@ -19,8 +19,10 @@ namespace sourcemeta::core {
 #endif
 
 /// @ingroup punycode
+/// An error that represents a Punycode encoding or decoding failure
 class SOURCEMETA_CORE_PUNYCODE_EXPORT PunycodeError : public std::exception {
 public:
+  /// Construct an error with the given message
   PunycodeError(const char *message) : message_{message} {}
   PunycodeError(std::string message) = delete;
   PunycodeError(std::string &&message) = delete;

--- a/src/core/regex/include/sourcemeta/core/regex.h
+++ b/src/core/regex/include/sourcemeta/core/regex.h
@@ -26,6 +26,7 @@
 namespace sourcemeta::core {
 
 /// @ingroup regex
+/// Matches any string that begins with a fixed prefix.
 using RegexTypePrefix = std::string;
 
 /// @ingroup regex
@@ -34,10 +35,13 @@ struct RegexTypeNonEmpty {
 };
 
 /// @ingroup regex
+/// Matches any string whose length falls within an inclusive range.
 using RegexTypeRange = std::pair<std::uint64_t, std::uint64_t>;
 
 /// @ingroup regex
+/// A regular expression compiled through the PCRE2 engine.
 struct RegexTypePCRE2 {
+  /// The opaque handle to the compiled expression.
   std::shared_ptr<void> code;
   auto operator==(const RegexTypePCRE2 &other) const noexcept -> bool {
     return this->code == other.code;
@@ -50,6 +54,7 @@ struct RegexTypeNoop {
 };
 
 /// @ingroup regex
+/// A compiled regular expression in one of its supported representations.
 using Regex = std::variant<RegexTypePrefix, RegexTypeNonEmpty, RegexTypeRange,
                            RegexTypePCRE2, RegexTypeNoop>;
 #if !defined(DOXYGEN)

--- a/src/core/semver/include/sourcemeta/core/semver.h
+++ b/src/core/semver/include/sourcemeta/core/semver.h
@@ -34,6 +34,7 @@ class SOURCEMETA_CORE_SEMVER_EXPORT SemVer {
 public:
   /// The level of strictness applied when parsing a version string.
   enum class Mode : std::uint8_t {
+    /// Require a fully compliant version string.
     Strict,
 
     // Permits the following deviations on the version core only:
@@ -41,6 +42,7 @@ public:
     // - Missing patch, defaulting to 0 (e.g. "1.2")
     // - Missing minor and patch, defaulting to 0 (e.g. "1")
     // - Combinations of the above (e.g. "v1", "v1.2")
+    /// Permit common shorthand deviations on the version core.
     Loose
   };
 

--- a/src/core/semver/include/sourcemeta/core/semver.h
+++ b/src/core/semver/include/sourcemeta/core/semver.h
@@ -32,6 +32,7 @@ namespace sourcemeta::core {
 /// The input string must outlive this object.
 class SOURCEMETA_CORE_SEMVER_EXPORT SemVer {
 public:
+  /// The level of strictness applied when parsing a version string.
   enum class Mode : std::uint8_t {
     Strict,
 
@@ -43,32 +44,39 @@ public:
     Loose
   };
 
+  /// Construct a version by parsing the given string, throwing on failure.
   SemVer(std::string_view input, Mode mode = Mode::Strict);
 
+  /// Parse a version from the given string, returning no value on failure.
   [[nodiscard]] static auto from(std::string_view input,
                                  Mode mode = Mode::Strict) noexcept
       -> std::optional<SemVer>;
 
+  /// The major version number.
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto major() const noexcept
       -> std::uint64_t {
     return this->major_;
   }
 
+  /// The minor version number.
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto minor() const noexcept
       -> std::uint64_t {
     return this->minor_;
   }
 
+  /// The patch version number.
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto patch() const noexcept
       -> std::uint64_t {
     return this->patch_;
   }
 
+  /// The pre-release identifier, or empty if none is present.
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto pre_release() const noexcept
       -> std::string_view {
     return this->pre_release_;
   }
 
+  /// The build metadata, or empty if none is present.
   [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto build() const noexcept
       -> std::string_view {
     return this->build_;
@@ -109,6 +117,7 @@ public:
     return !(*this < other);
   }
 
+  /// Serialise the version back into its string representation.
   [[nodiscard]] auto to_string() const -> std::string;
 
 private:

--- a/src/core/semver/include/sourcemeta/core/semver_error.h
+++ b/src/core/semver/include/sourcemeta/core/semver_error.h
@@ -14,14 +14,17 @@ namespace sourcemeta::core {
 #pragma warning(disable : 4251 4275)
 #endif
 
+/// An error raised when a string cannot be parsed as a Semantic Version.
 class SOURCEMETA_CORE_SEMVER_EXPORT SemVerParseError : public std::exception {
 public:
+  /// Construct an error located at the given column of the input.
   SemVerParseError(const std::uint64_t column) : column_{column} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "The input is not a valid Semantic Version";
   }
 
+  /// The column at which the parsing failure occurred.
   [[nodiscard]] auto column() const noexcept -> std::uint64_t {
     return this->column_;
   }
@@ -30,15 +33,18 @@ private:
   std::uint64_t column_;
 };
 
+/// An error raised when a numeric component of a Semantic Version overflows.
 class SOURCEMETA_CORE_SEMVER_EXPORT SemVerOverflowError
     : public std::exception {
 public:
+  /// Construct an error located at the given column of the input.
   SemVerOverflowError(const std::uint64_t column) : column_{column} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "The numeric component of the Semantic Version overflows";
   }
 
+  /// The column at which the overflow occurred.
   [[nodiscard]] auto column() const noexcept -> std::uint64_t {
     return this->column_;
   }

--- a/src/core/unicode/include/sourcemeta/core/unicode_ucd.h
+++ b/src/core/unicode/include/sourcemeta/core/unicode_ucd.h
@@ -19,9 +19,11 @@ namespace sourcemeta::core {
 /// The joining type of a Unicode codepoint per UAX #44. See
 /// https://www.unicode.org/reports/tr44/ for the property's definition.
 enum class JoiningType : std::uint8_t {
+#if !defined(DOXYGEN)
 #define SOURCEMETA_CORE_UCD_ENUM_ENTRY(name, alias) name,
   SOURCEMETA_CORE_JOINING_TYPE_LIST(SOURCEMETA_CORE_UCD_ENUM_ENTRY)
 #undef SOURCEMETA_CORE_UCD_ENUM_ENTRY
+#endif
 };
 
 /// @ingroup unicode
@@ -55,9 +57,11 @@ enum class JoiningType : std::uint8_t {
 /// The bidirectional class of a Unicode codepoint per UAX #44. See
 /// https://www.unicode.org/reports/tr44/ for the property's definition.
 enum class BidiClass : std::uint8_t {
+#if !defined(DOXYGEN)
 #define SOURCEMETA_CORE_UCD_ENUM_ENTRY(name, alias) name,
   SOURCEMETA_CORE_BIDI_CLASS_LIST(SOURCEMETA_CORE_UCD_ENUM_ENTRY)
 #undef SOURCEMETA_CORE_UCD_ENUM_ENTRY
+#endif
 };
 
 /// @ingroup unicode
@@ -246,9 +250,11 @@ enum class BidiClass : std::uint8_t {
 /// The script of a Unicode codepoint per UAX #24. See
 /// https://www.unicode.org/reports/tr24/ for the property's definition.
 enum class UnicodeScript : std::uint8_t {
+#if !defined(DOXYGEN)
 #define SOURCEMETA_CORE_UCD_ENUM_ENTRY(name, alias) name,
   SOURCEMETA_CORE_UNICODE_SCRIPT_LIST(SOURCEMETA_CORE_UCD_ENUM_ENTRY)
 #undef SOURCEMETA_CORE_UCD_ENUM_ENTRY
+#endif
 };
 
 /// @ingroup unicode
@@ -262,9 +268,11 @@ enum class UnicodeScript : std::uint8_t {
 /// The NFC quick-check result for a Unicode codepoint per UAX #15.
 /// See https://www.unicode.org/reports/tr15/ for the property's definition.
 enum class NFCQuickCheck : std::uint8_t {
+#if !defined(DOXYGEN)
 #define SOURCEMETA_CORE_UCD_ENUM_ENTRY(name, alias) name,
   SOURCEMETA_CORE_NFC_QUICK_CHECK_LIST(SOURCEMETA_CORE_UCD_ENUM_ENTRY)
 #undef SOURCEMETA_CORE_UCD_ENUM_ENTRY
+#endif
 };
 
 } // namespace sourcemeta::core

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -37,6 +37,7 @@
 namespace sourcemeta::core {
 
 /// @ingroup uri
+/// A parsed URI that can be inspected, resolved, and recomposed
 class SOURCEMETA_CORE_URI_EXPORT URI {
 public:
   /// Default constructor creates an empty URI
@@ -285,6 +286,7 @@ public:
   /// uri.path(std::move(path));
   /// assert(uri.path().has_value());
   /// assert(uri.path().value() == "/foo/bar");
+  /// ```
   auto path(std::string &&path) -> URI &;
 
   /// Append a path to the existing URI path or set a path if such component
@@ -299,6 +301,7 @@ public:
   /// sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo"};
   /// uri.append_path("bar/baz");
   /// assert(uri.recompose() == "https://www.sourcemeta.com/foo/bar/baz");
+  /// ```
   auto append_path(std::string_view path) -> URI &;
 
   /// Append a path to the existing URI from a parsed reference. The
@@ -313,6 +316,7 @@ public:
   /// const sourcemeta::core::URI reference{"bar/baz"};
   /// uri.append_path(reference);
   /// assert(uri.recompose() == "https://www.sourcemeta.com/foo/bar/baz");
+  /// ```
   auto append_path(const URI &reference) -> URI &;
 
   /// Append a path to the existing URI from a parsed reference, moving the
@@ -342,6 +346,7 @@ public:
   /// sourcemeta::core::URI uri{"https://www.sourcemeta.com/foo"};
   /// uri.extension("json");
   /// assert(uri.recompose() == "https://www.sourcemeta.com/foo.json");
+  /// ```
   auto extension(std::string &&extension) -> URI &;
 
   /// Get the fragment part of the URI, if any. For example:

--- a/src/core/uri/include/sourcemeta/core/uri_error.h
+++ b/src/core/uri/include/sourcemeta/core/uri_error.h
@@ -23,6 +23,7 @@ namespace sourcemeta::core {
 /// An error that represents a URI parsing failure
 class SOURCEMETA_CORE_URI_EXPORT URIParseError : public std::exception {
 public:
+  /// Construct an error from the column at which parsing failed
   URIParseError(const std::uint64_t column) : column_{column} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
@@ -42,6 +43,7 @@ private:
 /// An error that represents a general URI error event
 class SOURCEMETA_CORE_URI_EXPORT URIError : public std::exception {
 public:
+  /// Construct an error with the given message
   URIError(const char *message) : message_{message} {}
   URIError(std::string message) = delete;
   URIError(std::string &&message) = delete;

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_error.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_error.h
@@ -27,6 +27,7 @@ namespace sourcemeta::core {
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateParseError
     : public std::exception {
 public:
+  /// Construct an error given the column number where parsing failed
   URITemplateParseError(const std::uint64_t column) : column_{column} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
@@ -47,6 +48,7 @@ private:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateExpansionError
     : public std::runtime_error {
 public:
+  /// Construct an error with a descriptive message
   URITemplateExpansionError(const std::string &message)
       : std::runtime_error{message} {}
 };
@@ -56,6 +58,7 @@ public:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateRouterVariableMismatchError
     : public std::exception {
 public:
+  /// Construct an error given the existing and conflicting variable names
   URITemplateRouterVariableMismatchError(const std::string_view left,
                                          const std::string_view right)
       : left_{left}, right_{right} {}
@@ -84,6 +87,7 @@ private:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateRouterInvalidSegmentError
     : public std::exception {
 public:
+  /// Construct an error given a descriptive message and the offending segment
   URITemplateRouterInvalidSegmentError(const char *message,
                                        const std::string_view segment)
       : message_{message}, segment_{segment} {}
@@ -108,6 +112,7 @@ private:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT
     URITemplateRouterInvalidOperationIdError : public std::exception {
 public:
+  /// Construct an error given the offending operation identifier
   URITemplateRouterInvalidOperationIdError(const std::string_view operation_id)
       : operation_id_{operation_id} {}
 
@@ -130,6 +135,7 @@ private:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT
     URITemplateRouterDuplicateOperationIdError : public std::exception {
 public:
+  /// Construct an error given the conflicting operation identifier
   URITemplateRouterDuplicateOperationIdError(
       const std::string_view operation_id)
       : operation_id_{operation_id} {}
@@ -152,6 +158,7 @@ private:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateRouterSaveError
     : public std::exception {
 public:
+  /// Construct an error given the target path and a descriptive message
   URITemplateRouterSaveError(std::filesystem::path path, const char *message)
       : path_{std::move(path)}, message_{message} {}
 
@@ -159,6 +166,7 @@ public:
     return this->message_;
   }
 
+  /// Get the path that could not be saved
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -173,6 +181,7 @@ private:
 class SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateRouterReadError
     : public std::exception {
 public:
+  /// Construct an error given the target path
   URITemplateRouterReadError(std::filesystem::path path)
       : path_{std::move(path)} {}
 
@@ -180,6 +189,7 @@ public:
     return "Failed to open router file for reading";
   }
 
+  /// Get the path that could not be read
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -56,8 +56,13 @@ public:
   using Callback =
       std::function<void(Index, std::string_view, std::string_view)>;
 
+  /// The value of a route argument
   using ArgumentValue = std::variant<std::string_view, std::int64_t, bool>;
+
+  /// A named route argument
   using Argument = std::pair<std::string_view, ArgumentValue>;
+
+  /// The argument callback (name, value)
   using ArgumentCallback =
       std::function<void(std::string_view, const ArgumentValue &)>;
 
@@ -72,15 +77,21 @@ public:
 
   /// A node in the router trie
   struct Node {
+    /// The handler identifier of the route ending at this node
     Identifier identifier{0};
+    /// The context identifier associated with this node
     Identifier context{0};
+    /// The kind of component this node represents
     NodeType type{NodeType::Root};
+    /// The literal text or variable name of this node
     std::string_view value;
 
     // This children distinction enforces that there can only be one non-literal
     // child at the type level. Also allows us to more efficiently search on
     // literals
+    /// The literal children of this node
     std::vector<std::unique_ptr<Node>> literals;
+    /// The single non-literal child of this node
     std::unique_ptr<Node> variable;
   };
 
@@ -192,6 +203,7 @@ public:
   static auto save(const URITemplateRouter &router,
                    const std::filesystem::path &path) -> void;
 
+  /// Construct a view by loading a serialized router from a file
   URITemplateRouterView(const std::filesystem::path &path);
 
   /// Construct a view over an externally-owned buffer. The buffer must

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -68,10 +68,15 @@ public:
 
   /// The type of a node in the router trie
   enum class NodeType : std::uint8_t {
+    /// The root of the trie
     Root = 0,
+    /// A fixed literal path segment
     Literal = 1,
+    /// A single path segment capture
     Variable = 2,
+    /// A greedy capture requiring at least one trailing segment
     Expansion = 3,
+    /// A greedy capture allowing zero trailing segments
     OptionalExpansion = 4
   };
 

--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_token.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_token.h
@@ -23,67 +23,98 @@ namespace sourcemeta::core {
 /// @ingroup uritemplate
 /// A literal string segment in a URI Template
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenLiteral {
+  /// The literal string content
   std::string_view value;
 };
 
 /// @ingroup uritemplate
 /// A variable specification within a URI Template expression
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateVariableSpecification {
+  /// The variable name
   std::string_view name;
   // As per the RFC, the range is 1-9999. 0 means "no prefix length"
+  /// The maximum prefix length to apply to the value
   std::uint16_t length{0};
+  /// Whether the variable is exploded into multiple values
   bool explode{false};
 };
 
 /// @ingroup uritemplate
 /// A simple string variable expansion {var} in a URI Template (Level 1)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenVariable {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The character that separates expanded values
   static constexpr char separator = ',';
+  /// Whether the expansion includes variable names
   static constexpr bool named = false;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = false;
 };
 
 /// @ingroup uritemplate
 /// A reserved expansion {+var} in a URI Template (Level 2)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenReservedExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = '+';
+  /// The character that separates expanded values
   static constexpr char separator = ',';
+  /// Whether the expansion includes variable names
   static constexpr bool named = false;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = true;
 };
 
 /// @ingroup uritemplate
-/// A fragment expansion {#var} in a URI Template (Level 2)
+/// A fragment expansion {\#var} in a URI Template (Level 2)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenFragmentExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = '#';
+  /// The character that separates expanded values
   static constexpr char separator = ',';
+  /// The character prepended to the expansion output
   static constexpr char prefix = '#';
+  /// Whether the expansion includes variable names
   static constexpr bool named = false;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = true;
 };
 
 /// @ingroup uritemplate
 /// A label expansion {.var} in a URI Template (Level 3)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenLabelExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = '.';
+  /// The character that separates expanded values
   static constexpr char separator = '.';
+  /// The character prepended to the expansion output
   static constexpr char prefix = '.';
+  /// Whether the expansion includes variable names
   static constexpr bool named = false;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = false;
 };
 
 /// @ingroup uritemplate
 /// A path expansion {/var} in a URI Template (Level 3)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenPathExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = '/';
+  /// The character that separates expanded values
   static constexpr char separator = '/';
+  /// The character prepended to the expansion output
   static constexpr char prefix = '/';
+  /// Whether the expansion includes variable names
   static constexpr bool named = false;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = false;
 };
 
@@ -91,23 +122,36 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenPathExpansion {
 /// A path parameter expansion {;var} in a URI Template (Level 3)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT
     URITemplateTokenPathParameterExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = ';';
+  /// The character that separates expanded values
   static constexpr char separator = ';';
+  /// The character prepended to the expansion output
   static constexpr char prefix = ';';
+  /// Whether the expansion includes variable names
   static constexpr bool named = true;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = false;
 };
 
 /// @ingroup uritemplate
 /// A query expansion {?var} in a URI Template (Level 3)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenQueryExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = '?';
+  /// The character that separates expanded values
   static constexpr char separator = '&';
+  /// The character prepended to the expansion output
   static constexpr char prefix = '?';
+  /// Whether the expansion includes variable names
   static constexpr bool named = true;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = false;
+  /// The character appended to names with empty values
   static constexpr char empty_suffix = '=';
 };
 
@@ -115,12 +159,19 @@ struct SOURCEMETA_CORE_URITEMPLATE_EXPORT URITemplateTokenQueryExpansion {
 /// A query continuation expansion {&var} in a URI Template (Level 3)
 struct SOURCEMETA_CORE_URITEMPLATE_EXPORT
     URITemplateTokenQueryContinuationExpansion {
+  /// The variable specifications to expand
   std::vector<URITemplateVariableSpecification> variables;
+  /// The operator character that introduces the expression
   static constexpr char op = '&';
+  /// The character that separates expanded values
   static constexpr char separator = '&';
+  /// The character prepended to the expansion output
   static constexpr char prefix = '&';
+  /// Whether the expansion includes variable names
   static constexpr bool named = true;
+  /// Whether reserved characters are preserved unencoded
   static constexpr bool allow_reserved = false;
+  /// The character appended to names with empty values
   static constexpr char empty_suffix = '=';
 };
 

--- a/src/core/yaml/include/sourcemeta/core/yaml_error.h
+++ b/src/core/yaml/include/sourcemeta/core/yaml_error.h
@@ -25,6 +25,7 @@ namespace sourcemeta::core {
 /// An error that represents a general YAML error event
 class SOURCEMETA_CORE_YAML_EXPORT YAMLError : public std::exception {
 public:
+  /// Create a general error
   YAMLError(const char *message) : message_{message} {}
   YAMLError(std::string message) = delete;
   YAMLError(std::string &&message) = delete;
@@ -42,10 +43,12 @@ private:
 /// An error that represents a YAML parse error event
 class SOURCEMETA_CORE_YAML_EXPORT YAMLParseError : public std::exception {
 public:
+  /// Create a parsing error
   YAMLParseError(const std::uint64_t line, const std::uint64_t column)
       : line_{line}, column_{column},
         message_{"Failed to parse the YAML document"} {}
 
+  /// Create a parsing error with a custom error
   YAMLParseError(const std::uint64_t line, const std::uint64_t column,
                  const char *message)
       : line_{line}, column_{column}, message_{message} {}
@@ -60,10 +63,12 @@ public:
     return this->message_;
   }
 
+  /// Get the line number of the error
   [[nodiscard]] auto line() const noexcept -> std::uint64_t {
     return this->line_;
   }
 
+  /// Get the column number of the error
   [[nodiscard]] auto column() const noexcept -> std::uint64_t {
     return this->column_;
   }
@@ -78,6 +83,7 @@ private:
 /// An error that represents a YAML parse error occurring from parsing a file
 class SOURCEMETA_CORE_YAML_EXPORT YAMLFileParseError : public YAMLParseError {
 public:
+  /// Create a file parsing error
   YAMLFileParseError(std::filesystem::path path, const std::uint64_t line,
                      const std::uint64_t column, const char *message)
       : YAMLParseError{line, column, message}, path_{std::move(path)} {}
@@ -90,10 +96,12 @@ public:
                      const std::uint64_t column,
                      std::string_view message) = delete;
 
+  /// Create a file parsing error from a parse error
   YAMLFileParseError(std::filesystem::path path, const YAMLParseError &parent)
       : YAMLParseError{parent.line(), parent.column(), parent.what()},
         path_{std::move(path)} {}
 
+  /// Get the file path of the error
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -107,11 +115,13 @@ private:
 class SOURCEMETA_CORE_YAML_EXPORT YAMLUnknownAnchorError
     : public YAMLParseError {
 public:
+  /// Create an unknown anchor error
   YAMLUnknownAnchorError(const std::string_view anchor_name,
                          const std::uint64_t line, const std::uint64_t column)
       : YAMLParseError{line, column, "YAML alias references undefined anchor"},
         anchor_name_{anchor_name} {}
 
+  /// Get the anchor name of the error
   [[nodiscard]] auto anchor() const noexcept -> std::string_view {
     return this->anchor_name_;
   }
@@ -127,11 +137,13 @@ private:
 class SOURCEMETA_CORE_YAML_EXPORT YAMLDuplicateKeyError
     : public YAMLParseError {
 public:
+  /// Create a duplicate key error
   YAMLDuplicateKeyError(const std::string_view key_name,
                         const std::uint64_t line, const std::uint64_t column)
       : YAMLParseError{line, column, "Duplicate key in YAML mapping"},
         key_name_{key_name} {}
 
+  /// Get the key name of the error
   [[nodiscard]] auto key() const noexcept -> std::string_view {
     return this->key_name_;
   }

--- a/src/core/yaml/include/sourcemeta/core/yaml_roundtrip.h
+++ b/src/core/yaml/include/sourcemeta/core/yaml_roundtrip.h
@@ -28,6 +28,7 @@ namespace sourcemeta::core {
 /// original formatting
 class SOURCEMETA_CORE_YAML_EXPORT YAMLRoundTrip {
 public:
+  /// The presentation style of a scalar value
   enum class ScalarStyle : std::uint8_t {
     Plain,
     SingleQuoted,
@@ -36,38 +37,67 @@ public:
     Folded
   };
 
+  /// The presentation style of a collection
   enum class CollectionStyle : std::uint8_t { Block, Flow };
 
+  /// The chomping behavior applied to a block scalar
   enum class Chomping : std::uint8_t { Clip, Strip, Keep };
 
+  /// Holds the formatting details recorded for a single node
   struct NodeStyle {
+    /// The scalar presentation style
     std::optional<ScalarStyle> scalar;
+    /// The collection presentation style
     std::optional<CollectionStyle> collection;
+    /// The chomping behavior for a block scalar
     std::optional<Chomping> chomping;
+    /// The explicit block scalar indentation width
     std::size_t explicit_indent{0};
+    /// Whether the indentation indicator precedes the chomping indicator
     bool indent_before_chomping{false};
+    /// The original block scalar content
     std::optional<std::string> block_content;
+    /// The original plain scalar content
     std::optional<std::string> plain_content;
+    /// The original quoted scalar content
     std::optional<std::string> quoted_content;
+    /// The anchor name attached to the node
     std::optional<std::string> anchor;
+    /// The comments preceding the node
     std::vector<std::string> comments_before;
+    /// The comment on the same line as the node
     std::optional<std::string> comment_inline;
+    /// The comment attached to a block scalar indicator
     std::optional<std::string> comment_on_indicator;
+    /// Whether the flow collection uses compact formatting
     bool compact_flow{false};
   };
 
+  /// The recorded formatting for each node by pointer
   std::unordered_map<Pointer, NodeStyle, Pointer::Hasher> styles;
+  /// The alias name for each node referencing an anchor
   std::unordered_map<Pointer, std::string, Pointer::Hasher> aliases;
+  /// The scalar style for each mapping key by pointer
   std::unordered_map<Pointer, ScalarStyle, Pointer::Hasher> key_styles;
+  /// The original quoted content for each mapping key
   std::unordered_map<Pointer, std::string, Pointer::Hasher> key_quoted_contents;
+  /// Whether the document begins with an explicit start marker
   bool explicit_document_start{false};
+  /// Whether the document ends with an explicit end marker
   bool explicit_document_end{false};
+  /// The comment on the document start marker
   std::optional<std::string> document_start_comment;
+  /// The comment on the document end marker
   std::optional<std::string> document_end_comment;
+  /// The comments preceding the document
   std::vector<std::string> leading_comments;
+  /// The comments following the document start marker
   std::vector<std::string> post_start_comments;
+  /// The comments preceding the document end marker
   std::vector<std::string> pre_end_comments;
+  /// The comments following the document
   std::vector<std::string> trailing_comments;
+  /// The indentation width used when emitting the document
   std::size_t indent_width{2};
 };
 

--- a/src/core/yaml/include/sourcemeta/core/yaml_roundtrip.h
+++ b/src/core/yaml/include/sourcemeta/core/yaml_roundtrip.h
@@ -30,18 +30,35 @@ class SOURCEMETA_CORE_YAML_EXPORT YAMLRoundTrip {
 public:
   /// The presentation style of a scalar value
   enum class ScalarStyle : std::uint8_t {
+    /// The unquoted scalar style
     Plain,
+    /// The single-quoted scalar style
     SingleQuoted,
+    /// The double-quoted scalar style
     DoubleQuoted,
+    /// The literal block scalar style that preserves line breaks
     Literal,
+    /// The folded block scalar style that joins lines with spaces
     Folded
   };
 
   /// The presentation style of a collection
-  enum class CollectionStyle : std::uint8_t { Block, Flow };
+  enum class CollectionStyle : std::uint8_t {
+    /// The indentation-based block collection style
+    Block,
+    /// The inline flow collection style delimited by brackets or braces
+    Flow
+  };
 
   /// The chomping behavior applied to a block scalar
-  enum class Chomping : std::uint8_t { Clip, Strip, Keep };
+  enum class Chomping : std::uint8_t {
+    /// Keep a single trailing line break and drop the rest
+    Clip,
+    /// Remove all trailing line breaks
+    Strip,
+    /// Preserve every trailing line break
+    Keep
+  };
 
   /// Holds the formatting details recorded for a single node
   struct NodeStyle {

--- a/src/lang/error/include/sourcemeta/core/error_file.h
+++ b/src/lang/error/include/sourcemeta/core/error_file.h
@@ -18,10 +18,13 @@ namespace sourcemeta::core {
 /// ```
 template <typename T> class FileError : public T {
 public:
+  /// Construct the error given the offending file path and the underlying
+  /// exception arguments.
   template <typename... Args>
   FileError(std::filesystem::path path, Args &&...args)
       : T{std::forward<Args>(args)...}, path_{std::move(path)} {}
 
+  /// The offending file path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }

--- a/src/lang/io/include/sourcemeta/core/io_binary.h
+++ b/src/lang/io/include/sourcemeta/core/io_binary.h
@@ -29,6 +29,7 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_IO_EXPORT BinaryWriter {
 public:
+  /// Construct a writer over the given output stream.
   BinaryWriter(std::ostream &stream) noexcept;
 
   // Prevent copying, as this class is tied to a stream resource
@@ -37,13 +38,19 @@ public:
   auto operator=(const BinaryWriter &) -> BinaryWriter & = delete;
   auto operator=(BinaryWriter &&) -> BinaryWriter & = delete;
 
+  /// Write a single byte.
   auto put_byte(const std::uint8_t value) -> void;
+  /// Write a 16-bit unsigned integer.
   auto put_word(const std::uint16_t value) -> void;
+  /// Write a 32-bit unsigned integer.
   auto put_dword(const std::uint32_t value) -> void;
+  /// Write a 64-bit unsigned integer.
   auto put_qword(const std::uint64_t value) -> void;
 
+  /// Write a raw sequence of bytes.
   auto put_bytes(const std::byte *data, const std::size_t size) -> void;
 
+  /// The number of bytes written so far.
   [[nodiscard]] auto position() const -> std::size_t;
 
 private:
@@ -69,7 +76,9 @@ private:
 /// ```
 class SOURCEMETA_CORE_IO_EXPORT BinaryReader {
 public:
+  /// Construct a reader over the given file view.
   BinaryReader(const FileView &view) noexcept;
+  /// Construct a reader over the given input stream.
   BinaryReader(std::istream &stream) noexcept;
 
   // Prevent copying, as this class is tied to an input resource
@@ -78,13 +87,19 @@ public:
   auto operator=(const BinaryReader &) -> BinaryReader & = delete;
   auto operator=(BinaryReader &&) -> BinaryReader & = delete;
 
+  /// Read a single byte.
   [[nodiscard]] auto get_byte() -> std::uint8_t;
+  /// Read a 16-bit unsigned integer.
   [[nodiscard]] auto get_word() -> std::uint16_t;
+  /// Read a 32-bit unsigned integer.
   [[nodiscard]] auto get_dword() -> std::uint32_t;
+  /// Read a 64-bit unsigned integer.
   [[nodiscard]] auto get_qword() -> std::uint64_t;
 
+  /// Read a raw sequence of bytes.
   auto get_bytes(std::byte *destination, const std::size_t size) -> void;
 
+  /// The current cursor position in bytes.
   [[nodiscard]] auto position() const -> std::size_t;
 
   /// Move the cursor to `position`.

--- a/src/lang/io/include/sourcemeta/core/io_bytestream.h
+++ b/src/lang/io/include/sourcemeta/core/io_bytestream.h
@@ -34,6 +34,7 @@ namespace sourcemeta::core {
 /// ```
 class InputByteStream : public std::istringstream {
 public:
+  /// Construct the stream from the given byte values.
   SOURCEMETA_CORE_IO_EXPORT
   InputByteStream(std::initializer_list<std::uint8_t> bytes);
 };
@@ -52,6 +53,7 @@ public:
 /// ```
 class OutputByteStream : public std::ostringstream {
 public:
+  /// The accumulated bytes.
   SOURCEMETA_CORE_IO_EXPORT
   auto bytes() const -> std::vector<std::byte>;
 };

--- a/src/lang/io/include/sourcemeta/core/io_error.h
+++ b/src/lang/io/include/sourcemeta/core/io_error.h
@@ -24,6 +24,7 @@ namespace sourcemeta::core {
 /// An error that represents a failure to memory-map a file
 class SOURCEMETA_CORE_IO_EXPORT FileViewError : public std::exception {
 public:
+  /// Construct the error given the offending path and a message.
   FileViewError(std::filesystem::path path, const char *message)
       : path_{std::move(path)}, message_{message} {}
   FileViewError(std::filesystem::path path, std::string message) = delete;
@@ -34,6 +35,7 @@ public:
     return this->message_;
   }
 
+  /// The offending path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -47,12 +49,14 @@ private:
 /// The requested file does not exist.
 class SOURCEMETA_CORE_IO_EXPORT IOFileNotFoundError : public std::exception {
 public:
+  /// Construct the error given the offending path.
   IOFileNotFoundError(std::filesystem::path path) : path_{std::move(path)} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "File not found";
   }
 
+  /// The offending path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -65,12 +69,14 @@ private:
 /// The current process lacks permission to access the requested path.
 class SOURCEMETA_CORE_IO_EXPORT IOFilePermissionError : public std::exception {
 public:
+  /// Construct the error given the offending path.
   IOFilePermissionError(std::filesystem::path path) : path_{std::move(path)} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "Permission denied";
   }
 
+  /// The offending path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -83,12 +89,14 @@ private:
 /// The path resolves to a directory where a regular file was expected.
 class SOURCEMETA_CORE_IO_EXPORT IOIsADirectoryError : public std::exception {
 public:
+  /// Construct the error given the offending path.
   IOIsADirectoryError(std::filesystem::path path) : path_{std::move(path)} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "Expected a file but got a directory";
   }
 
+  /// The offending path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -101,12 +109,14 @@ private:
 /// The path resolves to a regular file where a directory was expected.
 class SOURCEMETA_CORE_IO_EXPORT IONotADirectoryError : public std::exception {
 public:
+  /// Construct the error given the offending path.
   IONotADirectoryError(std::filesystem::path path) : path_{std::move(path)} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "Expected a directory but got a file";
   }
 
+  /// The offending path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }
@@ -120,6 +130,7 @@ private:
 class SOURCEMETA_CORE_IO_EXPORT IOFileAlreadyExistsError
     : public std::exception {
 public:
+  /// Construct the error given the offending path.
   IOFileAlreadyExistsError(std::filesystem::path path)
       : path_{std::move(path)} {}
 
@@ -127,6 +138,7 @@ public:
     return "File already exists";
   }
 
+  /// The offending path.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path & {
     return this->path_;
   }

--- a/src/lang/io/include/sourcemeta/core/io_fileview.h
+++ b/src/lang/io/include/sourcemeta/core/io_fileview.h
@@ -30,6 +30,7 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_IO_EXPORT FileView {
 public:
+  /// Memory-map the file at the given path.
   FileView(const std::filesystem::path &path);
   ~FileView();
 

--- a/src/lang/io/include/sourcemeta/core/io_temporary.h
+++ b/src/lang/io/include/sourcemeta/core/io_temporary.h
@@ -23,6 +23,8 @@ namespace sourcemeta::core {
 /// ```
 class SOURCEMETA_CORE_IO_EXPORT TemporaryDirectory {
 public:
+  /// Create a uniquely-named temporary directory under the given parent using
+  /// the given name prefix.
   TemporaryDirectory(const std::filesystem::path &parent,
                      const std::string_view prefix);
   ~TemporaryDirectory();
@@ -32,6 +34,7 @@ public:
   TemporaryDirectory(TemporaryDirectory &&) = delete;
   auto operator=(TemporaryDirectory &&) -> TemporaryDirectory & = delete;
 
+  /// The path to the temporary directory.
   [[nodiscard]] auto path() const noexcept -> const std::filesystem::path &;
 
 private:

--- a/src/lang/numeric/include/sourcemeta/core/numeric.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric.h
@@ -1,6 +1,16 @@
 #ifndef SOURCEMETA_CORE_NUMERIC_H_
 #define SOURCEMETA_CORE_NUMERIC_H_
 
+/// @defgroup numeric Numeric
+/// @brief Fixed-width integer types, decimal numbers, and numeric parsing and
+/// encoding utilities.
+///
+/// This functionality is included as follows:
+///
+/// ```cpp
+/// #include <sourcemeta/core/numeric.h>
+/// ```
+
 // NOLINTBEGIN(misc-include-cleaner)
 #include <sourcemeta/core/numeric_decimal.h>
 #include <sourcemeta/core/numeric_error.h>

--- a/src/lang/numeric/include/sourcemeta/core/numeric_uint128.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_uint128.h
@@ -23,19 +23,26 @@ using uint128_t = __uint128_t;
 // We keep the full implementation header-only to allow the compiler to better
 // inline
 struct uint128_t {
+  /// The lower 64 bits of the value.
   std::uint64_t low;
+  /// The upper 64 bits of the value.
   std::uint64_t high;
 
   uint128_t() noexcept : low{0}, high{0} {}
+  /// Construct from a signed integer, sign-extending negative values.
   uint128_t(int value) noexcept
       : low{static_cast<std::uint64_t>(value)},
         high{value < 0 ? UINT64_MAX : 0} {}
+  /// Construct from an unsigned integer.
   uint128_t(unsigned int value) noexcept
       : low{static_cast<std::uint64_t>(value)}, high{0} {}
+  /// Construct from a 64-bit unsigned integer.
   uint128_t(std::uint64_t value) noexcept : low{value}, high{0} {}
+  /// Construct from a 64-bit signed integer, sign-extending negative values.
   uint128_t(std::int64_t value) noexcept
       : low{static_cast<std::uint64_t>(value)},
         high{value < 0 ? UINT64_MAX : 0} {}
+  /// Construct from separate upper and lower 64-bit halves.
   uint128_t(std::uint64_t high_part, std::uint64_t low_part) noexcept
       : low{low_part}, high{high_part} {}
 

--- a/src/lang/options/include/sourcemeta/core/options.h
+++ b/src/lang/options/include/sourcemeta/core/options.h
@@ -73,6 +73,7 @@ public:
   // Disallow copies given the unique pointers
   Options(const Options &) = delete;
   auto operator=(const Options &) -> Options & = delete;
+  /// Move constructor
   Options(Options &&) noexcept = default;
   auto operator=(Options &&) noexcept -> Options & = default;
 

--- a/src/lang/options/include/sourcemeta/core/options_error.h
+++ b/src/lang/options/include/sourcemeta/core/options_error.h
@@ -22,6 +22,7 @@ namespace sourcemeta::core {
 /// This class represents a general options error
 class SOURCEMETA_CORE_OPTIONS_EXPORT OptionsError : public std::exception {
 public:
+  /// Construct the error given a message.
   explicit OptionsError(const char *message) : message_{message} {}
   explicit OptionsError(std::string message) = delete;
   explicit OptionsError(std::string &&message) = delete;
@@ -39,8 +40,10 @@ private:
 /// This class represents a unknown option error
 struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsUnknownOptionError
     : public OptionsError {
+  /// Construct the error given the offending option.
   explicit OptionsUnknownOptionError(const std::string_view option)
       : OptionsError{"Unknown option"}, option_{option} {}
+  /// The offending option.
   [[nodiscard]] auto option() const noexcept -> std::string_view {
     return this->option_;
   }
@@ -53,8 +56,10 @@ private:
 /// This class represents a value being passed to a flag
 struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsUnexpectedValueFlagError
     : public OptionsError {
+  /// Construct the error given the offending option.
   explicit OptionsUnexpectedValueFlagError(const std::string_view option)
       : OptionsError{"This flag cannot take a value"}, option_{option} {}
+  /// The offending option.
   [[nodiscard]] auto option() const noexcept -> std::string_view {
     return this->option_;
   }
@@ -67,8 +72,10 @@ private:
 /// This class represents a missing value from an option
 struct SOURCEMETA_CORE_OPTIONS_EXPORT OptionsMissingOptionValueError
     : public OptionsError {
+  /// Construct the error given the offending option.
   explicit OptionsMissingOptionValueError(const std::string_view option)
       : OptionsError{"This option must take a value"}, option_{option} {}
+  /// The offending option.
   [[nodiscard]] auto option() const noexcept -> std::string_view {
     return this->option_;
   }

--- a/src/lang/process/include/sourcemeta/core/process_error.h
+++ b/src/lang/process/include/sourcemeta/core/process_error.h
@@ -27,6 +27,7 @@ namespace sourcemeta::core {
 class SOURCEMETA_CORE_PROCESS_EXPORT ProcessProgramNotFoundError
     : public std::exception {
 public:
+  /// Construct the error given the offending program.
   ProcessProgramNotFoundError(const std::string_view program)
       : program_{program} {}
 
@@ -34,6 +35,7 @@ public:
     return "Could not locate the requested program";
   }
 
+  /// The offending program.
   [[nodiscard]] auto program() const noexcept -> std::string_view {
     return this->program_;
   }
@@ -46,10 +48,12 @@ private:
 /// A spawned process terminated abnormally
 class SOURCEMETA_CORE_PROCESS_EXPORT ProcessSpawnError : public std::exception {
 public:
+  /// Construct the error given the offending program and its arguments.
   ProcessSpawnError(const std::string_view program,
                     std::initializer_list<std::string_view> arguments)
       : program_{program}, arguments_{arguments.begin(), arguments.end()} {}
 
+  /// Construct the error given the offending program and its arguments.
   ProcessSpawnError(const std::string_view program,
                     std::span<const std::string_view> arguments)
       : program_{program}, arguments_{arguments.begin(), arguments.end()} {}
@@ -58,10 +62,12 @@ public:
     return "Process terminated abnormally";
   }
 
+  /// The offending program.
   [[nodiscard]] auto program() const noexcept -> std::string_view {
     return this->program_;
   }
 
+  /// The arguments the program was spawned with.
   [[nodiscard]] auto arguments() const noexcept
       -> const std::vector<std::string> & {
     return this->arguments_;

--- a/src/lang/test/include/sourcemeta/core/test.h
+++ b/src/lang/test/include/sourcemeta/core/test.h
@@ -40,6 +40,7 @@ namespace sourcemeta::core {
 /// not derive from the standard exception hierarchy so that a broad catch block
 /// in a test does not accidentally swallow it.
 struct SOURCEMETA_CORE_TEST_EXPORT TestAbortError {
+  /// The message describing the failed expectation.
   std::string message;
 };
 
@@ -188,9 +189,12 @@ inline auto test_c_string_label(const char *const value) -> std::string_view {
 // without rejecting comparisons of non-copyable types. This aggregate only ever
 // lives for the duration of a single comparison call, so the usual hazards of
 // reference members do not apply here.
+/// A pair of operands captured by reference for one comparison.
 template <typename Left, typename Right> struct test_operands {
   // NOLINTBEGIN(cppcoreguidelines-avoid-const-or-ref-data-members)
+  /// The left-hand operand.
   const Left &left;
+  /// The right-hand operand.
   const Right &right;
   // NOLINTEND(cppcoreguidelines-avoid-const-or-ref-data-members)
 };


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

