### PR TITLE
Various misc correctness fixes throughout the codebase

### DIFF
--- a/src/core/crypto/crypto_verify_other.cc
+++ b/src/core/crypto/crypto_verify_other.cc
@@ -15,6 +15,12 @@
 #include <utility>     // std::unreachable
 
 namespace sourcemeta::core {
+
+// The big integer capacity must hold the product of two maximum-size operands
+// plus a normalisation limb and Knuth's implicit leading-zero digit, otherwise
+// the modular reduction would index past the fixed-capacity word array
+static_assert(Bignum::capacity >= 2 * ((MAXIMUM_KEY_BYTES + 7) / 8) + 2);
+
 namespace {
 
 // The DigestInfo prefixes for the EMSA-PKCS1-v1_5 encoding, taken verbatim

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -84,6 +84,42 @@ static auto internal_parse_json(const char *&cursor, const char *end,
   return output;
 }
 
+// RFC 8259 §2: JSON-text = ws value ws. A string_view input has no continuation
+// consumer, so anything other than whitespace after the top-level value is a
+// parse error. This advances past the trailing whitespace and returns the first
+// non-whitespace character, or the end if the remainder is all whitespace
+static auto skip_trailing_whitespace(const char *cursor, const char *end)
+    -> const char * {
+  using namespace internal;
+  while (cursor != end &&
+         (*cursor == token_whitespace_tabulation<JSON::Char> ||
+          *cursor == token_whitespace_line_feed<JSON::Char> ||
+          *cursor == token_whitespace_carriage_return<JSON::Char> ||
+          *cursor == token_whitespace_space<JSON::Char>)) {
+    ++cursor;
+  }
+
+  return cursor;
+}
+
+// Compute the line and column of a position within the input, matching the
+// convention the scanner uses, so that a trailing-content error points at the
+// offending character rather than where the value happened to end
+static auto position_of(const char *begin, const char *target,
+                        std::uint64_t &line, std::uint64_t &column) -> void {
+  using namespace internal;
+  line = 1;
+  column = 1;
+  for (const char *iterator{begin}; iterator != target; ++iterator) {
+    if (*iterator == token_whitespace_line_feed<JSON::Char>) {
+      line += 1;
+      column = 1;
+    } else {
+      column += 1;
+    }
+  }
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
                 std::uint64_t &line, std::uint64_t &column) -> JSON {
@@ -104,6 +140,9 @@ auto parse_json(std::basic_istream<JSON::Char, JSON::CharTraits> &stream,
 auto parse_json(
     const std::basic_string_view<JSON::Char, JSON::CharTraits> input,
     std::uint64_t &line, std::uint64_t &column) -> JSON {
+  // The overloads that expose the line and column are continuation-style: they
+  // parse a single value and leave the cursor for the caller to resume from,
+  // so they do not reject trailing content (see the position-less overloads)
   const char *cursor{input.empty() ? "" : input.data()};
   return internal_parse_json(cursor, cursor + input.size(), line, column, true);
 }
@@ -130,9 +169,17 @@ auto parse_json(
     const std::basic_string_view<JSON::Char, JSON::CharTraits> input) -> JSON {
   std::uint64_t line{1};
   std::uint64_t column{0};
-  const char *cursor{input.empty() ? "" : input.data()};
-  return internal_parse_json(cursor, cursor + input.size(), line, column,
-                             false);
+  const char *begin{input.empty() ? "" : input.data()};
+  const char *cursor{begin};
+  const char *end{cursor + input.size()};
+  auto result{internal_parse_json(cursor, end, line, column, false)};
+  const char *trailing{skip_trailing_whitespace(cursor, end)};
+  if (trailing != end) {
+    position_of(begin, trailing, line, column);
+    throw JSONParseError(line, column);
+  }
+
+  return result;
 }
 
 auto try_parse_json(
@@ -141,9 +188,11 @@ auto try_parse_json(
   std::uint64_t line{1};
   std::uint64_t column{0};
   const char *cursor{input.empty() ? "" : input.data()};
+  const char *end{cursor + input.size()};
   JSON output{nullptr};
-  if (internal_parse_json<false>(cursor, cursor + input.size(), line, column,
-                                 nullptr, false, output)) {
+  if (internal_parse_json<false>(cursor, end, line, column, nullptr, false,
+                                 output) &&
+      skip_trailing_whitespace(cursor, end) == end) {
     return output;
   }
 
@@ -179,6 +228,7 @@ auto parse_json(
     const std::basic_string_view<JSON::Char, JSON::CharTraits> input,
     std::uint64_t &line, std::uint64_t &column, JSON &output,
     const JSON::ParseCallback &callback) -> void {
+  // Continuation-style overload: see the note on the non-callback variant
   const char *cursor{input.empty() ? "" : input.data()};
   internal_parse_json<true>(cursor, cursor + input.size(), line, column,
                             callback, true, output);
@@ -206,9 +256,15 @@ auto parse_json(
     JSON &output, const JSON::ParseCallback &callback) -> void {
   std::uint64_t line{1};
   std::uint64_t column{0};
-  const char *cursor{input.empty() ? "" : input.data()};
-  internal_parse_json<true>(cursor, cursor + input.size(), line, column,
-                            callback, false, output);
+  const char *begin{input.empty() ? "" : input.data()};
+  const char *cursor{begin};
+  const char *end{cursor + input.size()};
+  internal_parse_json<true>(cursor, end, line, column, callback, false, output);
+  const char *trailing{skip_trailing_whitespace(cursor, end)};
+  if (trailing != end) {
+    position_of(begin, trailing, line, column);
+    throw JSONParseError(line, column);
+  }
 }
 
 auto read_json(const std::filesystem::path &path, JSON &output,

--- a/src/core/json/json.cc
+++ b/src/core/json/json.cc
@@ -16,7 +16,7 @@
 #include <optional>    // std::optional, std::nullopt
 #include <ostream>     // std::basic_ostream
 #include <type_traits> // std::conditional_t
-#include <utility>     // std::cmp_greater
+#include <utility>     // std::cmp_greater, std::move
 #include <vector>      // std::vector
 
 namespace sourcemeta::core {
@@ -259,12 +259,17 @@ auto parse_json(
   const char *begin{input.empty() ? "" : input.data()};
   const char *cursor{begin};
   const char *end{cursor + input.size()};
-  internal_parse_json<true>(cursor, end, line, column, callback, false, output);
+  // Parse into a temporary so that a trailing-content failure leaves the output
+  // untouched, matching how a malformed value fails before ever populating it
+  JSON result{nullptr};
+  internal_parse_json<true>(cursor, end, line, column, callback, false, result);
   const char *trailing{skip_trailing_whitespace(cursor, end)};
   if (trailing != end) {
     position_of(begin, trailing, line, column);
     throw JSONParseError(line, column);
   }
+
+  output = std::move(result);
 }
 
 auto read_json(const std::filesystem::path &path, JSON &output,

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -9,6 +9,7 @@
 #include <exception>        // std::terminate
 #include <functional>       // std::reference_wrapper
 #include <initializer_list> // std::initializer_list
+#include <limits>           // std::numeric_limits
 #include <memory>           // std::construct_at
 #include <sstream>          // std::basic_istringstream
 #include <stdexcept>        // std::invalid_argument
@@ -552,7 +553,16 @@ auto JSON::operator+(const JSON &other) const -> JSON {
                                                : Decimal{other.to_real()};
     return JSON{left + right};
   } else if (this->is_integer() && other.is_integer()) {
-    return JSON{this->to_integer() + other.to_integer()};
+    const auto left{this->to_integer()};
+    const auto right{other.to_integer()};
+    // Promote to arbitrary precision when the sum would not fit, since signed
+    // integer overflow is undefined behavior
+    if ((right > 0 && left > std::numeric_limits<Integer>::max() - right) ||
+        (right < 0 && left < std::numeric_limits<Integer>::min() - right)) {
+      return JSON{Decimal{left} + Decimal{right}};
+    }
+
+    return JSON{left + right};
   } else if (this->is_integer() && other.is_real()) {
     return JSON{this->as_real() + other.to_real()};
   } else if (this->is_real() && other.is_integer()) {
@@ -575,7 +585,16 @@ auto JSON::operator-(const JSON &other) const -> JSON {
                                                : Decimal{other.to_real()};
     return JSON{left - right};
   } else if (this->is_integer() && other.is_integer()) {
-    return JSON{this->to_integer() - other.to_integer()};
+    const auto left{this->to_integer()};
+    const auto right{other.to_integer()};
+    // Promote to arbitrary precision when the difference would not fit, since
+    // signed integer overflow is undefined behavior
+    if ((right < 0 && left > std::numeric_limits<Integer>::max() + right) ||
+        (right > 0 && left < std::numeric_limits<Integer>::min() + right)) {
+      return JSON{Decimal{left} - Decimal{right}};
+    }
+
+    return JSON{left - right};
   } else if (this->is_integer() && other.is_real()) {
     return JSON{this->as_real() - other.to_real()};
   } else if (this->is_real() && other.is_integer()) {

--- a/src/core/regex/regex.cc
+++ b/src/core/regex/regex.cc
@@ -4,7 +4,6 @@
 
 #include "preprocess.h"
 
-#include <cassert>      // assert
 #include <charconv>     // std::from_chars
 #include <cstdint>      // std::uint64_t
 #include <regex>        // std::regex, std::smatch, std::regex_match
@@ -55,7 +54,12 @@ auto to_regex(const std::string_view pattern) -> std::optional<Regex> {
       return std::nullopt;
     }
 
-    assert(minimum <= maximum);
+    // ECMA-262 defines "numbers out of order in {} quantifier" as a
+    // SyntaxError, so such a pattern is not a valid regular expression
+    if (minimum > maximum) {
+      return std::nullopt;
+    }
+
     return RegexTypeRange{minimum, maximum};
   }
 

--- a/src/core/time/asctime.cc
+++ b/src/core/time/asctime.cc
@@ -80,6 +80,11 @@ auto from_asctime(const std::string_view value) noexcept
   if (!is_valid_broken_down_time(parts)) {
     return std::nullopt;
   }
+  // RFC 9110 §5.6.7: HTTP-date is case sensitive
+  if (!is_case_sensitive_day_abbreviation(value.substr(0, 3), parts.tm_wday) ||
+      !is_case_sensitive_month_abbreviation(value.substr(4, 3), parts.tm_mon)) {
+    return std::nullopt;
+  }
 #if defined(_MSC_VER)
   return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
 #else

--- a/src/core/time/helpers.h
+++ b/src/core/time/helpers.h
@@ -3,11 +3,33 @@
 
 #include <sourcemeta/core/time.h>
 
-#include <cstdint> // std::uint8_t, std::uint16_t
-#include <ctime>   // std::tm
-#include <utility> // std::cmp_greater
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t, std::uint16_t
+#include <ctime>       // std::tm
+#include <string_view> // std::string_view
+#include <utility>     // std::cmp_greater
 
 namespace sourcemeta::core {
+
+// RFC 9110 §5.6.7: "HTTP-date is case sensitive". The standard library's
+// std::get_time matches day and month names case-insensitively on some
+// implementations, so the exact spelling is verified against the parsed index
+inline auto is_case_sensitive_day_abbreviation(const std::string_view name,
+                                               const int weekday) -> bool {
+  static constexpr std::array<std::string_view, 7> names{
+      {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}};
+  return weekday >= 0 && weekday < 7 &&
+         name == names[static_cast<std::size_t>(weekday)];
+}
+
+inline auto is_case_sensitive_month_abbreviation(const std::string_view name,
+                                                 const int month) -> bool {
+  static constexpr std::array<std::string_view, 12> names{
+      {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct",
+       "Nov", "Dec"}};
+  return month >= 0 && month < 12 &&
+         name == names[static_cast<std::size_t>(month)];
+}
 
 // Validate the calendar fields of a broken-down time, since the conversion to
 // an epoch time point would otherwise silently normalise out-of-range values

--- a/src/core/time/imf_fixdate.cc
+++ b/src/core/time/imf_fixdate.cc
@@ -75,6 +75,11 @@ auto from_imf_fixdate(const std::string_view value) noexcept
   if (!is_valid_broken_down_time(parts)) {
     return std::nullopt;
   }
+  // RFC 9110 §5.6.7: HTTP-date is case sensitive
+  if (!is_case_sensitive_day_abbreviation(value.substr(0, 3), parts.tm_wday) ||
+      !is_case_sensitive_month_abbreviation(value.substr(8, 3), parts.tm_mon)) {
+    return std::nullopt;
+  }
 #if defined(_MSC_VER)
   return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
 #else

--- a/src/core/time/rfc850_date.cc
+++ b/src/core/time/rfc850_date.cc
@@ -118,6 +118,11 @@ auto from_rfc850_date(const std::string_view value) noexcept
   if (!is_valid_broken_down_time(parts)) {
     return std::nullopt;
   }
+  // RFC 9110 §5.6.7: HTTP-date is case sensitive (the day name is already
+  // matched exactly against the table above)
+  if (!is_case_sensitive_month_abbreviation(rest.substr(4, 3), parts.tm_mon)) {
+    return std::nullopt;
+  }
 #if defined(_MSC_VER)
   return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
 #else

--- a/src/core/unicode/unicode.cc
+++ b/src/core/unicode/unicode.cc
@@ -225,6 +225,16 @@ auto utf8_to_wide(const std::string_view input) -> std::wstring {
   std::size_t read{0};
   while (read < input.size()) {
     const auto lead{static_cast<std::uint8_t>(input[read])};
+    // Stop on a multi-byte sequence that is truncated by the end of the input
+    // rather than reading past it
+    const std::size_t sequence{lead < 0x80    ? 1U
+                               : lead < 0xE0U ? 2U
+                               : lead < 0xF0U ? 3U
+                                              : 4U};
+    if (read + sequence > input.size()) {
+      break;
+    }
+
     if (lead < 0x80) {
       result[write++] = static_cast<wchar_t>(lead);
       read += 1;

--- a/src/core/uritemplate/helpers.h
+++ b/src/core/uritemplate/helpers.h
@@ -436,8 +436,14 @@ auto expand_expression(
 
         if (object_key.has_value()) {
           encode<T>(result, object_key.value());
-          result += '=';
-          encode<T>(result, actual_value);
+          if (actual_value.empty()) {
+            if constexpr (has_empty_suffix<T>::value) {
+              result += T::empty_suffix;
+            }
+          } else {
+            result += '=';
+            encode<T>(result, actual_value);
+          }
         } else if constexpr (T::named) {
           result += variable.name;
           if (actual_value.empty()) {
@@ -452,20 +458,23 @@ auto expand_expression(
           encode<T>(result, actual_value);
         }
       } else {
+        // An associative-array pair always contributes its key, so it is never
+        // empty even when the pair value is the empty string
+        const bool value_empty{!object_key.has_value() && actual_value.empty()};
         if (first_var && first_value) {
           if constexpr (has_prefix<T>::value) {
             result += T::prefix;
           }
           first_var = false;
-          append_name<T>(result, variable.name, actual_value.empty(), has_more);
+          append_name<T>(result, variable.name, value_empty, has_more);
         } else if (first_value) {
           result += T::separator;
-          append_name<T>(result, variable.name, actual_value.empty(), has_more);
+          append_name<T>(result, variable.name, value_empty, has_more);
         } else {
           result += ',';
         }
 
-        if (!first_value || !actual_value.empty() || has_more) {
+        if (!first_value || !value_empty || has_more) {
           if (object_key.has_value()) {
             encode<T>(result, object_key.value());
             result += ',';

--- a/src/core/yaml/parser.h
+++ b/src/core/yaml/parser.h
@@ -10,7 +10,8 @@
 #include <sourcemeta/core/yaml_roundtrip.h>
 
 #include <cassert>       // assert
-#include <cstdint>       // std::uint64_t
+#include <cstdint>       // std::uint64_t, std::int64_t
+#include <limits>        // std::numeric_limits
 #include <optional>      // std::optional
 #include <sstream>       // std::ostringstream
 #include <string>        // std::string
@@ -894,12 +895,21 @@ private:
       return JSON{Decimal{value}};
     }
 
-    const auto as_integer{static_cast<std::int64_t>(result.value())};
-    if (result.value() == static_cast<double>(as_integer)) {
-      return JSON{as_integer};
+    // Only convert to an integer when the value is within the representable
+    // range, since casting an out-of-range double to an integer is undefined
+    // behavior
+    const auto number{result.value()};
+    if (number >=
+            static_cast<double>(std::numeric_limits<std::int64_t>::min()) &&
+        number <
+            static_cast<double>(std::numeric_limits<std::int64_t>::max())) {
+      const auto as_integer{static_cast<std::int64_t>(number)};
+      if (number == static_cast<double>(as_integer)) {
+        return JSON{as_integer};
+      }
     }
 
-    return JSON{result.value()};
+    return JSON{number};
   }
 
   auto parse_flow_mapping(const Token &start_token,

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -25,28 +25,33 @@ auto strip_trailing_zeros(std::int64_t &coefficient, std::int32_t &exponent)
     return;
   }
 
+  // The exponent is already clamped to the representable range at parse time,
+  // so a strip is only performed when the exponent can absorb the matching
+  // increment. Otherwise the increment would overflow, and dividing the
+  // coefficient without it would change the represented value
+  constexpr std::int32_t maximum{std::numeric_limits<std::int32_t>::max()};
   constexpr std::int64_t POWER_OF_10_16 = 10000000000000000LL;
-  if (coefficient % POWER_OF_10_16 == 0) {
+  if (exponent <= maximum - 16 && coefficient % POWER_OF_10_16 == 0) {
     coefficient /= POWER_OF_10_16;
     exponent += 16;
   }
 
-  if (coefficient % 100000000 == 0) {
+  if (exponent <= maximum - 8 && coefficient % 100000000 == 0) {
     coefficient /= 100000000;
     exponent += 8;
   }
 
-  if (coefficient % 10000 == 0) {
+  if (exponent <= maximum - 4 && coefficient % 10000 == 0) {
     coefficient /= 10000;
     exponent += 4;
   }
 
-  if (coefficient % 100 == 0) {
+  if (exponent <= maximum - 2 && coefficient % 100 == 0) {
     coefficient /= 100;
     exponent += 2;
   }
 
-  if (coefficient % 10 == 0) {
+  if (exponent <= maximum - 1 && coefficient % 10 == 0) {
     coefficient /= 10;
     exponent += 1;
   }
@@ -469,12 +474,22 @@ Decimal::Decimal(const std::int64_t value) {
     this->coefficient_ = static_cast<std::int64_t>(absolute_value % BASE);
     this->coefficient_high_ = absolute_value / BASE;
     this->flags_ = FLAG_BIG | FLAG_SIGN | FLAG_INTEGER_LITERAL;
-  } else if (value < 0) {
-    this->coefficient_ = -value;
-    this->flags_ = FLAG_SIGN | FLAG_INTEGER_LITERAL;
+    return;
+  }
+
+  const bool negative{value < 0};
+  const auto magnitude{static_cast<std::uint64_t>(negative ? -value : value)};
+  // A magnitude beyond the compact range must use the big representation, since
+  // the compact arithmetic paths assume operands fit within it
+  if (magnitude > static_cast<std::uint64_t>(COMPACT_MAX)) {
+    this->coefficient_ = static_cast<std::int64_t>(magnitude % BASE);
+    this->coefficient_high_ = magnitude / BASE;
+    this->flags_ = static_cast<std::uint8_t>(FLAG_BIG | FLAG_INTEGER_LITERAL |
+                                             (negative ? FLAG_SIGN : 0));
   } else {
-    this->coefficient_ = value;
-    this->flags_ = FLAG_INTEGER_LITERAL;
+    this->coefficient_ = static_cast<std::int64_t>(magnitude);
+    this->flags_ = static_cast<std::uint8_t>(FLAG_INTEGER_LITERAL |
+                                             (negative ? FLAG_SIGN : 0));
   }
 }
 

--- a/test/json/json_decimal_test.cc
+++ b/test/json/json_decimal_test.cc
@@ -1212,3 +1212,11 @@ TEST(negative_exponent_non_integral) {
   EXPECT_FALSE(document.to_decimal().is_integer());
   EXPECT_FALSE(document.to_decimal().is_integral());
 }
+
+// A parse-clamped exponent must not overflow the internal 32-bit exponent
+// while stripping trailing zeros during a comparison.
+TEST(large_exponent_comparison_no_overflow) {
+  const auto value{
+      sourcemeta::core::parse_json("10000000000000000e2147483647")};
+  EXPECT_TRUE(value == value);
+}

--- a/test/json/json_integer_test.cc
+++ b/test/json/json_integer_test.cc
@@ -1,6 +1,9 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/test.h>
 
+#include <cstdint> // std::int64_t
+#include <limits>  // std::numeric_limits
+
 TEST(positive) {
   const sourcemeta::core::JSON document{10};
   EXPECT_TRUE(document.is_integer());
@@ -135,4 +138,24 @@ TEST(subtraction_assignment_integer_decimal) {
   integer -= decimal;
   EXPECT_TRUE(integer.is_decimal());
   EXPECT_EQ(integer.to_decimal().to_string(), "1.8");
+}
+
+// Adding or subtracting past the integer range promotes to arbitrary precision
+// rather than wrapping, since signed integer overflow is undefined behavior.
+TEST(addition_overflow_promotes_to_decimal) {
+  const sourcemeta::core::JSON maximum{
+      std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON one{static_cast<std::int64_t>(1)};
+  const auto result{maximum + one};
+  EXPECT_TRUE(result.is_decimal());
+  EXPECT_FALSE(result.is_integer());
+}
+
+TEST(subtraction_overflow_promotes_to_decimal) {
+  const sourcemeta::core::JSON minimum{
+      std::numeric_limits<std::int64_t>::min()};
+  const sourcemeta::core::JSON one{static_cast<std::int64_t>(1)};
+  const auto result{minimum - one};
+  EXPECT_TRUE(result.is_decimal());
+  EXPECT_FALSE(result.is_integer());
 }

--- a/test/json/json_parse_callback_test.cc
+++ b/test/json/json_parse_callback_test.cc
@@ -386,3 +386,21 @@ TEST(read_json_stub_bigint) {
   EXPECT_TRACE(0, Pre, Decimal, 1, 1, Root, 0, "");
   EXPECT_TRACE(1, Post, Decimal, 1, 19, Root, 0, "");
 }
+
+// A trailing-content failure must leave the output untouched, since the value
+// is parsed into a temporary and only moved out on success.
+TEST(trailing_content_leaves_output_untouched) {
+  sourcemeta::core::JSON output{"sentinel"};
+  const auto callback =
+      [](const sourcemeta::core::JSON::ParsePhase,
+         const sourcemeta::core::JSON::Type, const std::uint64_t,
+         const std::uint64_t, const sourcemeta::core::JSON::ParseContext,
+         const std::size_t, const sourcemeta::core::JSON::String &) {};
+  try {
+    sourcemeta::core::parse_json("1 x", output, callback);
+    FAIL();
+  } catch (const sourcemeta::core::JSONParseError &) {
+    EXPECT_TRUE(output.is_string());
+    EXPECT_EQ(output.to_string(), "sentinel");
+  }
+}

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -744,3 +744,29 @@ TEST(parsing_nan_keyword_fails) {
   std::istringstream input{"NaN"};
   EXPECT_PARSE_ERROR(input, 1, 1);
 }
+
+// The string_view overloads reject trailing content and report the position of
+// the offending character rather than where the value ended.
+TEST(trailing_content_reports_position) {
+  bool threw{false};
+  try {
+    sourcemeta::core::parse_json("1 x");
+  } catch (const sourcemeta::core::JSONParseError &error) {
+    threw = true;
+    EXPECT_EQ(error.line(), 1);
+    EXPECT_EQ(error.column(), 3);
+  }
+  EXPECT_TRUE(threw);
+}
+
+TEST(trailing_content_after_newline_reports_position) {
+  bool threw{false};
+  try {
+    sourcemeta::core::parse_json("1\n  x");
+  } catch (const sourcemeta::core::JSONParseError &error) {
+    threw = true;
+    EXPECT_EQ(error.line(), 2);
+    EXPECT_EQ(error.column(), 3);
+  }
+  EXPECT_TRUE(threw);
+}

--- a/test/json/json_parse_error_test.cc
+++ b/test/json/json_parse_error_test.cc
@@ -748,25 +748,21 @@ TEST(parsing_nan_keyword_fails) {
 // The string_view overloads reject trailing content and report the position of
 // the offending character rather than where the value ended.
 TEST(trailing_content_reports_position) {
-  bool threw{false};
   try {
     sourcemeta::core::parse_json("1 x");
+    FAIL();
   } catch (const sourcemeta::core::JSONParseError &error) {
-    threw = true;
     EXPECT_EQ(error.line(), 1);
     EXPECT_EQ(error.column(), 3);
   }
-  EXPECT_TRUE(threw);
 }
 
 TEST(trailing_content_after_newline_reports_position) {
-  bool threw{false};
   try {
     sourcemeta::core::parse_json("1\n  x");
+    FAIL();
   } catch (const sourcemeta::core::JSONParseError &error) {
-    threw = true;
     EXPECT_EQ(error.line(), 2);
     EXPECT_EQ(error.column(), 3);
   }
-  EXPECT_TRUE(threw);
 }

--- a/test/json/json_try_parse_test.cc
+++ b/test/json/json_try_parse_test.cc
@@ -61,3 +61,13 @@ TEST(rejects_unclosed_object) {
 TEST(rejects_invalid_number) {
   EXPECT_FALSE(sourcemeta::core::try_parse_json("01").has_value());
 }
+
+// RFC 8259 Section 2: a JSON text is a single value optionally surrounded by
+// whitespace, so trailing content after the value must be rejected.
+TEST(rejects_trailing_content) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("123abc").has_value());
+}
+
+TEST(rejects_trailing_literal) {
+  EXPECT_FALSE(sourcemeta::core::try_parse_json("true false").has_value());
+}

--- a/test/regex/regex_matches_ecma262_test.cc
+++ b/test/regex/regex_matches_ecma262_test.cc
@@ -3395,3 +3395,8 @@ TEST(ecma262_empty_class_negated_quantified) {
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
 }
+
+TEST(ecma262_bounded_quantifier_out_of_order_is_invalid) {
+  EXPECT_FALSE(sourcemeta::core::to_regex("^.{5,2}$").has_value());
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("^.{5,2}$"));
+}

--- a/test/time/asctime_test.cc
+++ b/test/time/asctime_test.cc
@@ -164,3 +164,14 @@ TEST(format_two_digit_day) {
 #endif
   EXPECT_EQ(sourcemeta::core::to_asctime(point), "Wed Oct 21 11:28:00 2015");
 }
+
+// RFC 9110 s5.6.7: HTTP-date is case sensitive.
+TEST(parse_wrong_case_month_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::from_asctime("Sun nOV  6 08:49:37 1994").has_value());
+}
+
+TEST(parse_wrong_case_day_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::from_asctime("sun Nov  6 08:49:37 1994").has_value());
+}

--- a/test/time/imf_fixdate_test.cc
+++ b/test/time/imf_fixdate_test.cc
@@ -234,3 +234,23 @@ TEST(format_epoch) {
   EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point),
             "Thu, 01 Jan 1970 00:00:00 GMT");
 }
+
+// RFC 9110 §5.6.7: "HTTP-date is case sensitive". Wrong-case day or month
+// names must be rejected.
+TEST(parse_wrong_case_day_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::from_imf_fixdate("wed, 21 Oct 2015 11:28:00 GMT")
+          .has_value());
+}
+
+TEST(parse_wrong_case_month_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::from_imf_fixdate("Wed, 21 oCT 2015 11:28:00 GMT")
+          .has_value());
+}
+
+TEST(parse_upper_case_month_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::from_imf_fixdate("Wed, 21 OCT 2015 11:28:00 GMT")
+          .has_value());
+}

--- a/test/time/rfc850_date_test.cc
+++ b/test/time/rfc850_date_test.cc
@@ -255,3 +255,10 @@ TEST(format_round_trip) {
   EXPECT_EQ(sourcemeta::core::to_rfc850_date(point),
             "Thursday, 01-Jan-70 00:00:00 GMT");
 }
+
+// RFC 9110 s5.6.7: HTTP-date is case sensitive.
+TEST(parse_wrong_case_month_name) {
+  EXPECT_FALSE(
+      sourcemeta::core::from_rfc850_date("Sunday, 06-nOV-94 08:49:37 GMT")
+          .has_value());
+}

--- a/test/unicode/unicode_utf8_to_wide_test.cc
+++ b/test/unicode/unicode_utf8_to_wide_test.cc
@@ -116,7 +116,10 @@ TEST(embedded_null_byte) {
 
 // A multi-byte sequence truncated by the end of the input must not read past
 // the view. The buffer is exactly sized so a byte-count regression trips the
-// address sanitizer.
+// address sanitizer. These exercise the portable decoder, since on Windows the
+// conversion delegates to a platform API that substitutes a replacement
+// character instead, so the exact result differs there.
+#if !defined(_WIN32) && !defined(__CYGWIN__)
 TEST(truncated_four_byte_lead_no_overflow) {
   char *buffer{new char[1]};
   buffer[0] = static_cast<char>(0xF0);
@@ -144,3 +147,4 @@ TEST(truncated_two_byte_lead_no_overflow) {
   delete[] buffer;
   EXPECT_EQ(result, std::wstring{L"a"});
 }
+#endif

--- a/test/unicode/unicode_utf8_to_wide_test.cc
+++ b/test/unicode/unicode_utf8_to_wide_test.cc
@@ -113,3 +113,34 @@ TEST(embedded_null_byte) {
   const std::wstring expected{L"a\0b", 3};
   EXPECT_EQ(sourcemeta::core::utf8_to_wide(input), expected);
 }
+
+// A multi-byte sequence truncated by the end of the input must not read past
+// the view. The buffer is exactly sized so a byte-count regression trips the
+// address sanitizer.
+TEST(truncated_four_byte_lead_no_overflow) {
+  char *buffer{new char[1]};
+  buffer[0] = static_cast<char>(0xF0);
+  const std::string_view view{buffer, 1};
+  const auto result{sourcemeta::core::utf8_to_wide(view)};
+  delete[] buffer;
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(truncated_three_byte_lead_no_overflow) {
+  char *buffer{new char[1]};
+  buffer[0] = static_cast<char>(0xE0);
+  const std::string_view view{buffer, 1};
+  const auto result{sourcemeta::core::utf8_to_wide(view)};
+  delete[] buffer;
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(truncated_two_byte_lead_no_overflow) {
+  char *buffer{new char[2]};
+  buffer[0] = static_cast<char>(0x61);
+  buffer[1] = static_cast<char>(0xC2);
+  const std::string_view view{buffer, 2};
+  const auto result{sourcemeta::core::utf8_to_wide(view)};
+  delete[] buffer;
+  EXPECT_EQ(result, std::wstring{L"a"});
+}

--- a/test/uritemplate/uritemplate_expand_test.cc
+++ b/test/uritemplate/uritemplate_expand_test.cc
@@ -837,3 +837,45 @@ TEST(object_explode_path_param) {
 
   EXPECT_EQ(result, ";semi=%3B;dot=.");
 }
+
+// RFC 6570 3.2.1 + Appendix A: for the ";" operator, an exploded
+// associative-array pair with an empty value emits just the name (";a"), since
+// "ifemp" is empty for ";". The "=" only applies to form-style (?/&).
+TEST(object_explode_empty_value_semicolon) {
+  const sourcemeta::core::URITemplate uri_template{"{;keys*}"};
+  const auto result = uri_template.expand(
+      [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
+        if (name == "keys") {
+          return std::make_tuple(std::string_view{""}, std::string_view{"a"},
+                                 false);
+        }
+        return std::nullopt;
+      });
+  EXPECT_EQ(result, ";a");
+}
+
+TEST(object_explode_empty_value_query) {
+  const sourcemeta::core::URITemplate uri_template{"{?keys*}"};
+  const auto result = uri_template.expand(
+      [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
+        if (name == "keys") {
+          return std::make_tuple(std::string_view{""}, std::string_view{"a"},
+                                 false);
+        }
+        return std::nullopt;
+      });
+  EXPECT_EQ(result, "?a=");
+}
+
+TEST(object_no_explode_empty_value_semicolon) {
+  const sourcemeta::core::URITemplate uri_template{"{;keys}"};
+  const auto result = uri_template.expand(
+      [](const std::string_view name) -> sourcemeta::core::URITemplateValue {
+        if (name == "keys") {
+          return std::make_tuple(std::string_view{""}, std::string_view{"a"},
+                                 false);
+        }
+        return std::nullopt;
+      });
+  EXPECT_EQ(result, ";keys=a,");
+}

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -569,3 +569,19 @@ TEST(exponential_alias_expansion_is_bounded) {
     FAIL();
   }
 }
+
+// A !!float tag whose value is outside the 64-bit integer range must not
+// invoke undefined behavior by casting an out-of-range double to an integer.
+TEST(float_tag_out_of_integer_range) {
+  const std::string input{"!!float 1e300"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  EXPECT_TRUE(result.is_real());
+  EXPECT_EQ(result.to_real(), 1e300);
+}
+
+TEST(float_tag_just_above_integer_range) {
+  const std::string input{"!!float 1e19"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  EXPECT_TRUE(result.is_real());
+  EXPECT_EQ(result.to_real(), 1e19);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

