### PR TITLE
Expose various lower-level HTTP parsing helpers

### DIFF
--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -10,11 +10,12 @@ endif()
 
 sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME http
   PRIVATE_HEADERS problem.h status.h method.h message.h error.h system.h
-    aws_sigv4.h
+    aws_sigv4.h syntax.h
   SOURCES helpers.h problem.cc match_accept.cc match_accept_language.cc
           negotiate_encoding.cc from_date.cc format_link.cc field_list.cc
           accept_includes_all.cc content_type_matches.cc parse_bearer.cc
           cache_control_max_age.cc serialize_cookie.cc aws_sigv4.cc
+          scan_quoted_string.cc
           ${SOURCEMETA_CORE_HTTP_CLIENT_SOURCE})
 
 if(SOURCEMETA_CORE_INSTALL)

--- a/src/core/http/helpers.h
+++ b/src/core/http/helpers.h
@@ -1,6 +1,7 @@
 #ifndef SOURCEMETA_CORE_HTTP_HELPERS_H_
 #define SOURCEMETA_CORE_HTTP_HELPERS_H_
 
+#include <sourcemeta/core/http_syntax.h>
 #include <sourcemeta/core/text.h>
 
 #include <cstddef>     // std::size_t
@@ -11,10 +12,6 @@
 // Bounds are validated by surrounding logic.
 // NOLINTBEGIN(bugprone-suspicious-stringview-data-usage)
 namespace sourcemeta::core {
-
-inline auto http_is_ows(const char character) noexcept -> bool {
-  return character == ' ' || character == '\t';
-}
 
 inline auto http_subview(const std::string_view value, const std::size_t offset,
                          const std::size_t length) noexcept
@@ -48,24 +45,6 @@ inline auto http_media_specificity(const std::string_view range,
     return 0;
   }
   return 2;
-}
-
-inline auto http_trim_trailing_ows(const std::string_view value) noexcept
-    -> std::string_view {
-  std::size_t size{value.size()};
-  while (size > 0 && http_is_ows(value[size - 1])) {
-    --size;
-  }
-  return http_subview(value, 0, size);
-}
-
-inline auto http_trim_leading_ows(const std::string_view value) noexcept
-    -> std::string_view {
-  std::size_t position{0};
-  while (position < value.size() && http_is_ows(value[position])) {
-    ++position;
-  }
-  return http_subview(value, position, value.size() - position);
 }
 
 template <typename Visitor>

--- a/src/core/http/include/sourcemeta/core/http.h
+++ b/src/core/http/include/sourcemeta/core/http.h
@@ -12,6 +12,7 @@
 #include <sourcemeta/core/http_method.h>
 #include <sourcemeta/core/http_problem.h>
 #include <sourcemeta/core/http_status.h>
+#include <sourcemeta/core/http_syntax.h>
 #include <sourcemeta/core/http_system.h>
 // NOLINTEND(misc-include-cleaner)
 

--- a/src/core/http/include/sourcemeta/core/http_syntax.h
+++ b/src/core/http/include/sourcemeta/core/http_syntax.h
@@ -1,0 +1,185 @@
+#ifndef SOURCEMETA_CORE_HTTP_SYNTAX_H_
+#define SOURCEMETA_CORE_HTTP_SYNTAX_H_
+
+#ifndef SOURCEMETA_CORE_HTTP_EXPORT
+#include <sourcemeta/core/http_export.h>
+#endif
+
+#include <sourcemeta/core/text.h>
+
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup http
+/// Whether a character is optional whitespace, a space or a horizontal tab
+/// (RFC 9110 Section 5.6.3). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_is_ows(' '));
+/// assert(!sourcemeta::core::http_is_ows('x'));
+/// ```
+inline auto http_is_ows(const char character) noexcept -> bool {
+  return character == ' ' || character == '\t';
+}
+
+/// @ingroup http
+/// Whether a character is a token character (RFC 9110 Section 5.6.2), the set a
+/// bare header token draws from. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_is_tchar('a'));
+/// assert(!sourcemeta::core::http_is_tchar('"'));
+/// ```
+inline auto http_is_tchar(const char character) noexcept -> bool {
+  switch (character) {
+    case '!':
+    case '#':
+    case '$':
+    case '%':
+    case '&':
+    case '\'':
+    case '*':
+    case '+':
+    case '-':
+    case '.':
+    case '^':
+    case '_':
+    case '`':
+    case '|':
+    case '~':
+      return true;
+    default:
+      return is_alphanum(character);
+  }
+}
+
+/// @ingroup http
+/// Whether a character may appear in the alphabet of a token68 (RFC 7235
+/// Section 2.1) or b64token (RFC 6750 Section 2.1) credential, before its
+/// padding. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_is_b64token_char('/'));
+/// assert(!sourcemeta::core::http_is_b64token_char('='));
+/// ```
+inline auto http_is_b64token_char(const char character) noexcept -> bool {
+  return is_alphanum(character) || character == '-' || character == '.' ||
+         character == '_' || character == '~' || character == '+' ||
+         character == '/';
+}
+
+/// @ingroup http
+/// Whether a string is a well-formed token68 (RFC 7235 Section 2.1) or b64token
+/// (RFC 6750 Section 2.1), at least one alphabet character followed by any "="
+/// padding. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_is_b64token("YWJj=="));
+/// assert(!sourcemeta::core::http_is_b64token("a b"));
+/// ```
+inline auto http_is_b64token(const std::string_view value) noexcept -> bool {
+  std::size_t position{0};
+  while (position < value.size() && http_is_b64token_char(value[position])) {
+    position += 1;
+  }
+
+  if (position == 0) {
+    return false;
+  }
+
+  while (position < value.size()) {
+    if (value[position] != '=') {
+      return false;
+    }
+
+    position += 1;
+  }
+
+  return true;
+}
+
+/// @ingroup http
+/// The view with any leading optional whitespace removed (RFC 9110
+/// Section 5.6.3). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_trim_leading_ows("  x") == "x");
+/// ```
+inline auto http_trim_leading_ows(std::string_view value) noexcept
+    -> std::string_view {
+  while (!value.empty() && http_is_ows(value.front())) {
+    value.remove_prefix(1);
+  }
+
+  return value;
+}
+
+/// @ingroup http
+/// The view with any trailing optional whitespace removed (RFC 9110
+/// Section 5.6.3). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::http_trim_trailing_ows("x  ") == "x");
+/// ```
+inline auto http_trim_trailing_ows(std::string_view value) noexcept
+    -> std::string_view {
+  while (!value.empty() && http_is_ows(value.back())) {
+    value.remove_suffix(1);
+  }
+
+  return value;
+}
+
+/// @ingroup http
+/// Scan a quoted-string (RFC 9110 Section 5.6.4) whose opening double quote is
+/// at position in input, returning the position just past the closing quote, or
+/// no value when it is malformed. The unescaped content is written to value,
+/// borrowing from input when it carries no quoted-pair and appending to storage
+/// otherwise, whose capacity should be reserved up front so that earlier views
+/// into it stay valid. Control characters other than horizontal tab are
+/// rejected as a header-injection defense. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/http.h>
+/// #include <cassert>
+/// #include <string>
+/// #include <string_view>
+///
+/// std::string storage;
+/// std::string_view value;
+/// const auto next{sourcemeta::core::http_scan_quoted_string(
+///     R"("hello")", 0, storage, value)};
+/// assert(next.has_value());
+/// assert(value == "hello");
+/// ```
+SOURCEMETA_CORE_HTTP_EXPORT
+auto http_scan_quoted_string(const std::string_view input,
+                             const std::size_t position, std::string &storage,
+                             std::string_view &value)
+    -> std::optional<std::size_t>;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/http/parse_bearer.cc
+++ b/src/core/http/parse_bearer.cc
@@ -5,41 +5,6 @@
 #include <cstddef>     // std::size_t
 #include <string_view> // std::string_view
 
-namespace {
-
-auto is_b64token_character(const char character) noexcept -> bool {
-  return (character >= 'A' && character <= 'Z') ||
-         (character >= 'a' && character <= 'z') ||
-         (character >= '0' && character <= '9') || character == '-' ||
-         character == '.' || character == '_' || character == '~' ||
-         character == '+' || character == '/';
-}
-
-// RFC 6750 §2.1: b64token = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" /
-// "/" ) *"=". At least one character from the alphabet, followed by optional
-// trailing padding.
-auto is_b64token(const std::string_view token) noexcept -> bool {
-  std::size_t position{0};
-  while (position < token.size() && is_b64token_character(token[position])) {
-    ++position;
-  }
-
-  if (position == 0) {
-    return false;
-  }
-
-  while (position < token.size()) {
-    if (token[position] != '=') {
-      return false;
-    }
-    ++position;
-  }
-
-  return true;
-}
-
-} // namespace
-
 namespace sourcemeta::core {
 
 auto http_parse_bearer(const std::string_view authorization) noexcept
@@ -58,7 +23,7 @@ auto http_parse_bearer(const std::string_view authorization) noexcept
   const auto token{http_trim_trailing_ows(http_trim_leading_ows(
       http_subview(authorization, scheme.size() + 1,
                    authorization.size() - scheme.size() - 1)))};
-  if (!is_b64token(token)) {
+  if (!http_is_b64token(token)) {
     return {};
   }
 

--- a/src/core/http/scan_quoted_string.cc
+++ b/src/core/http/scan_quoted_string.cc
@@ -1,0 +1,80 @@
+#include <sourcemeta/core/http_syntax.h>
+
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace {
+
+// RFC 9110 Section 5.6.4: qdtext and the escaped octet of a quoted-pair both
+// admit HTAB, SP, the visible characters, and obs-text, so every other control
+// character is rejected. The double quote and the backslash are handled by the
+// caller before this check
+auto http_is_quoted_content(const char character) noexcept -> bool {
+  const auto byte{static_cast<unsigned char>(character)};
+  return byte == 0x09 || (byte >= 0x20 && byte != 0x7f);
+}
+
+} // namespace
+
+namespace sourcemeta::core {
+
+auto http_scan_quoted_string(const std::string_view input,
+                             const std::size_t position, std::string &storage,
+                             std::string_view &value)
+    -> std::optional<std::size_t> {
+  if (position >= input.size() || input[position] != '"') {
+    return std::nullopt;
+  }
+
+  const std::size_t content_start{position + 1};
+  std::size_t scan{content_start};
+  bool escaped{false};
+  while (scan < input.size()) {
+    const char character{input[scan]};
+    if (character == '\\') {
+      if (scan + 1 >= input.size() ||
+          !http_is_quoted_content(input[scan + 1])) {
+        return std::nullopt;
+      }
+
+      escaped = true;
+      scan += 2;
+      continue;
+    }
+
+    if (character == '"') {
+      if (!escaped) {
+        value = input.substr(content_start, scan - content_start);
+      } else {
+        const std::size_t base{storage.size()};
+        storage.reserve(base + (scan - content_start));
+        std::size_t index{content_start};
+        while (index < scan) {
+          if (input[index] == '\\') {
+            storage.push_back(input[index + 1]);
+            index += 2;
+          } else {
+            storage.push_back(input[index]);
+            index += 1;
+          }
+        }
+
+        value = std::string_view{storage}.substr(base);
+      }
+
+      return scan + 1;
+    }
+
+    if (!http_is_quoted_content(character)) {
+      return std::nullopt;
+    }
+
+    scan += 1;
+  }
+
+  return std::nullopt;
+}
+
+} // namespace sourcemeta::core

--- a/test/http/CMakeLists.txt
+++ b/test/http/CMakeLists.txt
@@ -11,6 +11,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME http
           http_parse_bearer_test.cc http_cache_control_max_age_test.cc
           http_serialize_cookie_test.cc http_parse_cookies_test.cc
           http_cookie_valid_test.cc http_aws_sigv4_test.cc
+          http_syntax_test.cc
           http_system_request_test.cc)
 
 target_link_libraries(sourcemeta_core_http_unit

--- a/test/http/http_syntax_test.cc
+++ b/test/http/http_syntax_test.cc
@@ -1,0 +1,291 @@
+#include <sourcemeta/core/http.h>
+#include <sourcemeta/core/test.h>
+
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+TEST(is_ows_accepts_space_and_tab) {
+  EXPECT_TRUE(sourcemeta::core::http_is_ows(' '));
+  EXPECT_TRUE(sourcemeta::core::http_is_ows('\t'));
+}
+
+TEST(is_ows_rejects_other_characters) {
+  EXPECT_FALSE(sourcemeta::core::http_is_ows('\n'));
+  EXPECT_FALSE(sourcemeta::core::http_is_ows('\r'));
+  EXPECT_FALSE(sourcemeta::core::http_is_ows('x'));
+}
+
+TEST(is_tchar_accepts_token_characters) {
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('a'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('Z'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('0'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('!'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('~'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('+'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('*'));
+}
+
+TEST(is_tchar_rejects_separators) {
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('"'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar(' '));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar(','));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('='));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('('));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('/'));
+}
+
+TEST(is_b64token_char_accepts_the_alphabet) {
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('a'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('0'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('-'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('_'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('~'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('+'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('/'));
+}
+
+TEST(is_b64token_char_rejects_padding_and_separators) {
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token_char('='));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token_char(' '));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token_char('!'));
+}
+
+TEST(is_b64token_accepts_valid_credentials) {
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token("abc123"));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token("mF_9.B5f-4.1JqM"));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token("YWJj=="));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token("a="));
+}
+
+TEST(is_b64token_rejects_invalid_credentials) {
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token(""));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token("=="));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token("a b"));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token("a==b"));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token("a,b"));
+}
+
+TEST(trim_leading_ows_removes_spaces_and_tabs) {
+  EXPECT_EQ(sourcemeta::core::http_trim_leading_ows("  x"), "x");
+  EXPECT_EQ(sourcemeta::core::http_trim_leading_ows("\t x"), "x");
+  EXPECT_EQ(sourcemeta::core::http_trim_leading_ows("x"), "x");
+}
+
+TEST(trim_leading_ows_of_all_whitespace_is_empty) {
+  EXPECT_TRUE(sourcemeta::core::http_trim_leading_ows("   ").empty());
+  EXPECT_TRUE(sourcemeta::core::http_trim_leading_ows("").empty());
+}
+
+TEST(trim_trailing_ows_removes_spaces_and_tabs) {
+  EXPECT_EQ(sourcemeta::core::http_trim_trailing_ows("x  "), "x");
+  EXPECT_EQ(sourcemeta::core::http_trim_trailing_ows("x \t"), "x");
+  EXPECT_EQ(sourcemeta::core::http_trim_trailing_ows("x"), "x");
+}
+
+TEST(scan_quoted_string_reads_a_plain_value) {
+  std::string storage;
+  std::string_view value;
+  const auto next{sourcemeta::core::http_scan_quoted_string(R"("hello")", 0,
+                                                            storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(next.value(), 7);
+  EXPECT_EQ(value, "hello");
+}
+
+TEST(scan_quoted_string_reads_an_empty_value) {
+  std::string storage;
+  std::string_view value;
+  const auto next{
+      sourcemeta::core::http_scan_quoted_string(R"("")", 0, storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(next.value(), 2);
+  EXPECT_TRUE(value.empty());
+}
+
+TEST(scan_quoted_string_keeps_a_comma_inside) {
+  std::string storage;
+  std::string_view value;
+  const auto next{
+      sourcemeta::core::http_scan_quoted_string(R"("a,b")", 0, storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(value, "a,b");
+}
+
+TEST(scan_quoted_string_unescapes_a_quoted_pair) {
+  std::string storage;
+  std::string_view value;
+  const auto next{sourcemeta::core::http_scan_quoted_string(R"("say \"hi\"")",
+                                                            0, storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(value, R"(say "hi")");
+}
+
+TEST(scan_quoted_string_resumes_after_the_closing_quote) {
+  std::string storage;
+  std::string_view value;
+  const auto next{sourcemeta::core::http_scan_quoted_string(R"("a", "b")", 0,
+                                                            storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(next.value(), 3);
+  EXPECT_EQ(value, "a");
+}
+
+TEST(scan_quoted_string_rejects_a_missing_opening_quote) {
+  std::string storage;
+  std::string_view value;
+  EXPECT_FALSE(
+      sourcemeta::core::http_scan_quoted_string("abc", 0, storage, value)
+          .has_value());
+}
+
+TEST(scan_quoted_string_rejects_an_unterminated_value) {
+  std::string storage;
+  std::string_view value;
+  EXPECT_FALSE(
+      sourcemeta::core::http_scan_quoted_string(R"("abc)", 0, storage, value)
+          .has_value());
+}
+
+TEST(scan_quoted_string_rejects_a_dangling_backslash) {
+  std::string storage;
+  std::string_view value;
+  std::string input{"\"a\\"};
+  EXPECT_FALSE(
+      sourcemeta::core::http_scan_quoted_string(input, 0, storage, value)
+          .has_value());
+}
+
+TEST(scan_quoted_string_rejects_a_control_character) {
+  std::string storage;
+  std::string_view value;
+  std::string input{"\"a"};
+  input.push_back('\x01');
+  input.push_back('"');
+  EXPECT_FALSE(
+      sourcemeta::core::http_scan_quoted_string(input, 0, storage, value)
+          .has_value());
+}
+
+TEST(is_tchar_accepts_the_remaining_punctuation) {
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('#'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('$'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('&'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('^'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('_'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('`'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('|'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('-'));
+  EXPECT_TRUE(sourcemeta::core::http_is_tchar('.'));
+}
+
+TEST(is_tchar_rejects_the_remaining_separators_and_controls) {
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('@'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar(';'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar(':'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('\\'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('{'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('?'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('\t'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('\x7f'));
+  EXPECT_FALSE(sourcemeta::core::http_is_tchar('\x80'));
+}
+
+TEST(is_b64token_char_rejects_controls_and_high_bytes) {
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('.'));
+  EXPECT_TRUE(sourcemeta::core::http_is_b64token_char('Z'));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token_char('\t'));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token_char('\x7f'));
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token_char('\x80'));
+}
+
+TEST(is_b64token_rejects_a_lone_padding_run) {
+  EXPECT_FALSE(sourcemeta::core::http_is_b64token("="));
+}
+
+TEST(trim_trailing_ows_of_all_whitespace_is_empty) {
+  EXPECT_TRUE(sourcemeta::core::http_trim_trailing_ows("  \t").empty());
+  EXPECT_TRUE(sourcemeta::core::http_trim_trailing_ows("").empty());
+}
+
+TEST(trims_preserve_interior_whitespace) {
+  EXPECT_EQ(sourcemeta::core::http_trim_leading_ows("  a b "), "a b ");
+  EXPECT_EQ(sourcemeta::core::http_trim_trailing_ows(" a b  "), " a b");
+}
+
+TEST(scan_quoted_string_accepts_a_horizontal_tab) {
+  std::string storage;
+  std::string_view value;
+  std::string input{"\"a\tb\""};
+  const auto next{
+      sourcemeta::core::http_scan_quoted_string(input, 0, storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(value, std::string_view{"a\tb"});
+}
+
+TEST(scan_quoted_string_accepts_obs_text) {
+  std::string storage;
+  std::string_view value;
+  std::string input{"\"a"};
+  input.push_back('\x80');
+  input.push_back('"');
+  const auto next{
+      sourcemeta::core::http_scan_quoted_string(input, 0, storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(value.size(), 2);
+  EXPECT_EQ(static_cast<unsigned char>(value.back()), 0x80);
+}
+
+TEST(scan_quoted_string_rejects_delete) {
+  std::string storage;
+  std::string_view value;
+  std::string input{"\"a"};
+  input.push_back('\x7f');
+  input.push_back('"');
+  EXPECT_FALSE(
+      sourcemeta::core::http_scan_quoted_string(input, 0, storage, value)
+          .has_value());
+}
+
+TEST(scan_quoted_string_unescapes_a_backslash) {
+  std::string storage;
+  std::string_view value;
+  const auto next{sourcemeta::core::http_scan_quoted_string(R"("a\\b")", 0,
+                                                            storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(value, R"(a\b)");
+}
+
+TEST(scan_quoted_string_unescapes_a_plain_character) {
+  std::string storage;
+  std::string_view value;
+  const auto next{sourcemeta::core::http_scan_quoted_string(R"("a\bc")", 0,
+                                                            storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(value, "abc");
+}
+
+TEST(scan_quoted_string_scans_at_an_offset) {
+  std::string storage;
+  std::string_view value;
+  const auto next{sourcemeta::core::http_scan_quoted_string(R"(realm="value")",
+                                                            6, storage, value)};
+  EXPECT_TRUE(next.has_value());
+  EXPECT_EQ(next.value(), 13);
+  EXPECT_EQ(value, "value");
+}
+
+TEST(scan_quoted_string_accumulates_into_shared_storage) {
+  std::string storage;
+  storage.reserve(64);
+  std::string_view first;
+  std::string_view second;
+  const auto after_first{sourcemeta::core::http_scan_quoted_string(
+      R"("a\"a")", 0, storage, first)};
+  EXPECT_TRUE(after_first.has_value());
+  const auto after_second{sourcemeta::core::http_scan_quoted_string(
+      R"("b\"b")", 0, storage, second)};
+  EXPECT_TRUE(after_second.has_value());
+  // The first view must survive the second append, given the reserve
+  EXPECT_EQ(first, R"(a"a)");
+  EXPECT_EQ(second, R"(b"b)");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

