### PR TITLE
More correctness fixes throughout the codebase

### DIFF
--- a/src/core/email/email.cc
+++ b/src/core/email/email.cc
@@ -17,6 +17,12 @@ static auto is_mailbox(const std::string_view value) -> bool {
     return false;
   }
 
+  // RFC 5321 §4.5.3.1.3: a path is at most 256 octets including the enclosing
+  // angle brackets, so the mailbox it carries is at most 254
+  if (value.size() > 254) {
+    return false;
+  }
+
   std::string_view::size_type position{0};
 
   if (value[0] == '"') {

--- a/src/core/email/helpers.h
+++ b/src/core/email/helpers.h
@@ -100,6 +100,11 @@ inline constexpr auto is_ipv4_address_literal(const std::string_view value)
       return false;
     }
     octets = static_cast<std::uint8_t>(octets + 1);
+    // A valid literal has exactly four octets, so stop before the counter could
+    // wrap on a pathological run of segments
+    if (octets > 4) {
+      return false;
+    }
     if (dot == std::string_view::npos) {
       break;
     }

--- a/src/core/http/match_accept_language.cc
+++ b/src/core/http/match_accept_language.cc
@@ -62,10 +62,10 @@ auto http_match_accept_language(
           if (specificity == 0) {
             return;
           }
-          // RFC 9110 Section 12.5.1: the most specific matching range has
-          // precedence, so its quality governs even when a less specific range
-          // offers a higher one. This makes a q=0 on the most specific match
-          // refuse the candidate rather than be overridden
+          // RFC 9110 Section 12.4.2: a quality of zero means "not acceptable".
+          // Honour that by letting the most specific matching range govern, so
+          // an explicit refusal of a specific range is not overridden by a less
+          // specific range that offers a higher quality
           if (specificity > candidate_specificity ||
               (specificity == candidate_specificity &&
                quality > candidate_quality)) {

--- a/src/core/http/match_accept_language.cc
+++ b/src/core/http/match_accept_language.cc
@@ -62,9 +62,13 @@ auto http_match_accept_language(
           if (specificity == 0) {
             return;
           }
-          if (quality > candidate_quality ||
-              (quality == candidate_quality &&
-               specificity > candidate_specificity)) {
+          // RFC 9110 Section 12.5.1: the most specific matching range has
+          // precedence, so its quality governs even when a less specific range
+          // offers a higher one. This makes a q=0 on the most specific match
+          // refuse the candidate rather than be overridden
+          if (specificity > candidate_specificity ||
+              (specificity == candidate_specificity &&
+               quality > candidate_quality)) {
             candidate_quality = quality;
             candidate_specificity = specificity;
           }

--- a/src/core/idna/codegen.cc
+++ b/src/core/idna/codegen.cc
@@ -137,9 +137,12 @@ auto compress_pages(const std::vector<std::uint8_t> &values) -> TwoStageTable {
 }
 
 auto build_pages(const std::vector<PropertyEntry> &entries) -> TwoStageTable {
+  // RFC 5892 Section 2.10: a code point not covered by the derived-property
+  // data defaults to Unassigned (which validation treats as disallowed), so an
+  // uncovered code point fails closed rather than being accepted
   std::vector<std::uint8_t> values(
       TOTAL_CODEPOINTS,
-      static_cast<std::uint8_t>(sourcemeta::core::IDNAProperty::PValid));
+      static_cast<std::uint8_t>(sourcemeta::core::IDNAProperty::Unassigned));
   for (const auto &entry : entries) {
     for (std::uint32_t codepoint{entry.first}; codepoint <= entry.last;
          codepoint += 1) {

--- a/src/core/jose/jose_jwt_check_claims.cc
+++ b/src/core/jose/jose_jwt_check_claims.cc
@@ -38,8 +38,11 @@ auto jwt_check_claims(const JWT &token, const std::string_view expected_issuer,
   // A bearer credential without an expiry is not acceptable for authentication,
   // so the claim is required here even though RFC 7519 makes it optional in
   // general (RFC 9068 Section 2.2)
+  // The skew is applied to the server clock rather than the attacker-controlled
+  // claim, so a NumericDate near the representable bound cannot overflow the
+  // time point arithmetic (the two forms are otherwise equivalent)
   const auto expires_at{token.expires_at()};
-  if (!expires_at.has_value() || now >= expires_at.value() + clock_skew) {
+  if (!expires_at.has_value() || now - clock_skew >= expires_at.value()) {
     return JWTClaimError::Expiration;
   }
 
@@ -49,7 +52,7 @@ auto jwt_check_claims(const JWT &token, const std::string_view expected_issuer,
   const auto &payload{token.payload()};
   if (payload.defines("nbf")) {
     const auto not_before{token.not_before()};
-    if (!not_before.has_value() || now < not_before.value() - clock_skew) {
+    if (!not_before.has_value() || now + clock_skew < not_before.value()) {
       return JWTClaimError::NotBefore;
     }
   }
@@ -58,7 +61,7 @@ auto jwt_check_claims(const JWT &token, const std::string_view expected_issuer,
   // in the future (RFC 7519 Section 4.1.6)
   if (payload.defines("iat")) {
     const auto issued_at{token.issued_at()};
-    if (!issued_at.has_value() || now < issued_at.value() - clock_skew) {
+    if (!issued_at.has_value() || now + clock_skew < issued_at.value()) {
       return JWTClaimError::IssuedAt;
     }
   }

--- a/src/core/jose/jose_jwt_check_claims.cc
+++ b/src/core/jose/jose_jwt_check_claims.cc
@@ -1,5 +1,6 @@
 #include <sourcemeta/core/jose_verify.h>
 
+#include <algorithm>   // std::clamp
 #include <chrono>      // std::chrono::seconds, std::chrono::system_clock
 #include <optional>    // std::optional, std::nullopt
 #include <string_view> // std::string_view
@@ -35,14 +36,28 @@ auto jwt_check_claims(const JWT &token, const std::string_view expected_issuer,
     return JWTClaimError::Audience;
   }
 
+  // The skew is applied to the server clock rather than the attacker-controlled
+  // claim, so a NumericDate near the representable bound cannot overflow the
+  // comparison (the two forms are otherwise equivalent). The skew is also
+  // clamped to a non-negative, bounded grace period and the shift saturates, so
+  // an extreme caller-supplied clock or skew stays well-defined too
+  using Clock = std::chrono::system_clock;
+  const auto skew{std::clamp(clock_skew, std::chrono::seconds::zero(),
+                             std::chrono::seconds{31556952})};
+  const auto skew_ticks{std::chrono::duration_cast<Clock::duration>(skew)};
+  const auto since_epoch{now.time_since_epoch()};
+  const auto now_minus_skew{(since_epoch < Clock::duration::min() + skew_ticks)
+                                ? Clock::time_point{Clock::duration::min()}
+                                : now - skew_ticks};
+  const auto now_plus_skew{(since_epoch > Clock::duration::max() - skew_ticks)
+                               ? Clock::time_point{Clock::duration::max()}
+                               : now + skew_ticks};
+
   // A bearer credential without an expiry is not acceptable for authentication,
   // so the claim is required here even though RFC 7519 makes it optional in
   // general (RFC 9068 Section 2.2)
-  // The skew is applied to the server clock rather than the attacker-controlled
-  // claim, so a NumericDate near the representable bound cannot overflow the
-  // time point arithmetic (the two forms are otherwise equivalent)
   const auto expires_at{token.expires_at()};
-  if (!expires_at.has_value() || now - clock_skew >= expires_at.value()) {
+  if (!expires_at.has_value() || now_minus_skew >= expires_at.value()) {
     return JWTClaimError::Expiration;
   }
 
@@ -52,7 +67,7 @@ auto jwt_check_claims(const JWT &token, const std::string_view expected_issuer,
   const auto &payload{token.payload()};
   if (payload.defines("nbf")) {
     const auto not_before{token.not_before()};
-    if (!not_before.has_value() || now + clock_skew < not_before.value()) {
+    if (!not_before.has_value() || now_plus_skew < not_before.value()) {
       return JWTClaimError::NotBefore;
     }
   }
@@ -61,7 +76,7 @@ auto jwt_check_claims(const JWT &token, const std::string_view expected_issuer,
   // in the future (RFC 7519 Section 4.1.6)
   if (payload.defines("iat")) {
     const auto issued_at{token.issued_at()};
-    if (!issued_at.has_value() || now + clock_skew < issued_at.value()) {
+    if (!issued_at.has_value() || now_plus_skew < issued_at.value()) {
       return JWTClaimError::IssuedAt;
     }
   }

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -45,9 +45,9 @@ namespace sourcemeta::core {
 /// ```
 ///
 /// The tracker keeps references to the property names of the document it was
-/// populated from, so that document must outlive every `get`, `size`, and
-/// `to_json` call. Querying the tracker after the source document has been
-/// destroyed is undefined behavior.
+/// populated from, so that document must outlive every query against the
+/// tracker. Reading the tracker after the source document has been destroyed is
+/// undefined behavior.
 class SOURCEMETA_CORE_JSONPOINTER_EXPORT PointerPositionTracker {
 public:
   /// The pointer type used to look up positions

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_position.h
@@ -43,6 +43,11 @@ namespace sourcemeta::core {
 /// assert(std::get<3>(foo.value()) == 2);
 /// assert(std::get<4>(foo.value()) == 14);
 /// ```
+///
+/// The tracker keeps references to the property names of the document it was
+/// populated from, so that document must outlive every `get`, `size`, and
+/// `to_json` call. Querying the tracker after the source document has been
+/// destroyed is undefined behavior.
 class SOURCEMETA_CORE_JSONPOINTER_EXPORT PointerPositionTracker {
 public:
   /// The pointer type used to look up positions

--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_walker.h
@@ -3,8 +3,10 @@
 
 #include <sourcemeta/core/json.h>
 
-#include <cstddef> // std::size_t
-#include <vector>  // std::vector
+#include <algorithm> // std::reverse
+#include <cstddef>   // std::size_t, std::ptrdiff_t
+#include <utility>   // std::pair, std::move
+#include <vector>    // std::vector
 
 namespace sourcemeta::core {
 
@@ -38,19 +40,35 @@ public:
 
 private:
   auto walk(const JSON &document, PointerT &pointer) -> void {
-    this->pointers.push_back(pointer);
-    if (document.is_array()) {
-      for (std::size_t index = 0; index < document.size(); index++) {
-        pointer.emplace_back(index);
-        this->walk(document.at(index), pointer);
-        pointer.pop_back();
+    // Traversal is iterative with an explicit stack so that a deeply nested
+    // document cannot overflow the call stack. The output ordering is
+    // unspecified either way
+    std::vector<std::pair<const JSON *, PointerT>> pending;
+    pending.emplace_back(&document, pointer);
+    while (!pending.empty()) {
+      auto entry{std::move(pending.back())};
+      pending.pop_back();
+      const JSON &node{*entry.first};
+      // Children are queued then reversed so that they are popped in their
+      // natural order, preserving the pre-order traversal of the recursive form
+      const auto start{pending.size()};
+      if (node.is_array()) {
+        for (std::size_t index = 0; index < node.size(); index++) {
+          PointerT child{entry.second};
+          child.emplace_back(index);
+          pending.emplace_back(&node.at(index), std::move(child));
+        }
+      } else if (node.is_object()) {
+        for (const auto &pair : node.as_object()) {
+          PointerT child{entry.second};
+          child.emplace_back(pair.first);
+          pending.emplace_back(&pair.second, std::move(child));
+        }
       }
-    } else if (document.is_object()) {
-      for (const auto &pair : document.as_object()) {
-        pointer.emplace_back(pair.first);
-        this->walk(pair.second, pointer);
-        pointer.pop_back();
-      }
+
+      std::reverse(pending.begin() + static_cast<std::ptrdiff_t>(start),
+                   pending.end());
+      this->pointers.push_back(std::move(entry.second));
     }
   }
 

--- a/src/core/mcp/mcp.cc
+++ b/src/core/mcp/mcp.cc
@@ -318,13 +318,16 @@ auto mcp_make_initialize_result(const sourcemeta::core::JSON &request,
     return sourcemeta::core::jsonrpc_make_error_invalid_request(identifier);
   }
 
-  JSON::StringView requested_version{};
   const auto *protocol_version_field{
       parameters->try_at("protocolVersion", MCP_HASH_PROTOCOL_VERSION)};
-  if (protocol_version_field != nullptr &&
-      protocol_version_field->is_string()) {
-    requested_version = protocol_version_field->to_string();
+  // MCP requires protocolVersion in the initialize request, so a missing or
+  // non-string value is a malformed request rather than a version to negotiate
+  if (protocol_version_field == nullptr ||
+      !protocol_version_field->is_string()) {
+    return sourcemeta::core::jsonrpc_make_error_invalid_params(*identifier);
   }
+
+  const JSON::StringView requested_version{protocol_version_field->to_string()};
   const auto resolved{mcp_resolve_protocol_version(requested_version)};
   // MCP lifecycle, version negotiation: "If the server supports the requested
   // protocol version, it MUST respond with the same version. Otherwise, the

--- a/src/core/punycode/punycode.cc
+++ b/src/core/punycode/punycode.cc
@@ -80,6 +80,12 @@ static constexpr auto is_basic(const char32_t code_point) -> bool {
 
 static auto punycode_encode(const std::u32string_view codepoints,
                             std::string &output) -> void {
+  // RFC 3492 Section 6.4 requires failing rather than letting the code point
+  // counters wrap on an input that does not fit a 32-bit count
+  if (codepoints.size() > std::numeric_limits<std::uint32_t>::max()) {
+    throw PunycodeError("Input is too large");
+  }
+
   std::vector<char32_t> non_basic_sorted;
   non_basic_sorted.reserve(codepoints.size());
 
@@ -172,6 +178,12 @@ static auto punycode_encode(const std::u32string_view codepoints,
 
 static auto punycode_decode(const std::string_view encoded,
                             std::u32string &decoded) -> void {
+  // RFC 3492 Section 6.4 requires failing rather than letting the output
+  // position counter wrap on an input that does not fit a 32-bit count
+  if (encoded.size() > std::numeric_limits<std::uint32_t>::max()) {
+    throw PunycodeError("Input is too large");
+  }
+
   std::uint32_t current_code_point{INITIAL_N};
   std::uint32_t insertion_index{0};
   std::uint32_t bias{INITIAL_BIAS};

--- a/src/core/regex/preprocess.h
+++ b/src/core/regex/preprocess.h
@@ -80,6 +80,12 @@ inline auto parse_hex_digits(const std::string &content, std::size_t start,
   int value = 0;
   for (std::size_t offset = 0; offset < count; ++offset) {
     value = (value << 4) | hex_digit_value(content[start + offset]);
+    // Stop once the value is unambiguously past the Unicode range, so a long
+    // "\u{...}" digit run cannot overflow the accumulator. The callers only
+    // care whether the result is a small ASCII value
+    if (value > 0x10FFFF) {
+      return value;
+    }
   }
 
   return value;

--- a/src/core/regex/regex.cc
+++ b/src/core/regex/regex.cc
@@ -74,9 +74,11 @@ auto to_regex(const std::string_view pattern) -> std::optional<Regex> {
   pcre2_code *pcre2_regex_raw{pcre2_compile(
       reinterpret_cast<PCRE2_SPTR>(preprocessed.transformed.value().c_str()),
       preprocessed.transformed.value().size(),
-      PCRE2_UTF | PCRE2_UCP | PCRE2_NO_AUTO_CAPTURE | PCRE2_DOTALL |
-          PCRE2_DOLLAR_ENDONLY | PCRE2_NEVER_BACKSLASH_C |
-          PCRE2_MATCH_INVALID_UTF | PCRE2_ALLOW_EMPTY_CLASS,
+      // Capturing groups are kept enabled so that ECMA-262 numbered
+      // backreferences like (a)\1 compile and match, at a small tracking cost
+      PCRE2_UTF | PCRE2_UCP | PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY |
+          PCRE2_NEVER_BACKSLASH_C | PCRE2_MATCH_INVALID_UTF |
+          PCRE2_ALLOW_EMPTY_CLASS,
       &pcre2_error_code, &pcre2_error_offset, nullptr)};
 
   if (pcre2_regex_raw != nullptr) {
@@ -142,9 +144,11 @@ auto is_regex_ecma(const std::string_view pattern) -> bool {
   pcre2_code *pcre2_regex_raw{pcre2_compile(
       reinterpret_cast<PCRE2_SPTR>(preprocessed.transformed.value().c_str()),
       preprocessed.transformed.value().size(),
-      PCRE2_UTF | PCRE2_UCP | PCRE2_NO_AUTO_CAPTURE | PCRE2_DOTALL |
-          PCRE2_DOLLAR_ENDONLY | PCRE2_NEVER_BACKSLASH_C |
-          PCRE2_MATCH_INVALID_UTF | PCRE2_ALLOW_EMPTY_CLASS,
+      // Capturing groups are kept enabled so that ECMA-262 numbered
+      // backreferences like (a)\1 compile and match, at a small tracking cost
+      PCRE2_UTF | PCRE2_UCP | PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY |
+          PCRE2_NEVER_BACKSLASH_C | PCRE2_MATCH_INVALID_UTF |
+          PCRE2_ALLOW_EMPTY_CLASS,
       &pcre2_error_code, &pcre2_error_offset, nullptr)};
 
   if (pcre2_regex_raw == nullptr) {

--- a/src/lang/numeric/decimal.cc
+++ b/src/lang/numeric/decimal.cc
@@ -148,14 +148,19 @@ struct ParsedDecimal {
 };
 
 auto parse_digit_payload(const char *cursor, std::size_t count)
-    -> std::int64_t {
-  // The diagnostic payload of a NaN carries no arithmetic meaning here, so a
+    -> std::optional<std::int64_t> {
+  // The diagnostic payload of a NaN is a sequence of digits, so a non-digit
+  // byte makes the whole token invalid rather than being silently accepted. A
   // payload longer than the storage saturates rather than overflowing, which
   // would otherwise be signed integer overflow (undefined behaviour)
   constexpr auto maximum{
       static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())};
   std::uint64_t payload = 0;
   for (std::size_t index = 0; index < count; index++) {
+    if (cursor[index] < '0' || cursor[index] > '9') {
+      return std::nullopt;
+    }
+
     const auto digit = static_cast<std::uint64_t>(cursor[index] - '0');
     if (payload > (maximum - digit) / 10) {
       return std::numeric_limits<std::int64_t>::max();
@@ -187,10 +192,15 @@ auto parse_special(const char *input, std::size_t length)
   if (remaining >= 3 && (cursor[0] == 'N' || cursor[0] == 'n') &&
       (cursor[1] == 'a' || cursor[1] == 'A') &&
       (cursor[2] == 'N' || cursor[2] == 'n')) {
+    const auto payload{parse_digit_payload(cursor + 3, remaining - 3)};
+    if (!payload.has_value()) {
+      return std::nullopt;
+    }
+
     result.flags = FLAG_NAN | sign_flag;
     result.exponent = 0;
     result.coefficient_high = 0;
-    result.coefficient = parse_digit_payload(cursor + 3, remaining - 3);
+    result.coefficient = payload.value();
     return result;
   }
 
@@ -198,10 +208,15 @@ auto parse_special(const char *input, std::size_t length)
       (cursor[1] == 'N' || cursor[1] == 'n') &&
       (cursor[2] == 'a' || cursor[2] == 'A') &&
       (cursor[3] == 'N' || cursor[3] == 'n')) {
+    const auto payload{parse_digit_payload(cursor + 4, remaining - 4)};
+    if (!payload.has_value()) {
+      return std::nullopt;
+    }
+
     result.flags = FLAG_NAN | FLAG_SNAN | sign_flag;
     result.exponent = 0;
     result.coefficient_high = 0;
-    result.coefficient = parse_digit_payload(cursor + 4, remaining - 4);
+    result.coefficient = payload.value();
     return result;
   }
 

--- a/test/email/email_test.cc
+++ b/test/email/email_test.cc
@@ -387,10 +387,11 @@ TEST(valid_domain_label_63) {
   EXPECT_TRUE(sourcemeta::core::is_idn_email("a@" + std::string(63, 'b')));
 }
 
-// RFC 5321 §4.5.3.1.2 Domain: 255-byte domain is the RFC 1123 cap.
-// RFC 1035 §3.1: IDN strict presentation form caps the domain at 253 octets
+// RFC 5321 §4.5.3.1.3: a 255-octet domain pushes the mailbox past the 254
+// octet total, so the address is rejected even though the domain is within its
+// own 255-octet limit
 TEST(domain_total_255) {
-  EXPECT_TRUE(sourcemeta::core::is_email(
+  EXPECT_FALSE(sourcemeta::core::is_email(
       "a@" + std::string(63, 'b') + "." + std::string(63, 'c') + "." +
       std::string(63, 'd') + "." + std::string(63, 'e')));
   EXPECT_FALSE(sourcemeta::core::is_idn_email(
@@ -1095,10 +1096,11 @@ TEST(invalid_general_dcontent_high_bit) {
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a@[X400:\x80]"));
 }
 
-// RFC 5321 §4.5.3.1: 64-byte Local-part plus "@" plus a 254-byte Domain fits
-// the RFC 1123 cap. RFC 1035 §3.1 caps the IDN domain at 253 octets
+// RFC 5321 §4.5.3.1.3: a 64-byte Local-part plus "@" plus a 254-byte Domain is
+// 319 octets, which exceeds the 254 octet mailbox total even though each
+// component is within its own limit
 TEST(max_length_email) {
-  EXPECT_TRUE(sourcemeta::core::is_email(
+  EXPECT_FALSE(sourcemeta::core::is_email(
       std::string(64, 'a') + "@" + std::string(63, 'b') + "." +
       std::string(63, 'c') + "." + std::string(63, 'd') + "." +
       std::string(62, 'e')));
@@ -1167,10 +1169,12 @@ TEST(valid_dot_string_with_general_literal) {
 
 // RFC 5321 §4.5.3.1.2: an address-literal whose total length equals the
 // 255-octet domain cap (including the surrounding "[" and "]") is accepted
-TEST(valid_address_literal_length_255) {
-  EXPECT_TRUE(
+// RFC 5321 §4.5.3.1.3: the mailbox total is capped at 254 octets, so an
+// address literal that pushes it to 257 is rejected
+TEST(address_literal_over_total_length_rejected) {
+  EXPECT_FALSE(
       sourcemeta::core::is_email("a@[X:" + std::string(251, 'a') + "]"));
-  EXPECT_TRUE(
+  EXPECT_FALSE(
       sourcemeta::core::is_idn_email("a@[X:" + std::string(251, 'a') + "]"));
 }
 
@@ -1498,10 +1502,12 @@ TEST(invalid_general_dcontent_del_byte) {
 // RFC 5321 §4.1.3 + §4.5.3.1.2: a General-address-literal whose Domain total
 // length equals the 255-octet cap ("[" + "Tag" + ":" + 249 dcontent + "]") is
 // accepted
-TEST(valid_general_literal_inner_at_cap) {
-  EXPECT_TRUE(
+// RFC 5321 §4.5.3.1.3: the mailbox total is capped at 254 octets, so this
+// 257 octet address with a long general literal is rejected
+TEST(general_literal_over_total_length_rejected) {
+  EXPECT_FALSE(
       sourcemeta::core::is_email("a@[Tag:" + std::string(249, 'x') + "]"));
-  EXPECT_TRUE(
+  EXPECT_FALSE(
       sourcemeta::core::is_idn_email("a@[Tag:" + std::string(249, 'x') + "]"));
 }
 
@@ -1525,4 +1531,33 @@ TEST(valid_quoted_single_letter_then_minimal_domain) {
 TEST(invalid_dot_then_at) {
   EXPECT_FALSE(sourcemeta::core::is_email("a.@b"));
   EXPECT_FALSE(sourcemeta::core::is_idn_email("a.@b"));
+}
+
+// RFC 5321 §4.5.3.1.3: a path is at most 256 octets including the angle
+// brackets, so a mailbox is at most 254
+TEST(valid_total_length_254) {
+  const auto address{std::string(64, 'a') + "@" + std::string(63, 'b') + "." +
+                     std::string(63, 'b') + "." + std::string(61, 'b')};
+  EXPECT_EQ(address.size(), 254);
+  EXPECT_TRUE(sourcemeta::core::is_email(address));
+  EXPECT_TRUE(sourcemeta::core::is_idn_email(address));
+}
+
+TEST(invalid_total_length_255) {
+  const auto address{std::string(64, 'a') + "@" + std::string(63, 'b') + "." +
+                     std::string(63, 'b') + "." + std::string(62, 'b')};
+  EXPECT_EQ(address.size(), 255);
+  EXPECT_FALSE(sourcemeta::core::is_email(address));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email(address));
+}
+
+// RFC 5321 §4.1.3: IPv4-address-literal has exactly four octets
+TEST(invalid_ipv4_literal_five_octets) {
+  EXPECT_FALSE(sourcemeta::core::is_email("user@[1.1.1.1.1]"));
+  EXPECT_FALSE(sourcemeta::core::is_idn_email("user@[1.1.1.1.1]"));
+}
+
+TEST(valid_ipv4_literal_four_octets) {
+  EXPECT_TRUE(sourcemeta::core::is_email("user@[192.168.1.1]"));
+  EXPECT_TRUE(sourcemeta::core::is_idn_email("user@[192.168.1.1]"));
 }

--- a/test/http/http_match_accept_language_test.cc
+++ b/test/http/http_match_accept_language_test.cc
@@ -151,3 +151,33 @@ TEST(three_subtag_match) {
                                                          {"en-GB", "en"}),
             "en-GB");
 }
+
+TEST(specific_zero_quality_refuses_despite_less_specific_acceptance) {
+  // RFC 9110 Section 12.5.1: the exact "en;q=0" is more specific than "en-US"
+  // matching the "en" candidate, so it refuses that candidate despite the
+  // higher-quality less specific range
+  EXPECT_EQ(sourcemeta::core::http_match_accept_language("en;q=0, en-US;q=1",
+                                                         {"en", "de"}),
+            "");
+}
+
+TEST(specific_quality_governs_over_less_specific_higher_quality) {
+  // The exact "en;q=0.2" governs the "en" candidate over the less specific
+  // "en-US;q=0.9", so "fr;q=0.5" outranks it
+  EXPECT_EQ(sourcemeta::core::http_match_accept_language(
+                "en;q=0.2, en-US;q=0.9, fr;q=0.5", {"en", "fr"}),
+            "fr");
+}
+
+TEST(specific_higher_quality_governs_over_less_specific) {
+  // The exact "en;q=0.9" governs the "en" candidate over "en-US;q=0.1"
+  EXPECT_EQ(sourcemeta::core::http_match_accept_language(
+                "en;q=0.9, en-US;q=0.1", {"en", "de"}),
+            "en");
+}
+
+TEST(specific_zero_quality_alone_refuses_candidate) {
+  EXPECT_EQ(sourcemeta::core::http_match_accept_language("en-US;q=0",
+                                                         {"en-US", "fr"}),
+            "");
+}

--- a/test/http/http_match_accept_language_test.cc
+++ b/test/http/http_match_accept_language_test.cc
@@ -153,7 +153,7 @@ TEST(three_subtag_match) {
 }
 
 TEST(specific_zero_quality_refuses_despite_less_specific_acceptance) {
-  // RFC 9110 Section 12.5.1: the exact "en;q=0" is more specific than "en-US"
+  // RFC 9110 Section 12.4.2: q=0 means not acceptable, so the exact "en;q=0"
   // matching the "en" candidate, so it refuses that candidate despite the
   // higher-quality less specific range
   EXPECT_EQ(sourcemeta::core::http_match_accept_language("en;q=0, en-US;q=1",

--- a/test/jose/jose_jwt_check_claims_test.cc
+++ b/test/jose/jose_jwt_check_claims_test.cc
@@ -64,6 +64,23 @@ TEST(not_before_near_clock_minimum_does_not_underflow) {
   EXPECT_FALSE(error.has_value());
 }
 
+TEST(issued_at_near_clock_minimum_does_not_underflow) {
+  const auto minimum{std::chrono::duration_cast<std::chrono::duration<double>>(
+                         std::chrono::system_clock::duration::min())
+                         .count()};
+  const auto payload{
+      std::string{R"({ "iss": "acme", "aud": "client", "exp": 2000, "iat": )"} +
+      std::to_string(minimum + 2.0) + " }"};
+  const auto input{make_token(R"({ "alg": "RS256" })", payload, "sig")};
+  const auto token{sourcemeta::core::JWT::from(input)};
+  EXPECT_TRUE(token.has_value());
+  const auto error{sourcemeta::core::jwt_check_claims(
+      token.value(), "acme", "client",
+      std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{60})};
+  // The far-past issued-at is not in the future, so the token is valid
+  EXPECT_FALSE(error.has_value());
+}
+
 TEST(missing_issuer) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "aud": "client", "exp": 2000 })", "sig")};

--- a/test/jose/jose_jwt_check_claims_test.cc
+++ b/test/jose/jose_jwt_check_claims_test.cc
@@ -28,6 +28,42 @@ TEST(valid) {
   EXPECT_FALSE(error.has_value());
 }
 
+TEST(expiration_near_clock_maximum_does_not_overflow) {
+  // A NumericDate just inside the clock's maximum, plus a positive skew, would
+  // overflow the time point if the skew were added to the attacker claim (§4)
+  const auto maximum{std::chrono::duration_cast<std::chrono::duration<double>>(
+                         std::chrono::system_clock::duration::max())
+                         .count()};
+  const auto payload{
+      std::string{R"({ "iss": "acme", "aud": "client", "exp": )"} +
+      std::to_string(maximum - 2.0) + " }"};
+  const auto input{make_token(R"({ "alg": "RS256" })", payload, "sig")};
+  const auto token{sourcemeta::core::JWT::from(input)};
+  EXPECT_TRUE(token.has_value());
+  const auto error{sourcemeta::core::jwt_check_claims(
+      token.value(), "acme", "client",
+      std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{60})};
+  // The far-future expiry means the token is not expired
+  EXPECT_FALSE(error.has_value());
+}
+
+TEST(not_before_near_clock_minimum_does_not_underflow) {
+  const auto minimum{std::chrono::duration_cast<std::chrono::duration<double>>(
+                         std::chrono::system_clock::duration::min())
+                         .count()};
+  const auto payload{
+      std::string{R"({ "iss": "acme", "aud": "client", "exp": 2000, "nbf": )"} +
+      std::to_string(minimum + 2.0) + " }"};
+  const auto input{make_token(R"({ "alg": "RS256" })", payload, "sig")};
+  const auto token{sourcemeta::core::JWT::from(input)};
+  EXPECT_TRUE(token.has_value());
+  const auto error{sourcemeta::core::jwt_check_claims(
+      token.value(), "acme", "client",
+      std::chrono::system_clock::from_time_t(1000), std::chrono::seconds{60})};
+  // The far-past not-before means the token is already valid
+  EXPECT_FALSE(error.has_value());
+}
+
 TEST(missing_issuer) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "aud": "client", "exp": 2000 })", "sig")};

--- a/test/jose/jose_jwt_check_claims_test.cc
+++ b/test/jose/jose_jwt_check_claims_test.cc
@@ -81,6 +81,37 @@ TEST(issued_at_near_clock_minimum_does_not_underflow) {
   EXPECT_FALSE(error.has_value());
 }
 
+TEST(now_at_clock_maximum_with_skew_does_not_overflow) {
+  // A caller passing now at the clock's maximum, plus a skew, would overflow
+  // the shifted server clock without the saturating guard
+  const auto input{
+      make_token(R"({ "alg": "RS256" })",
+                 R"({ "iss": "acme", "aud": "client", "exp": 2000 })", "sig")};
+  const auto token{sourcemeta::core::JWT::from(input)};
+  EXPECT_TRUE(token.has_value());
+  const auto error{sourcemeta::core::jwt_check_claims(
+      token.value(), "acme", "client",
+      std::chrono::system_clock::time_point::max(), std::chrono::seconds{60})};
+  // now is far past the expiry, so the token is expired
+  EXPECT_TRUE(error.has_value());
+  EXPECT_EQ(error.value(), sourcemeta::core::JWTClaimError::Expiration);
+}
+
+TEST(negative_clock_skew_is_clamped_to_zero) {
+  // A negative skew is clamped to zero rather than extending validity into the
+  // past, so a not-yet-expired token stays valid
+  const auto input{
+      make_token(R"({ "alg": "RS256" })",
+                 R"({ "iss": "acme", "aud": "client", "exp": 2000 })", "sig")};
+  const auto token{sourcemeta::core::JWT::from(input)};
+  EXPECT_TRUE(token.has_value());
+  const auto error{sourcemeta::core::jwt_check_claims(
+      token.value(), "acme", "client",
+      std::chrono::system_clock::from_time_t(1500),
+      std::chrono::seconds{-1000})};
+  EXPECT_FALSE(error.has_value());
+}
+
 TEST(missing_issuer) {
   const auto input{make_token(R"({ "alg": "RS256" })",
                               R"({ "aud": "client", "exp": 2000 })", "sig")};

--- a/test/jsonpointer/jsonpointer_walker_test.cc
+++ b/test/jsonpointer/jsonpointer_walker_test.cc
@@ -2,6 +2,7 @@
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/test.h>
 
+#include <cstddef>
 #include <set>
 #include <string>
 #include <vector>

--- a/test/mcp/mcp_test.cc
+++ b/test/mcp/mcp_test.cc
@@ -885,6 +885,36 @@ TEST(make_initialize_result_minimal_2025_11_25) {
   EXPECT_EQ(envelope, expected);
 }
 
+TEST(make_initialize_result_missing_protocol_version_is_invalid_params) {
+  const auto request{sourcemeta::core::parse_json(R"JSON({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {}
+  })JSON")};
+  const sourcemeta::core::MCPServerCapabilities capabilities;
+  const sourcemeta::core::MCPImplementation server{"srv", "1.0.0", {}, {}, {}};
+  const auto envelope{sourcemeta::core::mcp_make_initialize_result(
+      request, capabilities, server)};
+  EXPECT_TRUE(envelope.defines("error"));
+  EXPECT_EQ(envelope.at("error").at("code").to_integer(), -32602);
+}
+
+TEST(make_initialize_result_non_string_protocol_version_is_invalid_params) {
+  const auto request{sourcemeta::core::parse_json(R"JSON({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": { "protocolVersion": 123 }
+  })JSON")};
+  const sourcemeta::core::MCPServerCapabilities capabilities;
+  const sourcemeta::core::MCPImplementation server{"srv", "1.0.0", {}, {}, {}};
+  const auto envelope{sourcemeta::core::mcp_make_initialize_result(
+      request, capabilities, server)};
+  EXPECT_TRUE(envelope.defines("error"));
+  EXPECT_EQ(envelope.at("error").at("code").to_integer(), -32602);
+}
+
 TEST(make_initialize_result_with_all_capabilities) {
   const auto request{sourcemeta::core::parse_json(R"JSON({
     "jsonrpc": "2.0",

--- a/test/mcp/mcp_test.cc
+++ b/test/mcp/mcp_test.cc
@@ -896,8 +896,12 @@ TEST(make_initialize_result_missing_protocol_version_is_invalid_params) {
   const sourcemeta::core::MCPImplementation server{"srv", "1.0.0", {}, {}, {}};
   const auto envelope{sourcemeta::core::mcp_make_initialize_result(
       request, capabilities, server)};
-  EXPECT_TRUE(envelope.defines("error"));
-  EXPECT_EQ(envelope.at("error").at("code").to_integer(), -32602);
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": { "code": -32602, "message": "Invalid params" }
+  })JSON")};
+  EXPECT_EQ(envelope, expected);
 }
 
 TEST(make_initialize_result_non_string_protocol_version_is_invalid_params) {
@@ -911,8 +915,35 @@ TEST(make_initialize_result_non_string_protocol_version_is_invalid_params) {
   const sourcemeta::core::MCPImplementation server{"srv", "1.0.0", {}, {}, {}};
   const auto envelope{sourcemeta::core::mcp_make_initialize_result(
       request, capabilities, server)};
-  EXPECT_TRUE(envelope.defines("error"));
-  EXPECT_EQ(envelope.at("error").at("code").to_integer(), -32602);
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "error": { "code": -32602, "message": "Invalid params" }
+  })JSON")};
+  EXPECT_EQ(envelope, expected);
+}
+
+TEST(make_initialize_result_unsupported_protocol_version_negotiates_latest) {
+  const auto request{sourcemeta::core::parse_json(R"JSON({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": { "protocolVersion": "9999-01-01" }
+  })JSON")};
+  const sourcemeta::core::MCPServerCapabilities capabilities;
+  const sourcemeta::core::MCPImplementation server{"srv", "1.0.0", {}, {}, {}};
+  const auto envelope{sourcemeta::core::mcp_make_initialize_result(
+      request, capabilities, server)};
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+      "protocolVersion": "2025-11-25",
+      "capabilities": {},
+      "serverInfo": { "name": "srv", "version": "1.0.0" }
+    }
+  })JSON")};
+  EXPECT_EQ(envelope, expected);
 }
 
 TEST(make_initialize_result_with_all_capabilities) {

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -1431,6 +1431,29 @@ TEST(exception_conversion_syntax_invalid_string) {
   }
 }
 
+TEST(nan_with_non_digit_payload_is_invalid) {
+  // The diagnostic payload of a NaN must be digits, so a non-digit payload is
+  // rejected rather than silently accepted
+  try {
+    const sourcemeta::core::Decimal value{"NaNxyz"};
+    FAIL();
+  } catch (const sourcemeta::core::DecimalParseError &) {
+  }
+}
+
+TEST(nan_with_digit_payload_is_valid) {
+  const sourcemeta::core::Decimal value{"NaN123"};
+  EXPECT_TRUE(value.is_nan());
+}
+
+TEST(snan_with_non_digit_payload_is_invalid) {
+  try {
+    const sourcemeta::core::Decimal value{"sNaNz"};
+    FAIL();
+  } catch (const sourcemeta::core::DecimalParseError &) {
+  }
+}
+
 TEST(exception_conversion_syntax_empty_string) {
   try {
     const sourcemeta::core::Decimal value{""};

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -1437,7 +1437,8 @@ TEST(nan_with_non_digit_payload_is_invalid) {
   try {
     const sourcemeta::core::Decimal value{"NaNxyz"};
     FAIL();
-  } catch (const sourcemeta::core::DecimalParseError &) {
+  } catch (const sourcemeta::core::DecimalParseError &error) {
+    EXPECT_STREQ(error.what(), "Invalid decimal string format");
   }
 }
 
@@ -1450,7 +1451,8 @@ TEST(snan_with_non_digit_payload_is_invalid) {
   try {
     const sourcemeta::core::Decimal value{"sNaNz"};
     FAIL();
-  } catch (const sourcemeta::core::DecimalParseError &) {
+  } catch (const sourcemeta::core::DecimalParseError &error) {
+    EXPECT_STREQ(error.what(), "Invalid decimal string format");
   }
 }
 

--- a/test/regex/regex_to_regex_test.cc
+++ b/test/regex/regex_to_regex_test.cc
@@ -69,3 +69,25 @@ TEST(pcre_unknown_escape) {
   EXPECT_TRUE(sourcemeta::core::matches(*regex, "abc"));
   EXPECT_FALSE(sourcemeta::core::matches(*regex, "xabc"));
 }
+
+TEST(numbered_backreference) {
+  const auto regex{sourcemeta::core::to_regex("^(a)\\1$")};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(*regex, "aa"));
+  EXPECT_FALSE(sourcemeta::core::matches(*regex, "ab"));
+  EXPECT_FALSE(sourcemeta::core::matches(*regex, "a"));
+}
+
+TEST(unicode_brace_escape_with_leading_zeros) {
+  const auto regex{sourcemeta::core::to_regex("^\\u{00000041}$")};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(*regex, "A"));
+  EXPECT_FALSE(sourcemeta::core::matches(*regex, "B"));
+}
+
+TEST(oversized_unicode_brace_escape_does_not_overflow) {
+  // A digit run long enough to overflow a 32-bit accumulator must be handled
+  // without undefined behavior
+  const auto regex{sourcemeta::core::to_regex("\\u{FFFFFFFFFFFFFFFFFFFFFFFF}")};
+  EXPECT_FALSE(regex.has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

