### PR TITLE
Implement a new `IRegexpSearch` dialect

### DIFF
--- a/src/core/regex/include/sourcemeta/core/regex.h
+++ b/src/core/regex/include/sourcemeta/core/regex.h
@@ -79,7 +79,10 @@ enum class RegexDialect : std::uint8_t {
   /// interpreted through the RFC 9485 Section 5.4 engine mapping, so an
   /// unescaped caret or dollar acts as an assertion instead of a literal
   /// and rejects quantification
-  IRegexp
+  IRegexp,
+  /// Like the strict RFC 9485 dialect, except that matching considers any
+  /// substring of the input
+  IRegexpSearch
 };
 
 /// @ingroup regex

--- a/src/core/regex/include/sourcemeta/core/regex.h
+++ b/src/core/regex/include/sourcemeta/core/regex.h
@@ -92,7 +92,8 @@ enum class RegexDialect : std::uint8_t {
 ///
 /// - Permissive regexes are NOT automatically anchored
 /// - Permissive regexes assume `DOTALL`
-/// - RFC 9485 regexes match the whole input
+/// - RFC 9485 regexes match the whole input, except in the search dialect,
+///   which matches any substring
 /// - Regexes assume Unicode
 /// - Regexes are case sensitive
 /// - No matching happens (only boolean validation)

--- a/src/core/regex/iregexp.h
+++ b/src/core/regex/iregexp.h
@@ -367,18 +367,20 @@ inline auto iregexp_branches(const std::string_view pattern,
 
 // Validate a pattern against the RFC 9485 grammar and produce the equivalent
 // engine pattern following the RFC 9485 Section 5.4 mapping, which encloses
-// the translation "in \A(?: and )\z"
-inline auto translate_iregexp(const std::string_view pattern)
+// the translation "in \A(?: and )\z". Skipping the enclosure yields substring
+// search semantics instead of whole input matching
+inline auto translate_iregexp(const std::string_view pattern,
+                              const bool anchored)
     -> std::optional<std::string> {
   std::string result;
   result.reserve(pattern.size() + 8);
-  result += "\\A(?:";
+  result += anchored ? "\\A(?:" : "(?:";
   std::size_t position{0};
   if (!iregexp_branches(pattern, position, result, 0)) {
     return std::nullopt;
   }
 
-  result += ")\\z";
+  result += anchored ? ")\\z" : ")";
   return result;
 }
 

--- a/src/core/regex/regex.cc
+++ b/src/core/regex/regex.cc
@@ -39,8 +39,9 @@ auto compile_pcre2(const std::string &pattern, const std::uint32_t options)
 
 auto to_regex(const std::string_view pattern, const RegexDialect dialect)
     -> std::optional<Regex> {
-  if (dialect == RegexDialect::IRegexp) {
-    const auto translated{translate_iregexp(pattern)};
+  if (dialect != RegexDialect::Permissive) {
+    const auto translated{
+        translate_iregexp(pattern, dialect == RegexDialect::IRegexp)};
     if (!translated.has_value()) {
       return std::nullopt;
     }

--- a/test/regex/CMakeLists.txt
+++ b/test/regex/CMakeLists.txt
@@ -4,6 +4,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME regex
     regex_permissive_matches_ecma262_test.cc
     regex_permissive_matches_rfc9485_test.cc
     regex_rfc9485_matches_test.cc
+    regex_rfc9485_search_matches_test.cc
     regex_is_ecma_test.cc
     regex_to_regex_test.cc
     regex_test.cc)

--- a/test/regex/regex_rfc9485_search_matches_test.cc
+++ b/test/regex/regex_rfc9485_search_matches_test.cc
@@ -1,0 +1,129 @@
+#include <sourcemeta/core/regex.h>
+#include <sourcemeta/core/test.h>
+
+TEST(rfc9485_search_substring_at_start) {
+  const auto regex{sourcemeta::core::to_regex(
+      "ab.*", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abyy"));
+}
+
+TEST(rfc9485_search_substring_in_middle) {
+  const auto regex{sourcemeta::core::to_regex(
+      "ab", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xxabyy"));
+}
+
+TEST(rfc9485_search_substring_at_end) {
+  const auto regex{sourcemeta::core::to_regex(
+      "ab", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xxab"));
+}
+
+TEST(rfc9485_search_full_input_still_matches) {
+  const auto regex{sourcemeta::core::to_regex(
+      "ab", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "ab"));
+}
+
+TEST(rfc9485_search_no_occurrence) {
+  const auto regex{sourcemeta::core::to_regex(
+      "ab", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xyz"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ba"));
+}
+
+TEST(rfc9485_search_empty_pattern_matches_everything) {
+  const auto regex{sourcemeta::core::to_regex(
+      "", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), ""));
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "anything"));
+}
+
+TEST(rfc9485_search_dot_excludes_line_feed) {
+  const auto regex{sourcemeta::core::to_regex(
+      ".", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\n"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "\n\r"));
+}
+
+TEST(rfc9485_search_occurrence_after_line_feed) {
+  const auto regex{sourcemeta::core::to_regex(
+      "b.", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a\nbc"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "a\nb\n"));
+}
+
+TEST(rfc9485_search_alternation) {
+  const auto regex{sourcemeta::core::to_regex(
+      "cat|dog", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "my cat sleeps"));
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "hotdog"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "bird"));
+}
+
+TEST(rfc9485_search_quantifier) {
+  const auto regex{sourcemeta::core::to_regex(
+      "a{2,3}", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "xaax"));
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aaaa"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "xax"));
+}
+
+TEST(rfc9485_search_class) {
+  const auto regex{sourcemeta::core::to_regex(
+      "[0-9]", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "abc5def"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abcdef"));
+}
+
+TEST(rfc9485_search_category) {
+  const auto regex{sourcemeta::core::to_regex(
+      "\\p{Lu}", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "aBc"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "abc"));
+}
+
+TEST(rfc9485_search_astral) {
+  const auto regex{sourcemeta::core::to_regex(
+      "🤔", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_TRUE(regex.has_value());
+  EXPECT_TRUE(sourcemeta::core::matches(regex.value(), "a🤔b"));
+  EXPECT_FALSE(sourcemeta::core::matches(regex.value(), "ab"));
+}
+
+TEST(rfc9485_search_invalid_shorthand_escape) {
+  const auto regex{sourcemeta::core::to_regex(
+      "\\d", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_FALSE(regex.has_value());
+}
+
+TEST(rfc9485_search_invalid_double_quantifier) {
+  const auto regex{sourcemeta::core::to_regex(
+      "a**", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_FALSE(regex.has_value());
+}
+
+TEST(rfc9485_search_invalid_reversed_range) {
+  const auto regex{sourcemeta::core::to_regex(
+      "[z-a]", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_FALSE(regex.has_value());
+}
+
+TEST(rfc9485_search_invalid_lookahead) {
+  const auto regex{sourcemeta::core::to_regex(
+      "(?=a)", sourcemeta::core::RegexDialect::IRegexpSearch)};
+  EXPECT_FALSE(regex.has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

