### PR TITLE
Add a few extra convenience methods around `GenericPointer`

### DIFF
--- a/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
+++ b/src/core/jsonpointer/include/sourcemeta/core/jsonpointer_pointer.h
@@ -8,7 +8,7 @@
 #include <cstddef>          // std::size_t
 #include <functional>       // std::reference_wrapper
 #include <initializer_list> // std::initializer_list
-#include <iterator>         // std::advance, std::back_inserter
+#include <iterator>         // std::advance, std::back_inserter, std::next
 #include <optional>         // std::optional
 #include <ranges>           // std::ranges::subrange
 #include <type_traits>      // std::is_same_v, std::decay_t
@@ -661,6 +661,47 @@ public:
            this->starts_with(other, tail_left) &&
            this->data[prefix_size + 1].is_property() &&
            this->data[prefix_size + 1].to_property() == tail_right;
+  }
+
+  /// Check whether two JSON Pointers are equal up to a given number of
+  /// leading tokens. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  /// const sourcemeta::core::Pointer other{"foo", "bar", "qux"};
+  /// assert(pointer.shares_prefix(other, 2));
+  /// assert(!pointer.shares_prefix(other, 3));
+  /// ```
+  [[nodiscard]] auto shares_prefix(const GenericPointer<PropertyT, Hash> &other,
+                                   const size_type prefix_size) const -> bool {
+    return this->data.size() >= prefix_size &&
+           other.data.size() >= prefix_size &&
+           std::equal(this->data.cbegin(),
+                      std::next(this->data.cbegin(),
+                                static_cast<difference_type>(prefix_size)),
+                      other.data.cbegin());
+  }
+
+  /// Check whether a JSON Pointer starts with another JSON Pointer without
+  /// the two being equal. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/jsonpointer.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  /// const sourcemeta::core::Pointer prefix{"foo", "bar"};
+  /// assert(pointer.starts_with_strict(prefix));
+  /// assert(!pointer.starts_with_strict(pointer));
+  /// ```
+  [[nodiscard]] auto
+  starts_with_strict(const GenericPointer<PropertyT, Hash> &other) const
+      -> bool {
+    return this->data.size() > other.data.size() &&
+           this->shares_prefix(other, other.data.size());
   }
 
   /// Check whether a JSON Pointer starts with the initial part of another JSON

--- a/test/jsonpointer/CMakeLists.txt
+++ b/test/jsonpointer/CMakeLists.txt
@@ -20,7 +20,9 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonpointer
     jsonpointer_fragment_to_pointer_test.cc
     jsonpointer_concat_test.cc
     jsonpointer_starts_with_test.cc
+    jsonpointer_starts_with_strict_test.cc
     jsonpointer_starts_with_initial_test.cc
+    jsonpointer_shares_prefix_test.cc
     jsonpointer_json_auto_test.cc
     jsonpointer_rebase_test.cc
     jsonpointer_remove_test.cc

--- a/test/jsonpointer/jsonpointer_shares_prefix_test.cc
+++ b/test/jsonpointer/jsonpointer_shares_prefix_test.cc
@@ -1,0 +1,93 @@
+#include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
+
+TEST(property_common_prefix_true) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer other{"foo", "bar", "qux"};
+  EXPECT_TRUE(pointer.shares_prefix(other, 2));
+}
+
+TEST(property_common_prefix_false) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer other{"foo", "bar", "qux"};
+  EXPECT_FALSE(pointer.shares_prefix(other, 3));
+}
+
+TEST(index_common_prefix_true) {
+  const sourcemeta::core::Pointer pointer{0, 1, 2};
+  const sourcemeta::core::Pointer other{0, 1, 3};
+  EXPECT_TRUE(pointer.shares_prefix(other, 2));
+}
+
+TEST(index_common_prefix_false) {
+  const sourcemeta::core::Pointer pointer{0, 1, 2};
+  const sourcemeta::core::Pointer other{0, 1, 3};
+  EXPECT_FALSE(pointer.shares_prefix(other, 3));
+}
+
+TEST(equal_pointers_full_size) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  const sourcemeta::core::Pointer other{"foo", "bar"};
+  EXPECT_TRUE(pointer.shares_prefix(other, 2));
+}
+
+TEST(different_first_token) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  const sourcemeta::core::Pointer other{"baz", "bar"};
+  EXPECT_FALSE(pointer.shares_prefix(other, 1));
+}
+
+TEST(zero_size_non_empty) {
+  const sourcemeta::core::Pointer pointer{"foo"};
+  const sourcemeta::core::Pointer other{"bar"};
+  EXPECT_TRUE(pointer.shares_prefix(other, 0));
+}
+
+TEST(zero_size_empty) {
+  const sourcemeta::core::Pointer pointer;
+  const sourcemeta::core::Pointer other;
+  EXPECT_TRUE(pointer.shares_prefix(other, 0));
+}
+
+TEST(size_beyond_left) {
+  const sourcemeta::core::Pointer pointer{"foo"};
+  const sourcemeta::core::Pointer other{"foo", "bar"};
+  EXPECT_FALSE(pointer.shares_prefix(other, 2));
+}
+
+TEST(size_beyond_right) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  const sourcemeta::core::Pointer other{"foo"};
+  EXPECT_FALSE(pointer.shares_prefix(other, 2));
+}
+
+TEST(size_beyond_both) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  const sourcemeta::core::Pointer other{"foo", "bar"};
+  EXPECT_FALSE(pointer.shares_prefix(other, 3));
+}
+
+TEST(commutative_true) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer other{"foo", "bar"};
+  EXPECT_TRUE(pointer.shares_prefix(other, 2));
+  EXPECT_TRUE(other.shares_prefix(pointer, 2));
+}
+
+TEST(property_and_index_mixed_true) {
+  const sourcemeta::core::Pointer pointer{"foo", 0, "bar"};
+  const sourcemeta::core::Pointer other{"foo", 0, "baz"};
+  EXPECT_TRUE(pointer.shares_prefix(other, 2));
+}
+
+TEST(property_and_index_mixed_false) {
+  const sourcemeta::core::Pointer pointer{"foo", 0, "bar"};
+  const sourcemeta::core::Pointer other{"foo", 1, "bar"};
+  EXPECT_FALSE(pointer.shares_prefix(other, 2));
+}
+
+TEST(property_token_against_index_token) {
+  const sourcemeta::core::Pointer pointer{"foo", "0"};
+  const sourcemeta::core::Pointer other{"foo", 0};
+  EXPECT_FALSE(pointer.shares_prefix(other, 2));
+}

--- a/test/jsonpointer/jsonpointer_starts_with_strict_test.cc
+++ b/test/jsonpointer/jsonpointer_starts_with_strict_test.cc
@@ -1,0 +1,91 @@
+#include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
+
+TEST(property_prefix_true) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+  EXPECT_TRUE(pointer.starts_with_strict(prefix));
+}
+
+TEST(property_prefix_false) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix{"bar", "baz"};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(index_prefix_true) {
+  const sourcemeta::core::Pointer pointer{0, 1, 2};
+  const sourcemeta::core::Pointer prefix{0, 1};
+  EXPECT_TRUE(pointer.starts_with_strict(prefix));
+}
+
+TEST(index_prefix_false) {
+  const sourcemeta::core::Pointer pointer{0, 1, 2};
+  const sourcemeta::core::Pointer prefix{1, 2};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(property_equal) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  const sourcemeta::core::Pointer prefix{"foo", "bar"};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(index_equal) {
+  const sourcemeta::core::Pointer pointer{0, 1};
+  const sourcemeta::core::Pointer prefix{0, 1};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(same_pointer) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  EXPECT_FALSE(pointer.starts_with_strict(pointer));
+}
+
+TEST(longer_prefix) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar"};
+  const sourcemeta::core::Pointer prefix{"foo", "bar", "baz"};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(non_empty_empty) {
+  const sourcemeta::core::Pointer pointer{"foo"};
+  const sourcemeta::core::Pointer prefix;
+  EXPECT_TRUE(pointer.starts_with_strict(prefix));
+}
+
+TEST(empty_non_empty) {
+  const sourcemeta::core::Pointer pointer;
+  const sourcemeta::core::Pointer prefix{"foo"};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(empty_empty) {
+  const sourcemeta::core::Pointer pointer;
+  const sourcemeta::core::Pointer prefix;
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(divergent_last_prefix_token) {
+  const sourcemeta::core::Pointer pointer{"foo", "bar", "baz"};
+  const sourcemeta::core::Pointer prefix{"foo", "qux"};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(property_and_index_mixed_true) {
+  const sourcemeta::core::Pointer pointer{"foo", 0, "bar"};
+  const sourcemeta::core::Pointer prefix{"foo", 0};
+  EXPECT_TRUE(pointer.starts_with_strict(prefix));
+}
+
+TEST(property_and_index_mixed_false) {
+  const sourcemeta::core::Pointer pointer{"foo", 0, "bar"};
+  const sourcemeta::core::Pointer prefix{"foo", 1};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}
+
+TEST(property_token_against_index_token) {
+  const sourcemeta::core::Pointer pointer{"foo", "0", "bar"};
+  const sourcemeta::core::Pointer prefix{"foo", 0};
+  EXPECT_FALSE(pointer.starts_with_strict(prefix));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

