### PR TITLE
Revise `JSON::operator==` for mathematical equality

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -328,14 +328,16 @@ public:
    * Operators
    */
 
-  auto operator<(const JSON &other) const noexcept -> bool;
-  auto operator<=(const JSON &other) const noexcept -> bool;
-  auto operator>(const JSON &other) const noexcept -> bool;
-  auto operator>=(const JSON &other) const noexcept -> bool;
+  auto operator<(const JSON &other) const -> bool;
+  auto operator<=(const JSON &other) const -> bool;
+  auto operator>(const JSON &other) const -> bool;
+  auto operator>=(const JSON &other) const -> bool;
 
   /// Compare two JSON instances for equality. Numbers compare by exact
   /// mathematical value across the integer, real, and decimal representations,
-  /// so the same value written in different forms is equal. For example:
+  /// so the same value in different forms is equal. A real compares by the
+  /// exact number its floating point form stores, which can differ from the
+  /// same digits written as a decimal. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/json.h>
@@ -343,8 +345,8 @@ public:
   ///
   /// assert(sourcemeta::core::JSON{2} == sourcemeta::core::JSON{2.0});
   /// ```
-  auto operator==(const JSON &other) const noexcept -> bool;
-  auto operator!=(const JSON &) const noexcept -> bool = default;
+  auto operator==(const JSON &other) const -> bool;
+  auto operator!=(const JSON &) const -> bool = default;
 
   /// Add two numeric JSON instances and get a new instance with the result. For
   /// example:

--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -332,6 +332,17 @@ public:
   auto operator<=(const JSON &other) const noexcept -> bool;
   auto operator>(const JSON &other) const noexcept -> bool;
   auto operator>=(const JSON &other) const noexcept -> bool;
+
+  /// Compare two JSON instances for equality. Numbers compare by exact
+  /// mathematical value across the integer, real, and decimal representations,
+  /// so the same value written in different forms is equal. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// assert(sourcemeta::core::JSON{2} == sourcemeta::core::JSON{2.0});
+  /// ```
   auto operator==(const JSON &other) const noexcept -> bool;
   auto operator!=(const JSON &) const noexcept -> bool = default;
 

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -3,7 +3,8 @@
 
 #include <algorithm>        // std::ranges::contains, std::ranges::fold_left
 #include <cassert>          // assert
-#include <cmath>            // std::isinf, std::isnan, std::modf
+#include <cmath>            // std::isinf, std::isnan, std::modf, std::floor
+#include <compare>          // std::strong_ordering, std::is_eq, std::is_lt
 #include <cstddef>          // std::size_t
 #include <cstdint>          // std::int64_t
 #include <exception>        // std::terminate
@@ -21,6 +22,95 @@
 namespace sourcemeta::core {
 
 static constexpr auto TRIM_WHITESPACE = " \t\n\r\v\f";
+
+namespace {
+
+// Reverse the direction of a comparison result
+auto reverse_ordering(const std::strong_ordering ordering)
+    -> std::strong_ordering {
+  if (std::is_lt(ordering)) {
+    return std::strong_ordering::greater;
+  }
+
+  if (std::is_gt(ordering)) {
+    return std::strong_ordering::less;
+  }
+
+  return std::strong_ordering::equal;
+}
+
+// Order a 64-bit integer against a real by exact value, without ever converting
+// the integer to a double, which would lose precision beyond 2^53
+auto integer_real_ordering(const std::int64_t left, const double right)
+    -> std::strong_ordering {
+  // Real values in a JSON document are always finite
+  constexpr double lowest{-9223372036854775808.0};
+  constexpr double past_highest{9223372036854775808.0};
+  const double floor_of_right{std::floor(right)};
+  if (floor_of_right >= past_highest) {
+    return std::strong_ordering::less;
+  }
+
+  if (floor_of_right < lowest) {
+    return std::strong_ordering::greater;
+  }
+
+  const auto integer_floor{static_cast<std::int64_t>(floor_of_right)};
+  if (left != integer_floor) {
+    return left < integer_floor ? std::strong_ordering::less
+                                : std::strong_ordering::greater;
+  }
+
+  // The integer equals the floor of the real, so they are equal only when the
+  // real has no fractional part, and otherwise the real is the larger of the
+  // two
+  return floor_of_right == right ? std::strong_ordering::equal
+                                 : std::strong_ordering::less;
+}
+
+// Order two numbers held in different representations by exact mathematical
+// value. Integer and integral operands are compared without allocating, and
+// only a real against a non-integral or out-of-range decimal falls back to the
+// exact arbitrary precision expansion
+auto cross_numeric_ordering(const JSON &left, const JSON &right)
+    -> std::strong_ordering {
+  if (left.is_integer() && right.is_real()) {
+    return integer_real_ordering(left.to_integer(), right.to_real());
+  }
+
+  if (left.is_real() && right.is_integer()) {
+    return reverse_ordering(
+        integer_real_ordering(right.to_integer(), left.to_real()));
+  }
+
+  if (left.is_real() && right.is_decimal() &&
+      right.to_decimal().is_integral() && right.to_decimal().is_int64()) {
+    return reverse_ordering(
+        integer_real_ordering(right.to_decimal().to_int64(), left.to_real()));
+  }
+
+  if (left.is_decimal() && right.is_real() && left.to_decimal().is_integral() &&
+      left.to_decimal().is_int64()) {
+    return integer_real_ordering(left.to_decimal().to_int64(), right.to_real());
+  }
+
+  const Decimal left_decimal = left.is_decimal() ? left.to_decimal()
+                               : left.is_integer()
+                                   ? Decimal{left.to_integer()}
+                                   : Decimal::exact_from(left.to_real());
+  const Decimal right_decimal = right.is_decimal() ? right.to_decimal()
+                                : right.is_integer()
+                                    ? Decimal{right.to_integer()}
+                                    : Decimal::exact_from(right.to_real());
+  if (left_decimal == right_decimal) {
+    return std::strong_ordering::equal;
+  }
+
+  return left_decimal < right_decimal ? std::strong_ordering::less
+                                      : std::strong_ordering::greater;
+}
+
+} // namespace
 
 JSON::JSON(const std::int64_t value) : current_type{Type::Integer} {
   this->data_integer = value;
@@ -434,23 +524,14 @@ auto JSON::size(const String &value) noexcept -> std::size_t {
   return result;
 }
 
-// Two numbers of different representations are ordered by exact mathematical
-// value, which is done by promoting both operands to the arbitrary precision
-// type. That conversion can allocate, so this is not strictly non-throwing, but
-// the only possible escape is an allocation failure, which is fatal regardless
+// Ordering numbers of different representations by exact value may allocate an
+// arbitrary precision expansion, so this is not strictly non-throwing, but the
+// only possible escape is an allocation failure, which is fatal regardless
 // NOLINTNEXTLINE(bugprone-exception-escape)
 auto JSON::operator<(const JSON &other) const noexcept -> bool {
   if (this->is_number() && other.is_number() &&
       this->current_type != other.current_type) {
-    const Decimal left = this->is_decimal() ? this->to_decimal()
-                         : this->is_integer()
-                             ? Decimal{this->to_integer()}
-                             : Decimal::exact_from(this->to_real());
-    const Decimal right = other.is_decimal() ? other.to_decimal()
-                          : other.is_integer()
-                              ? Decimal{other.to_integer()}
-                              : Decimal::exact_from(other.to_real());
-    return left < right;
+    return std::is_lt(cross_numeric_ordering(*this, other));
   }
 
   if (this->type() != other.type()) {
@@ -491,23 +572,14 @@ auto JSON::operator>=(const JSON &other) const noexcept -> bool {
   return *this > other || *this == other;
 }
 
-// Two numbers of different representations are compared by exact mathematical
-// value, which is done by promoting both operands to the arbitrary precision
-// type. That conversion can allocate, so this is not strictly non-throwing, but
-// the only possible escape is an allocation failure, which is fatal regardless
+// Comparing numbers of different representations by exact value may allocate an
+// arbitrary precision expansion, so this is not strictly non-throwing, but the
+// only possible escape is an allocation failure, which is fatal regardless
 // NOLINTNEXTLINE(bugprone-exception-escape)
 auto JSON::operator==(const JSON &other) const noexcept -> bool {
   if (this->is_number() && other.is_number() &&
       this->current_type != other.current_type) {
-    const Decimal left = this->is_decimal() ? this->to_decimal()
-                         : this->is_integer()
-                             ? Decimal{this->to_integer()}
-                             : Decimal::exact_from(this->to_real());
-    const Decimal right = other.is_decimal() ? other.to_decimal()
-                          : other.is_integer()
-                              ? Decimal{other.to_integer()}
-                              : Decimal::exact_from(other.to_real());
-    return left == right;
+    return std::is_eq(cross_numeric_ordering(*this, other));
   }
 
   if (this->current_type != other.current_type) {

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -434,25 +434,22 @@ auto JSON::size(const String &value) noexcept -> std::size_t {
   return result;
 }
 
-// `as_real` is reached only for integer and real operands here, never a
-// decimal, so it cannot throw even though it is no longer noexcept
+// Two numbers of different representations are ordered by exact mathematical
+// value, which is done by promoting both operands to the arbitrary precision
+// type. That conversion can allocate, so this is not strictly non-throwing, but
+// the only possible escape is an allocation failure, which is fatal regardless
 // NOLINTNEXTLINE(bugprone-exception-escape)
 auto JSON::operator<(const JSON &other) const noexcept -> bool {
-  if ((this->type() == Type::Integer && other.type() == Type::Real) ||
-      (this->type() == Type::Real && other.type() == Type::Integer)) {
-    return this->as_real() < other.as_real();
-  }
-
-  if ((this->type() == Type::Decimal &&
-       (other.type() == Type::Integer || other.type() == Type::Real)) ||
-      ((this->type() == Type::Integer || this->type() == Type::Real) &&
-       other.type() == Type::Decimal)) {
-    const Decimal left = this->is_decimal()   ? this->to_decimal()
-                         : this->is_integer() ? Decimal{this->to_integer()}
-                                              : Decimal{this->to_real()};
-    const Decimal right = other.is_decimal()   ? other.to_decimal()
-                          : other.is_integer() ? Decimal{other.to_integer()}
-                                               : Decimal{other.to_real()};
+  if (this->is_number() && other.is_number() &&
+      this->current_type != other.current_type) {
+    const Decimal left = this->is_decimal() ? this->to_decimal()
+                         : this->is_integer()
+                             ? Decimal{this->to_integer()}
+                             : Decimal::exact_from(this->to_real());
+    const Decimal right = other.is_decimal() ? other.to_decimal()
+                          : other.is_integer()
+                              ? Decimal{other.to_integer()}
+                              : Decimal::exact_from(other.to_real());
     return left < right;
   }
 
@@ -494,25 +491,22 @@ auto JSON::operator>=(const JSON &other) const noexcept -> bool {
   return *this > other || *this == other;
 }
 
-// `as_real` is reached only for integer and real operands here, never a
-// decimal, so it cannot throw even though it is no longer noexcept
+// Two numbers of different representations are compared by exact mathematical
+// value, which is done by promoting both operands to the arbitrary precision
+// type. That conversion can allocate, so this is not strictly non-throwing, but
+// the only possible escape is an allocation failure, which is fatal regardless
 // NOLINTNEXTLINE(bugprone-exception-escape)
 auto JSON::operator==(const JSON &other) const noexcept -> bool {
-  if ((this->type() == Type::Integer && other.type() == Type::Real) ||
-      (this->type() == Type::Real && other.type() == Type::Integer)) {
-    return this->as_real() == other.as_real();
-  }
-
-  if ((this->type() == Type::Decimal &&
-       (other.type() == Type::Integer || other.type() == Type::Real)) ||
-      ((this->type() == Type::Integer || this->type() == Type::Real) &&
-       other.type() == Type::Decimal)) {
-    const Decimal left = this->is_decimal()   ? this->to_decimal()
-                         : this->is_integer() ? Decimal{this->to_integer()}
-                                              : Decimal{this->to_real()};
-    const Decimal right = other.is_decimal()   ? other.to_decimal()
-                          : other.is_integer() ? Decimal{other.to_integer()}
-                                               : Decimal{other.to_real()};
+  if (this->is_number() && other.is_number() &&
+      this->current_type != other.current_type) {
+    const Decimal left = this->is_decimal() ? this->to_decimal()
+                         : this->is_integer()
+                             ? Decimal{this->to_integer()}
+                             : Decimal::exact_from(this->to_real());
+    const Decimal right = other.is_decimal() ? other.to_decimal()
+                          : other.is_integer()
+                              ? Decimal{other.to_integer()}
+                              : Decimal::exact_from(other.to_real());
     return left == right;
   }
 

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -525,10 +525,8 @@ auto JSON::size(const String &value) noexcept -> std::size_t {
 }
 
 // Ordering numbers of different representations by exact value may allocate an
-// arbitrary precision expansion, so this is not strictly non-throwing, but the
-// only possible escape is an allocation failure, which is fatal regardless
-// NOLINTNEXTLINE(bugprone-exception-escape)
-auto JSON::operator<(const JSON &other) const noexcept -> bool {
+// arbitrary precision expansion, so this comparison is not noexcept
+auto JSON::operator<(const JSON &other) const -> bool {
   if (this->is_number() && other.is_number() &&
       this->current_type != other.current_type) {
     return std::is_lt(cross_numeric_ordering(*this, other));
@@ -560,23 +558,21 @@ auto JSON::operator<(const JSON &other) const noexcept -> bool {
   }
 }
 
-auto JSON::operator<=(const JSON &other) const noexcept -> bool {
+auto JSON::operator<=(const JSON &other) const -> bool {
   return *this < other || *this == other;
 }
 
-auto JSON::operator>(const JSON &other) const noexcept -> bool {
+auto JSON::operator>(const JSON &other) const -> bool {
   return !(*this < other) && *this != other;
 }
 
-auto JSON::operator>=(const JSON &other) const noexcept -> bool {
+auto JSON::operator>=(const JSON &other) const -> bool {
   return *this > other || *this == other;
 }
 
 // Comparing numbers of different representations by exact value may allocate an
-// arbitrary precision expansion, so this is not strictly non-throwing, but the
-// only possible escape is an allocation failure, which is fatal regardless
-// NOLINTNEXTLINE(bugprone-exception-escape)
-auto JSON::operator==(const JSON &other) const noexcept -> bool {
+// arbitrary precision expansion, so this comparison is not noexcept
+auto JSON::operator==(const JSON &other) const -> bool {
   if (this->is_number() && other.is_number() &&
       this->current_type != other.current_type) {
     return std::is_eq(cross_numeric_ordering(*this, other));

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -6,8 +6,8 @@
 #include <array>     // std::array
 #include <cassert>   // assert
 #include <charconv>  // std::to_chars
-#include <cmath>     // std::isfinite, std::isnan, std::isinf, std::signbit,
-                     // std::abs, std::frexp, std::ldexp
+#include <cmath>     // std::isfinite, std::isnan, std::isinf, std::abs,
+                     // std::frexp, std::ldexp
 #include <cstddef>   // std::size_t
 #include <cstring>   // std::strlen
 #include <iomanip>   // std::setprecision
@@ -659,12 +659,10 @@ auto Decimal::exact_from(const double value) -> Decimal {
     return value < 0 ? Decimal::negative_infinity() : Decimal::infinity();
   }
 
+  // The library builds without IEEE signed zeros, so a negative zero is
+  // indistinguishable from a positive zero and always yields an unsigned zero
   if (value == 0.0) {
     Decimal output{static_cast<std::int64_t>(0)};
-    if (std::signbit(value)) {
-      output.flags_ |= FLAG_SIGN;
-    }
-
     output.flags_ =
         static_cast<std::uint8_t>(output.flags_ & ~FLAG_INTEGER_LITERAL);
     return output;
@@ -672,7 +670,7 @@ auto Decimal::exact_from(const double value) -> Decimal {
 
   const std::string magnitude{
       exact_magnitude_to_decimal_string(std::abs(value))};
-  Decimal output{std::signbit(value) ? "-" + magnitude : magnitude};
+  Decimal output{value < 0.0 ? "-" + magnitude : magnitude};
   output.flags_ =
       static_cast<std::uint8_t>(output.flags_ & ~FLAG_INTEGER_LITERAL);
   return output;

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -6,7 +6,8 @@
 #include <array>     // std::array
 #include <cassert>   // assert
 #include <charconv>  // std::to_chars
-#include <cmath>     // std::isfinite
+#include <cmath>     // std::isfinite, std::isnan, std::isinf, std::signbit,
+                     // std::abs, std::frexp, std::ldexp
 #include <cstddef>   // std::size_t
 #include <cstring>   // std::strlen
 #include <iomanip>   // std::setprecision
@@ -55,6 +56,78 @@ auto strip_trailing_zeros(std::int64_t &coefficient, std::int32_t &exponent)
     coefficient /= 10;
     exponent += 1;
   }
+}
+
+// Multiply a magnitude held as base-10 digits, least significant first, by a
+// small factor in place
+auto multiply_decimal_digits(std::vector<std::uint8_t> &digits,
+                             const unsigned factor) -> void {
+  unsigned carry{0};
+  for (auto &digit : digits) {
+    const unsigned product{digit * factor + carry};
+    digit = static_cast<std::uint8_t>(product % 10);
+    carry = product / 10;
+  }
+
+  while (carry > 0) {
+    digits.push_back(static_cast<std::uint8_t>(carry % 10));
+    carry /= 10;
+  }
+}
+
+// Build the exact decimal string of a finite, non-zero magnitude. Every finite
+// double is a dyadic rational, so its exact value has a finite decimal
+// expansion recovered from the integer mantissa and the binary exponent
+auto exact_magnitude_to_decimal_string(const double magnitude) -> std::string {
+  int fraction_exponent{0};
+  const double fraction{std::frexp(magnitude, &fraction_exponent)};
+  // The fraction lies in [0.5, 1), so scaling it by 2^53 yields the exact
+  // integer mantissa
+  std::uint64_t mantissa{static_cast<std::uint64_t>(std::ldexp(fraction, 53))};
+  std::int32_t binary_exponent{static_cast<std::int32_t>(fraction_exponent) -
+                               53};
+
+  // Dropping trailing zero bits keeps the following multiplications short and
+  // avoids emitting spurious trailing decimal zeros
+  while (mantissa != 0 && (mantissa & 1U) == 0) {
+    mantissa >>= 1U;
+    binary_exponent += 1;
+  }
+
+  std::vector<std::uint8_t> digits;
+  for (std::uint64_t remaining{mantissa}; remaining > 0; remaining /= 10) {
+    digits.push_back(static_cast<std::uint8_t>(remaining % 10));
+  }
+
+  std::int32_t fractional_length{0};
+  if (binary_exponent >= 0) {
+    for (std::int32_t index = 0; index < binary_exponent; index += 1) {
+      multiply_decimal_digits(digits, 2);
+    }
+  } else {
+    fractional_length = -binary_exponent;
+    for (std::int32_t index = 0; index < fractional_length; index += 1) {
+      multiply_decimal_digits(digits, 5);
+    }
+  }
+
+  std::string coefficient;
+  coefficient.reserve(digits.size());
+  for (std::size_t index = digits.size(); index > 0; index -= 1) {
+    coefficient.push_back(static_cast<char>('0' + digits[index - 1]));
+  }
+
+  if (fractional_length == 0) {
+    return coefficient;
+  }
+
+  const auto fractional{static_cast<std::size_t>(fractional_length)};
+  if (coefficient.size() > fractional) {
+    const std::size_t split{coefficient.size() - fractional};
+    return coefficient.substr(0, split) + "." + coefficient.substr(split);
+  }
+
+  return "0." + std::string(fractional - coefficient.size(), '0') + coefficient;
 }
 
 template <typename FloatingPointType>
@@ -572,6 +645,34 @@ auto Decimal::strict_from(const double value) -> Decimal {
   assert(result.ec == std::errc{});
   Decimal output{std::string_view{
       buffer.data(), static_cast<std::size_t>(result.ptr - buffer.data())}};
+  output.flags_ =
+      static_cast<std::uint8_t>(output.flags_ & ~FLAG_INTEGER_LITERAL);
+  return output;
+}
+
+auto Decimal::exact_from(const double value) -> Decimal {
+  if (std::isnan(value)) {
+    return Decimal::nan();
+  }
+
+  if (std::isinf(value)) {
+    return value < 0 ? Decimal::negative_infinity() : Decimal::infinity();
+  }
+
+  if (value == 0.0) {
+    Decimal output{static_cast<std::int64_t>(0)};
+    if (std::signbit(value)) {
+      output.flags_ |= FLAG_SIGN;
+    }
+
+    output.flags_ =
+        static_cast<std::uint8_t>(output.flags_ & ~FLAG_INTEGER_LITERAL);
+    return output;
+  }
+
+  const std::string magnitude{
+      exact_magnitude_to_decimal_string(std::abs(value))};
+  Decimal output{std::signbit(value) ? "-" + magnitude : magnitude};
   output.flags_ =
       static_cast<std::uint8_t>(output.flags_ & ~FLAG_INTEGER_LITERAL);
   return output;

--- a/src/lang/numeric/include/sourcemeta/core/numeric_decimal.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_decimal.h
@@ -81,6 +81,10 @@ public:
   /// round-trip string representation, avoiding IEEE 754 precision artifacts
   [[nodiscard]] static auto strict_from(double value) -> Decimal;
 
+  /// Create a decimal that preserves the exact value stored by a double,
+  /// expanding every digit of its underlying binary representation
+  [[nodiscard]] static auto exact_from(double value) -> Decimal;
+
   /// Create a positive infinity value
   [[nodiscard]] static auto infinity() -> Decimal;
 

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -1112,3 +1112,113 @@ TEST(not_equal_operator_integer_maximum_and_real_two_pow_63) {
   const sourcemeta::core::JSON right{9223372036854775808.0};
   EXPECT_TRUE(left != right);
 }
+
+TEST(less_integer_below_fractional_real) {
+  const sourcemeta::core::JSON integer{2};
+  const sourcemeta::core::JSON real{2.5};
+  EXPECT_TRUE(integer < real);
+  EXPECT_FALSE(real < integer);
+}
+
+TEST(less_integer_above_fractional_real) {
+  const sourcemeta::core::JSON integer{3};
+  const sourcemeta::core::JSON real{2.5};
+  EXPECT_FALSE(integer < real);
+  EXPECT_TRUE(real < integer);
+}
+
+TEST(less_integer_and_integral_real_are_neither) {
+  const sourcemeta::core::JSON integer{3};
+  const sourcemeta::core::JSON real{3.0};
+  EXPECT_FALSE(integer < real);
+  EXPECT_FALSE(real < integer);
+  EXPECT_TRUE(integer == real);
+}
+
+TEST(less_negative_integer_below_fractional_real) {
+  const sourcemeta::core::JSON integer{-3};
+  const sourcemeta::core::JSON real{-2.5};
+  EXPECT_TRUE(integer < real);
+  EXPECT_FALSE(real < integer);
+}
+
+TEST(less_negative_integer_above_fractional_real) {
+  const sourcemeta::core::JSON integer{-2};
+  const sourcemeta::core::JSON real{-2.5};
+  EXPECT_FALSE(integer < real);
+  EXPECT_TRUE(real < integer);
+}
+
+TEST(less_integer_maximum_below_two_pow_63) {
+  const sourcemeta::core::JSON integer{
+      std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON real{9223372036854775808.0};
+  EXPECT_TRUE(integer < real);
+  EXPECT_FALSE(real < integer);
+}
+
+TEST(greater_integer_minimum_above_below_range_real) {
+  const sourcemeta::core::JSON integer{
+      std::numeric_limits<std::int64_t>::min()};
+  const sourcemeta::core::JSON real{-1e19};
+  EXPECT_FALSE(integer < real);
+  EXPECT_TRUE(real < integer);
+}
+
+TEST(less_integer_beyond_double_precision_is_greater_than_real) {
+  const sourcemeta::core::JSON integer{
+      static_cast<std::int64_t>(9007199254740993)};
+  const sourcemeta::core::JSON real{9007199254740992.0};
+  EXPECT_FALSE(integer < real);
+  EXPECT_TRUE(real < integer);
+}
+
+TEST(less_real_below_integral_decimal) {
+  const sourcemeta::core::JSON real{2.5};
+  const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3"}};
+  EXPECT_TRUE(real < decimal);
+  EXPECT_FALSE(decimal < real);
+}
+
+TEST(less_integral_decimal_below_real) {
+  const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"3"}};
+  const sourcemeta::core::JSON real{3.5};
+  EXPECT_TRUE(decimal < real);
+  EXPECT_FALSE(real < decimal);
+}
+
+TEST(less_real_below_fractional_decimal) {
+  const sourcemeta::core::JSON real{2.0};
+  const sourcemeta::core::JSON decimal{sourcemeta::core::Decimal{"2.5"}};
+  EXPECT_TRUE(real < decimal);
+  EXPECT_FALSE(decimal < real);
+}
+
+TEST(ordering_at_two_pow_63_boundary_is_trichotomous) {
+  const sourcemeta::core::JSON integer{
+      std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON real{9223372036854775808.0};
+  EXPECT_FALSE(integer == real);
+  EXPECT_TRUE(integer < real);
+  EXPECT_FALSE(integer > real);
+  EXPECT_FALSE(real < integer);
+  EXPECT_TRUE(real > integer);
+}
+
+TEST(less_equal_and_greater_equal_cross_type_equal) {
+  const sourcemeta::core::JSON integer{2};
+  const sourcemeta::core::JSON real{2.0};
+  EXPECT_TRUE(integer <= real);
+  EXPECT_TRUE(integer >= real);
+  EXPECT_TRUE(real <= integer);
+  EXPECT_TRUE(real >= integer);
+}
+
+TEST(less_equal_and_greater_equal_cross_type_distinct) {
+  const sourcemeta::core::JSON integer{2};
+  const sourcemeta::core::JSON real{2.5};
+  EXPECT_TRUE(integer <= real);
+  EXPECT_FALSE(integer >= real);
+  EXPECT_FALSE(real <= integer);
+  EXPECT_TRUE(real >= integer);
+}

--- a/test/json/json_number_test.cc
+++ b/test/json/json_number_test.cc
@@ -1,6 +1,8 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/test.h>
 
+#include <cstdint>   // std::int64_t
+#include <limits>    // std::numeric_limits
 #include <stdexcept> // std::out_of_range
 
 TEST(is_number_zero) {
@@ -707,4 +709,406 @@ TEST(is_integer_real_storage_integer_valued) {
 TEST(is_integer_real_storage_fractional) {
   const sourcemeta::core::JSON document{3.14};
   EXPECT_FALSE(document.is_integer());
+}
+
+TEST(equal_integer_same_value) {
+  const sourcemeta::core::JSON left{5};
+  const sourcemeta::core::JSON right{5};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_different_value) {
+  const sourcemeta::core::JSON left{5};
+  const sourcemeta::core::JSON right{6};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_zero) {
+  const sourcemeta::core::JSON left{0};
+  const sourcemeta::core::JSON right{0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_negative_same_value) {
+  const sourcemeta::core::JSON left{-5};
+  const sourcemeta::core::JSON right{-5};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_sign_differs) {
+  const sourcemeta::core::JSON left{5};
+  const sourcemeta::core::JSON right{-5};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_maximum) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON right{std::numeric_limits<std::int64_t>::max()};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_minimum) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::min()};
+  const sourcemeta::core::JSON right{std::numeric_limits<std::int64_t>::min()};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_minimum_and_maximum) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::min()};
+  const sourcemeta::core::JSON right{std::numeric_limits<std::int64_t>::max()};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_real_same_value) {
+  const sourcemeta::core::JSON left{5.5};
+  const sourcemeta::core::JSON right{5.5};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_different_value) {
+  const sourcemeta::core::JSON left{5.5};
+  const sourcemeta::core::JSON right{5.6};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_real_positive_and_negative_zero) {
+  const sourcemeta::core::JSON left{0.0};
+  const sourcemeta::core::JSON right{-0.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_decimal_same_value) {
+  const sourcemeta::core::JSON left{sourcemeta::core::Decimal{"3.14"}};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"3.14"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_decimal_trailing_zeros) {
+  const sourcemeta::core::JSON left{sourcemeta::core::Decimal{"1.0"}};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"1.00"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_decimal_positive_and_negative_zero) {
+  const sourcemeta::core::JSON left{sourcemeta::core::Decimal{"0"}};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"-0"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_decimal_different_value) {
+  const sourcemeta::core::JSON left{sourcemeta::core::Decimal{"3.14"}};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"3.15"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_decimal_big_same_value) {
+  const sourcemeta::core::JSON left{
+      sourcemeta::core::Decimal{"123456789012345678901234567890"}};
+  const sourcemeta::core::JSON right{
+      sourcemeta::core::Decimal{"123456789012345678901234567890"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_decimal_big_different_value) {
+  const sourcemeta::core::JSON left{
+      sourcemeta::core::Decimal{"123456789012345678901234567890"}};
+  const sourcemeta::core::JSON right{
+      sourcemeta::core::Decimal{"123456789012345678901234567891"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_and_real_same_value) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{1.0};
+  EXPECT_TRUE(left == right);
+  EXPECT_TRUE(right == left);
+}
+
+TEST(equal_integer_and_real_thousand) {
+  const sourcemeta::core::JSON left{1000};
+  const sourcemeta::core::JSON right{1000.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_real_zero) {
+  const sourcemeta::core::JSON left{0};
+  const sourcemeta::core::JSON right{0.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_real_negative_zero) {
+  const sourcemeta::core::JSON left{0};
+  const sourcemeta::core::JSON right{-0.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_real_negative) {
+  const sourcemeta::core::JSON left{-5};
+  const sourcemeta::core::JSON right{-5.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_real_fractional_differs) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{1.5};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_and_real_close_but_distinct) {
+  const sourcemeta::core::JSON left{1000};
+  const sourcemeta::core::JSON right{1000.0001};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_and_real_large_exact_power_of_two) {
+  const sourcemeta::core::JSON left{
+      static_cast<std::int64_t>(4503599627370496)};
+  const sourcemeta::core::JSON right{4503599627370496.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_maximum_and_real_two_pow_63) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON right{9223372036854775808.0};
+  EXPECT_FALSE(left == right);
+  EXPECT_FALSE(right == left);
+}
+
+TEST(equal_integer_beyond_double_precision_and_real) {
+  const sourcemeta::core::JSON left{
+      static_cast<std::int64_t>(9007199254740993)};
+  const sourcemeta::core::JSON right{9007199254740993.0};
+  EXPECT_FALSE(left == right);
+  EXPECT_FALSE(right == left);
+}
+
+TEST(equal_integer_minimum_and_real_negative_two_pow_63) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::min()};
+  const sourcemeta::core::JSON right{-9223372036854775808.0};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_decimal_same_value) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"1"}};
+  EXPECT_TRUE(left == right);
+  EXPECT_TRUE(right == left);
+}
+
+TEST(equal_integer_and_decimal_trailing_zeros) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"1.00"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_decimal_exponent) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"1e0"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_decimal_negative) {
+  const sourcemeta::core::JSON left{-5};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"-5"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_decimal_zero) {
+  const sourcemeta::core::JSON left{0};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"0"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_decimal_negative_zero) {
+  const sourcemeta::core::JSON left{0};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"-0"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_integer_and_decimal_fractional_differs) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"1.5"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_and_decimal_big_differs) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{
+      sourcemeta::core::Decimal{"123456789012345678901234567890"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_maximum_and_decimal_same_value) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON right{
+      sourcemeta::core::Decimal{"9223372036854775807"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_and_decimal_integral) {
+  const sourcemeta::core::JSON left{5.0};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"5"}};
+  EXPECT_TRUE(left == right);
+  EXPECT_TRUE(right == left);
+}
+
+TEST(equal_real_and_decimal_dyadic_half) {
+  const sourcemeta::core::JSON left{0.5};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"0.5"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_and_decimal_dyadic_quarter) {
+  const sourcemeta::core::JSON left{0.25};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"0.25"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_and_decimal_dyadic_trailing_zeros) {
+  const sourcemeta::core::JSON left{2.5};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"2.50"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_and_decimal_negative) {
+  const sourcemeta::core::JSON left{-2.5};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"-2.5"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_two_pow_63_and_decimal) {
+  const sourcemeta::core::JSON left{9223372036854775808.0};
+  const sourcemeta::core::JSON right{
+      sourcemeta::core::Decimal{"9223372036854775808"}};
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_real_and_decimal_non_dyadic_are_distinct) {
+  // A double cannot store 2.1 exactly, so the real holds an approximation while
+  // the decimal is exact. They are genuinely different stored values
+  const sourcemeta::core::JSON left{2.1};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"2.1"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_real_and_decimal_one_tenth_are_distinct) {
+  const sourcemeta::core::JSON left{0.1};
+  const sourcemeta::core::JSON right{sourcemeta::core::Decimal{"0.1"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_real_and_decimal_big_differs) {
+  const sourcemeta::core::JSON left{1.0};
+  const sourcemeta::core::JSON right{
+      sourcemeta::core::Decimal{"123456789012345678901234567890"}};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_transitive_integer_real_decimal) {
+  const sourcemeta::core::JSON as_integer{1000};
+  const sourcemeta::core::JSON as_real{1000.0};
+  const sourcemeta::core::JSON as_decimal{sourcemeta::core::Decimal{"1000"}};
+  EXPECT_TRUE(as_integer == as_real);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_TRUE(as_integer == as_decimal);
+}
+
+TEST(equal_transitivity_holds_at_two_pow_63_boundary) {
+  const sourcemeta::core::JSON as_integer{
+      std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON as_real{9223372036854775808.0};
+  const sourcemeta::core::JSON as_decimal{
+      sourcemeta::core::Decimal{"9223372036854775808"}};
+  EXPECT_FALSE(as_integer == as_real);
+  EXPECT_TRUE(as_real == as_decimal);
+  EXPECT_FALSE(as_integer == as_decimal);
+}
+
+TEST(equal_integer_and_string_differ) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{"1"};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_one_and_boolean_true_differ) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{true};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_zero_and_boolean_false_differ) {
+  const sourcemeta::core::JSON left{0};
+  const sourcemeta::core::JSON right{false};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_real_and_null_differ) {
+  const sourcemeta::core::JSON left{1.0};
+  const sourcemeta::core::JSON right{nullptr};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_decimal_and_string_differ) {
+  const sourcemeta::core::JSON left{sourcemeta::core::Decimal{"1"}};
+  const sourcemeta::core::JSON right{"1"};
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_and_array_differ) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right = sourcemeta::core::parse_json("[ 1 ]");
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_integer_and_object_differ) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right =
+      sourcemeta::core::parse_json("{ \"a\": 1 }");
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_array_with_integer_and_real_elements) {
+  const sourcemeta::core::JSON left = sourcemeta::core::parse_json("[ 1 ]");
+  const sourcemeta::core::JSON right = sourcemeta::core::parse_json("[ 1.0 ]");
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_array_with_real_and_decimal_precision_differ) {
+  const sourcemeta::core::JSON left = sourcemeta::core::parse_json("[ 2.1 ]");
+  const sourcemeta::core::JSON right =
+      sourcemeta::core::parse_json("[ 2.1e0 ]");
+  EXPECT_FALSE(left == right);
+}
+
+TEST(equal_object_with_integer_and_real_values) {
+  const sourcemeta::core::JSON left =
+      sourcemeta::core::parse_json("{ \"a\": 1 }");
+  const sourcemeta::core::JSON right =
+      sourcemeta::core::parse_json("{ \"a\": 1.0 }");
+  EXPECT_TRUE(left == right);
+}
+
+TEST(equal_nested_array_with_integer_and_real) {
+  const sourcemeta::core::JSON left = sourcemeta::core::parse_json("[ [ 1 ] ]");
+  const sourcemeta::core::JSON right =
+      sourcemeta::core::parse_json("[ [ 1.0 ] ]");
+  EXPECT_TRUE(left == right);
+}
+
+TEST(not_equal_operator_integer_and_real_distinct) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{1.5};
+  EXPECT_TRUE(left != right);
+}
+
+TEST(not_equal_operator_integer_and_real_equal) {
+  const sourcemeta::core::JSON left{1};
+  const sourcemeta::core::JSON right{1.0};
+  EXPECT_FALSE(left != right);
+}
+
+TEST(not_equal_operator_integer_maximum_and_real_two_pow_63) {
+  const sourcemeta::core::JSON left{std::numeric_limits<std::int64_t>::max()};
+  const sourcemeta::core::JSON right{9223372036854775808.0};
+  EXPECT_TRUE(left != right);
 }

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -3860,9 +3860,11 @@ TEST(exact_from_zero) {
 }
 
 TEST(exact_from_negative_zero) {
+  // The library builds without IEEE signed zeros, so a negative zero converts
+  // to a plain unsigned zero
   const auto value{sourcemeta::core::Decimal::exact_from(-0.0)};
   EXPECT_TRUE(value.is_zero());
-  EXPECT_TRUE(value.is_signed());
+  EXPECT_TRUE(value == sourcemeta::core::Decimal{0});
 }
 
 TEST(exact_from_dyadic_half) {

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -3829,3 +3829,144 @@ TEST(parse_extreme_negative_exponent_does_not_overflow) {
   const sourcemeta::core::Decimal value{"1.5e-2147483648"};
   EXPECT_TRUE(value.is_finite());
 }
+
+TEST(exact_from_integer_one) {
+  const auto value{sourcemeta::core::Decimal::exact_from(1.0)};
+  EXPECT_EQ(value.to_string(), "1");
+  EXPECT_TRUE(value == sourcemeta::core::Decimal{"1"});
+}
+
+TEST(exact_from_integer_five) {
+  const auto value{sourcemeta::core::Decimal::exact_from(5.0)};
+  EXPECT_EQ(value.to_string(), "5");
+}
+
+TEST(exact_from_integer_negative) {
+  const auto value{sourcemeta::core::Decimal::exact_from(-3.0)};
+  EXPECT_EQ(value.to_string(), "-3");
+}
+
+TEST(exact_from_integer_is_not_integer_literal_but_is_integral) {
+  const auto value{sourcemeta::core::Decimal::exact_from(5.0)};
+  EXPECT_FALSE(value.is_integer());
+  EXPECT_TRUE(value.is_integral());
+}
+
+TEST(exact_from_zero) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.0)};
+  EXPECT_TRUE(value.is_zero());
+  EXPECT_FALSE(value.is_signed());
+  EXPECT_EQ(value.to_string(), "0");
+}
+
+TEST(exact_from_negative_zero) {
+  const auto value{sourcemeta::core::Decimal::exact_from(-0.0)};
+  EXPECT_TRUE(value.is_zero());
+  EXPECT_TRUE(value.is_signed());
+}
+
+TEST(exact_from_dyadic_half) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.5)};
+  EXPECT_EQ(value.to_string(), "0.5");
+}
+
+TEST(exact_from_dyadic_quarter) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.25)};
+  EXPECT_EQ(value.to_string(), "0.25");
+}
+
+TEST(exact_from_dyadic_eighth) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.125)};
+  EXPECT_EQ(value.to_string(), "0.125");
+}
+
+TEST(exact_from_dyadic_three_and_a_half) {
+  const auto value{sourcemeta::core::Decimal::exact_from(3.5)};
+  EXPECT_EQ(value.to_string(), "3.5");
+}
+
+TEST(exact_from_dyadic_negative) {
+  const auto value{sourcemeta::core::Decimal::exact_from(-7.25)};
+  EXPECT_EQ(value.to_string(), "-7.25");
+}
+
+TEST(exact_from_two_pow_53) {
+  const auto value{sourcemeta::core::Decimal::exact_from(9007199254740992.0)};
+  EXPECT_EQ(value.to_string(), "9007199254740992");
+}
+
+TEST(exact_from_two_pow_63) {
+  const auto value{
+      sourcemeta::core::Decimal::exact_from(9223372036854775808.0)};
+  EXPECT_EQ(value.to_string(), "9223372036854775808");
+  EXPECT_TRUE(value == sourcemeta::core::Decimal{"9223372036854775808"});
+}
+
+TEST(exact_from_one_tenth_full_expansion) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.1)};
+  EXPECT_EQ(value.to_string(),
+            "0.1000000000000000055511151231257827021181583404541015625");
+}
+
+TEST(exact_from_one_tenth_differs_from_clean_decimal) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.1)};
+  EXPECT_FALSE(value == sourcemeta::core::Decimal{"0.1"});
+  EXPECT_TRUE(value > sourcemeta::core::Decimal{"0.1"});
+}
+
+TEST(exact_from_two_point_one_differs_from_clean_decimal) {
+  const auto value{sourcemeta::core::Decimal::exact_from(2.1)};
+  EXPECT_FALSE(value == sourcemeta::core::Decimal{"2.1"});
+  EXPECT_TRUE(value > sourcemeta::core::Decimal{"2.1"});
+}
+
+TEST(exact_from_roundtrips_one_tenth) {
+  const auto value{sourcemeta::core::Decimal::exact_from(0.1)};
+  EXPECT_EQ(value.to_double(), 0.1);
+}
+
+TEST(exact_from_roundtrips_two_point_one) {
+  const auto value{sourcemeta::core::Decimal::exact_from(2.1)};
+  EXPECT_EQ(value.to_double(), 2.1);
+}
+
+TEST(exact_from_roundtrips_negative_fraction) {
+  const auto value{sourcemeta::core::Decimal::exact_from(-3.2)};
+  EXPECT_EQ(value.to_double(), -3.2);
+}
+
+TEST(exact_from_roundtrips_large_magnitude) {
+  const auto value{sourcemeta::core::Decimal::exact_from(1e300)};
+  EXPECT_EQ(value.to_double(), 1e300);
+}
+
+TEST(exact_from_smallest_subnormal_is_exact) {
+  // The smallest positive double is 2^-1074, roughly 4.9407e-324, so its exact
+  // expansion is tightly bracketed here without a lossy round-trip
+  const double subnormal{std::numeric_limits<double>::denorm_min()};
+  const auto value{sourcemeta::core::Decimal::exact_from(subnormal)};
+  EXPECT_TRUE(value.is_finite());
+  EXPECT_FALSE(value.is_zero());
+  EXPECT_TRUE(value > sourcemeta::core::Decimal{"4e-324"});
+  EXPECT_TRUE(value < sourcemeta::core::Decimal{"5e-324"});
+}
+
+TEST(exact_from_nan) {
+  const auto value{sourcemeta::core::Decimal::exact_from(
+      std::numeric_limits<double>::quiet_NaN())};
+  EXPECT_TRUE(value.is_nan());
+}
+
+TEST(exact_from_positive_infinity) {
+  const auto value{sourcemeta::core::Decimal::exact_from(
+      std::numeric_limits<double>::infinity())};
+  EXPECT_TRUE(value.is_infinite());
+  EXPECT_FALSE(value.is_signed());
+}
+
+TEST(exact_from_negative_infinity) {
+  const auto value{sourcemeta::core::Decimal::exact_from(
+      -std::numeric_limits<double>::infinity())};
+  EXPECT_TRUE(value.is_infinite());
+  EXPECT_TRUE(value.is_signed());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

