### PR TITLE
Fix JSON fast hashing not respecting `a == b => hash(a) == hash(b)`

### DIFF
--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -749,8 +749,21 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
       return this->to_boolean() ? 1 : 0;
     case Type::Integer:
       return 4 + (static_cast<std::uint64_t>(this->to_integer()) % 256);
-    case Type::Real:
+    case Type::Real: {
+      // A number that equals an in-range integer must hash like that integer,
+      // otherwise equal values across representations would hash differently.
+      // The integer round-trip avoids a std::modf library call
+      const auto value{this->to_real()};
+      if (value >= static_cast<Real>(std::numeric_limits<Integer>::min()) &&
+          value < static_cast<Real>(std::numeric_limits<Integer>::max())) {
+        const auto truncated{static_cast<Integer>(value)};
+        if (static_cast<Real>(truncated) == value) {
+          return 4 + (static_cast<std::uint64_t>(truncated) % 256);
+        }
+      }
+
       return 5;
+    }
     case Type::String:
       return 3 + this->byte_size();
     case Type::Array:
@@ -768,8 +781,17 @@ auto JSON::operator-=(const JSON &substractive) -> JSON & {
             return accumulator + 1 + pair.first.size() +
                    pair.second.fast_hash();
           });
-    case Type::Decimal:
-      return 8;
+    case Type::Decimal: {
+      const auto &decimal{this->to_decimal()};
+      if (decimal.is_integral()) {
+        const auto integral{decimal.to_integral()};
+        if (integral.is_int64()) {
+          return 4 + (static_cast<std::uint64_t>(integral.to_int64()) % 256);
+        }
+      }
+
+      return 5;
+    }
     default:
       assert(false);
       return 0;

--- a/test/json/json_array_test.cc
+++ b/test/json/json_array_test.cc
@@ -581,6 +581,50 @@ TEST(unique_false) {
   EXPECT_FALSE(document.unique());
 }
 
+// The same numeric value in different representations is a duplicate, even
+// when the values are large enough to fall in distinct hash buckets
+TEST(unique_false_integer_and_real_same_value) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ 1000, 1000.0 ]");
+  EXPECT_FALSE(document.unique());
+}
+
+TEST(unique_false_integer_and_decimal_same_value) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ 1000, 1000e0 ]");
+  EXPECT_FALSE(document.unique());
+}
+
+TEST(unique_true_distinct_numeric_values) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ 1000, 1001.0 ]");
+  EXPECT_TRUE(document.unique());
+}
+
+TEST(unique_false_integer_real_and_decimal_same_value) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ 1000, 1000.0, 1000e0 ]");
+  EXPECT_FALSE(document.unique());
+}
+
+TEST(unique_false_negative_number_same_value) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ -1000, -1000.0 ]");
+  EXPECT_FALSE(document.unique());
+}
+
+TEST(unique_false_fractional_real_and_decimal_same_value) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ 0.25, 2.5e-1 ]");
+  EXPECT_FALSE(document.unique());
+}
+
+TEST(unique_true_distinct_fractional_values) {
+  const sourcemeta::core::JSON document =
+      sourcemeta::core::parse_json("[ 0.25, 0.5 ]");
+  EXPECT_TRUE(document.unique());
+}
+
 TEST(sort_object_items) {
   auto document = sourcemeta::core::parse_json(R"JSON([
     { "type": "string" },

--- a/test/json/json_decimal_test.cc
+++ b/test/json/json_decimal_test.cc
@@ -1186,6 +1186,17 @@ TEST(fast_hash_matches_equal_real_integral) {
   EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
 }
 
+// An integral value stored in a non-normalized form, such as a negative
+// exponent that leaves trailing zeros in the coefficient, must still hash like
+// the same integer, which relies on normalizing before the integer extraction
+TEST(fast_hash_negative_exponent_integral_decimal) {
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"30e-1"}};
+  const sourcemeta::core::JSON as_integer{static_cast<std::int64_t>(3)};
+  EXPECT_TRUE(as_decimal.is_integral());
+  EXPECT_TRUE(as_decimal == as_integer);
+  EXPECT_EQ(as_decimal.fast_hash(), as_integer.fast_hash());
+}
+
 TEST(lexical_bignum_integer) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{
       "12345678910111213141516171819202122232425262728293031"}};

--- a/test/json/json_decimal_test.cc
+++ b/test/json/json_decimal_test.cc
@@ -1147,23 +1147,43 @@ TEST(divisible_by_large_decimal_decimal_0_001_true) {
 
 TEST(fast_hash_positive) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"3.14"}};
-  EXPECT_EQ(document.fast_hash(), 8);
+  EXPECT_EQ(document.fast_hash(), 5);
 }
 
 TEST(fast_hash_negative) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{"-3.14"}};
-  EXPECT_EQ(document.fast_hash(), 8);
+  EXPECT_EQ(document.fast_hash(), 5);
 }
 
+// An integral decimal hashes like the same integer so that equal numeric
+// values across representations hash equally
 TEST(fast_hash_zero) {
   const sourcemeta::core::JSON document{sourcemeta::core::Decimal{0}};
-  EXPECT_EQ(document.fast_hash(), 8);
+  EXPECT_EQ(document.fast_hash(), 4);
+  EXPECT_EQ(document.fast_hash(),
+            sourcemeta::core::JSON{static_cast<std::int64_t>(0)}.fast_hash());
 }
 
 TEST(fast_hash_large) {
   const sourcemeta::core::JSON document{
       sourcemeta::core::Decimal{"123456789012345678901234567890"}};
-  EXPECT_EQ(document.fast_hash(), 8);
+  EXPECT_EQ(document.fast_hash(), 5);
+}
+
+// A real and a decimal of the same value compare equal, so they must hash
+// equally, whether the shared value is fractional or integral.
+TEST(fast_hash_matches_equal_real_fractional) {
+  const sourcemeta::core::JSON as_real{0.5};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"0.5"}};
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
+}
+
+TEST(fast_hash_matches_equal_real_integral) {
+  const sourcemeta::core::JSON as_real{5.0};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"5"}};
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
 }
 
 TEST(lexical_bignum_integer) {

--- a/test/json/json_integer_test.cc
+++ b/test/json/json_integer_test.cc
@@ -159,3 +159,36 @@ TEST(subtraction_overflow_promotes_to_decimal) {
   EXPECT_TRUE(result.is_decimal());
   EXPECT_FALSE(result.is_integer());
 }
+
+// Numeric equality is exact and transitive across the integer, real and
+// decimal representations.
+TEST(equal_across_numeric_representations) {
+  const sourcemeta::core::JSON as_integer{static_cast<std::int64_t>(1000)};
+  const sourcemeta::core::JSON as_real{1000.0};
+  const auto as_decimal{sourcemeta::core::parse_json("1000e0")};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_TRUE(as_integer == as_decimal);
+}
+
+// The comparison is exact, so INT64_MAX and 2^63 (which differ by one) are not
+// treated as equal even though they round to the same double.
+TEST(equal_integer_real_is_exact_not_lossy) {
+  const sourcemeta::core::JSON real_two_pow_63{9223372036854775808.0};
+  const sourcemeta::core::JSON integer_maximum{
+      std::numeric_limits<std::int64_t>::max()};
+  EXPECT_FALSE(real_two_pow_63 == integer_maximum);
+  const sourcemeta::core::JSON two{static_cast<std::int64_t>(2)};
+  const sourcemeta::core::JSON two_and_a_half{2.5};
+  EXPECT_FALSE(two == two_and_a_half);
+}
+
+// Values that compare equal must produce the same fast hash. Equality checks
+// that use the hash as a prefilter skip the comparison when the hashes differ,
+// so an equal pair across numeric representations would otherwise be missed.
+TEST(fast_hash_matches_equal_real) {
+  const sourcemeta::core::JSON as_integer{static_cast<std::int64_t>(1000)};
+  const sourcemeta::core::JSON as_real{1000.0};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_EQ(as_integer.fast_hash(), as_real.fast_hash());
+}

--- a/test/json/json_real_test.cc
+++ b/test/json/json_real_test.cc
@@ -205,14 +205,18 @@ TEST(fast_hash_minus_3_14) {
   EXPECT_EQ(document.fast_hash(), 5);
 }
 
+// An integral real hashes like the same integer so that equal numeric values
+// across representations hash equally
 TEST(fast_hash_minus_5_0) {
   const sourcemeta::core::JSON document{5.0};
-  EXPECT_EQ(document.fast_hash(), 5);
+  EXPECT_EQ(document.fast_hash(), 9);
+  EXPECT_EQ(document.fast_hash(),
+            sourcemeta::core::JSON{static_cast<std::int64_t>(5)}.fast_hash());
 }
 
 TEST(fast_hash_minus_0_0) {
   const sourcemeta::core::JSON document{0.0};
-  EXPECT_EQ(document.fast_hash(), 5);
+  EXPECT_EQ(document.fast_hash(), 4);
 }
 
 TEST(less_than_real_decimal) {

--- a/test/json/json_value_test.cc
+++ b/test/json/json_value_test.cc
@@ -2,6 +2,7 @@
 #include <sourcemeta/core/test.h>
 
 #include <cstddef>       // std::size_t
+#include <cstdint>       // std::int64_t
 #include <functional>    // std::reference_wrapper
 #include <string>        // std::string
 #include <type_traits>   // std::is_default_constructible, etc
@@ -410,6 +411,155 @@ TEST(unordered_set_with_custom_hash) {
   EXPECT_TRUE(value.contains(sourcemeta::core::JSON{"foo"}));
   EXPECT_TRUE(value.contains(sourcemeta::core::JSON{"bar"}));
   EXPECT_TRUE(value.contains(sourcemeta::core::JSON{"baz"}));
+}
+
+// The same numeric value in different representations is a single element, so
+// the hash and the equality must agree for the container to deduplicate it
+TEST(unordered_set_deduplicates_equal_numbers_across_representations) {
+  std::unordered_set<sourcemeta::core::JSON,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.insert(sourcemeta::core::JSON{1000});
+  value.insert(sourcemeta::core::JSON{1000.0});
+  EXPECT_EQ(value.size(), 1);
+}
+
+TEST(unordered_set_deduplicates_integer_real_and_decimal) {
+  std::unordered_set<sourcemeta::core::JSON,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.insert(sourcemeta::core::JSON{static_cast<std::int64_t>(1000)});
+  value.insert(sourcemeta::core::JSON{1000.0});
+  value.insert(sourcemeta::core::JSON{sourcemeta::core::Decimal{"1000"}});
+  EXPECT_EQ(value.size(), 1);
+}
+
+// A lookup through any representation finds an element stored under another
+TEST(unordered_set_finds_equal_number_across_representations) {
+  std::unordered_set<sourcemeta::core::JSON,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.insert(sourcemeta::core::JSON{static_cast<std::int64_t>(1000)});
+  EXPECT_TRUE(value.contains(sourcemeta::core::JSON{1000.0}));
+  EXPECT_TRUE(value.contains(
+      sourcemeta::core::JSON{sourcemeta::core::Decimal{"1000"}}));
+}
+
+TEST(unordered_set_keeps_distinct_numbers_separate) {
+  std::unordered_set<sourcemeta::core::JSON,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.insert(sourcemeta::core::JSON{static_cast<std::int64_t>(1000)});
+  value.insert(sourcemeta::core::JSON{1001.0});
+  value.insert(sourcemeta::core::JSON{sourcemeta::core::Decimal{"1002"}});
+  EXPECT_EQ(value.size(), 3);
+}
+
+// A map keyed by JSON must treat equal numbers across representations as one
+// key
+TEST(unordered_map_deduplicates_equal_number_keys) {
+  std::unordered_map<sourcemeta::core::JSON, int,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.emplace(sourcemeta::core::JSON{static_cast<std::int64_t>(1000)}, 1);
+  value.emplace(sourcemeta::core::JSON{1000.0}, 2);
+  value.emplace(sourcemeta::core::JSON{sourcemeta::core::Decimal{"1000"}}, 3);
+  EXPECT_EQ(value.size(), 1);
+}
+
+TEST(unordered_map_finds_equal_number_key_across_representations) {
+  std::unordered_map<sourcemeta::core::JSON, int,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.emplace(sourcemeta::core::JSON{static_cast<std::int64_t>(1000)}, 42);
+  EXPECT_TRUE(value.contains(sourcemeta::core::JSON{1000.0}));
+  EXPECT_TRUE(value.contains(
+      sourcemeta::core::JSON{sourcemeta::core::Decimal{"1000"}}));
+  EXPECT_EQ(value.at(sourcemeta::core::JSON{1000.0}), 42);
+  EXPECT_EQ(value.at(sourcemeta::core::JSON{sourcemeta::core::Decimal{"1000"}}),
+            42);
+}
+
+TEST(unordered_map_keeps_distinct_number_keys_separate) {
+  std::unordered_map<sourcemeta::core::JSON, int,
+                     sourcemeta::core::HashJSON<sourcemeta::core::JSON>>
+      value;
+  value.emplace(sourcemeta::core::JSON{static_cast<std::int64_t>(1000)}, 1);
+  value.emplace(sourcemeta::core::JSON{1001.0}, 2);
+  EXPECT_EQ(value.size(), 2);
+}
+
+// Equal values must hash equally, otherwise hash-based containers and the hash
+// prefilter in equality checks would treat them as different
+TEST(equal_integral_number_representations_hash_equally) {
+  const sourcemeta::core::JSON as_integer{static_cast<std::int64_t>(1000)};
+  const sourcemeta::core::JSON as_real{1000.0};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"1000"}};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_TRUE(as_integer == as_decimal);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_integer.fast_hash(), as_real.fast_hash());
+  EXPECT_EQ(as_integer.fast_hash(), as_decimal.fast_hash());
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
+}
+
+TEST(equal_zero_representations_hash_equally) {
+  const sourcemeta::core::JSON as_integer{static_cast<std::int64_t>(0)};
+  const sourcemeta::core::JSON as_real{0.0};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"0"}};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_TRUE(as_integer == as_decimal);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_integer.fast_hash(), as_real.fast_hash());
+  EXPECT_EQ(as_integer.fast_hash(), as_decimal.fast_hash());
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
+}
+
+TEST(equal_negative_integral_representations_hash_equally) {
+  const sourcemeta::core::JSON as_integer{static_cast<std::int64_t>(-1000)};
+  const sourcemeta::core::JSON as_real{-1000.0};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"-1000"}};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_TRUE(as_integer == as_decimal);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_integer.fast_hash(), as_real.fast_hash());
+  EXPECT_EQ(as_integer.fast_hash(), as_decimal.fast_hash());
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
+}
+
+// A power of two that is exactly representable as a real, so the integer and
+// real forms are genuinely equal and must hash equally
+TEST(equal_large_integral_representations_hash_equally) {
+  const sourcemeta::core::JSON as_integer{
+      static_cast<std::int64_t>(4503599627370496)};
+  const sourcemeta::core::JSON as_real{4503599627370496.0};
+  const sourcemeta::core::JSON as_decimal{
+      sourcemeta::core::Decimal{"4503599627370496"}};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_TRUE(as_integer == as_decimal);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_integer.fast_hash(), as_real.fast_hash());
+  EXPECT_EQ(as_integer.fast_hash(), as_decimal.fast_hash());
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
+}
+
+TEST(equal_fractional_representations_hash_equally) {
+  const sourcemeta::core::JSON as_real{0.25};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"0.25"}};
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_EQ(as_real.fast_hash(), as_decimal.fast_hash());
+}
+
+// Values that are not equal are free to hash apart and must never compare equal
+TEST(distinct_numbers_are_not_equal_across_representations) {
+  const sourcemeta::core::JSON integer_thousand{
+      static_cast<std::int64_t>(1000)};
+  const sourcemeta::core::JSON real_thousand_and_one{1001.0};
+  const sourcemeta::core::JSON decimal_thousand_and_two{
+      sourcemeta::core::Decimal{"1002"}};
+  EXPECT_FALSE(integer_thousand == real_thousand_and_one);
+  EXPECT_FALSE(integer_thousand == decimal_thousand_and_two);
+  EXPECT_FALSE(real_thousand_and_one == decimal_thousand_and_two);
 }
 
 TEST(unordered_set_with_reference_wrapper) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

