### PR TITLE
Fix a case of undefined behavior in `URITemplateRouter`

### DIFF
--- a/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
+++ b/src/core/uritemplate/include/sourcemeta/core/uritemplate_router.h
@@ -288,6 +288,9 @@ private:
   const std::uint8_t *data_{nullptr};
   std::size_t size_{0};
   std::unique_ptr<FileView> owner_;
+  // Holds an eight-byte-aligned copy of an unaligned external buffer, so the
+  // over-aligned serialized nodes are always read from aligned storage
+  std::vector<std::uint64_t> owned_;
 };
 
 #if defined(_MSC_VER)

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -539,10 +539,10 @@ URITemplateRouterView::URITemplateRouterView(const std::uint8_t *data,
   // unaligned external buffer would make those reads undefined. Keep the
   // zero-copy path when the caller's buffer is already aligned, and otherwise
   // mirror it into aligned storage that outlives the view
-  if (data != nullptr &&
+  if (data != nullptr && size > 0 &&
       (reinterpret_cast<std::uintptr_t>(data) % alignof(SerializedNode)) != 0) {
-    this->owned_.resize((size + sizeof(std::uint64_t) - 1) /
-                        sizeof(std::uint64_t));
+    this->owned_.resize(size / sizeof(std::uint64_t) +
+                        (size % sizeof(std::uint64_t) != 0 ? 1 : 0));
     std::memcpy(this->owned_.data(), data, size);
     this->data_ = reinterpret_cast<const std::uint8_t *>(this->owned_.data());
   }

--- a/src/core/uritemplate/uritemplate_router_view.cc
+++ b/src/core/uritemplate/uritemplate_router_view.cc
@@ -86,6 +86,10 @@ struct alignas(8) SerializedNode {
   std::array<std::uint8_t, 6> padding2;
 };
 
+// The nodes follow the header contiguously, so the header size must be a
+// multiple of the node alignment for the nodes to land on an aligned offset
+static_assert(sizeof(RouterHeader) % alignof(SerializedNode) == 0);
+
 inline auto
 finalize_match(const URITemplateRouter::Identifier otherwise_context,
                const URITemplateRouter::Identifier identifier,
@@ -530,7 +534,19 @@ URITemplateRouterView::URITemplateRouterView(
 
 URITemplateRouterView::URITemplateRouterView(const std::uint8_t *data,
                                              const std::size_t size)
-    : data_{data}, size_{size} {}
+    : data_{data}, size_{size} {
+  // The header and serialized nodes are read through over-aligned types, so an
+  // unaligned external buffer would make those reads undefined. Keep the
+  // zero-copy path when the caller's buffer is already aligned, and otherwise
+  // mirror it into aligned storage that outlives the view
+  if (data != nullptr &&
+      (reinterpret_cast<std::uintptr_t>(data) % alignof(SerializedNode)) != 0) {
+    this->owned_.resize((size + sizeof(std::uint64_t) - 1) /
+                        sizeof(std::uint64_t));
+    std::memcpy(this->owned_.data(), data, size);
+    this->data_ = reinterpret_cast<const std::uint8_t *>(this->owned_.data());
+  }
+}
 
 URITemplateRouterView::~URITemplateRouterView() = default;
 

--- a/test/uritemplate/uritemplate_router_view_test.cc
+++ b/test/uritemplate/uritemplate_router_view_test.cc
@@ -9,6 +9,7 @@
 #include <cstring>    // std::memset
 #include <filesystem> // std::filesystem::path, std::filesystem::remove, std::filesystem::temp_directory_path
 #include <fstream>    // std::ifstream
+#include <iterator>   // std::istreambuf_iterator
 #include <span>       // std::span
 #include <string>     // std::string
 #include <string_view>  // std::string_view
@@ -717,6 +718,27 @@ TEST(corrupt_empty_data) {
   const sourcemeta::core::URITemplateRouterView view{nullptr, 0};
   EXPECT_ROUTER_MATCH(view, "/users", 0, 0, captures);
   EXPECT_EQ(captures.size(), 0);
+}
+
+TEST_F(URITemplateRouterViewTest, matches_from_unaligned_external_buffer) {
+  {
+    sourcemeta::core::URITemplateRouter router;
+    router.add("/users", "op_1", 1);
+    sourcemeta::core::URITemplateRouterView::save(router, this->path);
+  }
+
+  std::ifstream input{this->path, std::ios::binary};
+  const std::vector<std::uint8_t> bytes{std::istreambuf_iterator<char>{input},
+                                        std::istreambuf_iterator<char>{}};
+
+  // Offset the serialized bytes by one so the pointer the view receives is not
+  // aligned to the over-aligned node type
+  std::vector<std::uint8_t> misaligned(bytes.size() + 1);
+  std::memcpy(misaligned.data() + 1, bytes.data(), bytes.size());
+
+  const sourcemeta::core::URITemplateRouterView view{misaligned.data() + 1,
+                                                     bytes.size()};
+  EXPECT_ROUTER_MATCH(view, "/users", 1, 0, captures);
 }
 
 TEST(corrupt_too_small_for_header) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

