### PR TITLE
Fix `Decimal::reduce` corrupting multiple word coefficients with trailing zeros

### DIFF
--- a/src/lang/numeric/big_coefficient.h
+++ b/src/lang/numeric/big_coefficient.h
@@ -197,8 +197,20 @@ public:
     }
 
     if (this->words[0] != 0) {
+      // Each word holds a fixed slice of the whole number, so dividing by 10
+      // must carry the remainder of every higher word into the word below
       while (this->words[0] % 10 == 0) {
-        this->words[0] /= 10;
+        std::uint64_t borrow = 0;
+        for (auto index = this->length; index > 0; index--) {
+          const auto word = this->words[index - 1];
+          this->words[index - 1] = word / 10 + borrow * (BASE / 10);
+          borrow = word % 10;
+        }
+
+        if (this->length > 1 && this->words[this->length - 1] == 0) {
+          this->length--;
+        }
+
         total_stripped++;
       }
     }

--- a/test/numeric/numeric_decimal_test.cc
+++ b/test/numeric/numeric_decimal_test.cc
@@ -3441,6 +3441,32 @@ TEST(reduce_negative) {
   EXPECT_EQ(value.reduce(), expected);
 }
 
+// Stripping a trailing zero from a multiple word coefficient must borrow the
+// low digit of every higher word into the word below
+TEST(reduce_big_coefficient_trailing_zero) {
+  const sourcemeta::core::Decimal value{"123456789012345678901234567890"};
+  const auto result{value.reduce()};
+  EXPECT_EQ(result, value);
+  EXPECT_EQ(result.to_scientific_string(),
+            "1.2345678901234567890123456789e+29");
+}
+
+TEST(reduce_big_coefficient_zero_low_word) {
+  const sourcemeta::core::Decimal value{"123456789012000000000000000000000"};
+  const auto result{value.reduce()};
+  EXPECT_EQ(result, value);
+  EXPECT_EQ(result.to_scientific_string(), "1.23456789012e+32");
+}
+
+TEST(reduce_heap_coefficient_trailing_zeros) {
+  const sourcemeta::core::Decimal value{
+      "55555555555555555555555555555555555555500"};
+  const auto result{value.reduce()};
+  EXPECT_EQ(result, value);
+  EXPECT_EQ(result.to_scientific_string(),
+            "5.55555555555555555555555555555555555555e+40");
+}
+
 TEST(reduce_infinity) {
   EXPECT_TRUE(sourcemeta::core::Decimal::infinity().reduce().is_infinite());
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

