### PR TITLE
Add the concept of regex dialects to `to_regex`

### DIFF
--- a/src/core/regex/include/sourcemeta/core/regex.h
+++ b/src/core/regex/include/sourcemeta/core/regex.h
@@ -70,12 +70,19 @@ enum class RegexIndex : std::uint8_t {
 #endif
 
 /// @ingroup regex
+/// The dialects that a regular expression pattern can be interpreted with.
+enum class RegexDialect : std::uint8_t {
+  /// A permissive superset of ECMA 262 with PCRE2 extensions
+  Permissive
+};
+
+/// @ingroup regex
 ///
 /// Compile a regular expression from a string. If the regular expression is
 /// invalid, no value is returned. In this function:
 ///
-/// - Regexes are NOT automatically anchored
-/// - Regexes assume `DOTALL`
+/// - Permissive regexes are NOT automatically anchored
+/// - Permissive regexes assume `DOTALL`
 /// - Regexes assume Unicode
 /// - Regexes are case sensitive
 /// - No matching happens (only boolean validation)
@@ -87,11 +94,14 @@ enum class RegexIndex : std::uint8_t {
 /// #include <cassert>
 ///
 /// const sourcemeta::core::Regex regex{
-///   sourcemeta::core::to_regex("^foo")};
+///   sourcemeta::core::to_regex("^foo",
+///     sourcemeta::core::RegexDialect::Permissive)};
 /// assert(regex.has_value());
 /// ```
 SOURCEMETA_CORE_REGEX_EXPORT
-auto to_regex(const std::string_view pattern) -> std::optional<Regex>;
+auto to_regex(const std::string_view pattern,
+              const RegexDialect dialect = RegexDialect::Permissive)
+    -> std::optional<Regex>;
 
 /// @ingroup regex
 ///
@@ -123,7 +133,9 @@ auto matches(const Regex &regex, const std::string_view value) -> bool;
 /// ```
 SOURCEMETA_CORE_REGEX_EXPORT
 auto matches_if_valid(const std::string_view pattern,
-                      const std::string_view value) -> bool;
+                      const std::string_view value,
+                      const RegexDialect dialect = RegexDialect::Permissive)
+    -> bool;
 
 /// @ingroup regex
 ///

--- a/src/core/regex/regex.cc
+++ b/src/core/regex/regex.cc
@@ -15,7 +15,9 @@
 
 namespace sourcemeta::core {
 
-auto to_regex(const std::string_view pattern) -> std::optional<Regex> {
+auto to_regex(const std::string_view pattern,
+              [[maybe_unused]] const RegexDialect dialect)
+    -> std::optional<Regex> {
   if (pattern == ".*" || pattern == "^.*$" || pattern == "^(.*)$" ||
       pattern == "(.*)" || pattern == "[\\s\\S]*" || pattern == "^[\\s\\S]*$") {
     return RegexTypeNoop{};
@@ -128,8 +130,9 @@ auto matches(const Regex &regex, const std::string_view value) -> bool {
 }
 
 auto matches_if_valid(const std::string_view pattern,
-                      const std::string_view value) -> bool {
-  const auto regex{to_regex(pattern)};
+                      const std::string_view value, const RegexDialect dialect)
+    -> bool {
+  const auto regex{to_regex(pattern, dialect)};
   return regex.has_value() && matches(regex.value(), value);
 }
 

--- a/test/regex/CMakeLists.txt
+++ b/test/regex/CMakeLists.txt
@@ -1,8 +1,8 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME regex
   SOURCES
     regex_matches_if_valid_test.cc
-    regex_matches_ecma262_test.cc
-    regex_matches_rfc9485_test.cc
+    regex_permissive_matches_ecma262_test.cc
+    regex_permissive_matches_rfc9485_test.cc
     regex_is_ecma_test.cc
     regex_to_regex_test.cc
     regex_test.cc)

--- a/test/regex/regex_permissive_matches_ecma262_test.cc
+++ b/test/regex/regex_permissive_matches_ecma262_test.cc
@@ -4,7 +4,8 @@
 #include <string>
 
 TEST(ecma262_anchor_start) {
-  const auto regex{sourcemeta::core::to_regex("^foo")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^foo", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -13,7 +14,8 @@ TEST(ecma262_anchor_start) {
 }
 
 TEST(ecma262_anchor_end) {
-  const auto regex{sourcemeta::core::to_regex("foo$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -22,7 +24,8 @@ TEST(ecma262_anchor_end) {
 }
 
 TEST(ecma262_anchor_both) {
-  const auto regex{sourcemeta::core::to_regex("^foo$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^foo$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -31,7 +34,8 @@ TEST(ecma262_anchor_both) {
 }
 
 TEST(ecma262_anchor_start_with_alternation) {
-  const auto regex{sourcemeta::core::to_regex("^(foo|bar)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^(foo|bar)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^(foo|bar)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -40,7 +44,8 @@ TEST(ecma262_anchor_start_with_alternation) {
 }
 
 TEST(ecma262_digit_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\d+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\d+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -50,7 +55,8 @@ TEST(ecma262_digit_escape) {
 }
 
 TEST(ecma262_non_digit_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\D+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\D+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\D+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -59,7 +65,8 @@ TEST(ecma262_non_digit_escape) {
 }
 
 TEST(ecma262_word_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\w+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\w+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\w+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -70,7 +77,8 @@ TEST(ecma262_word_escape) {
 }
 
 TEST(ecma262_non_word_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\W+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\W+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\W+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!!!"));
@@ -79,7 +87,8 @@ TEST(ecma262_non_word_escape) {
 }
 
 TEST(ecma262_whitespace_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\s+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\s+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\s+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -90,7 +99,8 @@ TEST(ecma262_whitespace_escape) {
 }
 
 TEST(ecma262_non_whitespace_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\S+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\S+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\S+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -99,7 +109,8 @@ TEST(ecma262_non_whitespace_escape) {
 }
 
 TEST(ecma262_word_boundary_start) {
-  const auto regex{sourcemeta::core::to_regex("\\bfoo")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\bfoo", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bfoo"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -109,7 +120,8 @@ TEST(ecma262_word_boundary_start) {
 }
 
 TEST(ecma262_word_boundary_end) {
-  const auto regex{sourcemeta::core::to_regex("foo\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo\\b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -119,7 +131,8 @@ TEST(ecma262_word_boundary_end) {
 }
 
 TEST(ecma262_word_boundary_both) {
-  const auto regex{sourcemeta::core::to_regex("\\bfoo\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\bfoo\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bfoo\\b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -129,7 +142,8 @@ TEST(ecma262_word_boundary_both) {
 }
 
 TEST(ecma262_non_word_boundary) {
-  const auto regex{sourcemeta::core::to_regex("\\Boo")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\Boo", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\Boo"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -137,7 +151,8 @@ TEST(ecma262_non_word_boundary) {
 }
 
 TEST(ecma262_hex_escape_2digit) {
-  const auto regex{sourcemeta::core::to_regex("\\x41")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\x41", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\x41"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -145,7 +160,8 @@ TEST(ecma262_hex_escape_2digit) {
 }
 
 TEST(ecma262_hex_escape_in_pattern) {
-  const auto regex{sourcemeta::core::to_regex("a\\x20b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\x20b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\x20b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a b"));
@@ -153,7 +169,8 @@ TEST(ecma262_hex_escape_in_pattern) {
 }
 
 TEST(ecma262_unicode_escape_4digit) {
-  const auto regex{sourcemeta::core::to_regex("\\u0041")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\u0041", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\u0041"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -161,7 +178,8 @@ TEST(ecma262_unicode_escape_4digit) {
 }
 
 TEST(ecma262_unicode_escape_brace) {
-  const auto regex{sourcemeta::core::to_regex("\\u{1F600}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\u{1F600}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\u{1F600}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "😀"));
@@ -169,7 +187,8 @@ TEST(ecma262_unicode_escape_brace) {
 }
 
 TEST(ecma262_null_escape) {
-  const auto regex{sourcemeta::core::to_regex("a\\0b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\0b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\0b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), std::string("a\0b", 3)));
@@ -177,7 +196,8 @@ TEST(ecma262_null_escape) {
 }
 
 TEST(ecma262_non_capturing_group) {
-  const auto regex{sourcemeta::core::to_regex("(?:abc)+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?:abc)+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:abc)+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -186,7 +206,8 @@ TEST(ecma262_non_capturing_group) {
 }
 
 TEST(ecma262_lookahead_positive) {
-  const auto regex{sourcemeta::core::to_regex("foo(?=bar)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo(?=bar)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo(?=bar)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -194,7 +215,8 @@ TEST(ecma262_lookahead_positive) {
 }
 
 TEST(ecma262_lookahead_negative) {
-  const auto regex{sourcemeta::core::to_regex("foo(?!bar)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo(?!bar)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo(?!bar)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobaz"));
@@ -202,7 +224,8 @@ TEST(ecma262_lookahead_negative) {
 }
 
 TEST(ecma262_lookbehind_positive) {
-  const auto regex{sourcemeta::core::to_regex("(?<=foo)bar")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?<=foo)bar", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=foo)bar"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -210,7 +233,8 @@ TEST(ecma262_lookbehind_positive) {
 }
 
 TEST(ecma262_lookbehind_negative) {
-  const auto regex{sourcemeta::core::to_regex("(?<!foo)bar")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?<!foo)bar", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<!foo)bar"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "bazbar"));
@@ -218,7 +242,8 @@ TEST(ecma262_lookbehind_negative) {
 }
 
 TEST(ecma262_combined_digit_word_anchors) {
-  const auto regex{sourcemeta::core::to_regex("^\\w+@\\w+\\.\\w+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\w+@\\w+\\.\\w+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\w+@\\w+\\.\\w+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "user@example.com"));
@@ -226,7 +251,8 @@ TEST(ecma262_combined_digit_word_anchors) {
 }
 
 TEST(ecma262_digit_range_pattern) {
-  const auto regex{sourcemeta::core::to_regex("\\d{3}-\\d{2}-\\d{4}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\d{3}-\\d{2}-\\d{4}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d{3}-\\d{2}-\\d{4}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123-45-6789"));
@@ -234,7 +260,8 @@ TEST(ecma262_digit_range_pattern) {
 }
 
 TEST(ecma262_mixed_escapes) {
-  const auto regex{sourcemeta::core::to_regex("\\w+\\s+\\d+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\w+\\s+\\d+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\w+\\s+\\d+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "hello 123"));
@@ -243,7 +270,8 @@ TEST(ecma262_mixed_escapes) {
 }
 
 TEST(ecma262_anchor_with_digit) {
-  const auto regex{sourcemeta::core::to_regex("^\\d+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\d+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -252,7 +280,8 @@ TEST(ecma262_anchor_with_digit) {
 }
 
 TEST(ecma262_word_boundary_with_digit) {
-  const auto regex{sourcemeta::core::to_regex("\\b\\d{3}\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\b\\d{3}\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\b\\d{3}\\b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -261,7 +290,8 @@ TEST(ecma262_word_boundary_with_digit) {
 }
 
 TEST(ecma262_whitespace_variants) {
-  const auto regex{sourcemeta::core::to_regex("a\\sb")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\sb", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\sb"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a b"));
@@ -273,7 +303,8 @@ TEST(ecma262_whitespace_variants) {
 
 TEST(ecma262_complex_email_pattern) {
   const auto regex{
-      sourcemeta::core::to_regex("^[\\w.+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$")};
+      sourcemeta::core::to_regex("^[\\w.+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("^[\\w.+-]+@[\\w.-]+\\.[a-zA-Z]{2,}$"));
@@ -285,7 +316,8 @@ TEST(ecma262_complex_email_pattern) {
 
 TEST(ecma262_complex_url_pattern) {
   const auto regex{
-      sourcemeta::core::to_regex("^https?://[\\w.-]+\\.[a-z]{2,}")};
+      sourcemeta::core::to_regex("^https?://[\\w.-]+\\.[a-z]{2,}",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("^https?://[\\w.-]+\\.[a-z]{2,}"));
@@ -297,7 +329,8 @@ TEST(ecma262_complex_url_pattern) {
 
 TEST(ecma262_phone_number_pattern) {
   const auto regex{
-      sourcemeta::core::to_regex("^\\(\\d{3}\\)\\s*\\d{3}-\\d{4}$")};
+      sourcemeta::core::to_regex("^\\(\\d{3}\\)\\s*\\d{3}-\\d{4}$",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("^\\(\\d{3}\\)\\s*\\d{3}-\\d{4}$"));
@@ -307,7 +340,8 @@ TEST(ecma262_phone_number_pattern) {
 }
 
 TEST(ecma262_hex_color_with_anchor) {
-  const auto regex{sourcemeta::core::to_regex("^#[0-9a-fA-F]{6}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^#[0-9a-fA-F]{6}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^#[0-9a-fA-F]{6}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "#FF5733"));
@@ -316,7 +350,8 @@ TEST(ecma262_hex_color_with_anchor) {
 }
 
 TEST(ecma262_non_capturing_with_alternation) {
-  const auto regex{sourcemeta::core::to_regex("(?:red|green|blue)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?:red|green|blue)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:red|green|blue)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "red"));
@@ -326,7 +361,8 @@ TEST(ecma262_non_capturing_with_alternation) {
 }
 
 TEST(ecma262_lookahead_with_quantifier) {
-  const auto regex{sourcemeta::core::to_regex("\\d+(?=px)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\d+(?=px)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\d+(?=px)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "100px"));
@@ -335,7 +371,8 @@ TEST(ecma262_lookahead_with_quantifier) {
 }
 
 TEST(ecma262_multiple_word_boundaries) {
-  const auto regex{sourcemeta::core::to_regex("\\btest\\b.*\\bcase\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\btest\\b.*\\bcase\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\btest\\b.*\\bcase\\b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "test case"));
@@ -344,7 +381,8 @@ TEST(ecma262_multiple_word_boundaries) {
 }
 
 TEST(ecma262_unicode_with_anchors) {
-  const auto regex{sourcemeta::core::to_regex("^\\u{1F600}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\u{1F600}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\u{1F600}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "😀"));
@@ -353,7 +391,8 @@ TEST(ecma262_unicode_with_anchors) {
 }
 
 TEST(ecma262_word_ascii_only_in_charclass) {
-  const auto regex{sourcemeta::core::to_regex("^[\\w.-]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[\\w.-]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\w.-]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "hello-world"));
@@ -362,7 +401,8 @@ TEST(ecma262_word_ascii_only_in_charclass) {
 }
 
 TEST(ecma262_digit_ascii_only_in_charclass) {
-  const auto regex{sourcemeta::core::to_regex("^[\\d.-]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[\\d.-]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\d.-]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123-456"));
@@ -370,7 +410,8 @@ TEST(ecma262_digit_ascii_only_in_charclass) {
 }
 
 TEST(ecma262_whitespace_in_charclass) {
-  const auto regex{sourcemeta::core::to_regex("^[\\s]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[\\s]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\s]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " \t\n"));
@@ -378,7 +419,8 @@ TEST(ecma262_whitespace_in_charclass) {
 }
 
 TEST(ecma262_dollar_anchor_no_trailing_newline) {
-  const auto regex{sourcemeta::core::to_regex("^abc$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^abc$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^abc$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -386,7 +428,8 @@ TEST(ecma262_dollar_anchor_no_trailing_newline) {
 }
 
 TEST(ecma262_tab_escape) {
-  const auto regex{sourcemeta::core::to_regex("^\\t$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\t$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\t$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\t"));
@@ -394,7 +437,8 @@ TEST(ecma262_tab_escape) {
 }
 
 TEST(ecma262_control_escape_upper) {
-  const auto regex{sourcemeta::core::to_regex("^\\cC$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\cC$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\cC$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0003"));
@@ -402,7 +446,8 @@ TEST(ecma262_control_escape_upper) {
 }
 
 TEST(ecma262_control_escape_lower) {
-  const auto regex{sourcemeta::core::to_regex("^\\cc$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\cc$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\cc$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0003"));
@@ -410,7 +455,8 @@ TEST(ecma262_control_escape_lower) {
 }
 
 TEST(ecma262_whitespace_unicode_nbsp) {
-  const auto regex{sourcemeta::core::to_regex("^\\s$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\s$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\s$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -427,7 +473,8 @@ TEST(ecma262_whitespace_unicode_nbsp) {
 }
 
 TEST(ecma262_non_whitespace_unicode) {
-  const auto regex{sourcemeta::core::to_regex("^\\S$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\S$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\S$"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), " "));
@@ -444,7 +491,8 @@ TEST(ecma262_non_whitespace_unicode) {
 }
 
 TEST(ecma262_digit_not_bengali) {
-  const auto regex{sourcemeta::core::to_regex("^\\d+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\d+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "42"));
@@ -453,7 +501,8 @@ TEST(ecma262_digit_not_bengali) {
 }
 
 TEST(ecma262_unicode_digit_property) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{Nd}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{Nd}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Nd}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "42"));
@@ -462,7 +511,8 @@ TEST(ecma262_unicode_digit_property) {
 }
 
 TEST(ecma262_unicode_digit_property_lowercase) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{digit}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{digit}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{digit}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "42"));
@@ -471,7 +521,8 @@ TEST(ecma262_unicode_digit_property_lowercase) {
 }
 
 TEST(ecma262_unicode_space_property_lowercase) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{space}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{space}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{space}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " \t"));
@@ -479,7 +530,8 @@ TEST(ecma262_unicode_space_property_lowercase) {
 }
 
 TEST(ecma262_unicode_ASCII_property) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{ASCII}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{ASCII}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{ASCII}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc123"));
@@ -487,7 +539,8 @@ TEST(ecma262_unicode_ASCII_property) {
 }
 
 TEST(ecma262_unicode_Hex_Digit_property) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{Hex_Digit}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{Hex_Digit}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Hex_Digit}+$"));
   EXPECT_TRUE(
@@ -496,7 +549,8 @@ TEST(ecma262_unicode_Hex_Digit_property) {
 }
 
 TEST(ecma262_unicode_Alphabetic_property) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{Alphabetic}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{Alphabetic}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Alphabetic}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -505,7 +559,8 @@ TEST(ecma262_unicode_Alphabetic_property) {
 }
 
 TEST(ecma262_unicode_White_Space_property) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{White_Space}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{White_Space}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{White_Space}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " \t\n"));
@@ -513,7 +568,8 @@ TEST(ecma262_unicode_White_Space_property) {
 }
 
 TEST(ecma262_escaped_backslash_before_charclass) {
-  const auto regex{sourcemeta::core::to_regex("\\\\[abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\[abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\[abc]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\a"));
@@ -524,7 +580,8 @@ TEST(ecma262_escaped_backslash_before_charclass) {
 }
 
 TEST(ecma262_escaped_backslash_before_digit_class) {
-  const auto regex{sourcemeta::core::to_regex("\\\\d")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\d", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\d"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\d"));
@@ -532,7 +589,8 @@ TEST(ecma262_escaped_backslash_before_digit_class) {
 }
 
 TEST(ecma262_digit_hyphen_in_charclass) {
-  const auto regex{sourcemeta::core::to_regex("^[\\d-]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[\\d-]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\d-]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -543,7 +601,8 @@ TEST(ecma262_digit_hyphen_in_charclass) {
 }
 
 TEST(ecma262_word_boundary_ascii_only) {
-  const auto regex{sourcemeta::core::to_regex("\\bcafé\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\bcafé\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bcafé\\b"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "café"));
@@ -552,7 +611,8 @@ TEST(ecma262_word_boundary_ascii_only) {
 }
 
 TEST(ecma262_non_greedy_quantifiers) {
-  const auto regex{sourcemeta::core::to_regex("^a+?b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^a+?b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a+?b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ab"));
@@ -561,7 +621,8 @@ TEST(ecma262_non_greedy_quantifiers) {
 }
 
 TEST(ecma262_quantifier_exact) {
-  const auto regex{sourcemeta::core::to_regex("^a{3}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^a{3}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a{3}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaa"));
@@ -570,7 +631,8 @@ TEST(ecma262_quantifier_exact) {
 }
 
 TEST(ecma262_quantifier_range) {
-  const auto regex{sourcemeta::core::to_regex("^a{2,4}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^a{2,4}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a{2,4}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aa"));
@@ -581,7 +643,8 @@ TEST(ecma262_quantifier_range) {
 }
 
 TEST(ecma262_quantifier_min_only) {
-  const auto regex{sourcemeta::core::to_regex("^a{2,}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^a{2,}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^a{2,}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aa"));
@@ -590,7 +653,8 @@ TEST(ecma262_quantifier_min_only) {
 }
 
 TEST(ecma262_negated_charclass) {
-  const auto regex{sourcemeta::core::to_regex("^[^abc]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[^abc]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[^abc]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xyz"));
@@ -600,7 +664,8 @@ TEST(ecma262_negated_charclass) {
 }
 
 TEST(ecma262_escaped_metacharacters) {
-  const auto regex{sourcemeta::core::to_regex("^\\.\\.\\.$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\.\\.\\.$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\.\\.\\.$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "..."));
@@ -608,7 +673,8 @@ TEST(ecma262_escaped_metacharacters) {
 }
 
 TEST(ecma262_hex_escape_hi) {
-  const auto regex{sourcemeta::core::to_regex("^\\x48\\x69$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\x48\\x69$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\x48\\x69$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "Hi"));
@@ -616,7 +682,8 @@ TEST(ecma262_hex_escape_hi) {
 }
 
 TEST(ecma262_unicode_property_letter_all) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{L}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{L}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{L}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ABC"));
@@ -626,7 +693,8 @@ TEST(ecma262_unicode_property_letter_all) {
 }
 
 TEST(ecma262_unicode_property_letter_uppercase) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{Lu}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{Lu}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Lu}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ABC"));
@@ -635,7 +703,8 @@ TEST(ecma262_unicode_property_letter_uppercase) {
 }
 
 TEST(ecma262_unicode_property_letter_lowercase) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{Ll}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{Ll}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{Ll}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -643,7 +712,8 @@ TEST(ecma262_unicode_property_letter_lowercase) {
 }
 
 TEST(ecma262_unicode_property_mark) {
-  const auto regex{sourcemeta::core::to_regex("\\p{M}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{M}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{M}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\u0301"));
@@ -651,7 +721,8 @@ TEST(ecma262_unicode_property_mark) {
 }
 
 TEST(ecma262_unicode_property_number) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{N}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{N}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{N}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -660,7 +731,8 @@ TEST(ecma262_unicode_property_number) {
 }
 
 TEST(ecma262_unicode_property_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("^\\p{P}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\p{P}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\p{P}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!.,;"));
@@ -668,7 +740,8 @@ TEST(ecma262_unicode_property_punctuation) {
 }
 
 TEST(ecma262_unicode_property_symbol) {
-  const auto regex{sourcemeta::core::to_regex("\\p{S}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{S}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{S}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
@@ -677,7 +750,8 @@ TEST(ecma262_unicode_property_symbol) {
 }
 
 TEST(ecma262_unicode_property_separator) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Z}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Z}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Z}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -685,7 +759,8 @@ TEST(ecma262_unicode_property_separator) {
 }
 
 TEST(ecma262_unicode_property_other) {
-  const auto regex{sourcemeta::core::to_regex("\\p{C}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{C}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{C}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), std::string(1, '\0')));
@@ -693,7 +768,8 @@ TEST(ecma262_unicode_property_other) {
 }
 
 TEST(ecma262_unicode_property_negated_letter) {
-  const auto regex{sourcemeta::core::to_regex("^\\P{L}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\P{L}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\P{L}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -702,7 +778,8 @@ TEST(ecma262_unicode_property_negated_letter) {
 }
 
 TEST(ecma262_unicode_property_negated_number) {
-  const auto regex{sourcemeta::core::to_regex("^\\P{N}+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\P{N}+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\P{N}+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -711,7 +788,8 @@ TEST(ecma262_unicode_property_negated_number) {
 }
 
 TEST(ecma262_quantifier_star_any_string) {
-  const auto regex{sourcemeta::core::to_regex(".*")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -719,7 +797,8 @@ TEST(ecma262_quantifier_star_any_string) {
 }
 
 TEST(ecma262_quantifier_plus_non_empty) {
-  const auto regex{sourcemeta::core::to_regex(".+")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -727,21 +806,24 @@ TEST(ecma262_quantifier_plus_non_empty) {
 }
 
 TEST(ecma262_dot_matches_newline) {
-  const auto regex{sourcemeta::core::to_regex(".")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
 TEST(ecma262_dot_matches_carriage_return) {
-  const auto regex{sourcemeta::core::to_regex(".")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\r"));
 }
 
 TEST(ecma262_unicode_range_4byte_deseret) {
-  const auto regex{sourcemeta::core::to_regex("[\\u{10400}-\\u{1044F}]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\u{10400}-\\u{1044F}]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\u{10400}-\\u{1044F}]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\U00010400"));
@@ -750,7 +832,8 @@ TEST(ecma262_unicode_range_4byte_deseret) {
 }
 
 TEST(ecma262_anchor_start_prefix_match) {
-  const auto regex{sourcemeta::core::to_regex("^foo")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^foo", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^foo"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -758,21 +841,24 @@ TEST(ecma262_anchor_start_prefix_match) {
 }
 
 TEST(ecma262_anchor_both_full_match) {
-  const auto regex{sourcemeta::core::to_regex("^.*$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.*$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.*$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
 TEST(ecma262_anchor_both_with_group) {
-  const auto regex{sourcemeta::core::to_regex("^(.*)$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^(.*)$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^(.*)$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
 }
 
 TEST(ecma262_anchor_start_slash_path) {
-  const auto regex{sourcemeta::core::to_regex("^/.*")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^/.*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^/.*"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "/foo/bar"));
@@ -781,7 +867,8 @@ TEST(ecma262_anchor_start_slash_path) {
 }
 
 TEST(ecma262_anchor_both_length_range) {
-  const auto regex{sourcemeta::core::to_regex("^.{1,256}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.{1,256}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.{1,256}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -791,7 +878,8 @@ TEST(ecma262_anchor_both_length_range) {
 }
 
 TEST(ecma262_anchor_start_at_sign) {
-  const auto regex{sourcemeta::core::to_regex("^@")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^@", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^@"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "@foo"));
@@ -799,7 +887,8 @@ TEST(ecma262_anchor_start_at_sign) {
 }
 
 TEST(ecma262_anchor_end_letter_o) {
-  const auto regex{sourcemeta::core::to_regex("o$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "o$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("o$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -807,7 +896,8 @@ TEST(ecma262_anchor_end_letter_o) {
 }
 
 TEST(ecma262_anchor_both_identifier_pattern) {
-  const auto regex{sourcemeta::core::to_regex("^[a-z][a-z0-9-_]{1,63}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[a-z][a-z0-9-_]{1,63}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[a-z][a-z0-9-_]{1,63}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abcd"));
@@ -815,7 +905,8 @@ TEST(ecma262_anchor_both_identifier_pattern) {
 
 TEST(ecma262_anchor_both_package_name) {
   const auto regex{
-      sourcemeta::core::to_regex("^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$")};
+      sourcemeta::core::to_regex("^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "^(?:@[0-9a-z-_.]+\\/)?[a-z][0-9a-z-_.]*$"));
@@ -823,14 +914,16 @@ TEST(ecma262_anchor_both_package_name) {
 }
 
 TEST(ecma262_anchor_both_multiline_string) {
-  const auto regex{sourcemeta::core::to_regex("^.+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo\nbar\r"));
 }
 
 TEST(ecma262_unicode_escape_4digit_arabic_digit_range) {
-  const auto regex{sourcemeta::core::to_regex("[\\u0660-\\u0669]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\u0660-\\u0669]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\u0660-\\u0669]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0660"));
@@ -840,7 +933,8 @@ TEST(ecma262_unicode_escape_4digit_arabic_digit_range) {
 
 TEST(ecma262_unicode_property_letter_identifier) {
   const auto regex{
-      sourcemeta::core::to_regex("^\\p{Letter}[\\p{Letter}\\p{Number}]*$")};
+      sourcemeta::core::to_regex("^\\p{Letter}[\\p{Letter}\\p{Number}]*$",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "^\\p{Letter}[\\p{Letter}\\p{Number}]*$"));
@@ -854,7 +948,8 @@ TEST(ecma262_unicode_property_letter_identifier) {
 
 TEST(ecma262_unicode_property_negative_lookahead_identifier) {
   const auto regex{sourcemeta::core::to_regex(
-      "^(?!\\p{Number})\\p{Letter}[\\p{Letter}\\p{Number}\\-_.]*$")};
+      "^(?!\\p{Number})\\p{Letter}[\\p{Letter}\\p{Number}\\-_.]*$",
+      sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "^(?!\\p{Number})\\p{Letter}[\\p{Letter}\\p{Number}\\-_.]*$"));
@@ -865,7 +960,8 @@ TEST(ecma262_unicode_property_negative_lookahead_identifier) {
 }
 
 TEST(ecma262_unicode_dot_single_codepoint) {
-  const auto regex{sourcemeta::core::to_regex("^.$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -875,7 +971,8 @@ TEST(ecma262_unicode_dot_single_codepoint) {
 }
 
 TEST(ecma262_unicode_quantifier_three_codepoints) {
-  const auto regex{sourcemeta::core::to_regex("^.{3}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.{3}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.{3}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ABC"));
@@ -886,7 +983,8 @@ TEST(ecma262_unicode_quantifier_three_codepoints) {
 }
 
 TEST(ecma262_digit_class_ascii_only) {
-  const auto regex{sourcemeta::core::to_regex("^\\d$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\d$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\d$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -894,7 +992,8 @@ TEST(ecma262_digit_class_ascii_only) {
 }
 
 TEST(ecma262_word_class_ascii_only) {
-  const auto regex{sourcemeta::core::to_regex("^\\w$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\\w$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\\w$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -902,7 +1001,8 @@ TEST(ecma262_word_class_ascii_only) {
 }
 
 TEST(ecma262_nonbmp_emoji_quantifier_codepoint) {
-  const auto regex{sourcemeta::core::to_regex("^\U0001F432*$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\U0001F432*$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\U0001F432*$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -913,7 +1013,8 @@ TEST(ecma262_nonbmp_emoji_quantifier_codepoint) {
 }
 
 TEST(ecma262_nonbmp_literal_exact_match) {
-  const auto regex{sourcemeta::core::to_regex("^\U0001F432$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^\U0001F432$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^\U0001F432$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\U0001F432"));
@@ -924,7 +1025,8 @@ TEST(ecma262_nonbmp_literal_exact_match) {
 
 TEST(ecma262_xml_ncname_unicode_identifier) {
   const auto regex{sourcemeta::core::to_regex(
-      "^(?![:\\p{Nd}])[\\p{L}_][\\p{L}\\p{Nd}\\-._·]*$")};
+      "^(?![:\\p{Nd}])[\\p{L}_][\\p{L}\\p{Nd}\\-._·]*$",
+      sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "^(?![:\\p{Nd}])[\\p{L}_][\\p{L}\\p{Nd}\\-._·]*$"));
@@ -942,7 +1044,8 @@ TEST(ecma262_xml_ncname_unicode_identifier) {
 }
 
 TEST(ecma262_escaped_backslash_before_bracket) {
-  const auto regex{sourcemeta::core::to_regex("\\\\[abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\[abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\[abc]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\a"));
@@ -953,7 +1056,8 @@ TEST(ecma262_escaped_backslash_before_bracket) {
 }
 
 TEST(ecma262_triple_backslash_before_bracket) {
-  const auto regex{sourcemeta::core::to_regex("\\\\\\[")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\\\[", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\["));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\["));
@@ -962,7 +1066,8 @@ TEST(ecma262_triple_backslash_before_bracket) {
 }
 
 TEST(ecma262_dollar_in_middle_never_matches) {
-  const auto regex{sourcemeta::core::to_regex("foo$bar")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo$bar", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$bar"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "foo$bar"));
@@ -971,7 +1076,8 @@ TEST(ecma262_dollar_in_middle_never_matches) {
 }
 
 TEST(ecma262_dollar_in_character_class) {
-  const auto regex{sourcemeta::core::to_regex("[$]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[$]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[$]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
@@ -979,7 +1085,8 @@ TEST(ecma262_dollar_in_character_class) {
 }
 
 TEST(ecma262_escaped_dollar) {
-  const auto regex{sourcemeta::core::to_regex("\\$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
@@ -987,7 +1094,8 @@ TEST(ecma262_escaped_dollar) {
 }
 
 TEST(ecma262_multiple_dollars) {
-  const auto regex{sourcemeta::core::to_regex("$$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "$$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -995,7 +1103,8 @@ TEST(ecma262_multiple_dollars) {
 }
 
 TEST(ecma262_negated_digit_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\D]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\D]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\D]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1005,7 +1114,8 @@ TEST(ecma262_negated_digit_in_char_class) {
 }
 
 TEST(ecma262_negated_word_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\W]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\W]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\W]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -1017,7 +1127,8 @@ TEST(ecma262_negated_word_in_char_class) {
 }
 
 TEST(ecma262_negated_space_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\S]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\S]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\S]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1029,7 +1140,8 @@ TEST(ecma262_negated_space_in_char_class) {
 }
 
 TEST(ecma262_mixed_escapes_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\d\\D]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\d\\D]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d\\D]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1039,7 +1151,8 @@ TEST(ecma262_mixed_escapes_in_char_class) {
 }
 
 TEST(ecma262_escaped_bracket_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "]"));
@@ -1048,7 +1161,8 @@ TEST(ecma262_escaped_bracket_in_char_class) {
 }
 
 TEST(ecma262_backslash_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\\\]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\\\]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\\\]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\"));
@@ -1056,7 +1170,8 @@ TEST(ecma262_backslash_in_char_class) {
 }
 
 TEST(ecma262_complex_char_class_with_escaped_chars) {
-  const auto regex{sourcemeta::core::to_regex("[a\\]b\\\\c]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a\\]b\\\\c]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a\\]b\\\\c]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1069,25 +1184,29 @@ TEST(ecma262_complex_char_class_with_escaped_chars) {
 }
 
 TEST(ecma262_incomplete_unicode_property) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Letter")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Letter", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\p{Letter"));
 }
 
 TEST(ecma262_incomplete_unicode_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\u{DEAD")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\u{DEAD", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\u{DEAD"));
 }
 
 TEST(ecma262_backslash_at_end) {
-  const auto regex{sourcemeta::core::to_regex("foo\\")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo\\", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("foo\\"));
 }
 
 TEST(ecma262_nested_char_class_attempt) {
-  const auto regex{sourcemeta::core::to_regex("[[abc]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[abc]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1099,7 +1218,8 @@ TEST(ecma262_nested_char_class_attempt) {
 }
 
 TEST(ecma262_dollar_before_alternation) {
-  const auto regex{sourcemeta::core::to_regex("foo$|bar")};
+  const auto regex{sourcemeta::core::to_regex(
+      "foo$|bar", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("foo$|bar"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foo"));
@@ -1109,7 +1229,8 @@ TEST(ecma262_dollar_before_alternation) {
 }
 
 TEST(ecma262_multiple_backslashes_complex) {
-  const auto regex{sourcemeta::core::to_regex("\\\\\\\\\\\\\\\\")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\\\\\\\\\\\\\", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\\\\\\\\\\\"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\\\\\\\"));
@@ -1117,7 +1238,8 @@ TEST(ecma262_multiple_backslashes_complex) {
 }
 
 TEST(ecma262_right_bracket_as_first_char_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "]"));
@@ -1127,7 +1249,8 @@ TEST(ecma262_right_bracket_as_first_char_in_class) {
 }
 
 TEST(ecma262_right_bracket_negated_class) {
-  const auto regex{sourcemeta::core::to_regex("[^]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[^]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a]"));
@@ -1139,7 +1262,8 @@ TEST(ecma262_right_bracket_negated_class) {
 }
 
 TEST(ecma262_dollar_before_opening_paren) {
-  const auto regex{sourcemeta::core::to_regex("$(abc)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "$(abc)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$(abc)"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "$abc"));
@@ -1147,7 +1271,8 @@ TEST(ecma262_dollar_before_opening_paren) {
 }
 
 TEST(ecma262_caret_not_at_start_of_class) {
-  const auto regex{sourcemeta::core::to_regex("[a^b]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a^b]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a^b]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1157,7 +1282,8 @@ TEST(ecma262_caret_not_at_start_of_class) {
 }
 
 TEST(ecma262_caret_in_middle_of_pattern) {
-  const auto regex{sourcemeta::core::to_regex("a^b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a^b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a^b"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a^b"));
@@ -1166,7 +1292,8 @@ TEST(ecma262_caret_in_middle_of_pattern) {
 }
 
 TEST(ecma262_backslash_before_digit_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\\\\\d")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\\\d", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\d"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\0"));
@@ -1175,7 +1302,8 @@ TEST(ecma262_backslash_before_digit_escape) {
 }
 
 TEST(ecma262_dash_at_end_of_class) {
-  const auto regex{sourcemeta::core::to_regex("[abc-]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[abc-]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc-]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1184,7 +1312,8 @@ TEST(ecma262_dash_at_end_of_class) {
 }
 
 TEST(ecma262_dash_at_start_of_class) {
-  const auto regex{sourcemeta::core::to_regex("[-abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[-abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-abc]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -1193,7 +1322,8 @@ TEST(ecma262_dash_at_start_of_class) {
 }
 
 TEST(ecma262_double_caret) {
-  const auto regex{sourcemeta::core::to_regex("^^abc")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^^abc", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^^abc"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1203,7 +1333,8 @@ TEST(ecma262_double_caret) {
 }
 
 TEST(ecma262_caret_after_alternation) {
-  const auto regex{sourcemeta::core::to_regex("a|^b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a|^b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|^b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1212,7 +1343,8 @@ TEST(ecma262_caret_after_alternation) {
 }
 
 TEST(ecma262_caret_after_opening_paren) {
-  const auto regex{sourcemeta::core::to_regex("(^abc)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(^abc)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(^abc)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1220,7 +1352,8 @@ TEST(ecma262_caret_after_opening_paren) {
 }
 
 TEST(ecma262_dollar_then_caret) {
-  const auto regex{sourcemeta::core::to_regex("a$^b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a$^b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a$^b"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a$^b"));
@@ -1228,7 +1361,8 @@ TEST(ecma262_dollar_then_caret) {
 }
 
 TEST(ecma262_backspace_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\b]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\b]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\b]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\b"));
@@ -1236,7 +1370,8 @@ TEST(ecma262_backspace_in_char_class) {
 }
 
 TEST(ecma262_whitespace_and_non_whitespace_class) {
-  const auto regex{sourcemeta::core::to_regex("[\\s\\S]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\s\\S]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\s\\S]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -1246,7 +1381,8 @@ TEST(ecma262_whitespace_and_non_whitespace_class) {
 }
 
 TEST(ecma262_word_boundary_outside_class) {
-  const auto regex{sourcemeta::core::to_regex("\\bword\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\bword\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\bword\\b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "word"));
@@ -1256,25 +1392,29 @@ TEST(ecma262_word_boundary_outside_class) {
 }
 
 TEST(ecma262_unmatched_closing_paren) {
-  const auto regex{sourcemeta::core::to_regex("abc)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "abc)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("abc)"));
 }
 
 TEST(ecma262_unmatched_opening_paren) {
-  const auto regex{sourcemeta::core::to_regex("(abc")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(abc", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(abc"));
 }
 
 TEST(ecma262_quantifier_on_assertion) {
-  const auto regex{sourcemeta::core::to_regex("^*")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("^*"));
 }
 
 TEST(ecma262_escaped_closing_bracket_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[a\\]b]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a\\]b]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a\\]b]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1284,13 +1424,15 @@ TEST(ecma262_escaped_closing_bracket_in_class) {
 }
 
 TEST(ecma262_unicode_hex_too_large) {
-  const auto regex{sourcemeta::core::to_regex("\\u{110000}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\u{110000}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("\\u{110000}"));
 }
 
 TEST(ecma262_multiple_backslashes_before_d) {
-  const auto regex{sourcemeta::core::to_regex("\\\\\\\\d")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\\\\\d", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\\\\\d"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\\\d"));
@@ -1298,13 +1440,15 @@ TEST(ecma262_multiple_backslashes_before_d) {
 }
 
 TEST(ecma262_backslash_before_closing_bracket) {
-  const auto regex{sourcemeta::core::to_regex("[abc\\]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[abc\\]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[abc\\]"));
 }
 
 TEST(ecma262_empty_alternation_branch) {
-  const auto regex{sourcemeta::core::to_regex("a||b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a||b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a||b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1313,7 +1457,8 @@ TEST(ecma262_empty_alternation_branch) {
 }
 
 TEST(ecma262_pipe_at_start) {
-  const auto regex{sourcemeta::core::to_regex("|abc")};
+  const auto regex{sourcemeta::core::to_regex(
+      "|abc", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("|abc"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1321,7 +1466,8 @@ TEST(ecma262_pipe_at_start) {
 }
 
 TEST(ecma262_pipe_at_end) {
-  const auto regex{sourcemeta::core::to_regex("abc|")};
+  const auto regex{sourcemeta::core::to_regex(
+      "abc|", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("abc|"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1329,7 +1475,8 @@ TEST(ecma262_pipe_at_end) {
 }
 
 TEST(ecma262_dot_matches_any_except_newline) {
-  const auto regex{sourcemeta::core::to_regex("a.b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a.b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a.b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "axb"));
@@ -1338,7 +1485,8 @@ TEST(ecma262_dot_matches_any_except_newline) {
 }
 
 TEST(ecma262_escaped_dot_in_char_class) {
-  const auto regex{sourcemeta::core::to_regex("[.]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[.]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[.]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "."));
@@ -1346,7 +1494,8 @@ TEST(ecma262_escaped_dot_in_char_class) {
 }
 
 TEST(ecma262_non_greedy_star) {
-  const auto regex{sourcemeta::core::to_regex("a*?")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a*?", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a*?"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -1355,7 +1504,8 @@ TEST(ecma262_non_greedy_star) {
 }
 
 TEST(ecma262_non_greedy_plus) {
-  const auto regex{sourcemeta::core::to_regex("a+?")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a+?", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a+?"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
@@ -1364,7 +1514,8 @@ TEST(ecma262_non_greedy_plus) {
 }
 
 TEST(ecma262_lowercase_range) {
-  const auto regex{sourcemeta::core::to_regex("[a-z]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-z]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1375,7 +1526,8 @@ TEST(ecma262_lowercase_range) {
 }
 
 TEST(ecma262_hex_escape) {
-  const auto regex{sourcemeta::core::to_regex("\\x41")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\x41", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\x41"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -1383,7 +1535,8 @@ TEST(ecma262_hex_escape) {
 }
 
 TEST(ecma262_dollar_before_bracket) {
-  const auto regex{sourcemeta::core::to_regex("$[abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "$[abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$[abc]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "$a"));
@@ -1392,7 +1545,8 @@ TEST(ecma262_dollar_before_bracket) {
 }
 
 TEST(ecma262_quantifier_on_group) {
-  const auto regex{sourcemeta::core::to_regex("(ab)+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(ab)+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(ab)+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ab"));
@@ -1401,7 +1555,8 @@ TEST(ecma262_quantifier_on_group) {
 }
 
 TEST(ecma262_nested_groups) {
-  const auto regex{sourcemeta::core::to_regex("((abc))")};
+  const auto regex{sourcemeta::core::to_regex(
+      "((abc))", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((abc))"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1409,7 +1564,8 @@ TEST(ecma262_nested_groups) {
 }
 
 TEST(ecma262_escaped_pipe) {
-  const auto regex{sourcemeta::core::to_regex("a\\|b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\|b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\|b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a|b"));
@@ -1418,7 +1574,8 @@ TEST(ecma262_escaped_pipe) {
 }
 
 TEST(ecma262_escaped_paren) {
-  const auto regex{sourcemeta::core::to_regex("\\(abc\\)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\(abc\\)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\(abc\\)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "(abc)"));
@@ -1426,7 +1583,8 @@ TEST(ecma262_escaped_paren) {
 }
 
 TEST(ecma262_dollar_at_start) {
-  const auto regex{sourcemeta::core::to_regex("$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -1434,7 +1592,8 @@ TEST(ecma262_dollar_at_start) {
 }
 
 TEST(ecma262_caret_at_end) {
-  const auto regex{sourcemeta::core::to_regex("abc^")};
+  const auto regex{sourcemeta::core::to_regex(
+      "abc^", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("abc^"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc^"));
@@ -1442,7 +1601,8 @@ TEST(ecma262_caret_at_end) {
 }
 
 TEST(ecma262_escaped_quantifiers) {
-  const auto regex{sourcemeta::core::to_regex("\\*\\+\\?")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\*\\+\\?", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\*\\+\\?"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "*+?"));
@@ -1450,7 +1610,8 @@ TEST(ecma262_escaped_quantifiers) {
 }
 
 TEST(ecma262_escaped_curly_brace) {
-  const auto regex{sourcemeta::core::to_regex("\\{3\\}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\{3\\}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\{3\\}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "{3}"));
@@ -1458,7 +1619,8 @@ TEST(ecma262_escaped_curly_brace) {
 }
 
 TEST(ecma262_question_quantifier) {
-  const auto regex{sourcemeta::core::to_regex("ab?c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "ab?c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab?c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ac"));
@@ -1467,7 +1629,8 @@ TEST(ecma262_question_quantifier) {
 }
 
 TEST(ecma262_zero_quantifier) {
-  const auto regex{sourcemeta::core::to_regex("a{0}b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{0}b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0}b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -1476,7 +1639,8 @@ TEST(ecma262_zero_quantifier) {
 }
 
 TEST(ecma262_spaces_are_literal) {
-  const auto regex{sourcemeta::core::to_regex("a b c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a b c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a b c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a b c"));
@@ -1484,7 +1648,8 @@ TEST(ecma262_spaces_are_literal) {
 }
 
 TEST(ecma262_tab_is_literal) {
-  const auto regex{sourcemeta::core::to_regex("a\tb")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\tb", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\tb"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\tb"));
@@ -1492,13 +1657,15 @@ TEST(ecma262_tab_is_literal) {
 }
 
 TEST(ecma262_backslash_before_closing_paren) {
-  const auto regex{sourcemeta::core::to_regex("(abc\\)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(abc\\)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("(abc\\)"));
 }
 
 TEST(ecma262_caret_dollar_together) {
-  const auto regex{sourcemeta::core::to_regex("^$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -1506,7 +1673,8 @@ TEST(ecma262_caret_dollar_together) {
 }
 
 TEST(ecma262_multiple_carets_at_start) {
-  const auto regex{sourcemeta::core::to_regex("^^^abc")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^^^abc", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^^^abc"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1516,7 +1684,8 @@ TEST(ecma262_multiple_carets_at_start) {
 }
 
 TEST(ecma262_multiple_dollars_at_end) {
-  const auto regex{sourcemeta::core::to_regex("abc$$$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "abc$$$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("abc$$$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -1524,7 +1693,8 @@ TEST(ecma262_multiple_dollars_at_end) {
 }
 
 TEST(ecma262_v_flag_set_subtraction) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--a]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--a]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--a]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "z"));
@@ -1533,7 +1703,8 @@ TEST(ecma262_v_flag_set_subtraction) {
 }
 
 TEST(ecma262_v_flag_set_intersection) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[0-5]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[0-5]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[0-5]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1542,7 +1713,8 @@ TEST(ecma262_v_flag_set_intersection) {
 }
 
 TEST(ecma262_v_flag_subtract_vowels) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -1556,7 +1728,8 @@ TEST(ecma262_v_flag_subtract_vowels) {
 }
 
 TEST(ecma262_v_flag_subtract_range) {
-  const auto regex{sourcemeta::core::to_regex("[[0-9]--[3-7]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[0-9]--[3-7]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9]--[3-7]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1570,7 +1743,8 @@ TEST(ecma262_v_flag_subtract_range) {
 }
 
 TEST(ecma262_v_flag_subtract_from_digit) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]--[0]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]--[0]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[0]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "1"));
@@ -1580,7 +1754,8 @@ TEST(ecma262_v_flag_subtract_from_digit) {
 }
 
 TEST(ecma262_v_flag_subtract_from_word) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]--[0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]--[0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1592,7 +1767,8 @@ TEST(ecma262_v_flag_subtract_from_word) {
 }
 
 TEST(ecma262_v_flag_intersect_word_lowercase) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]&&[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]&&[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]&&[a-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1603,7 +1779,8 @@ TEST(ecma262_v_flag_intersect_word_lowercase) {
 }
 
 TEST(ecma262_v_flag_intersect_even_digits) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[02468]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[02468]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[02468]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1614,7 +1791,8 @@ TEST(ecma262_v_flag_intersect_even_digits) {
 }
 
 TEST(ecma262_v_flag_subtract_uppercase) {
-  const auto regex{sourcemeta::core::to_regex("[[A-Za-z]--[A-Z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[A-Za-z]--[A-Z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[A-Za-z]--[A-Z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1624,7 +1802,8 @@ TEST(ecma262_v_flag_subtract_uppercase) {
 }
 
 TEST(ecma262_v_flag_subtract_same_char) {
-  const auto regex{sourcemeta::core::to_regex("[[a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]--[a]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1632,7 +1811,8 @@ TEST(ecma262_v_flag_subtract_same_char) {
 }
 
 TEST(ecma262_v_flag_intersect_same_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]&&[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]&&[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[a-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1642,7 +1822,8 @@ TEST(ecma262_v_flag_intersect_same_range) {
 }
 
 TEST(ecma262_v_flag_intersect_disjoint) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]&&[x-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]&&[x-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]&&[x-z]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1651,7 +1832,8 @@ TEST(ecma262_v_flag_intersect_disjoint) {
 }
 
 TEST(ecma262_v_flag_subtract_hex_letters) {
-  const auto regex{sourcemeta::core::to_regex("[[0-9a-f]--[a-f]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[0-9a-f]--[a-f]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9a-f]--[a-f]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1661,7 +1843,8 @@ TEST(ecma262_v_flag_subtract_hex_letters) {
 }
 
 TEST(ecma262_v_flag_intersect_partial_overlap) {
-  const auto regex{sourcemeta::core::to_regex("[[a-m]&&[h-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-m]&&[h-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-m]&&[h-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "h"));
@@ -1674,7 +1857,8 @@ TEST(ecma262_v_flag_intersect_partial_overlap) {
 }
 
 TEST(ecma262_v_flag_subtract_start_of_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-e]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-e]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -1683,7 +1867,8 @@ TEST(ecma262_v_flag_subtract_start_of_range) {
 }
 
 TEST(ecma262_v_flag_subtract_end_of_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-e]--[e]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-e]--[e]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[e]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1692,7 +1877,8 @@ TEST(ecma262_v_flag_subtract_end_of_range) {
 }
 
 TEST(ecma262_v_flag_subtract_middle_of_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-e]--[c]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-e]--[c]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[c]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1703,7 +1889,8 @@ TEST(ecma262_v_flag_subtract_middle_of_range) {
 }
 
 TEST(ecma262_v_flag_intersect_single_char) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]&&[m]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]&&[m]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[m]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "m"));
@@ -1712,7 +1899,8 @@ TEST(ecma262_v_flag_intersect_single_char) {
 }
 
 TEST(ecma262_v_flag_subtraction_in_pattern) {
-  const auto regex{sourcemeta::core::to_regex("^[[a-z]--[aeiou]]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[[a-z]--[aeiou]]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "bcdfg"));
@@ -1722,7 +1910,8 @@ TEST(ecma262_v_flag_subtraction_in_pattern) {
 }
 
 TEST(ecma262_v_flag_intersection_in_pattern) {
-  const auto regex{sourcemeta::core::to_regex("^[\\d&&[0-5]]+$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[\\d&&[0-5]]+$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[\\d&&[0-5]]+$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "012345"));
@@ -1732,7 +1921,8 @@ TEST(ecma262_v_flag_intersection_in_pattern) {
 }
 
 TEST(ecma262_v_flag_subtract_digit_from_word) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]--[\\d]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]--[\\d]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[\\d]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1743,7 +1933,8 @@ TEST(ecma262_v_flag_subtract_digit_from_word) {
 }
 
 TEST(ecma262_v_flag_intersect_digit_word) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\w]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[\\w]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\w]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1753,7 +1944,8 @@ TEST(ecma262_v_flag_intersect_digit_word) {
 }
 
 TEST(ecma262_v_flag_subtract_specific_punct) {
-  const auto regex{sourcemeta::core::to_regex("[[\\!-\\/]--[#$%]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\!-\\/]--[#$%]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\!-\\/]--[#$%]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -1766,7 +1958,8 @@ TEST(ecma262_v_flag_subtract_specific_punct) {
 }
 
 TEST(ecma262_v_flag_subtract_empty) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]--[x-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]--[x-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[x-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1776,7 +1969,8 @@ TEST(ecma262_v_flag_subtract_empty) {
 }
 
 TEST(ecma262_v_flag_intersect_printable_alpha) {
-  const auto regex{sourcemeta::core::to_regex("[[ -~]&&[A-Z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[ -~]&&[A-Z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[ -~]&&[A-Z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -1788,7 +1982,8 @@ TEST(ecma262_v_flag_intersect_printable_alpha) {
 }
 
 TEST(ecma262_v_flag_subtract_multiple_ranges) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[a-cx-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[a-cx-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[a-cx-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "d"));
@@ -1803,7 +1998,8 @@ TEST(ecma262_v_flag_subtract_multiple_ranges) {
 }
 
 TEST(ecma262_v_flag_subtract_space) {
-  const auto regex{sourcemeta::core::to_regex("[[ -\\/]--[ ]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[ -\\/]--[ ]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[ -\\/]--[ ]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -1812,7 +2008,8 @@ TEST(ecma262_v_flag_subtract_space) {
 }
 
 TEST(ecma262_v_flag_intersect_to_single) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]&&[c-e]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]&&[c-e]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]&&[c-e]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "c"));
@@ -1823,7 +2020,8 @@ TEST(ecma262_v_flag_intersect_to_single) {
 }
 
 TEST(ecma262_v_flag_subtraction_with_quantifier) {
-  const auto regex{sourcemeta::core::to_regex("^[[0-9]--[0]]{3}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[[0-9]--[0]]{3}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[0-9]--[0]]{3}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "123"));
@@ -1834,7 +2032,8 @@ TEST(ecma262_v_flag_subtraction_with_quantifier) {
 }
 
 TEST(ecma262_v_flag_subtract_caret) {
-  const auto regex{sourcemeta::core::to_regex("[[!-@]--[\\^]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[!-@]--[\\^]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[!-@]--[\\^]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -1843,7 +2042,8 @@ TEST(ecma262_v_flag_subtract_caret) {
 }
 
 TEST(ecma262_v_flag_intersect_alphanum_upper) {
-  const auto regex{sourcemeta::core::to_regex("[[0-9A-Za-z]&&[A-Z0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[0-9A-Za-z]&&[A-Z0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9A-Za-z]&&[A-Z0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -1854,7 +2054,8 @@ TEST(ecma262_v_flag_intersect_alphanum_upper) {
 }
 
 TEST(ecma262_v_flag_subtract_entire_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]--[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]--[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[a-z]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1865,7 +2066,8 @@ TEST(ecma262_v_flag_subtract_entire_range) {
 
 TEST(ecma262_v_flag_multiple_set_ops_pattern) {
   const auto regex{
-      sourcemeta::core::to_regex("^[[a-z]--[aeiou]][[0-9]--[0]]$")};
+      sourcemeta::core::to_regex("^[[a-z]--[aeiou]][[0-9]--[0]]$",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]][[0-9]--[0]]$"));
@@ -1877,7 +2079,8 @@ TEST(ecma262_v_flag_multiple_set_ops_pattern) {
 }
 
 TEST(ecma262_v_flag_intersect_digit_ranges) {
-  const auto regex{sourcemeta::core::to_regex("[[0-5]&&[3-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[0-5]&&[3-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-5]&&[3-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "3"));
@@ -1890,7 +2093,8 @@ TEST(ecma262_v_flag_intersect_digit_ranges) {
 }
 
 TEST(ecma262_v_flag_subtract_preserving_hyphen) {
-  const auto regex{sourcemeta::core::to_regex("[[0-9\\-]--[5-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[0-9\\-]--[5-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9\\-]--[5-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -1901,7 +2105,8 @@ TEST(ecma262_v_flag_subtract_preserving_hyphen) {
 }
 
 TEST(ecma262_v_flag_intersect_word_underscore) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]&&[_]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]&&[_]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]&&[_]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "_"));
@@ -1910,7 +2115,8 @@ TEST(ecma262_v_flag_intersect_word_underscore) {
 }
 
 TEST(ecma262_v_flag_subtract_from_union) {
-  const auto regex{sourcemeta::core::to_regex("[[a-zA-Z0-9]--[A-Z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-zA-Z0-9]--[A-Z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-zA-Z0-9]--[A-Z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1921,7 +2127,9 @@ TEST(ecma262_v_flag_subtract_from_union) {
 }
 
 TEST(ecma262_v_flag_large_subtraction) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x20-\\x7e]--[a-zA-Z0-9]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[\\x20-\\x7e]--[a-zA-Z0-9]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x20-\\x7e]--[a-zA-Z0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -1934,7 +2142,8 @@ TEST(ecma262_v_flag_large_subtraction) {
 }
 
 TEST(ecma262_v_flag_hex_range_subtract_literal) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x61-\\x7a]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x61-\\x7a]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x61-\\x7a]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -1944,7 +2153,8 @@ TEST(ecma262_v_flag_hex_range_subtract_literal) {
 }
 
 TEST(ecma262_v_flag_subtract_single_from_single) {
-  const auto regex{sourcemeta::core::to_regex("[[a]--[b]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a]--[b]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]--[b]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1952,7 +2162,8 @@ TEST(ecma262_v_flag_subtract_single_from_single) {
 }
 
 TEST(ecma262_v_flag_intersect_single_chars_same) {
-  const auto regex{sourcemeta::core::to_regex("[[a]&&[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a]&&[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]&&[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1960,7 +2171,8 @@ TEST(ecma262_v_flag_intersect_single_chars_same) {
 }
 
 TEST(ecma262_v_flag_intersect_single_chars_different) {
-  const auto regex{sourcemeta::core::to_regex("[[a]&&[b]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a]&&[b]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]&&[b]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1969,7 +2181,8 @@ TEST(ecma262_v_flag_intersect_single_chars_different) {
 
 TEST(ecma262_v_flag_hex_intersect_hex) {
   const auto regex{
-      sourcemeta::core::to_regex("[[\\x30-\\x39]&&[\\x33-\\x37]]")};
+      sourcemeta::core::to_regex("[[\\x30-\\x39]&&[\\x33-\\x37]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[\\x30-\\x39]&&[\\x33-\\x37]]"));
@@ -1983,7 +2196,8 @@ TEST(ecma262_v_flag_hex_intersect_hex) {
 }
 
 TEST(ecma262_v_flag_subtract_all_digits_from_word) {
-  const auto regex{sourcemeta::core::to_regex("[[[\\w]--[\\d]]--[_]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[\\w]--[\\d]]--[_]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[\\w]--[\\d]]--[_]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1993,7 +2207,8 @@ TEST(ecma262_v_flag_subtract_all_digits_from_word) {
 }
 
 TEST(ecma262_v_flag_intersect_with_escaped_backslash) {
-  const auto regex{sourcemeta::core::to_regex("[[\\\\a-z]&&[\\\\]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\\\a-z]&&[\\\\]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\\\a-z]&&[\\\\]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\"));
@@ -2003,7 +2218,8 @@ TEST(ecma262_v_flag_intersect_with_escaped_backslash) {
 
 TEST(ecma262_v_flag_subtract_control_chars) {
   const auto regex{
-      sourcemeta::core::to_regex("[[\\x00-\\x1f]--[\\x00-\\x08]]")};
+      sourcemeta::core::to_regex("[[\\x00-\\x1f]--[\\x00-\\x08]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[\\x00-\\x1f]--[\\x00-\\x08]]"));
@@ -2014,7 +2230,8 @@ TEST(ecma262_v_flag_subtract_control_chars) {
 }
 
 TEST(ecma262_v_flag_intersect_with_tab_newline) {
-  const auto regex{sourcemeta::core::to_regex("[[\\t\\n\\r ]&&[\\t\\n]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\t\\n\\r ]&&[\\t\\n]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\t\\n\\r ]&&[\\t\\n]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\t"));
@@ -2024,7 +2241,8 @@ TEST(ecma262_v_flag_intersect_with_tab_newline) {
 }
 
 TEST(ecma262_v_flag_subtract_leaves_single) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]--[ab]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]--[ab]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[ab]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "c"));
@@ -2033,7 +2251,8 @@ TEST(ecma262_v_flag_subtract_leaves_single) {
 }
 
 TEST(ecma262_v_flag_intersect_overlapping_three_char) {
-  const auto regex{sourcemeta::core::to_regex("[[abc]&&[bcd]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[abc]&&[bcd]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]&&[bcd]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2043,7 +2262,8 @@ TEST(ecma262_v_flag_intersect_overlapping_three_char) {
 }
 
 TEST(ecma262_v_flag_mixed_hex_and_literal_in_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x41-\\x5a]--[AEIOU]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x41-\\x5a]--[AEIOU]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x41-\\x5a]--[AEIOU]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "B"));
@@ -2054,7 +2274,8 @@ TEST(ecma262_v_flag_mixed_hex_and_literal_in_subtract) {
 }
 
 TEST(ecma262_v_flag_subtract_boundary_chars) {
-  const auto regex{sourcemeta::core::to_regex("[[!-~]--[!~]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[!-~]--[!~]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[!-~]--[!~]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\""));
@@ -2066,7 +2287,8 @@ TEST(ecma262_v_flag_subtract_boundary_chars) {
 
 TEST(ecma262_v_flag_intersect_complement_like) {
   const auto regex{
-      sourcemeta::core::to_regex("[[\\x00-\\x60\\x7b-\\x7f]&&[\\x00-\\x7f]]")};
+      sourcemeta::core::to_regex("[[\\x00-\\x60\\x7b-\\x7f]&&[\\x00-\\x7f]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[[\\x00-\\x60\\x7b-\\x7f]&&[\\x00-\\x7f]]"));
@@ -2078,7 +2300,8 @@ TEST(ecma262_v_flag_intersect_complement_like) {
 }
 
 TEST(ecma262_v_flag_subtract_from_shorthand_with_hex) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]--[\\x30-\\x34]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]--[\\x30-\\x34]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[\\x30-\\x34]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "5"));
@@ -2088,7 +2311,8 @@ TEST(ecma262_v_flag_subtract_from_shorthand_with_hex) {
 }
 
 TEST(ecma262_v_flag_complex_alphanumeric_filter) {
-  const auto regex{sourcemeta::core::to_regex("[[0-9A-Fa-f]--[g-zG-Z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[0-9A-Fa-f]--[g-zG-Z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[0-9A-Fa-f]--[g-zG-Z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -2102,7 +2326,8 @@ TEST(ecma262_v_flag_complex_alphanumeric_filter) {
 }
 
 TEST(ecma262_v_flag_intersect_ranges_at_boundary) {
-  const auto regex{sourcemeta::core::to_regex("[[a-f]&&[f-k]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-f]&&[f-k]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-f]&&[f-k]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "f"));
@@ -2113,7 +2338,8 @@ TEST(ecma262_v_flag_intersect_ranges_at_boundary) {
 }
 
 TEST(ecma262_v_flag_subtract_all_but_one_from_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-e]--[abde]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-e]--[abde]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-e]--[abde]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "c"));
@@ -2125,7 +2351,8 @@ TEST(ecma262_v_flag_subtract_all_but_one_from_range) {
 
 TEST(ecma262_v_flag_multiple_hex_escapes_in_subtraction) {
   const auto regex{sourcemeta::core::to_regex(
-      "[[\\x20-\\x7e]--[\\x30-\\x39]--[\\x41-\\x5a]--[\\x61-\\x7a]]")};
+      "[[\\x20-\\x7e]--[\\x30-\\x39]--[\\x41-\\x5a]--[\\x61-\\x7a]]",
+      sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[[\\x20-\\x7e]--[\\x30-\\x39]--[\\x41-\\x5a]--[\\x61-\\x7a]]"));
@@ -2138,7 +2365,8 @@ TEST(ecma262_v_flag_multiple_hex_escapes_in_subtraction) {
 }
 
 TEST(ecma262_v_flag_mixed_subtract_then_intersect) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z]--[aeiou]]&&[a-m]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z]--[aeiou]]&&[a-m]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]--[aeiou]]&&[a-m]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2149,7 +2377,8 @@ TEST(ecma262_v_flag_mixed_subtract_then_intersect) {
 }
 
 TEST(ecma262_v_flag_mixed_intersect_then_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z]&&[a-m]]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z]&&[a-m]]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]&&[a-m]]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2160,7 +2389,8 @@ TEST(ecma262_v_flag_mixed_intersect_then_subtract) {
 }
 
 TEST(ecma262_v_flag_nested_class_in_operand) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z][0-9]]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z][0-9]]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z][0-9]]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2170,7 +2400,8 @@ TEST(ecma262_v_flag_nested_class_in_operand) {
 }
 
 TEST(ecma262_v_flag_deeply_nested_brackets) {
-  const auto regex{sourcemeta::core::to_regex("[[[[a-z]]]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[[a-z]]]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[[a-z]]]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2180,7 +2411,8 @@ TEST(ecma262_v_flag_deeply_nested_brackets) {
 }
 
 TEST(ecma262_v_flag_subtract_nested_from_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z]]--[[x-z]]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z]]--[[x-z]]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]]--[[x-z]]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2190,7 +2422,8 @@ TEST(ecma262_v_flag_subtract_nested_from_nested) {
 }
 
 TEST(ecma262_v_flag_shorthand_nested_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[[\\d]]--[0]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[\\d]]--[0]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[\\d]]--[0]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "1"));
@@ -2199,7 +2432,8 @@ TEST(ecma262_v_flag_shorthand_nested_subtract) {
 }
 
 TEST(ecma262_v_flag_triple_chained_intersection) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]&&[a-m]&&[f-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]&&[a-m]&&[f-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[a-m]&&[f-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "f"));
@@ -2211,7 +2445,8 @@ TEST(ecma262_v_flag_triple_chained_intersection) {
 }
 
 TEST(ecma262_v_flag_subtract_empty_result_in_chain) {
-  const auto regex{sourcemeta::core::to_regex("[[a]--[a]--[b]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a]--[a]--[b]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a]--[a]--[b]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2219,7 +2454,8 @@ TEST(ecma262_v_flag_subtract_empty_result_in_chain) {
 }
 
 TEST(ecma262_v_flag_intersect_empty_result_in_chain) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]&&[x-z]&&[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]&&[x-z]&&[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]&&[x-z]&&[a-z]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2227,7 +2463,8 @@ TEST(ecma262_v_flag_intersect_empty_result_in_chain) {
 }
 
 TEST(ecma262_v_flag_operator_inside_nested_not_toplevel) {
-  const auto regex{sourcemeta::core::to_regex("[[a\\-\\-b]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a\\-\\-b]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a\\-\\-b]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2236,7 +2473,9 @@ TEST(ecma262_v_flag_operator_inside_nested_not_toplevel) {
 }
 
 TEST(ecma262_v_flag_alternation_after_set_op) {
-  const auto regex{sourcemeta::core::to_regex("^([[a-z]--[aeiou]]|[0-9])$")};
+  const auto regex{
+      sourcemeta::core::to_regex("^([[a-z]--[aeiou]]|[0-9])$",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^([[a-z]--[aeiou]]|[0-9])$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2246,7 +2485,8 @@ TEST(ecma262_v_flag_alternation_after_set_op) {
 }
 
 TEST(ecma262_v_flag_set_op_with_dot_star) {
-  const auto regex{sourcemeta::core::to_regex("^.*[[a-z]--[aeiou]]$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.*[[a-z]--[aeiou]]$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^.*[[a-z]--[aeiou]]$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xxxb"));
@@ -2256,7 +2496,8 @@ TEST(ecma262_v_flag_set_op_with_dot_star) {
 }
 
 TEST(ecma262_v_flag_shorthand_only_intersection) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\w]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[\\w]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\w]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -2266,7 +2507,8 @@ TEST(ecma262_v_flag_shorthand_only_intersection) {
 }
 
 TEST(ecma262_v_flag_double_nested_with_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z]]--[[aeiou]]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z]]--[[aeiou]]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]]--[[aeiou]]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2276,7 +2518,8 @@ TEST(ecma262_v_flag_double_nested_with_subtract) {
 }
 
 TEST(ecma262_v_flag_union_in_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-c][x-z]]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-c][x-z]]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-c][x-z]]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2288,7 +2531,8 @@ TEST(ecma262_v_flag_union_in_nested) {
 }
 
 TEST(ecma262_v_flag_subtract_from_union_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z][0-9]]--[aeiou0]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z][0-9]]--[aeiou0]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z][0-9]]--[aeiou0]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2300,7 +2544,9 @@ TEST(ecma262_v_flag_subtract_from_union_nested) {
 }
 
 TEST(ecma262_v_flag_four_way_intersection) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]&&[a-m]&&[f-z]&&[g-l]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[a-z]&&[a-m]&&[f-z]&&[g-l]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[a-m]&&[f-z]&&[g-l]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "g"));
@@ -2312,7 +2558,8 @@ TEST(ecma262_v_flag_four_way_intersection) {
 
 TEST(ecma262_v_flag_alternating_ops) {
   const auto regex{
-      sourcemeta::core::to_regex("[[[[a-z]--[aeiou]]&&[a-m]]--[klm]]")};
+      sourcemeta::core::to_regex("[[[[a-z]--[aeiou]]&&[a-m]]--[klm]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[[[a-z]--[aeiou]]&&[a-m]]--[klm]]"));
@@ -2324,7 +2571,8 @@ TEST(ecma262_v_flag_alternating_ops) {
 }
 
 TEST(ecma262_v_flag_repeated_char_class) {
-  const auto regex{sourcemeta::core::to_regex("^[[a-c]][[d-f]]$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[[a-c]][[d-f]]$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-c]][[d-f]]$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ad"));
@@ -2335,7 +2583,8 @@ TEST(ecma262_v_flag_repeated_char_class) {
 }
 
 TEST(ecma262_v_flag_whitespace_subtract_space) {
-  const auto regex{sourcemeta::core::to_regex("[[\\s]--[ ]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\s]--[ ]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\s]--[ ]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\t"));
@@ -2345,7 +2594,8 @@ TEST(ecma262_v_flag_whitespace_subtract_space) {
 }
 
 TEST(ecma262_v_flag_negated_digit_intersect) {
-  const auto regex{sourcemeta::core::to_regex("[[\\D]&&[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\D]&&[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\D]&&[a-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2355,7 +2605,8 @@ TEST(ecma262_v_flag_negated_digit_intersect) {
 }
 
 TEST(ecma262_v_flag_negated_word_intersect) {
-  const auto regex{sourcemeta::core::to_regex("[[\\W]&&[\\!-\\/]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\W]&&[\\!-\\/]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\W]&&[\\!-\\/]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -2365,7 +2616,8 @@ TEST(ecma262_v_flag_negated_word_intersect) {
 }
 
 TEST(ecma262_v_flag_negated_space_intersect) {
-  const auto regex{sourcemeta::core::to_regex("[[\\S]&&[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\S]&&[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\S]&&[a-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2375,7 +2627,8 @@ TEST(ecma262_v_flag_negated_space_intersect) {
 }
 
 TEST(ecma262_v_flag_caret_negation_with_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[^a-z]--[0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[^a-z]--[0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[^a-z]--[0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -2385,7 +2638,8 @@ TEST(ecma262_v_flag_caret_negation_with_subtract) {
 }
 
 TEST(ecma262_v_flag_single_char_range) {
-  const auto regex{sourcemeta::core::to_regex("[[a-a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2393,7 +2647,8 @@ TEST(ecma262_v_flag_single_char_range) {
 }
 
 TEST(ecma262_v_flag_literal_hyphen_at_end) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z\\-]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z\\-]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z\\-]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2403,7 +2658,8 @@ TEST(ecma262_v_flag_literal_hyphen_at_end) {
 }
 
 TEST(ecma262_v_flag_literal_hyphen_at_start) {
-  const auto regex{sourcemeta::core::to_regex("[[\\-a-z]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\-a-z]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\-a-z]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2412,7 +2668,8 @@ TEST(ecma262_v_flag_literal_hyphen_at_start) {
 }
 
 TEST(ecma262_v_flag_subtract_with_caret_in_operand) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[^aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[^aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[^aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2422,7 +2679,8 @@ TEST(ecma262_v_flag_subtract_with_caret_in_operand) {
 }
 
 TEST(ecma262_v_flag_intersect_with_caret_in_operand) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]&&[^x-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]&&[^x-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]&&[^x-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2432,7 +2690,9 @@ TEST(ecma262_v_flag_intersect_with_caret_in_operand) {
 }
 
 TEST(ecma262_v_flag_unicode_escape_4digit_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[\\u0041-\\u005A]--[ABC]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[\\u0041-\\u005A]--[ABC]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\u0041-\\u005A]--[ABC]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "D"));
@@ -2444,7 +2704,8 @@ TEST(ecma262_v_flag_unicode_escape_4digit_subtract) {
 
 TEST(ecma262_v_flag_unicode_escape_brace_subtract) {
   const auto regex{
-      sourcemeta::core::to_regex("[[\\u{0041}-\\u{005A}]--[ABC]]")};
+      sourcemeta::core::to_regex("[[\\u{0041}-\\u{005A}]--[ABC]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[\\u{0041}-\\u{005A}]--[ABC]]"));
@@ -2456,7 +2717,8 @@ TEST(ecma262_v_flag_unicode_escape_brace_subtract) {
 }
 
 TEST(ecma262_v_flag_backspace_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[\\b]--[\\x08]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\b]--[\\x08]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\b]--[\\x08]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\b"));
@@ -2464,7 +2726,9 @@ TEST(ecma262_v_flag_backspace_in_class) {
 }
 
 TEST(ecma262_v_flag_control_escape_intersect) {
-  const auto regex{sourcemeta::core::to_regex("[[\\cA-\\cZ]&&[\\x01-\\x03]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[\\cA-\\cZ]&&[\\x01-\\x03]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\cA-\\cZ]&&[\\x01-\\x03]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\x01"));
@@ -2474,25 +2738,29 @@ TEST(ecma262_v_flag_control_escape_intersect) {
 }
 
 TEST(ecma262_v_flag_empty_first_operand) {
-  const auto regex{sourcemeta::core::to_regex("[--[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[--[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[--[a-z]]"));
 }
 
 TEST(ecma262_v_flag_empty_second_operand) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z]--]"));
 }
 
 TEST(ecma262_v_flag_double_operator_subtraction) {
-  const auto regex{sourcemeta::core::to_regex("[a-z----abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-z----abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[a-z----abc]"));
 }
 
 TEST(ecma262_v_flag_subtract_abc_from_az) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[abc]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[abc]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[abc]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "d"));
@@ -2503,7 +2771,8 @@ TEST(ecma262_v_flag_subtract_abc_from_az) {
 }
 
 TEST(ecma262_v_flag_rightbracket_first_in_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[\\]-a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\]-a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\]-a]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "]"));
@@ -2511,7 +2780,8 @@ TEST(ecma262_v_flag_rightbracket_first_in_nested) {
 }
 
 TEST(ecma262_v_flag_subtract_from_single_shorthand) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]--[5]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]--[5]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[5]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -2521,7 +2791,8 @@ TEST(ecma262_v_flag_subtract_from_single_shorthand) {
 }
 
 TEST(ecma262_v_flag_intersect_two_shorthands) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\w]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[\\w]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\w]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -2531,7 +2802,8 @@ TEST(ecma262_v_flag_intersect_two_shorthands) {
 }
 
 TEST(ecma262_v_flag_subtract_shorthand_from_shorthand) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]--[\\d]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]--[\\d]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[\\d]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2542,7 +2814,8 @@ TEST(ecma262_v_flag_subtract_shorthand_from_shorthand) {
 }
 
 TEST(ecma262_v_flag_triple_nested_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[[a-z]]--[[aeiou]]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[a-z]]--[[aeiou]]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[a-z]]--[[aeiou]]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2552,7 +2825,8 @@ TEST(ecma262_v_flag_triple_nested_subtract) {
 }
 
 TEST(ecma262_v_flag_subtract_empty_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2561,7 +2835,8 @@ TEST(ecma262_v_flag_subtract_empty_nested) {
 }
 
 TEST(ecma262_v_flag_word_minus_alphanumeric) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]--[a-zA-Z0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]--[a-zA-Z0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[a-zA-Z0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "_"));
@@ -2570,7 +2845,8 @@ TEST(ecma262_v_flag_word_minus_alphanumeric) {
 }
 
 TEST(ecma262_v_flag_multiple_escape_sequences_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[[\\t\\n\\r]]--[\\t]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[\\t\\n\\r]]--[\\t]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[\\t\\n\\r]]--[\\t]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
@@ -2579,7 +2855,9 @@ TEST(ecma262_v_flag_multiple_escape_sequences_subtract) {
 }
 
 TEST(ecma262_v_flag_mixed_unicode_escape_types) {
-  const auto regex{sourcemeta::core::to_regex("[[\\u0041-\\u{005A}]--[ABC]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[\\u0041-\\u{005A}]--[ABC]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\u0041-\\u{005A}]--[ABC]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "D"));
@@ -2590,7 +2868,8 @@ TEST(ecma262_v_flag_mixed_unicode_escape_types) {
 
 TEST(ecma262_v_flag_control_char_range_intersect) {
   const auto regex{
-      sourcemeta::core::to_regex("[[\\x00-\\x1F]&&[\\x00-\\x0F]]")};
+      sourcemeta::core::to_regex("[[\\x00-\\x1F]&&[\\x00-\\x0F]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[\\x00-\\x1F]&&[\\x00-\\x0F]]"));
@@ -2601,7 +2880,8 @@ TEST(ecma262_v_flag_control_char_range_intersect) {
 }
 
 TEST(ecma262_v_flag_del_char_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x7E-\\x7F]--[\\x7E]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x7E-\\x7F]--[\\x7E]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x7E-\\x7F]--[\\x7E]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\x7F"));
@@ -2610,7 +2890,8 @@ TEST(ecma262_v_flag_del_char_subtract) {
 }
 
 TEST(ecma262_v_flag_form_feed_and_vertical_tab) {
-  const auto regex{sourcemeta::core::to_regex("[[\\f\\v]--[\\f]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\f\\v]--[\\f]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\f\\v]--[\\f]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\v"));
@@ -2618,7 +2899,8 @@ TEST(ecma262_v_flag_form_feed_and_vertical_tab) {
 }
 
 TEST(ecma262_v_flag_null_char_in_operation) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x00-\\x02]--[\\x00]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x00-\\x02]--[\\x00]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x00-\\x02]--[\\x00]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\x01"));
@@ -2628,7 +2910,9 @@ TEST(ecma262_v_flag_null_char_in_operation) {
 }
 
 TEST(ecma262_v_flag_printable_minus_alphanumeric) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x20-\\x7E]--[a-zA-Z0-9]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[\\x20-\\x7E]--[a-zA-Z0-9]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x20-\\x7E]--[a-zA-Z0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -2640,7 +2924,8 @@ TEST(ecma262_v_flag_printable_minus_alphanumeric) {
 
 TEST(ecma262_v_flag_five_way_chained_intersection) {
   const auto regex{
-      sourcemeta::core::to_regex("[[a-z]&&[a-w]&&[a-t]&&[a-q]&&[a-n]]")};
+      sourcemeta::core::to_regex("[[a-z]&&[a-w]&&[a-t]&&[a-q]&&[a-n]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[a-z]&&[a-w]&&[a-t]&&[a-q]&&[a-n]]"));
@@ -2651,7 +2936,9 @@ TEST(ecma262_v_flag_five_way_chained_intersection) {
 }
 
 TEST(ecma262_v_flag_lowercase_control_escape) {
-  const auto regex{sourcemeta::core::to_regex("[[\\ca-\\cz]&&[\\x01-\\x03]]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[[\\ca-\\cz]&&[\\x01-\\x03]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\ca-\\cz]&&[\\x01-\\x03]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\x01"));
@@ -2660,7 +2947,8 @@ TEST(ecma262_v_flag_lowercase_control_escape) {
 }
 
 TEST(ecma262_v_flag_subtract_all_word_chars) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]--[\\w]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]--[\\w]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]--[\\w]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2669,7 +2957,8 @@ TEST(ecma262_v_flag_subtract_all_word_chars) {
 }
 
 TEST(ecma262_v_flag_intersect_with_itself) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[\\d]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[\\d]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[\\d]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -2678,7 +2967,8 @@ TEST(ecma262_v_flag_intersect_with_itself) {
 }
 
 TEST(ecma262_v_flag_double_backslash_in_operation) {
-  const auto regex{sourcemeta::core::to_regex("[[\\\\]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\\\]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\\\]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\"));
@@ -2689,7 +2979,8 @@ TEST(ecma262_v_flag_subtract_from_full_ascii_printable) {
   const auto regex{
       sourcemeta::core::to_regex("[[[[[[\\x20-\\x7E]--[\\x20-\\x2F]]--[\\x3A-"
                                  "\\x40]]--[\\x5B-\\x60]]--[\\x7"
-                                 "B-\\x7E]]]")};
+                                 "B-\\x7E]]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[[[[[[\\x20-\\x7E]--[\\x20-\\x2F]]--[\\x3A-"
@@ -2704,7 +2995,8 @@ TEST(ecma262_v_flag_subtract_from_full_ascii_printable) {
 }
 
 TEST(ecma262_v_flag_all_hex_digits_only) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[a-fA-F0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[a-fA-F0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[a-fA-F0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -2714,7 +3006,8 @@ TEST(ecma262_v_flag_all_hex_digits_only) {
 }
 
 TEST(ecma262_v_flag_hex_letter_only) {
-  const auto regex{sourcemeta::core::to_regex("[[a-fA-F0-9]--[\\d]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-fA-F0-9]--[\\d]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-fA-F0-9]--[\\d]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2727,7 +3020,8 @@ TEST(ecma262_v_flag_hex_letter_only) {
 }
 
 TEST(ecma262_v_flag_escaped_special_regex_chars) {
-  const auto regex{sourcemeta::core::to_regex("[[.+*?]--[.]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[.+*?]--[.]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[.+*?]--[.]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "+"));
@@ -2738,7 +3032,8 @@ TEST(ecma262_v_flag_escaped_special_regex_chars) {
 }
 
 TEST(ecma262_v_flag_escaped_open_bracket) {
-  const auto regex{sourcemeta::core::to_regex("[[\\[]--[x]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\[]--[x]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\[]--[x]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "["));
@@ -2747,7 +3042,8 @@ TEST(ecma262_v_flag_escaped_open_bracket) {
 }
 
 TEST(ecma262_v_flag_only_special_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("[[\\!-\\/]&&[\\(-+]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\!-\\/]&&[\\(-+]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\!-\\/]&&[\\(-+]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "("));
@@ -2759,7 +3055,8 @@ TEST(ecma262_v_flag_only_special_punctuation) {
 }
 
 TEST(ecma262_v_flag_range_with_same_start_end) {
-  const auto regex{sourcemeta::core::to_regex("[[a-a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2767,7 +3064,8 @@ TEST(ecma262_v_flag_range_with_same_start_end) {
 }
 
 TEST(ecma262_v_flag_at_sign_and_backtick) {
-  const auto regex{sourcemeta::core::to_regex("[[@`]--[@]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[@`]--[@]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[@`]--[@]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "`"));
@@ -2775,7 +3073,8 @@ TEST(ecma262_v_flag_at_sign_and_backtick) {
 }
 
 TEST(ecma262_v_flag_escaped_hyphen_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[a\\-z]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a\\-z]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a\\-z]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -2785,7 +3084,8 @@ TEST(ecma262_v_flag_escaped_hyphen_subtract) {
 }
 
 TEST(ecma262_v_flag_hex_to_literal_range) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x41-Z]--[ABC]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x41-Z]--[ABC]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x41-Z]--[ABC]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "D"));
@@ -2795,7 +3095,8 @@ TEST(ecma262_v_flag_hex_to_literal_range) {
 }
 
 TEST(ecma262_v_flag_literal_to_hex_range) {
-  const auto regex{sourcemeta::core::to_regex("[[A-\\x5A]--[ABC]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[A-\\x5A]--[ABC]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[A-\\x5A]--[ABC]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "D"));
@@ -2806,7 +3107,8 @@ TEST(ecma262_v_flag_literal_to_hex_range) {
 
 TEST(ecma262_v_flag_multiple_char_classes_in_pattern) {
   const auto regex{
-      sourcemeta::core::to_regex("[[a-z]--[aeiou]][[A-Z]--[AEIOU]]")};
+      sourcemeta::core::to_regex("[[a-z]--[aeiou]][[A-Z]--[AEIOU]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]][[A-Z]--[AEIOU]]"));
@@ -2817,7 +3119,8 @@ TEST(ecma262_v_flag_multiple_char_classes_in_pattern) {
 }
 
 TEST(ecma262_v_flag_in_group) {
-  const auto regex{sourcemeta::core::to_regex("(x[[a-z]--[aeiou]]y)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(x[[a-z]--[aeiou]]y)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(x[[a-z]--[aeiou]]y)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xby"));
@@ -2827,7 +3130,8 @@ TEST(ecma262_v_flag_in_group) {
 }
 
 TEST(ecma262_v_flag_with_quantifier_range) {
-  const auto regex{sourcemeta::core::to_regex("^[[a-z]--[aeiou]]{2,4}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[[a-z]--[aeiou]]{2,4}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]]{2,4}$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "bc"));
@@ -2837,7 +3141,8 @@ TEST(ecma262_v_flag_with_quantifier_range) {
 }
 
 TEST(ecma262_v_flag_anchored_both_ends) {
-  const auto regex{sourcemeta::core::to_regex("^[[a-z]--[aeiou]]$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[[a-z]--[aeiou]]$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[[a-z]--[aeiou]]$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2848,7 +3153,8 @@ TEST(ecma262_v_flag_anchored_both_ends) {
 
 TEST(ecma262_v_flag_alternation_both_branches) {
   const auto regex{
-      sourcemeta::core::to_regex("[[a-m]--[aeiou]]|[[n-z]--[aeiou]]")};
+      sourcemeta::core::to_regex("[[a-m]--[aeiou]]|[[n-z]--[aeiou]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[a-m]--[aeiou]]|[[n-z]--[aeiou]]"));
@@ -2860,7 +3166,8 @@ TEST(ecma262_v_flag_alternation_both_branches) {
 
 TEST(ecma262_v_flag_ten_way_chained_subtraction) {
   const auto regex{sourcemeta::core::to_regex(
-      "[[a-z]--[a]--[b]--[c]--[d]--[e]--[f]--[g]--[h]--[i]--[j]]")};
+      "[[a-z]--[a]--[b]--[c]--[d]--[e]--[f]--[g]--[h]--[i]--[j]]",
+      sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[[a-z]--[a]--[b]--[c]--[d]--[e]--[f]--[g]--[h]--[i]--[j]]"));
@@ -2871,7 +3178,8 @@ TEST(ecma262_v_flag_ten_way_chained_subtraction) {
 }
 
 TEST(ecma262_v_flag_single_char_minus_single_char_same) {
-  const auto regex{sourcemeta::core::to_regex("[[x]--[x]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[x]--[x]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[x]--[x]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "x"));
@@ -2879,7 +3187,8 @@ TEST(ecma262_v_flag_single_char_minus_single_char_same) {
 }
 
 TEST(ecma262_v_flag_single_char_minus_single_char_different) {
-  const auto regex{sourcemeta::core::to_regex("[[x]--[y]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[x]--[y]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[x]--[y]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "x"));
@@ -2887,7 +3196,8 @@ TEST(ecma262_v_flag_single_char_minus_single_char_different) {
 }
 
 TEST(ecma262_v_flag_caret_not_at_start_in_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[a^b]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a^b]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a^b]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "^"));
@@ -2896,7 +3206,8 @@ TEST(ecma262_v_flag_caret_not_at_start_in_nested) {
 }
 
 TEST(ecma262_v_flag_dollar_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[$a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[$a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[$a]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
@@ -2904,7 +3215,8 @@ TEST(ecma262_v_flag_dollar_in_class) {
 }
 
 TEST(ecma262_v_flag_pipe_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[\\|a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\|a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\|a]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "|"));
@@ -2912,7 +3224,8 @@ TEST(ecma262_v_flag_pipe_in_class) {
 }
 
 TEST(ecma262_v_flag_lookahead_with_operation) {
-  const auto regex{sourcemeta::core::to_regex("(?=[[a-z]--[aeiou]]).")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?=[[a-z]--[aeiou]]).", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?=[[a-z]--[aeiou]])."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -2922,7 +3235,8 @@ TEST(ecma262_v_flag_lookahead_with_operation) {
 }
 
 TEST(ecma262_v_flag_lookbehind_with_operation) {
-  const auto regex{sourcemeta::core::to_regex("(?<=[[a-z]--[aeiou]])x")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?<=[[a-z]--[aeiou]])x", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=[[a-z]--[aeiou]])x"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "bx"));
@@ -2931,7 +3245,8 @@ TEST(ecma262_v_flag_lookbehind_with_operation) {
 }
 
 TEST(ecma262_v_flag_full_ascii_intersect_to_alpha) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x00-\\x7F]&&[a-zA-Z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x00-\\x7F]&&[a-zA-Z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x00-\\x7F]&&[a-zA-Z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -2941,7 +3256,8 @@ TEST(ecma262_v_flag_full_ascii_intersect_to_alpha) {
 }
 
 TEST(ecma262_v_flag_subtract_to_result_one_char) {
-  const auto regex{sourcemeta::core::to_regex("[[a-c]--[ab]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-c]--[ab]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-c]--[ab]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "c"));
@@ -2951,7 +3267,8 @@ TEST(ecma262_v_flag_subtract_to_result_one_char) {
 }
 
 TEST(ecma262_v_flag_intersect_to_result_one_char) {
-  const auto regex{sourcemeta::core::to_regex("[[abc]&&[cde]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[abc]&&[cde]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]&&[cde]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "c"));
@@ -2960,7 +3277,8 @@ TEST(ecma262_v_flag_intersect_to_result_one_char) {
 }
 
 TEST(ecma262_v_flag_space_in_operation) {
-  const auto regex{sourcemeta::core::to_regex("[[ a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[ a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[ a]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -2968,7 +3286,8 @@ TEST(ecma262_v_flag_space_in_operation) {
 }
 
 TEST(ecma262_v_flag_bell_char_subtract) {
-  const auto regex{sourcemeta::core::to_regex("[[\\x07-\\x09]--[\\x08]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\x07-\\x09]--[\\x08]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\x07-\\x09]--[\\x08]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\x07"));
@@ -2977,7 +3296,8 @@ TEST(ecma262_v_flag_bell_char_subtract) {
 }
 
 TEST(ecma262_v_flag_escape_sequence_vs_hex) {
-  const auto regex{sourcemeta::core::to_regex("[\\t--[\\x09]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\t--[\\x09]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\t--[\\x09]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\t"));
@@ -2985,7 +3305,8 @@ TEST(ecma262_v_flag_escape_sequence_vs_hex) {
 }
 
 TEST(ecma262_v_flag_carriage_return_line_feed) {
-  const auto regex{sourcemeta::core::to_regex("[[\\r\\n]--[\\n]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\r\\n]--[\\n]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\r\\n]--[\\n]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\r"));
@@ -2993,7 +3314,8 @@ TEST(ecma262_v_flag_carriage_return_line_feed) {
 }
 
 TEST(ecma262_v_flag_repeated_same_subtraction) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[aeiou]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]--[aeiou]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -3001,7 +3323,8 @@ TEST(ecma262_v_flag_repeated_same_subtraction) {
 }
 
 TEST(ecma262_v_flag_quadruple_nested) {
-  const auto regex{sourcemeta::core::to_regex("[[[[a-z]]]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[[[a-z]]]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[[[a-z]]]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3010,7 +3333,8 @@ TEST(ecma262_v_flag_quadruple_nested) {
 }
 
 TEST(ecma262_v_flag_subtract_superset) {
-  const auto regex{sourcemeta::core::to_regex("[[abc]--[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[abc]--[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]--[a-z]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3019,7 +3343,8 @@ TEST(ecma262_v_flag_subtract_superset) {
 }
 
 TEST(ecma262_v_flag_intersect_disjoint_sets) {
-  const auto regex{sourcemeta::core::to_regex("[[abc]&&[xyz]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[abc]&&[xyz]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[abc]&&[xyz]]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3027,7 +3352,8 @@ TEST(ecma262_v_flag_intersect_disjoint_sets) {
 }
 
 TEST(ecma262_v_flag_negative_lookahead_with_operation) {
-  const auto regex{sourcemeta::core::to_regex("a(?![[a-z]--[aeiou]])")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a(?![[a-z]--[aeiou]])", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a(?![[a-z]--[aeiou]])"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ae"));
@@ -3037,7 +3363,8 @@ TEST(ecma262_v_flag_negative_lookahead_with_operation) {
 }
 
 TEST(ecma262_v_flag_negative_lookbehind_with_operation) {
-  const auto regex{sourcemeta::core::to_regex("(?<![[a-z]--[aeiou]])x")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?<![[a-z]--[aeiou]])x", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<![[a-z]--[aeiou]])x"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ax"));
@@ -3047,7 +3374,8 @@ TEST(ecma262_v_flag_negative_lookbehind_with_operation) {
 }
 
 TEST(ecma262_v_flag_non_capturing_group) {
-  const auto regex{sourcemeta::core::to_regex("(?:[[a-z]--[aeiou]])+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(?:[[a-z]--[aeiou]])+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?:[[a-z]--[aeiou]])+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "bcdf"));
@@ -3055,7 +3383,8 @@ TEST(ecma262_v_flag_non_capturing_group) {
 }
 
 TEST(ecma262_v_flag_nested_groups_with_operation) {
-  const auto regex{sourcemeta::core::to_regex("(([[a-z]--[aeiou]]))")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(([[a-z]--[aeiou]]))", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(([[a-z]--[aeiou]]))"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -3063,13 +3392,15 @@ TEST(ecma262_v_flag_nested_groups_with_operation) {
 }
 
 TEST(ecma262_v_flag_unknown_escape_sequence) {
-  const auto regex{sourcemeta::core::to_regex("[[\\q]--[x]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\q]--[x]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[\\q]--[x]]"));
 }
 
 TEST(ecma262_v_flag_tilde_and_special_chars) {
-  const auto regex{sourcemeta::core::to_regex("[[~!@#]--[~]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[~!@#]--[~]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[~!@#]--[~]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -3079,7 +3410,8 @@ TEST(ecma262_v_flag_tilde_and_special_chars) {
 }
 
 TEST(ecma262_v_flag_equals_and_less_greater) {
-  const auto regex{sourcemeta::core::to_regex("[[<=>]--[=]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[<=>]--[=]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[<=>]--[=]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "<"));
@@ -3088,7 +3420,8 @@ TEST(ecma262_v_flag_equals_and_less_greater) {
 }
 
 TEST(ecma262_v_flag_curly_braces_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[\\{\\}]--[\\{]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\{\\}]--[\\{]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\{\\}]--[\\{]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "}"));
@@ -3096,7 +3429,8 @@ TEST(ecma262_v_flag_curly_braces_in_class) {
 }
 
 TEST(ecma262_v_flag_parentheses_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[\\(\\)]--[\\(]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\(\\)]--[\\(]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\(\\)]--[\\(]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ")"));
@@ -3105,7 +3439,8 @@ TEST(ecma262_v_flag_parentheses_in_class) {
 
 TEST(ecma262_v_flag_complex_subtract_intersect_subtract) {
   const auto regex{
-      sourcemeta::core::to_regex("[[[[a-z]--[aeiou]]&&[b-y]]--[xyz]]")};
+      sourcemeta::core::to_regex("[[[[a-z]--[aeiou]]&&[b-y]]--[xyz]]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(
       sourcemeta::core::is_regex_ecma("[[[[a-z]--[aeiou]]&&[b-y]]--[xyz]]"));
@@ -3117,7 +3452,8 @@ TEST(ecma262_v_flag_complex_subtract_intersect_subtract) {
 }
 
 TEST(ecma262_v_flag_ampersand_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[&a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[&a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[&a]--[a]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "&"));
@@ -3125,7 +3461,8 @@ TEST(ecma262_v_flag_ampersand_in_class) {
 }
 
 TEST(ecma262_v_flag_percent_and_hash) {
-  const auto regex{sourcemeta::core::to_regex("[[%#]--[%]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[%#]--[%]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[%#]--[%]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "#"));
@@ -3133,7 +3470,8 @@ TEST(ecma262_v_flag_percent_and_hash) {
 }
 
 TEST(ecma262_v_flag_colon_semicolon_comma) {
-  const auto regex{sourcemeta::core::to_regex("[[:;,]--[;]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[:;,]--[;]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[:;,]--[;]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ":"));
@@ -3142,7 +3480,8 @@ TEST(ecma262_v_flag_colon_semicolon_comma) {
 }
 
 TEST(ecma262_v_flag_question_exclamation) {
-  const auto regex{sourcemeta::core::to_regex("[[?!]--[?]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[?!]--[?]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[?!]--[?]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -3150,7 +3489,8 @@ TEST(ecma262_v_flag_question_exclamation) {
 }
 
 TEST(ecma262_v_flag_underscore_intersect) {
-  const auto regex{sourcemeta::core::to_regex("[[\\w]&&[^a-zA-Z0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\w]&&[^a-zA-Z0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\w]&&[^a-zA-Z0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "_"));
@@ -3159,7 +3499,8 @@ TEST(ecma262_v_flag_underscore_intersect) {
 }
 
 TEST(ecma262_v_flag_digits_odd_only) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]--[02468]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]--[02468]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]--[02468]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "1"));
@@ -3170,7 +3511,8 @@ TEST(ecma262_v_flag_digits_odd_only) {
 }
 
 TEST(ecma262_v_flag_digits_even_only) {
-  const auto regex{sourcemeta::core::to_regex("[[\\d]&&[02468]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\d]&&[02468]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\d]&&[02468]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -3181,7 +3523,8 @@ TEST(ecma262_v_flag_digits_even_only) {
 }
 
 TEST(ecma262_v_flag_single_quote_double_quote) {
-  const auto regex{sourcemeta::core::to_regex("[['\"']--[']]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[['\"']--[']]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[['\"']--[']]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\""));
@@ -3189,7 +3532,8 @@ TEST(ecma262_v_flag_single_quote_double_quote) {
 }
 
 TEST(ecma262_v_flag_forward_slash_backslash) {
-  const auto regex{sourcemeta::core::to_regex("[[\\\\]--[\\/]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[\\\\]--[\\/]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[\\\\]--[\\/]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\"));
@@ -3197,19 +3541,22 @@ TEST(ecma262_v_flag_forward_slash_backslash) {
 }
 
 TEST(ecma262_v_flag_invalid_unbalanced_parens) {
-  const auto regex{sourcemeta::core::to_regex("([[a-z]--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "([[a-z]--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("([[a-z]--[aeiou]]"));
 }
 
 TEST(ecma262_v_flag_invalid_bad_quantifier) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]]{5,2}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[aeiou]]{5,2}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]]{5,2}"));
 }
 
 TEST(ecma262_v_flag_shorthand_intersection_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\d&&[0-5]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\d&&[0-5]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d&&[0-5]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "3"));
@@ -3217,7 +3564,8 @@ TEST(ecma262_v_flag_shorthand_intersection_valid) {
 }
 
 TEST(ecma262_v_flag_shorthand_subtraction_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\w--[0-9]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\w--[0-9]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w--[0-9]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3225,7 +3573,8 @@ TEST(ecma262_v_flag_shorthand_subtraction_valid) {
 }
 
 TEST(ecma262_v_flag_shorthand_intersection_with_range_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\w&&[a-z]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\w&&[a-z]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w&&[a-z]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -3233,7 +3582,8 @@ TEST(ecma262_v_flag_shorthand_intersection_with_range_valid) {
 }
 
 TEST(ecma262_v_flag_shorthand_subtract_single_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\d--[0]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\d--[0]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d--[0]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "5"));
@@ -3241,7 +3591,8 @@ TEST(ecma262_v_flag_shorthand_subtract_single_valid) {
 }
 
 TEST(ecma262_v_flag_shorthand_to_shorthand_subtract_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\w--\\d]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\w--\\d]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w--\\d]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3249,7 +3600,8 @@ TEST(ecma262_v_flag_shorthand_to_shorthand_subtract_valid) {
 }
 
 TEST(ecma262_v_flag_shorthand_to_shorthand_intersect_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\d&&\\w]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\d&&\\w]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\d&&\\w]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "5"));
@@ -3257,7 +3609,8 @@ TEST(ecma262_v_flag_shorthand_to_shorthand_intersect_valid) {
 }
 
 TEST(ecma262_v_flag_chained_shorthand_ops_valid) {
-  const auto regex{sourcemeta::core::to_regex("[\\w--\\d--[_]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\w--\\d--[_]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\w--\\d--[_]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3266,32 +3619,37 @@ TEST(ecma262_v_flag_chained_shorthand_ops_valid) {
 }
 
 TEST(ecma262_v_flag_invalid_range_without_nesting) {
-  const auto regex{sourcemeta::core::to_regex("[\\x61-\\x7a--[aeiou]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\x61-\\x7a--[aeiou]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[\\x61-\\x7a--[aeiou]]"));
 }
 
 TEST(ecma262_v_flag_invalid_mixed_ops_without_nesting) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z]--[aeiou]&&[a-m]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z]--[aeiou]&&[a-m]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z]--[aeiou]&&[a-m]]"));
 }
 
 TEST(ecma262_v_flag_invalid_unescaped_hyphen_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[a-z-]--[x]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[a-z-]--[x]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[a-z-]--[x]]"));
 }
 
 TEST(ecma262_v_flag_invalid_unescaped_pipe) {
-  const auto regex{sourcemeta::core::to_regex("[[|a]--[a]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[|a]--[a]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_FALSE(regex.has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("[[|a]--[a]]"));
 }
 
 TEST(ecma262_lookahead_with_negated_class) {
   const auto regex{
-      sourcemeta::core::to_regex(R"(^(?=[^!*,;{}[\]~\n]+$)(?=(.*\w)).+$)")};
+      sourcemeta::core::to_regex(R"(^(?=[^!*,;{}[\]~\n]+$)(?=(.*\w)).+$)",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       R"(^(?=[^!*,;{}[\]~\n]+$)(?=(.*\w)).+$)"));
@@ -3302,7 +3660,8 @@ TEST(ecma262_lookahead_with_negated_class) {
 }
 
 TEST(ecma262_literal_open_bracket_in_class) {
-  const auto regex{sourcemeta::core::to_regex("[[(]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[[(]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[[(]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "["));
@@ -3311,7 +3670,8 @@ TEST(ecma262_literal_open_bracket_in_class) {
 }
 
 TEST(ecma262_literal_close_bracket_in_class) {
-  const auto regex{sourcemeta::core::to_regex(R"([)\]])")};
+  const auto regex{sourcemeta::core::to_regex(
+      R"([)\]])", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(R"([)\]])"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ")"));
@@ -3320,7 +3680,8 @@ TEST(ecma262_literal_close_bracket_in_class) {
 }
 
 TEST(ecma262_bracket_classes_in_complex_pattern) {
-  const auto regex{sourcemeta::core::to_regex(R"(^[[(]\d+,\d+[)\]]$)")};
+  const auto regex{sourcemeta::core::to_regex(
+      R"(^[[(]\d+,\d+[)\]]$)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(R"(^[[(]\d+,\d+[)\]]$)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "[1,2]"));
@@ -3332,7 +3693,8 @@ TEST(ecma262_bracket_classes_in_complex_pattern) {
 
 TEST(ecma262_datetime_range_pattern) {
   const auto regex{sourcemeta::core::to_regex(
-      R"(^((\d{4}-\d{2}-\d{2})|([[(](((\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?),(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)?)|(,(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)))[)\]]))$)")};
+      R"(^((\d{4}-\d{2}-\d{2})|([[(](((\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?),(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)?)|(,(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)))[)\]]))$)",
+      sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       R"(^((\d{4}-\d{2}-\d{2})|([[(](((\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?),(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)?)|(,(\d{4}-\d{2}-\d{2}([Tt]\d{2}:\d{2}:\d{2}(.\d{1,6})?[Zz])?)))[)\]]))$)"));
@@ -3357,7 +3719,8 @@ TEST(ecma262_datetime_range_pattern) {
 }
 
 TEST(ecma262_empty_class) {
-  const auto regex{sourcemeta::core::to_regex("[]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
@@ -3367,7 +3730,8 @@ TEST(ecma262_empty_class) {
 }
 
 TEST(ecma262_empty_class_negated) {
-  const auto regex{sourcemeta::core::to_regex("[^]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[^]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]"));
   EXPECT_FALSE(sourcemeta::core::matches(regex.value(), ""));
@@ -3378,7 +3742,8 @@ TEST(ecma262_empty_class_negated) {
 }
 
 TEST(ecma262_empty_class_negated_anchored) {
-  const auto regex{sourcemeta::core::to_regex("^[^]$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^[^]$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("^[^]$"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -3388,7 +3753,8 @@ TEST(ecma262_empty_class_negated_anchored) {
 }
 
 TEST(ecma262_empty_class_negated_quantified) {
-  const auto regex{sourcemeta::core::to_regex("[^]+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[^]+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^]+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -3397,7 +3763,8 @@ TEST(ecma262_empty_class_negated_quantified) {
 }
 
 TEST(ecma262_bounded_quantifier_counts_codepoints) {
-  const auto regex{sourcemeta::core::to_regex("^.{3,3}$")};
+  const auto regex{sourcemeta::core::to_regex(
+      "^.{3,3}$", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::matches(
       regex.value(), "\xE4\xB8\xAD\xE6\x96\x87\xE5\xAD\x97"));
@@ -3406,6 +3773,8 @@ TEST(ecma262_bounded_quantifier_counts_codepoints) {
 }
 
 TEST(ecma262_bounded_quantifier_out_of_order_is_invalid) {
-  EXPECT_FALSE(sourcemeta::core::to_regex("^.{5,2}$").has_value());
+  EXPECT_FALSE(sourcemeta::core::to_regex(
+                   "^.{5,2}$", sourcemeta::core::RegexDialect::Permissive)
+                   .has_value());
   EXPECT_FALSE(sourcemeta::core::is_regex_ecma("^.{5,2}$"));
 }

--- a/test/regex/regex_permissive_matches_rfc9485_test.cc
+++ b/test/regex/regex_permissive_matches_rfc9485_test.cc
@@ -6,7 +6,8 @@
 TEST(rfc9485_edge_dollar_literal) {
   // NOTE: This test deviates from RFC 9485, which allows $ as literal in
   // middle. We prefer ECMA-262 compliance where $ is ALWAYS an assertion.
-  const auto regex{sourcemeta::core::to_regex("a$b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a$b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a$b"));
   // In ECMA-262, $ is always an end assertion, never a literal
@@ -19,7 +20,8 @@ TEST(rfc9485_edge_dollar_literal) {
 TEST(rfc9485_preprocessing_escaped_backslash_dollar) {
   // NOTE: This test deviates from RFC 9485, which treats $ as literal in
   // middle. We prefer ECMA-262 compliance where $ is ALWAYS an assertion.
-  const auto regex{sourcemeta::core::to_regex("\\\\$foo")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\$foo", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\$foo"));
   // In ECMA-262: \\ = literal backslash, $ = end assertion, foo = literal "foo"
@@ -30,7 +32,8 @@ TEST(rfc9485_preprocessing_escaped_backslash_dollar) {
 }
 
 TEST(rfc9485_literal_single_char) {
-  const auto regex{sourcemeta::core::to_regex("a")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -39,7 +42,8 @@ TEST(rfc9485_literal_single_char) {
 }
 
 TEST(rfc9485_literal_sequence) {
-  const auto regex{sourcemeta::core::to_regex("hello")};
+  const auto regex{sourcemeta::core::to_regex(
+      "hello", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("hello"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "hello"));
@@ -48,7 +52,8 @@ TEST(rfc9485_literal_sequence) {
 }
 
 TEST(rfc9485_dot_wildcard) {
-  const auto regex{sourcemeta::core::to_regex("a.c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a.c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a.c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -58,7 +63,8 @@ TEST(rfc9485_dot_wildcard) {
 }
 
 TEST(rfc9485_quantifier_star) {
-  const auto regex{sourcemeta::core::to_regex("ab*c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "ab*c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab*c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ac"));
@@ -69,7 +75,8 @@ TEST(rfc9485_quantifier_star) {
 }
 
 TEST(rfc9485_quantifier_plus) {
-  const auto regex{sourcemeta::core::to_regex("ab+c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "ab+c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab+c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -79,7 +86,8 @@ TEST(rfc9485_quantifier_plus) {
 }
 
 TEST(rfc9485_quantifier_question) {
-  const auto regex{sourcemeta::core::to_regex("ab?c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "ab?c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("ab?c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ac"));
@@ -88,7 +96,8 @@ TEST(rfc9485_quantifier_question) {
 }
 
 TEST(rfc9485_quantifier_exact) {
-  const auto regex{sourcemeta::core::to_regex("a{3}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{3}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{3}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaa"));
@@ -97,7 +106,8 @@ TEST(rfc9485_quantifier_exact) {
 }
 
 TEST(rfc9485_quantifier_at_least) {
-  const auto regex{sourcemeta::core::to_regex("a{2,}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{2,}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aa"));
@@ -107,7 +117,8 @@ TEST(rfc9485_quantifier_at_least) {
 }
 
 TEST(rfc9485_quantifier_range) {
-  const auto regex{sourcemeta::core::to_regex("a{2,4}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{2,4}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,4}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aa"));
@@ -118,7 +129,8 @@ TEST(rfc9485_quantifier_range) {
 }
 
 TEST(rfc9485_alternation_simple) {
-  const auto regex{sourcemeta::core::to_regex("cat|dog")};
+  const auto regex{sourcemeta::core::to_regex(
+      "cat|dog", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("cat|dog"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "cat"));
@@ -127,7 +139,8 @@ TEST(rfc9485_alternation_simple) {
 }
 
 TEST(rfc9485_alternation_multiple) {
-  const auto regex{sourcemeta::core::to_regex("red|green|blue")};
+  const auto regex{sourcemeta::core::to_regex(
+      "red|green|blue", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("red|green|blue"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "red"));
@@ -137,7 +150,8 @@ TEST(rfc9485_alternation_multiple) {
 }
 
 TEST(rfc9485_alternation_empty_branch) {
-  const auto regex{sourcemeta::core::to_regex("a|")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a|", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -146,7 +160,8 @@ TEST(rfc9485_alternation_empty_branch) {
 }
 
 TEST(rfc9485_charclass_simple) {
-  const auto regex{sourcemeta::core::to_regex("[abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -156,7 +171,8 @@ TEST(rfc9485_charclass_simple) {
 }
 
 TEST(rfc9485_charclass_range) {
-  const auto regex{sourcemeta::core::to_regex("[a-z]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-z]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -167,7 +183,8 @@ TEST(rfc9485_charclass_range) {
 }
 
 TEST(rfc9485_charclass_multiple_ranges) {
-  const auto regex{sourcemeta::core::to_regex("[a-zA-Z0-9]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-zA-Z0-9]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-zA-Z0-9]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -177,7 +194,8 @@ TEST(rfc9485_charclass_multiple_ranges) {
 }
 
 TEST(rfc9485_charclass_negated) {
-  const auto regex{sourcemeta::core::to_regex("[^abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[^abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^abc]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "d"));
@@ -188,7 +206,8 @@ TEST(rfc9485_charclass_negated) {
 }
 
 TEST(rfc9485_charclass_dash_at_start) {
-  const auto regex{sourcemeta::core::to_regex("[-abc]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[-abc]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-abc]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -197,7 +216,8 @@ TEST(rfc9485_charclass_dash_at_start) {
 }
 
 TEST(rfc9485_charclass_dash_at_end) {
-  const auto regex{sourcemeta::core::to_regex("[abc-]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[abc-]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[abc-]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -206,7 +226,8 @@ TEST(rfc9485_charclass_dash_at_end) {
 }
 
 TEST(rfc9485_escape_left_paren) {
-  const auto regex{sourcemeta::core::to_regex("\\(test")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\(test", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\(test"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "(test"));
@@ -214,7 +235,8 @@ TEST(rfc9485_escape_left_paren) {
 }
 
 TEST(rfc9485_escape_right_paren) {
-  const auto regex{sourcemeta::core::to_regex("test\\)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "test\\)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("test\\)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "test)"));
@@ -222,7 +244,8 @@ TEST(rfc9485_escape_right_paren) {
 }
 
 TEST(rfc9485_escape_left_bracket) {
-  const auto regex{sourcemeta::core::to_regex("\\[test")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\[test", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\[test"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "[test"));
@@ -230,7 +253,8 @@ TEST(rfc9485_escape_left_bracket) {
 }
 
 TEST(rfc9485_escape_right_bracket) {
-  const auto regex{sourcemeta::core::to_regex("test\\]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "test\\]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("test\\]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "test]"));
@@ -238,7 +262,8 @@ TEST(rfc9485_escape_right_bracket) {
 }
 
 TEST(rfc9485_escape_left_brace) {
-  const auto regex{sourcemeta::core::to_regex("\\{test")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\{test", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\{test"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "{test"));
@@ -246,7 +271,8 @@ TEST(rfc9485_escape_left_brace) {
 }
 
 TEST(rfc9485_escape_right_brace) {
-  const auto regex{sourcemeta::core::to_regex("test\\}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "test\\}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("test\\}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "test}"));
@@ -254,7 +280,8 @@ TEST(rfc9485_escape_right_brace) {
 }
 
 TEST(rfc9485_escape_asterisk) {
-  const auto regex{sourcemeta::core::to_regex("a\\*b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\*b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\*b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a*b"));
@@ -263,7 +290,8 @@ TEST(rfc9485_escape_asterisk) {
 }
 
 TEST(rfc9485_escape_plus) {
-  const auto regex{sourcemeta::core::to_regex("a\\+b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\+b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\+b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a+b"));
@@ -271,7 +299,8 @@ TEST(rfc9485_escape_plus) {
 }
 
 TEST(rfc9485_escape_question) {
-  const auto regex{sourcemeta::core::to_regex("a\\?b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\?b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\?b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a?b"));
@@ -279,7 +308,8 @@ TEST(rfc9485_escape_question) {
 }
 
 TEST(rfc9485_escape_dot) {
-  const auto regex{sourcemeta::core::to_regex("a\\.b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\.b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\.b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a.b"));
@@ -287,7 +317,8 @@ TEST(rfc9485_escape_dot) {
 }
 
 TEST(rfc9485_escape_dash) {
-  const auto regex{sourcemeta::core::to_regex("a\\-b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\-b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\-b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a-b"));
@@ -295,7 +326,8 @@ TEST(rfc9485_escape_dash) {
 }
 
 TEST(rfc9485_escape_newline) {
-  const auto regex{sourcemeta::core::to_regex("a\\nb")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\nb", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\nb"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\nb"));
@@ -303,7 +335,8 @@ TEST(rfc9485_escape_newline) {
 }
 
 TEST(rfc9485_escape_carriage_return) {
-  const auto regex{sourcemeta::core::to_regex("a\\rb")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\rb", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\rb"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\rb"));
@@ -311,7 +344,8 @@ TEST(rfc9485_escape_carriage_return) {
 }
 
 TEST(rfc9485_escape_tab) {
-  const auto regex{sourcemeta::core::to_regex("a\\tb")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\tb", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\tb"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\tb"));
@@ -319,7 +353,8 @@ TEST(rfc9485_escape_tab) {
 }
 
 TEST(rfc9485_unicode_property_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\p{L}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{L}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{L}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -331,7 +366,8 @@ TEST(rfc9485_unicode_property_letter) {
 }
 
 TEST(rfc9485_unicode_property_uppercase_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Lu}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Lu}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lu}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -341,7 +377,8 @@ TEST(rfc9485_unicode_property_uppercase_letter) {
 }
 
 TEST(rfc9485_unicode_property_lowercase_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Ll}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Ll}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Ll}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -351,7 +388,8 @@ TEST(rfc9485_unicode_property_lowercase_letter) {
 }
 
 TEST(rfc9485_unicode_property_titlecase_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Lt}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Lt}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lt}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u01C5"));
@@ -359,7 +397,8 @@ TEST(rfc9485_unicode_property_titlecase_letter) {
 }
 
 TEST(rfc9485_unicode_property_modifier_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Lm}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Lm}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lm}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u02B0"));
@@ -367,7 +406,8 @@ TEST(rfc9485_unicode_property_modifier_letter) {
 }
 
 TEST(rfc9485_unicode_property_other_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Lo}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Lo}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lo}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "中"));
@@ -375,7 +415,8 @@ TEST(rfc9485_unicode_property_other_letter) {
 }
 
 TEST(rfc9485_unicode_property_mark) {
-  const auto regex{sourcemeta::core::to_regex("\\p{M}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{M}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{M}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0300"));
@@ -383,7 +424,8 @@ TEST(rfc9485_unicode_property_mark) {
 }
 
 TEST(rfc9485_unicode_property_nonspacing_mark) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Mn}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Mn}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Mn}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0300"));
@@ -391,7 +433,8 @@ TEST(rfc9485_unicode_property_nonspacing_mark) {
 }
 
 TEST(rfc9485_unicode_property_spacing_mark) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Mc}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Mc}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Mc}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0903"));
@@ -399,7 +442,8 @@ TEST(rfc9485_unicode_property_spacing_mark) {
 }
 
 TEST(rfc9485_unicode_property_enclosing_mark) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Me}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Me}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Me}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u0488"));
@@ -407,7 +451,8 @@ TEST(rfc9485_unicode_property_enclosing_mark) {
 }
 
 TEST(rfc9485_unicode_property_number) {
-  const auto regex{sourcemeta::core::to_regex("\\p{N}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{N}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{N}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -417,7 +462,8 @@ TEST(rfc9485_unicode_property_number) {
 }
 
 TEST(rfc9485_unicode_property_decimal_number) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Nd}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Nd}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Nd}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "0"));
@@ -427,7 +473,8 @@ TEST(rfc9485_unicode_property_decimal_number) {
 }
 
 TEST(rfc9485_unicode_property_letter_number) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Nl}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Nl}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Nl}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u2160"));
@@ -435,7 +482,8 @@ TEST(rfc9485_unicode_property_letter_number) {
 }
 
 TEST(rfc9485_unicode_property_other_number) {
-  const auto regex{sourcemeta::core::to_regex("\\p{No}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{No}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{No}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u00B2"));
@@ -443,7 +491,8 @@ TEST(rfc9485_unicode_property_other_number) {
 }
 
 TEST(rfc9485_unicode_property_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{P}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{P}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{P}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -453,7 +502,8 @@ TEST(rfc9485_unicode_property_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_connector_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Pc}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Pc}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pc}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "_"));
@@ -461,7 +511,8 @@ TEST(rfc9485_unicode_property_connector_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_dash_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Pd}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Pd}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pd}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -469,7 +520,8 @@ TEST(rfc9485_unicode_property_dash_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_open_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Ps}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Ps}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Ps}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "("));
@@ -478,7 +530,8 @@ TEST(rfc9485_unicode_property_open_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_close_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Pe}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Pe}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pe}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ")"));
@@ -487,7 +540,8 @@ TEST(rfc9485_unicode_property_close_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_initial_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Pi}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Pi}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pi}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u00AB"));
@@ -495,7 +549,8 @@ TEST(rfc9485_unicode_property_initial_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_final_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Pf}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Pf}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Pf}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u00BB"));
@@ -503,7 +558,8 @@ TEST(rfc9485_unicode_property_final_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_other_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Po}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Po}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Po}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "!"));
@@ -512,7 +568,8 @@ TEST(rfc9485_unicode_property_other_punctuation) {
 }
 
 TEST(rfc9485_unicode_property_separator) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Z}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Z}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Z}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -521,7 +578,8 @@ TEST(rfc9485_unicode_property_separator) {
 }
 
 TEST(rfc9485_unicode_property_space_separator) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Zs}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Zs}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Zs}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), " "));
@@ -530,7 +588,8 @@ TEST(rfc9485_unicode_property_space_separator) {
 }
 
 TEST(rfc9485_unicode_property_line_separator) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Zl}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Zl}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Zl}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u2028"));
@@ -538,7 +597,8 @@ TEST(rfc9485_unicode_property_line_separator) {
 }
 
 TEST(rfc9485_unicode_property_paragraph_separator) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Zp}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Zp}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Zp}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u2029"));
@@ -546,7 +606,8 @@ TEST(rfc9485_unicode_property_paragraph_separator) {
 }
 
 TEST(rfc9485_unicode_property_symbol) {
-  const auto regex{sourcemeta::core::to_regex("\\p{S}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{S}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{S}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
@@ -556,7 +617,8 @@ TEST(rfc9485_unicode_property_symbol) {
 }
 
 TEST(rfc9485_unicode_property_math_symbol) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Sm}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Sm}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Sm}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "+"));
@@ -565,7 +627,8 @@ TEST(rfc9485_unicode_property_math_symbol) {
 }
 
 TEST(rfc9485_unicode_property_currency_symbol) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Sc}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Sc}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Sc}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "$"));
@@ -574,7 +637,8 @@ TEST(rfc9485_unicode_property_currency_symbol) {
 }
 
 TEST(rfc9485_unicode_property_modifier_symbol) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Sk}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Sk}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Sk}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "^"));
@@ -582,7 +646,8 @@ TEST(rfc9485_unicode_property_modifier_symbol) {
 }
 
 TEST(rfc9485_unicode_property_other_symbol) {
-  const auto regex{sourcemeta::core::to_regex("\\p{So}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{So}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{So}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "©"));
@@ -590,7 +655,8 @@ TEST(rfc9485_unicode_property_other_symbol) {
 }
 
 TEST(rfc9485_unicode_property_other) {
-  const auto regex{sourcemeta::core::to_regex("\\p{C}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{C}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{C}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), std::string(1, '\0')));
@@ -598,7 +664,8 @@ TEST(rfc9485_unicode_property_other) {
 }
 
 TEST(rfc9485_unicode_property_control) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Cc}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Cc}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Cc}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), std::string(1, '\0')));
@@ -607,7 +674,8 @@ TEST(rfc9485_unicode_property_control) {
 }
 
 TEST(rfc9485_unicode_property_format) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Cf}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Cf}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Cf}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\u00AD"));
@@ -615,13 +683,15 @@ TEST(rfc9485_unicode_property_format) {
 }
 
 TEST(rfc9485_unicode_property_unassigned) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Cn}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Cn}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Cn}"));
 }
 
 TEST(rfc9485_unicode_property_private_use) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Co}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Co}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Co}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\uE000"));
@@ -629,7 +699,8 @@ TEST(rfc9485_unicode_property_private_use) {
 }
 
 TEST(rfc9485_unicode_property_complement_letter) {
-  const auto regex{sourcemeta::core::to_regex("\\P{L}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\P{L}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{L}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "5"));
@@ -638,7 +709,8 @@ TEST(rfc9485_unicode_property_complement_letter) {
 }
 
 TEST(rfc9485_unicode_property_complement_number) {
-  const auto regex{sourcemeta::core::to_regex("\\P{N}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\P{N}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{N}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -647,7 +719,8 @@ TEST(rfc9485_unicode_property_complement_number) {
 }
 
 TEST(rfc9485_unicode_property_complement_punctuation) {
-  const auto regex{sourcemeta::core::to_regex("\\P{P}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\P{P}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{P}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -656,7 +729,8 @@ TEST(rfc9485_unicode_property_complement_punctuation) {
 }
 
 TEST(rfc9485_group_simple) {
-  const auto regex{sourcemeta::core::to_regex("(ab)c")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(ab)c", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(ab)c"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -664,7 +738,8 @@ TEST(rfc9485_group_simple) {
 }
 
 TEST(rfc9485_group_nested) {
-  const auto regex{sourcemeta::core::to_regex("((ab)c)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "((ab)c)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((ab)c)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -672,7 +747,8 @@ TEST(rfc9485_group_nested) {
 }
 
 TEST(rfc9485_group_with_quantifier) {
-  const auto regex{sourcemeta::core::to_regex("(ab)+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(ab)+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(ab)+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ab"));
@@ -682,7 +758,8 @@ TEST(rfc9485_group_with_quantifier) {
 }
 
 TEST(rfc9485_group_with_alternation) {
-  const auto regex{sourcemeta::core::to_regex("(cat|dog)s")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(cat|dog)s", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(cat|dog)s"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "cats"));
@@ -691,7 +768,8 @@ TEST(rfc9485_group_with_alternation) {
 }
 
 TEST(rfc9485_complex_email_like) {
-  const auto regex{sourcemeta::core::to_regex("[a-z]+@[a-z]+\\.[a-z]+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-z]+@[a-z]+\\.[a-z]+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z]+@[a-z]+\\.[a-z]+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "user@example.com"));
@@ -700,7 +778,8 @@ TEST(rfc9485_complex_email_like) {
 }
 
 TEST(rfc9485_complex_identifier) {
-  const auto regex{sourcemeta::core::to_regex("[a-zA-Z_][a-zA-Z0-9_]*")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-zA-Z_][a-zA-Z0-9_]*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-zA-Z_][a-zA-Z0-9_]*"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "variable1"));
@@ -710,7 +789,8 @@ TEST(rfc9485_complex_identifier) {
 }
 
 TEST(rfc9485_complex_unicode_word) {
-  const auto regex{sourcemeta::core::to_regex("\\p{L}+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{L}+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{L}+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "hello"));
@@ -720,7 +800,8 @@ TEST(rfc9485_complex_unicode_word) {
 }
 
 TEST(rfc9485_complex_mixed_quantifiers) {
-  const auto regex{sourcemeta::core::to_regex("a{2,3}b+c*")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{2,3}b+c*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{2,3}b+c*"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aab"));
@@ -731,7 +812,8 @@ TEST(rfc9485_complex_mixed_quantifiers) {
 }
 
 TEST(rfc9485_complex_nested_groups_quantifiers) {
-  const auto regex{sourcemeta::core::to_regex("((ab)+c)*")};
+  const auto regex{sourcemeta::core::to_regex(
+      "((ab)+c)*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((ab)+c)*"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -742,7 +824,8 @@ TEST(rfc9485_complex_nested_groups_quantifiers) {
 }
 
 TEST(rfc9485_edge_empty_pattern) {
-  const auto regex{sourcemeta::core::to_regex("")};
+  const auto regex{sourcemeta::core::to_regex(
+      "", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(""));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -750,7 +833,8 @@ TEST(rfc9485_edge_empty_pattern) {
 }
 
 TEST(rfc9485_edge_alternation_empty_first) {
-  const auto regex{sourcemeta::core::to_regex("|abc")};
+  const auto regex{sourcemeta::core::to_regex(
+      "|abc", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("|abc"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -759,7 +843,8 @@ TEST(rfc9485_edge_alternation_empty_first) {
 }
 
 TEST(rfc9485_edge_alternation_empty_middle) {
-  const auto regex{sourcemeta::core::to_regex("a||b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a||b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a||b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -769,7 +854,8 @@ TEST(rfc9485_edge_alternation_empty_middle) {
 }
 
 TEST(rfc9485_edge_alternation_all_empty) {
-  const auto regex{sourcemeta::core::to_regex("||")};
+  const auto regex{sourcemeta::core::to_regex(
+      "||", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("||"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -777,7 +863,8 @@ TEST(rfc9485_edge_alternation_all_empty) {
 }
 
 TEST(rfc9485_edge_escape_backslash) {
-  const auto regex{sourcemeta::core::to_regex("a\\\\b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\\\b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\\\b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\\b"));
@@ -785,7 +872,8 @@ TEST(rfc9485_edge_escape_backslash) {
 }
 
 TEST(rfc9485_edge_escape_pipe) {
-  const auto regex{sourcemeta::core::to_regex("a\\|b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\|b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\|b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a|b"));
@@ -793,14 +881,16 @@ TEST(rfc9485_edge_escape_pipe) {
 }
 
 TEST(rfc9485_edge_caret_literal) {
-  const auto regex{sourcemeta::core::to_regex("a\\^b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a\\^b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\^b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a^b"));
 }
 
 TEST(rfc9485_edge_quantifier_zero_exact) {
-  const auto regex{sourcemeta::core::to_regex("a{0}b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{0}b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0}b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -808,7 +898,8 @@ TEST(rfc9485_edge_quantifier_zero_exact) {
 }
 
 TEST(rfc9485_edge_quantifier_zero_or_more) {
-  const auto regex{sourcemeta::core::to_regex("a{0,}b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{0,}b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0,}b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -817,7 +908,8 @@ TEST(rfc9485_edge_quantifier_zero_or_more) {
 }
 
 TEST(rfc9485_edge_quantifier_zero_to_n) {
-  const auto regex{sourcemeta::core::to_regex("a{0,3}b")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{0,3}b", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{0,3}b"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "b"));
@@ -828,7 +920,8 @@ TEST(rfc9485_edge_quantifier_zero_to_n) {
 }
 
 TEST(rfc9485_edge_nested_groups_deep) {
-  const auto regex{sourcemeta::core::to_regex("(((a)))")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(((a)))", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(((a)))"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -836,7 +929,8 @@ TEST(rfc9485_edge_nested_groups_deep) {
 }
 
 TEST(rfc9485_edge_charclass_only_dash) {
-  const auto regex{sourcemeta::core::to_regex("[-]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[-]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -844,7 +938,8 @@ TEST(rfc9485_edge_charclass_only_dash) {
 }
 
 TEST(rfc9485_edge_charclass_dash_both_ends) {
-  const auto regex{sourcemeta::core::to_regex("[-a-]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[-a-]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[-a-]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "-"));
@@ -853,7 +948,8 @@ TEST(rfc9485_edge_charclass_dash_both_ends) {
 }
 
 TEST(rfc9485_edge_charclass_mixed_content) {
-  const auto regex{sourcemeta::core::to_regex("[a-z\\p{N}._-]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-z\\p{N}._-]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-z\\p{N}._-]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -866,7 +962,8 @@ TEST(rfc9485_edge_charclass_mixed_content) {
 }
 
 TEST(rfc9485_edge_charclass_escaped_bracket) {
-  const auto regex{sourcemeta::core::to_regex("[\\[\\]]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\[\\]]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\[\\]]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "["));
@@ -875,7 +972,8 @@ TEST(rfc9485_edge_charclass_escaped_bracket) {
 }
 
 TEST(rfc9485_edge_charclass_multiple_ranges) {
-  const auto regex{sourcemeta::core::to_regex("[a-cA-C0-2]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a-cA-C0-2]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a-cA-C0-2]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -893,7 +991,8 @@ TEST(rfc9485_edge_charclass_multiple_ranges) {
 }
 
 TEST(rfc9485_edge_group_with_alternation_quantified) {
-  const auto regex{sourcemeta::core::to_regex("(a|b){2}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(a|b){2}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(a|b){2}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aa"));
@@ -904,7 +1003,8 @@ TEST(rfc9485_edge_group_with_alternation_quantified) {
 }
 
 TEST(rfc9485_edge_multiple_dots) {
-  const auto regex{sourcemeta::core::to_regex("...")};
+  const auto regex{sourcemeta::core::to_regex(
+      "...", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("..."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -914,7 +1014,8 @@ TEST(rfc9485_edge_multiple_dots) {
 }
 
 TEST(rfc9485_edge_quantifier_large_range) {
-  const auto regex{sourcemeta::core::to_regex("a{100,200}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a{100,200}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a{100,200}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), std::string(100, 'a')));
@@ -924,7 +1025,8 @@ TEST(rfc9485_edge_quantifier_large_range) {
 }
 
 TEST(rfc9485_edge_alternation_with_groups) {
-  const auto regex{sourcemeta::core::to_regex("(abc)|(def)|(ghi)")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(abc)|(def)|(ghi)", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(abc)|(def)|(ghi)"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc"));
@@ -934,7 +1036,8 @@ TEST(rfc9485_edge_alternation_with_groups) {
 }
 
 TEST(rfc9485_edge_charclass_with_unicode_properties) {
-  const auto regex{sourcemeta::core::to_regex("[\\p{Lu}\\p{Nd}]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\p{Lu}\\p{Nd}]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\p{Lu}\\p{Nd}]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -944,8 +1047,9 @@ TEST(rfc9485_edge_charclass_with_unicode_properties) {
 }
 
 TEST(rfc9485_all_major_categories_combined) {
-  const auto regex{sourcemeta::core::to_regex(
-      "[\\p{L}\\p{M}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{C}]")};
+  const auto regex{
+      sourcemeta::core::to_regex("[\\p{L}\\p{M}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{C}]",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[\\p{L}\\p{M}\\p{N}\\p{P}\\p{Z}\\p{S}\\p{C}]"));
@@ -957,7 +1061,8 @@ TEST(rfc9485_all_major_categories_combined) {
 }
 
 TEST(rfc9485_complement_all_major_categories) {
-  const auto regex{sourcemeta::core::to_regex("\\P{L}\\P{N}\\P{P}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\P{L}\\P{N}\\P{P}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\P{L}\\P{N}\\P{P}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "   "));
@@ -965,7 +1070,8 @@ TEST(rfc9485_complement_all_major_categories) {
 }
 
 TEST(rfc9485_edge_nested_quantifiers_group) {
-  const auto regex{sourcemeta::core::to_regex("((a+)+)+")};
+  const auto regex{sourcemeta::core::to_regex(
+      "((a+)+)+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("((a+)+)+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -975,7 +1081,8 @@ TEST(rfc9485_edge_nested_quantifiers_group) {
 }
 
 TEST(rfc9485_edge_charclass_negated_with_range) {
-  const auto regex{sourcemeta::core::to_regex("[^a-z]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[^a-z]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[^a-z]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -986,7 +1093,8 @@ TEST(rfc9485_edge_charclass_negated_with_range) {
 }
 
 TEST(rfc9485_edge_consecutive_alternations) {
-  const auto regex{sourcemeta::core::to_regex("a|b|c|d|e")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a|b|c|d|e", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a|b|c|d|e"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -998,7 +1106,8 @@ TEST(rfc9485_edge_consecutive_alternations) {
 }
 
 TEST(rfc9485_edge_group_quantifier_zero_or_one) {
-  const auto regex{sourcemeta::core::to_regex("(abc)?")};
+  const auto regex{sourcemeta::core::to_regex(
+      "(abc)?", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(abc)?"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
@@ -1007,7 +1116,8 @@ TEST(rfc9485_edge_group_quantifier_zero_or_one) {
 }
 
 TEST(rfc9485_edge_mixed_quantifiers_sequence) {
-  const auto regex{sourcemeta::core::to_regex("a?b+c*d{2}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "a?b+c*d{2}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a?b+c*d{2}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "bdd"));
@@ -1018,7 +1128,8 @@ TEST(rfc9485_edge_mixed_quantifiers_sequence) {
 }
 
 TEST(rfc9485_edge_unicode_in_alternation) {
-  const auto regex{sourcemeta::core::to_regex("\\p{Lu}|\\p{Ll}|\\p{Nd}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Lu}|\\p{Ll}|\\p{Nd}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\p{Lu}|\\p{Ll}|\\p{Nd}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "A"));
@@ -1028,7 +1139,8 @@ TEST(rfc9485_edge_unicode_in_alternation) {
 }
 
 TEST(rfc9485_edge_charclass_single_char) {
-  const auto regex{sourcemeta::core::to_regex("[a]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[a]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[a]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
@@ -1036,8 +1148,9 @@ TEST(rfc9485_edge_charclass_single_char) {
 }
 
 TEST(rfc9485_edge_complex_real_world_email_subset) {
-  const auto regex{sourcemeta::core::to_regex(
-      "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-z]{2,}")};
+  const auto regex{
+      sourcemeta::core::to_regex("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-z]{2,}",
+                                 sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-z]{2,}"));
@@ -1049,7 +1162,8 @@ TEST(rfc9485_edge_complex_real_world_email_subset) {
 }
 
 TEST(rfc9485_edge_complex_real_world_hex_color) {
-  const auto regex{sourcemeta::core::to_regex("#[0-9a-fA-F]{6}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "#[0-9a-fA-F]{6}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("#[0-9a-fA-F]{6}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "#FF5733"));
@@ -1060,7 +1174,8 @@ TEST(rfc9485_edge_complex_real_world_hex_color) {
 
 TEST(rfc9485_edge_complex_real_world_uuid_partial) {
   const auto regex{sourcemeta::core::to_regex(
-      "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")};
+      "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+      sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(
       "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"));
@@ -1070,7 +1185,8 @@ TEST(rfc9485_edge_complex_real_world_uuid_partial) {
 }
 
 TEST(rfc9485_preprocessing_literal_backslash_p) {
-  const auto regex{sourcemeta::core::to_regex("\\\\p\\{L\\}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\p\\{L\\}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\p\\{L\\}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\p{L}"));
@@ -1078,7 +1194,8 @@ TEST(rfc9485_preprocessing_literal_backslash_p) {
 }
 
 TEST(rfc9485_preprocessing_literal_backslash_P) {
-  const auto regex{sourcemeta::core::to_regex("\\\\P\\{N\\}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\P\\{N\\}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\P\\{N\\}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\P{N}"));
@@ -1086,7 +1203,8 @@ TEST(rfc9485_preprocessing_literal_backslash_P) {
 }
 
 TEST(rfc9485_preprocessing_mixed_escaped_and_unicode) {
-  const auto regex{sourcemeta::core::to_regex("\\\\p\\{L\\} \\p{L}")};
+  const auto regex{sourcemeta::core::to_regex(
+      "\\\\p\\{L\\} \\p{L}", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("\\\\p\\{L\\} \\p{L}"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\\p{L} A"));
@@ -1094,7 +1212,8 @@ TEST(rfc9485_preprocessing_mixed_escaped_and_unicode) {
 }
 
 TEST(rfc9485_quantifier_star_any_string) {
-  const auto regex{sourcemeta::core::to_regex(".*")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".*", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -1102,7 +1221,8 @@ TEST(rfc9485_quantifier_star_any_string) {
 }
 
 TEST(rfc9485_quantifier_plus_non_empty) {
-  const auto regex{sourcemeta::core::to_regex(".+")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".+", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".+"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "foobar"));
@@ -1110,21 +1230,24 @@ TEST(rfc9485_quantifier_plus_non_empty) {
 }
 
 TEST(rfc9485_dot_matches_newline) {
-  const auto regex{sourcemeta::core::to_regex(".")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\n"));
 }
 
 TEST(rfc9485_dot_matches_carriage_return) {
-  const auto regex{sourcemeta::core::to_regex(".")};
+  const auto regex{sourcemeta::core::to_regex(
+      ".", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("."));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\r"));
 }
 
 TEST(rfc9485_unicode_range_4byte_deseret) {
-  const auto regex{sourcemeta::core::to_regex("[\\u{10400}-\\u{1044F}]")};
+  const auto regex{sourcemeta::core::to_regex(
+      "[\\u{10400}-\\u{1044F}]", sourcemeta::core::RegexDialect::Permissive)};
   EXPECT_TRUE(regex.has_value());
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("[\\u{10400}-\\u{1044F}]"));
   EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "\U00010400"));


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

