### PR TITLE
More correctness fixes throughout the codebase

### DIFF
--- a/src/core/gzip/gzip.cc
+++ b/src/core/gzip/gzip.cc
@@ -65,8 +65,13 @@ auto gunzip(const std::uint8_t *input, const std::size_t size,
     capacity = size * 4;
   }
 
+  // Decompress the first member. Every gzip stream has at least one member, so
+  // a failure here is a real error rather than trailing data
+  std::size_t total_in{0};
+  std::size_t total_out{0};
   for (;;) {
-    std::size_t actual_size{0};
+    std::size_t member_in{0};
+    std::size_t member_out{0};
     auto result{LIBDEFLATE_BAD_DATA};
     // libdeflate writes only the decompressed bytes, so leaving the buffer
     // uninitialised avoids zero-filling multi-megabyte allocations on every
@@ -74,15 +79,16 @@ auto gunzip(const std::uint8_t *input, const std::size_t size,
     output.resize_and_overwrite(
         capacity,
         [&](char *const buffer, const std::size_t buffer_size) -> std::size_t {
-          result =
-              libdeflate_gzip_decompress(decompressor.get(), input, size,
-                                         buffer, buffer_size, &actual_size);
+          result = libdeflate_gzip_decompress_ex(decompressor.get(), input,
+                                                 size, buffer, buffer_size,
+                                                 &member_in, &member_out);
           return buffer_size;
         });
 
     if (result == LIBDEFLATE_SUCCESS) {
-      output.resize(actual_size);
-      return output;
+      total_in = member_in;
+      total_out = member_out;
+      break;
     }
 
     if (result == LIBDEFLATE_INSUFFICIENT_SPACE) {
@@ -98,6 +104,51 @@ auto gunzip(const std::uint8_t *input, const std::size_t size,
 
     throw GZIPError{"Could not decompress input"};
   }
+
+  // RFC 1952 Section 2.2 permits concatenated members. Like gzip(1) and the
+  // streaming decoder, decompress every subsequent member and silently ignore
+  // trailing data that does not begin a new member, so `resize` here preserves
+  // the members already decoded
+  while (total_in < size) {
+    if (size - total_in < 2 || input[total_in] != 0x1F ||
+        input[total_in + 1] != 0x8B) {
+      break;
+    }
+
+    std::size_t member_in{0};
+    std::size_t member_out{0};
+    for (;;) {
+      const auto result{libdeflate_gzip_decompress_ex(
+          decompressor.get(), input + total_in, size - total_in,
+          output.data() + total_out, output.size() - total_out, &member_in,
+          &member_out)};
+
+      if (result == LIBDEFLATE_SUCCESS) {
+        break;
+      }
+
+      if (result == LIBDEFLATE_INSUFFICIENT_SPACE) {
+        if (output.size() >= maximum_size) {
+          throw GZIPError{
+              "Decompressed output exceeds the maximum allowed size"};
+        }
+
+        output.resize((output.size() > maximum_size / 2) ? maximum_size
+                                                         : output.size() * 2);
+        continue;
+      }
+
+      // A run that begins with the gzip magic but fails to decode is a corrupt
+      // member, not trailing data, so it is a real error
+      throw GZIPError{"Could not decompress input"};
+    }
+
+    total_in += member_in;
+    total_out += member_out;
+  }
+
+  output.resize(total_out);
+  return output;
 }
 
 } // namespace sourcemeta::core

--- a/src/core/gzip/include/sourcemeta/core/gzip.h
+++ b/src/core/gzip/include/sourcemeta/core/gzip.h
@@ -44,8 +44,9 @@ auto SOURCEMETA_CORE_GZIP_EXPORT gzip(const std::uint8_t *input,
 /// Decompress a GZIP compressed byte buffer (RFC 1952). An optional output
 /// size hint can be provided to avoid repeated buffer resizing. The output is
 /// bounded by a maximum size (256 MiB by default) so that a highly compressed
-/// input cannot exhaust memory, and decompressing beyond it throws. Only the
-/// first GZIP member is decoded. For example:
+/// input cannot exhaust memory, and decompressing beyond it throws. Every
+/// concatenated member is decoded and any trailing data that does not begin a
+/// new member is ignored, matching gzip(1). For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/gzip.h>

--- a/src/core/json/include/sourcemeta/core/json_auto.h
+++ b/src/core/json/include/sourcemeta/core/json_auto.h
@@ -13,7 +13,7 @@
 #include <optional>   // std::optional, std::nullopt, std::bad_optional_access
 #include <tuple> // std::tuple, std::apply, std::tuple_element_t, std::tuple_size, std::tuple_size_v
 #include <type_traits> // std::false_type, std::true_type, std::is_enum_v, std::underlying_type_t, std::is_same_v, std::is_base_of_v, std::remove_cvref_t
-#include <utility> // std::pair, std:::make_index_sequence, std::index_sequence
+#include <utility> // std::pair, std::make_index_sequence, std::index_sequence, std::in_range
 #include <variant> // std::variant, std::variant_size_v, std::variant_alternative_t, std::visit
 
 namespace sourcemeta::core {
@@ -173,7 +173,9 @@ auto from_json(const JSON &value) -> std::optional<T> {
 template <typename T>
   requires(std::is_integral_v<T> && !std::is_same_v<T, bool>)
 auto from_json(const JSON &value) -> std::optional<T> {
-  if (value.is_integer()) {
+  // A value outside the target type's range yields no result rather than a
+  // silently narrowed one
+  if (value.is_integer() && std::in_range<T>(value.to_integer())) {
     return static_cast<T>(value.to_integer());
   } else {
     return std::nullopt;

--- a/src/core/time/asctime.cc
+++ b/src/core/time/asctime.cc
@@ -2,15 +2,13 @@
 
 #include "helpers.h"
 
-#include <cassert>     // assert
 #include <cctype>      // std::isdigit
 #include <chrono>      // std::chrono::system_clock
-#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
+#include <ctime>       // std::tm
 #include <iomanip>     // std::put_time, std::get_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
 #include <sstream>     // std::ostringstream, std::istringstream
-#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -23,22 +21,10 @@ namespace sourcemeta::core {
 
 auto to_asctime(const std::chrono::system_clock::time_point time)
     -> std::string {
-  const std::time_t ctime = std::chrono::system_clock::to_time_t(time);
-  std::tm buffer;
-#if defined(_MSC_VER)
-  if (gmtime_s(&buffer, &ctime) != 0) {
-    throw std::runtime_error("Could not convert time point to asctime");
-  }
-#else
-  if (gmtime_r(&ctime, &buffer) == nullptr) {
-    throw std::runtime_error("Could not convert time point to asctime");
-  }
-#endif
-  std::tm *parts = &buffer;
-  assert(parts);
+  const auto parts{time_point_to_broken_down(time)};
   std::ostringstream stream;
   stream.imbue(std::locale::classic());
-  stream << std::put_time(parts, FORMAT_ASCTIME_OUTPUT);
+  stream << std::put_time(&parts, FORMAT_ASCTIME_OUTPUT);
   return stream.str();
 }
 

--- a/src/core/time/asctime.cc
+++ b/src/core/time/asctime.cc
@@ -5,7 +5,7 @@
 #include <cassert>     // assert
 #include <cctype>      // std::isdigit
 #include <chrono>      // std::chrono::system_clock
-#include <ctime>       // std::time_t, std::tm, timegm, gmtime_r, gmtime_s
+#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
 #include <iomanip>     // std::put_time, std::get_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
@@ -85,11 +85,7 @@ auto from_asctime(const std::string_view value) noexcept
       !is_case_sensitive_month_abbreviation(value.substr(4, 3), parts.tm_mon)) {
     return std::nullopt;
   }
-#if defined(_MSC_VER)
-  return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
-#else
-  return std::chrono::system_clock::from_time_t(timegm(&parts));
-#endif
+  return broken_down_time_to_time_point(parts);
 } catch (...) {
   return std::nullopt;
 }

--- a/src/core/time/helpers.h
+++ b/src/core/time/helpers.h
@@ -7,6 +7,7 @@
 #include <chrono>      // std::chrono::system_clock, std::chrono::sys_days
 #include <cstdint>     // std::uint8_t, std::uint16_t
 #include <ctime>       // std::tm
+#include <optional>    // std::optional, std::nullopt
 #include <string_view> // std::string_view
 #include <utility>     // std::cmp_greater
 
@@ -15,9 +16,12 @@ namespace sourcemeta::core {
 // Convert an already-validated broken-down UTC time to a time point through
 // calendar arithmetic rather than timegm, which on a 32-bit time_t cannot
 // represent pre-1970 or far-future dates and signals failure with a
-// (time_t)-1 that is indistinguishable from a real 1969-12-31T23:59:59Z
+// (time_t)-1 that is indistinguishable from a real 1969-12-31T23:59:59Z. A date
+// whose seconds since the epoch fall outside what system_clock can represent
+// yields no result rather than silently wrapping during the cast to its finer
+// duration
 inline auto broken_down_time_to_time_point(const std::tm &parts)
-    -> std::chrono::system_clock::time_point {
+    -> std::optional<std::chrono::system_clock::time_point> {
   const std::chrono::year_month_day date{
       std::chrono::year{parts.tm_year + 1900},
       std::chrono::month{static_cast<unsigned>(parts.tm_mon + 1)},
@@ -26,9 +30,20 @@ inline auto broken_down_time_to_time_point(const std::tm &parts)
                          std::chrono::hours{parts.tm_hour} +
                          std::chrono::minutes{parts.tm_min} +
                          std::chrono::seconds{parts.tm_sec}};
-  return std::chrono::system_clock::time_point{
-      std::chrono::duration_cast<std::chrono::system_clock::duration>(
-          since_epoch)};
+
+  using TimePoint = std::chrono::system_clock::time_point;
+  // The bounds round inwards so the value cast back to the finer duration stays
+  // within range
+  constexpr auto minimum{std::chrono::ceil<std::chrono::seconds>(
+      TimePoint::min().time_since_epoch())};
+  constexpr auto maximum{std::chrono::floor<std::chrono::seconds>(
+      TimePoint::max().time_since_epoch())};
+  if (since_epoch < minimum || since_epoch > maximum) {
+    return std::nullopt;
+  }
+
+  return TimePoint{
+      std::chrono::duration_cast<TimePoint::duration>(since_epoch)};
 }
 
 // Break a time point down into UTC calendar fields through calendar arithmetic

--- a/src/core/time/helpers.h
+++ b/src/core/time/helpers.h
@@ -31,6 +31,29 @@ inline auto broken_down_time_to_time_point(const std::tm &parts)
           since_epoch)};
 }
 
+// Break a time point down into UTC calendar fields through calendar arithmetic
+// rather than gmtime, which on some platforms cannot represent a pre-1970 time
+// and computes the wrong weekday for the instant just before the epoch
+inline auto time_point_to_broken_down(
+    const std::chrono::system_clock::time_point time) noexcept -> std::tm {
+  const auto seconds{
+      std::chrono::floor<std::chrono::seconds>(time.time_since_epoch())};
+  const auto days{std::chrono::floor<std::chrono::days>(seconds)};
+  const std::chrono::year_month_day date{std::chrono::sys_days{days}};
+  const std::chrono::hh_mm_ss clock{seconds - days};
+  const std::chrono::weekday weekday{std::chrono::sys_days{days}};
+
+  std::tm parts{};
+  parts.tm_year = static_cast<int>(date.year()) - 1900;
+  parts.tm_mon = static_cast<int>(static_cast<unsigned>(date.month())) - 1;
+  parts.tm_mday = static_cast<int>(static_cast<unsigned>(date.day()));
+  parts.tm_hour = static_cast<int>(clock.hours().count());
+  parts.tm_min = static_cast<int>(clock.minutes().count());
+  parts.tm_sec = static_cast<int>(clock.seconds().count());
+  parts.tm_wday = static_cast<int>(weekday.c_encoding());
+  return parts;
+}
+
 // RFC 9110 §5.6.7: "HTTP-date is case sensitive". The standard library's
 // std::get_time matches day and month names case-insensitively on some
 // implementations, so the exact spelling is verified against the parsed index

--- a/src/core/time/helpers.h
+++ b/src/core/time/helpers.h
@@ -4,12 +4,32 @@
 #include <sourcemeta/core/time.h>
 
 #include <array>       // std::array
+#include <chrono>      // std::chrono::system_clock, std::chrono::sys_days
 #include <cstdint>     // std::uint8_t, std::uint16_t
 #include <ctime>       // std::tm
 #include <string_view> // std::string_view
 #include <utility>     // std::cmp_greater
 
 namespace sourcemeta::core {
+
+// Convert an already-validated broken-down UTC time to a time point through
+// calendar arithmetic rather than timegm, which on a 32-bit time_t cannot
+// represent pre-1970 or far-future dates and signals failure with a
+// (time_t)-1 that is indistinguishable from a real 1969-12-31T23:59:59Z
+inline auto broken_down_time_to_time_point(const std::tm &parts)
+    -> std::chrono::system_clock::time_point {
+  const std::chrono::year_month_day date{
+      std::chrono::year{parts.tm_year + 1900},
+      std::chrono::month{static_cast<unsigned>(parts.tm_mon + 1)},
+      std::chrono::day{static_cast<unsigned>(parts.tm_mday)}};
+  const auto since_epoch{std::chrono::sys_days{date}.time_since_epoch() +
+                         std::chrono::hours{parts.tm_hour} +
+                         std::chrono::minutes{parts.tm_min} +
+                         std::chrono::seconds{parts.tm_sec}};
+  return std::chrono::system_clock::time_point{
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          since_epoch)};
+}
 
 // RFC 9110 §5.6.7: "HTTP-date is case sensitive". The standard library's
 // std::get_time matches day and month names case-insensitively on some

--- a/src/core/time/imf_fixdate.cc
+++ b/src/core/time/imf_fixdate.cc
@@ -2,15 +2,13 @@
 
 #include "helpers.h"
 
-#include <cassert>     // assert
 #include <cctype>      // std::isdigit
 #include <chrono>      // std::chrono::system_clock
-#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
+#include <ctime>       // std::tm
 #include <iomanip>     // std::put_time, std::get_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
 #include <sstream>     // std::ostringstream, std::istringstream
-#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -22,22 +20,10 @@ namespace sourcemeta::core {
 
 auto to_imf_fixdate(const std::chrono::system_clock::time_point time)
     -> std::string {
-  const std::time_t ctime = std::chrono::system_clock::to_time_t(time);
-  std::tm buffer;
-#if defined(_MSC_VER)
-  if (gmtime_s(&buffer, &ctime) != 0) {
-    throw std::runtime_error("Could not convert time point to IMF-fixdate");
-  }
-#else
-  if (gmtime_r(&ctime, &buffer) == nullptr) {
-    throw std::runtime_error("Could not convert time point to IMF-fixdate");
-  }
-#endif
-  std::tm *parts = &buffer;
-  assert(parts);
+  const auto parts{time_point_to_broken_down(time)};
   std::ostringstream stream;
   stream.imbue(std::locale::classic());
-  stream << std::put_time(parts, FORMAT_IMF_FIXDATE);
+  stream << std::put_time(&parts, FORMAT_IMF_FIXDATE);
   return stream.str();
 }
 

--- a/src/core/time/imf_fixdate.cc
+++ b/src/core/time/imf_fixdate.cc
@@ -5,7 +5,7 @@
 #include <cassert>     // assert
 #include <cctype>      // std::isdigit
 #include <chrono>      // std::chrono::system_clock
-#include <ctime>       // std::time_t, std::tm, timegm, gmtime_r, gmtime_s
+#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
 #include <iomanip>     // std::put_time, std::get_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
@@ -80,11 +80,7 @@ auto from_imf_fixdate(const std::string_view value) noexcept
       !is_case_sensitive_month_abbreviation(value.substr(8, 3), parts.tm_mon)) {
     return std::nullopt;
   }
-#if defined(_MSC_VER)
-  return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
-#else
-  return std::chrono::system_clock::from_time_t(timegm(&parts));
-#endif
+  return broken_down_time_to_time_point(parts);
 } catch (...) {
   return std::nullopt;
 }

--- a/src/core/time/iso8601_basic.cc
+++ b/src/core/time/iso8601_basic.cc
@@ -5,12 +5,11 @@
 #include <charconv>    // std::from_chars
 #include <chrono>      // std::chrono::system_clock
 #include <cstddef>     // std::size_t
-#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
+#include <ctime>       // std::tm
 #include <iomanip>     // std::put_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
 #include <sstream>     // std::ostringstream
-#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -42,20 +41,10 @@ namespace sourcemeta::core {
 
 auto to_iso8601_basic(const std::chrono::system_clock::time_point time)
     -> std::string {
-  const std::time_t ctime = std::chrono::system_clock::to_time_t(time);
-  std::tm buffer;
-#if defined(_MSC_VER)
-  if (gmtime_s(&buffer, &ctime) != 0) {
-    throw std::runtime_error("Could not convert time point to ISO 8601 basic");
-  }
-#else
-  if (gmtime_r(&ctime, &buffer) == nullptr) {
-    throw std::runtime_error("Could not convert time point to ISO 8601 basic");
-  }
-#endif
+  const auto parts{time_point_to_broken_down(time)};
   std::ostringstream stream;
   stream.imbue(std::locale::classic());
-  stream << std::put_time(&buffer, FORMAT_ISO8601_BASIC);
+  stream << std::put_time(&parts, FORMAT_ISO8601_BASIC);
   return stream.str();
 }
 

--- a/src/core/time/iso8601_basic.cc
+++ b/src/core/time/iso8601_basic.cc
@@ -5,7 +5,7 @@
 #include <charconv>    // std::from_chars
 #include <chrono>      // std::chrono::system_clock
 #include <cstddef>     // std::size_t
-#include <ctime>       // std::time_t, std::tm, timegm, gmtime_r, gmtime_s
+#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
 #include <iomanip>     // std::put_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
@@ -84,11 +84,7 @@ auto from_iso8601_basic(const std::string_view value) noexcept
   if (!is_valid_broken_down_time(parts)) {
     return std::nullopt;
   }
-#if defined(_MSC_VER)
-  return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
-#else
-  return std::chrono::system_clock::from_time_t(timegm(&parts));
-#endif
+  return broken_down_time_to_time_point(parts);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/time/rfc850_date.cc
+++ b/src/core/time/rfc850_date.cc
@@ -7,7 +7,7 @@
 #include <cassert>     // assert
 #include <cctype>      // std::isdigit
 #include <chrono>      // std::chrono::system_clock
-#include <ctime>       // std::time_t, std::tm, timegm, gmtime_r, gmtime_s
+#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
 #include <iomanip>     // std::put_time, std::get_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
@@ -123,11 +123,7 @@ auto from_rfc850_date(const std::string_view value) noexcept
   if (!is_case_sensitive_month_abbreviation(rest.substr(4, 3), parts.tm_mon)) {
     return std::nullopt;
   }
-#if defined(_MSC_VER)
-  return std::chrono::system_clock::from_time_t(_mkgmtime(&parts));
-#else
-  return std::chrono::system_clock::from_time_t(timegm(&parts));
-#endif
+  return broken_down_time_to_time_point(parts);
 } catch (...) {
   return std::nullopt;
 }

--- a/src/core/time/rfc850_date.cc
+++ b/src/core/time/rfc850_date.cc
@@ -4,15 +4,13 @@
 
 #include <algorithm>   // std::ranges::find
 #include <array>       // std::array
-#include <cassert>     // assert
 #include <cctype>      // std::isdigit
 #include <chrono>      // std::chrono::system_clock
-#include <ctime>       // std::time_t, std::tm, gmtime_r, gmtime_s
+#include <ctime>       // std::tm
 #include <iomanip>     // std::put_time, std::get_time
 #include <locale>      // std::locale
 #include <optional>    // std::optional, std::nullopt
 #include <sstream>     // std::ostringstream, std::istringstream
-#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string, std::to_string
 #include <string_view> // std::string_view
 
@@ -27,18 +25,7 @@ constexpr std::array<std::string_view, 7> RFC850_DAY_NAMES{
 
 auto current_utc_year() noexcept -> std::optional<int> {
   const auto now{std::chrono::system_clock::now()};
-  const std::time_t ctime{std::chrono::system_clock::to_time_t(now)};
-  std::tm buffer;
-#if defined(_MSC_VER)
-  if (gmtime_s(&buffer, &ctime) != 0) {
-    return std::nullopt;
-  }
-#else
-  if (gmtime_r(&ctime, &buffer) == nullptr) {
-    return std::nullopt;
-  }
-#endif
-  return buffer.tm_year + 1900;
+  return sourcemeta::core::time_point_to_broken_down(now).tm_year + 1900;
 }
 
 } // namespace
@@ -47,22 +34,10 @@ namespace sourcemeta::core {
 
 auto to_rfc850_date(const std::chrono::system_clock::time_point time)
     -> std::string {
-  const std::time_t ctime = std::chrono::system_clock::to_time_t(time);
-  std::tm buffer;
-#if defined(_MSC_VER)
-  if (gmtime_s(&buffer, &ctime) != 0) {
-    throw std::runtime_error("Could not convert time point to RFC 850 date");
-  }
-#else
-  if (gmtime_r(&ctime, &buffer) == nullptr) {
-    throw std::runtime_error("Could not convert time point to RFC 850 date");
-  }
-#endif
-  std::tm *parts = &buffer;
-  assert(parts);
+  const auto parts{time_point_to_broken_down(time)};
   std::ostringstream stream;
   stream.imbue(std::locale::classic());
-  stream << std::put_time(parts, FORMAT_RFC850_OUTPUT);
+  stream << std::put_time(&parts, FORMAT_RFC850_OUTPUT);
   return stream.str();
 }
 

--- a/src/core/yaml/lexer.h
+++ b/src/core/yaml/lexer.h
@@ -888,7 +888,16 @@ private:
                            "Invalid hex escape sequence"};
     }
 
-    return codepoint_to_utf8(static_cast<char32_t>(codepoint));
+    // YAML 1.2.2 Section 5.7: an escape names a Unicode scalar value, so a
+    // surrogate or out-of-range code point is rejected rather than encoded as
+    // malformed UTF-8
+    const auto character{static_cast<char32_t>(codepoint)};
+    if (!is_valid_codepoint(character)) [[unlikely]] {
+      throw YAMLParseError{this->line_, this->column_,
+                           "Invalid Unicode escape sequence"};
+    }
+
+    return codepoint_to_utf8(character);
   }
 
   [[nodiscard]] auto calculate_parent_indentation(

--- a/src/core/yaml/parser.h
+++ b/src/core/yaml/parser.h
@@ -816,11 +816,15 @@ private:
     bool has_digit{false};
     bool has_dot{false};
     bool has_exp{false};
+    bool has_exp_digit{false};
 
     for (std::size_t index = start; index < value.size(); ++index) {
       const char current{value[index]};
       if (current >= '0' && current <= '9') {
         has_digit = true;
+        if (has_exp) {
+          has_exp_digit = true;
+        }
       } else if (current == '.') {
         if (has_dot || has_exp) {
           return false;
@@ -840,7 +844,9 @@ private:
       }
     }
 
-    return has_digit;
+    // YAML 1.2.2 core schema: an exponent must carry at least one digit, so
+    // "1e" is a plain string rather than a malformed number that would throw
+    return has_digit && (!has_exp || has_exp_digit);
   }
 
   auto parse_number(const std::string_view value) -> JSON {

--- a/test/gzip/gzip_test.cc
+++ b/test/gzip/gzip_test.cc
@@ -157,6 +157,21 @@ TEST(decompress_concatenated_members) {
   EXPECT_EQ(decompressed, "hello world");
 }
 
+TEST(decompress_concatenated_members_grows_across_members) {
+  // A tiny hint forces the second member to grow the buffer that already holds
+  // the first, exercising the multi-member growth path
+  const std::string first{"hello "};
+  const std::string second{"world"};
+  auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(first.data()), first.size())};
+  compressed += sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(second.data()), second.size());
+  const auto decompressed{sourcemeta::core::gunzip(
+      reinterpret_cast<const std::uint8_t *>(compressed.data()),
+      compressed.size(), 1, 1024)};
+  EXPECT_EQ(decompressed, "hello world");
+}
+
 TEST(decompress_ignores_trailing_data) {
   const std::string input{"hello world"};
   auto compressed{sourcemeta::core::gzip(

--- a/test/gzip/gzip_test.cc
+++ b/test/gzip/gzip_test.cc
@@ -143,3 +143,44 @@ TEST(decompress_within_maximum_size_succeeds) {
       compressed.size(), 0, 1024)};
   EXPECT_EQ(decompressed, input);
 }
+
+TEST(decompress_concatenated_members) {
+  const std::string first{"hello "};
+  const std::string second{"world"};
+  auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(first.data()), first.size())};
+  compressed += sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(second.data()), second.size());
+  const auto decompressed{sourcemeta::core::gunzip(
+      reinterpret_cast<const std::uint8_t *>(compressed.data()),
+      compressed.size())};
+  EXPECT_EQ(decompressed, "hello world");
+}
+
+TEST(decompress_ignores_trailing_data) {
+  const std::string input{"hello world"};
+  auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
+  compressed += "not a gzip member";
+  const auto decompressed{sourcemeta::core::gunzip(
+      reinterpret_cast<const std::uint8_t *>(compressed.data()),
+      compressed.size())};
+  EXPECT_EQ(decompressed, input);
+}
+
+TEST(decompress_corrupt_trailing_member_throws) {
+  const std::string input{"hello world"};
+  auto compressed{sourcemeta::core::gzip(
+      reinterpret_cast<const std::uint8_t *>(input.data()), input.size())};
+  compressed.push_back('\x1F');
+  compressed.push_back('\x8B');
+  compressed.append("corrupt");
+  try {
+    sourcemeta::core::gunzip(
+        reinterpret_cast<const std::uint8_t *>(compressed.data()),
+        compressed.size());
+    FAIL();
+  } catch (const sourcemeta::core::GZIPError &error) {
+    EXPECT_EQ(std::string{error.what()}, "Could not decompress input");
+  }
+}

--- a/test/json/json_auto_test.cc
+++ b/test/json/json_auto_test.cc
@@ -576,6 +576,32 @@ TEST(from_json_integer_within_range) {
   EXPECT_EQ(result.value(), 200);
 }
 
+TEST(from_json_integer_at_upper_boundary) {
+  const sourcemeta::core::JSON document{255};
+  const auto result{sourcemeta::core::from_json<std::uint8_t>(document)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 255);
+}
+
+TEST(from_json_integer_just_above_upper_boundary_is_rejected) {
+  const sourcemeta::core::JSON document{256};
+  const auto result{sourcemeta::core::from_json<std::uint8_t>(document)};
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(from_json_signed_at_lower_boundary) {
+  const sourcemeta::core::JSON document{-128};
+  const auto result{sourcemeta::core::from_json<std::int8_t>(document)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), -128);
+}
+
+TEST(from_json_signed_below_lower_boundary_is_rejected) {
+  const sourcemeta::core::JSON document{-129};
+  const auto result{sourcemeta::core::from_json<std::int8_t>(document)};
+  EXPECT_FALSE(result.has_value());
+}
+
 TEST(from_json_invalid_hash_1) {
   const sourcemeta::core::JSON document{true};
   const auto result{

--- a/test/json/json_auto_test.cc
+++ b/test/json/json_auto_test.cc
@@ -1,6 +1,7 @@
 #include <sourcemeta/core/test.h>
 
 #include <bitset>
+#include <cstdint>
 #include <filesystem>
 #include <map>
 #include <optional>
@@ -554,6 +555,25 @@ TEST(from_json_invalid_integer) {
   const sourcemeta::core::JSON document{true};
   const auto result{sourcemeta::core::from_json<int>(document)};
   EXPECT_FALSE(result.has_value());
+}
+
+TEST(from_json_integer_out_of_range_is_rejected) {
+  const sourcemeta::core::JSON document{300};
+  const auto result{sourcemeta::core::from_json<std::uint8_t>(document)};
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(from_json_integer_negative_into_unsigned_is_rejected) {
+  const sourcemeta::core::JSON document{-1};
+  const auto result{sourcemeta::core::from_json<std::uint8_t>(document)};
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST(from_json_integer_within_range) {
+  const sourcemeta::core::JSON document{200};
+  const auto result{sourcemeta::core::from_json<std::uint8_t>(document)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 200);
 }
 
 TEST(from_json_invalid_hash_1) {

--- a/test/time/asctime_test.cc
+++ b/test/time/asctime_test.cc
@@ -87,6 +87,23 @@ TEST(format_round_trip) {
   EXPECT_EQ(sourcemeta::core::to_asctime(point), "Thu Jan  1 00:00:00 1970");
 }
 
+// timegm returns (time_t)-1 for this instant, a valid time one second before
+// the epoch that must not be mistaken for a conversion failure
+TEST(parse_second_before_epoch) {
+  const auto point{sourcemeta::core::from_asctime("Wed Dec 31 23:59:59 1969")};
+  EXPECT_TRUE(point.has_value());
+  EXPECT_EQ(sourcemeta::core::to_asctime(point.value()),
+            "Wed Dec 31 23:59:59 1969");
+}
+
+TEST(parse_pre_epoch_round_trips) {
+  const auto point{sourcemeta::core::from_asctime("Mon Jan  1 00:00:00 1940")};
+  EXPECT_TRUE(point.has_value());
+  EXPECT_TRUE(point.value() < std::chrono::system_clock::from_time_t(0));
+  EXPECT_EQ(sourcemeta::core::to_asctime(point.value()),
+            "Mon Jan  1 00:00:00 1940");
+}
+
 TEST(parse_accepts_zero_padded_single_digit_day) {
   EXPECT_TRUE(
       sourcemeta::core::from_asctime("Sun Nov 06 08:49:37 1994").has_value());

--- a/test/time/imf_fixdate_test.cc
+++ b/test/time/imf_fixdate_test.cc
@@ -59,6 +59,17 @@ TEST(parse_then_format) {
             "Wed, 21 Oct 2015 11:28:00 GMT");
 }
 
+TEST(parse_pre_epoch_round_trips) {
+  // A pre-1970 date maps to a negative time point, which the previous
+  // timegm-based conversion could not represent on a 32-bit time_t
+  const auto point{
+      sourcemeta::core::from_imf_fixdate("Mon, 01 Jan 1900 00:00:00 GMT")};
+  EXPECT_TRUE(point.has_value());
+  EXPECT_TRUE(point.value() < std::chrono::system_clock::from_time_t(0));
+  EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point.value()),
+            "Mon, 01 Jan 1900 00:00:00 GMT");
+}
+
 TEST(parse_invalid_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("FOO").has_value());
 }

--- a/test/time/imf_fixdate_test.cc
+++ b/test/time/imf_fixdate_test.cc
@@ -80,6 +80,14 @@ TEST(parse_pre_epoch_round_trips) {
             "Mon, 01 Jan 1900 00:00:00 GMT");
 }
 
+TEST(parse_far_future_year_is_representable) {
+  // Year 2200 is within system_clock's range on every platform, so the range
+  // guard that rejects unrepresentable dates must not reject it
+  EXPECT_TRUE(
+      sourcemeta::core::from_imf_fixdate("Wed, 31 Dec 2200 23:59:59 GMT")
+          .has_value());
+}
+
 TEST(parse_invalid_returns_nullopt) {
   EXPECT_FALSE(sourcemeta::core::from_imf_fixdate("FOO").has_value());
 }

--- a/test/time/imf_fixdate_test.cc
+++ b/test/time/imf_fixdate_test.cc
@@ -59,6 +59,16 @@ TEST(parse_then_format) {
             "Wed, 21 Oct 2015 11:28:00 GMT");
 }
 
+// timegm returns (time_t)-1 for this instant, a valid time one second before
+// the epoch that must not be mistaken for a conversion failure
+TEST(parse_second_before_epoch) {
+  const auto point{
+      sourcemeta::core::from_imf_fixdate("Wed, 31 Dec 1969 23:59:59 GMT")};
+  EXPECT_TRUE(point.has_value());
+  EXPECT_EQ(sourcemeta::core::to_imf_fixdate(point.value()),
+            "Wed, 31 Dec 1969 23:59:59 GMT");
+}
+
 TEST(parse_pre_epoch_round_trips) {
   // A pre-1970 date maps to a negative time point, which the previous
   // timegm-based conversion could not represent on a 32-bit time_t

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -364,6 +364,16 @@ TEST(exponent_with_leading_plus) {
   EXPECT_TRUE(result.is_decimal());
 }
 
+TEST(incomplete_exponent_is_a_string) {
+  // YAML 1.2.2 core schema requires a digit after the exponent, so "1e" is a
+  // plain string rather than a malformed number
+  const std::string input{"1e"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  const sourcemeta::core::JSON expected{"1e"};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(result.is_string());
+}
+
 TEST(real_long_small_decimal) {
   const std::string input{
       "0.00000000000000000000000000000000000000000000000000000000000000000000"
@@ -550,6 +560,31 @@ TEST(invalid_unicode_escape_4) {
 
 TEST(invalid_unicode_escape_8) {
   const std::string input{"\"\\UZZZZZZZZ\""};
+  try {
+    sourcemeta::core::parse_yaml(input);
+    FAIL();
+  } catch (const sourcemeta::core::YAMLParseError &error) {
+    EXPECT_EQ(error.line(), 1);
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(surrogate_unicode_escape_is_rejected) {
+  // YAML 1.2.2 Section 5.7: a lone surrogate is not a Unicode scalar value
+  const std::string input{"\"\\uD800\""};
+  try {
+    sourcemeta::core::parse_yaml(input);
+    FAIL();
+  } catch (const sourcemeta::core::YAMLParseError &error) {
+    EXPECT_EQ(error.line(), 1);
+  } catch (...) {
+    FAIL();
+  }
+}
+
+TEST(out_of_range_unicode_escape_is_rejected) {
+  const std::string input{"\"\\UFFFFFFFF\""};
   try {
     sourcemeta::core::parse_yaml(input);
     FAIL();

--- a/test/yaml/yaml_parse_test.cc
+++ b/test/yaml/yaml_parse_test.cc
@@ -374,6 +374,14 @@ TEST(incomplete_exponent_is_a_string) {
   EXPECT_TRUE(result.is_string());
 }
 
+TEST(exponent_sign_without_digit_is_a_string) {
+  const std::string input{"1e+"};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  const sourcemeta::core::JSON expected{"1e+"};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(result.is_string());
+}
+
 TEST(real_long_small_decimal) {
   const std::string input{
       "0.00000000000000000000000000000000000000000000000000000000000000000000"
@@ -568,6 +576,20 @@ TEST(invalid_unicode_escape_8) {
   } catch (...) {
     FAIL();
   }
+}
+
+TEST(valid_bmp_unicode_escape) {
+  const std::string input{"\"\\u00e9\""};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  const sourcemeta::core::JSON expected{"\xC3\xA9"};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(valid_astral_unicode_escape) {
+  const std::string input{"\"\\U0001F600\""};
+  const auto result{sourcemeta::core::parse_yaml(input)};
+  const sourcemeta::core::JSON expected{"\xF0\x9F\x98\x80"};
+  EXPECT_EQ(result, expected);
 }
 
 TEST(surrogate_unicode_escape_is_rejected) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

