### PR TITLE
Fix ECMA-262 detection of possessive range quantifiers and variable-width lookbehinds

### DIFF
--- a/src/core/regex/permissive.h
+++ b/src/core/regex/permissive.h
@@ -600,6 +600,30 @@ inline auto is_escaped(const std::string &pattern, std::size_t index) -> bool {
   return (count % 2) == 1;
 }
 
+// Whether the closing brace at the given position terminates a bounded
+// quantifier, as opposed to standing for a literal brace character
+inline auto closes_brace_quantifier(const std::string &pattern,
+                                    std::size_t brace_position) -> bool {
+  auto cursor{brace_position};
+  bool has_digits{false};
+  while (cursor > 0 && is_digit(pattern[cursor - 1])) {
+    has_digits = true;
+    --cursor;
+  }
+
+  if (cursor > 0 && pattern[cursor - 1] == ',') {
+    --cursor;
+    has_digits = false;
+    while (cursor > 0 && is_digit(pattern[cursor - 1])) {
+      has_digits = true;
+      --cursor;
+    }
+  }
+
+  return has_digits && cursor > 0 && pattern[cursor - 1] == '{' &&
+         !is_escaped(pattern, cursor - 1);
+}
+
 struct ShorthandExpansion {
   char escape;
   std::string_view inside_class;
@@ -706,11 +730,12 @@ inline auto translate_permissive(const std::string &pattern)
       }
     }
 
-    // PCRE-only possessive quantifiers: *+ ++ ?+
+    // PCRE-only possessive quantifiers: *+ ++ ?+ {n,m}+
     if (current == '+' && position > 0 && !in_class) {
       const char prev = pattern[position - 1];
-      if ((prev == '*' || prev == '+' || prev == '?') &&
-          !is_escaped(pattern, position - 1)) {
+      if (!is_escaped(pattern, position - 1) &&
+          (prev == '*' || prev == '+' || prev == '?' ||
+           (prev == '}' && closes_brace_quantifier(pattern, position - 1)))) {
         ecma_valid = false;
       }
     }

--- a/src/core/regex/regex.cc
+++ b/src/core/regex/regex.cc
@@ -35,6 +35,60 @@ auto compile_pcre2(const std::string &pattern, const std::uint32_t options)
   return RegexTypePCRE2{std::shared_ptr<void>(pcre2_regex)};
 }
 
+auto compiles_with_ecma_options(const std::string &pattern) -> bool {
+  int pcre2_error_code{0};
+  PCRE2_SIZE pcre2_error_offset{0};
+  pcre2_code *pcre2_regex_raw{pcre2_compile(
+      reinterpret_cast<PCRE2_SPTR>(pattern.c_str()), pattern.size(),
+      // Capturing groups are kept enabled so that ECMA-262 numbered
+      // backreferences like (a)\1 compile and match, at a small tracking cost
+      PCRE2_UTF | PCRE2_UCP | PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY |
+          PCRE2_NEVER_BACKSLASH_C | PCRE2_MATCH_INVALID_UTF |
+          PCRE2_ALLOW_EMPTY_CLASS,
+      &pcre2_error_code, &pcre2_error_offset, nullptr)};
+
+  if (pcre2_regex_raw == nullptr) {
+    return false;
+  }
+
+  pcre2_code_free(pcre2_regex_raw);
+  return true;
+}
+
+auto lookbehinds_as_lookaheads(const std::string &pattern) -> std::string {
+  std::string result;
+  result.reserve(pattern.size());
+  bool in_class{false};
+  for (std::size_t position = 0; position < pattern.size(); ++position) {
+    const char current{pattern[position]};
+    if (current == '\\' && position + 1 < pattern.size()) {
+      result += current;
+      result += pattern[position + 1];
+      position += 1;
+      continue;
+    }
+
+    if (current == '[') {
+      in_class = true;
+    } else if (current == ']') {
+      in_class = false;
+    }
+
+    if (!in_class && current == '(' && position + 3 < pattern.size() &&
+        pattern[position + 1] == '?' && pattern[position + 2] == '<' &&
+        (pattern[position + 3] == '=' || pattern[position + 3] == '!')) {
+      result += "(?";
+      result += pattern[position + 3];
+      position += 3;
+      continue;
+    }
+
+    result += current;
+  }
+
+  return result;
+}
+
 } // namespace
 
 auto to_regex(const std::string_view pattern, const RegexDialect dialect)
@@ -164,24 +218,18 @@ auto is_regex_ecma(const std::string_view pattern) -> bool {
     return false;
   }
 
-  int pcre2_error_code{0};
-  PCRE2_SIZE pcre2_error_offset{0};
-  pcre2_code *pcre2_regex_raw{pcre2_compile(
-      reinterpret_cast<PCRE2_SPTR>(translated.transformed.value().c_str()),
-      translated.transformed.value().size(),
-      // Capturing groups are kept enabled so that ECMA-262 numbered
-      // backreferences like (a)\1 compile and match, at a small tracking cost
-      PCRE2_UTF | PCRE2_UCP | PCRE2_DOTALL | PCRE2_DOLLAR_ENDONLY |
-          PCRE2_NEVER_BACKSLASH_C | PCRE2_MATCH_INVALID_UTF |
-          PCRE2_ALLOW_EMPTY_CLASS,
-      &pcre2_error_code, &pcre2_error_offset, nullptr)};
-
-  if (pcre2_regex_raw == nullptr) {
-    return false;
+  if (compiles_with_ecma_options(translated.transformed.value())) {
+    return true;
   }
 
-  pcre2_code_free(pcre2_regex_raw);
-  return true;
+  // ECMA-262 places no width restriction on lookbehind assertions, while
+  // PCRE2 only accepts lookbehinds whose maximum width is bounded. As
+  // lookbehind and lookahead bodies follow the same grammar, the syntax
+  // check is retried with every lookbehind turned into a lookahead
+  const auto rewritten{
+      lookbehinds_as_lookaheads(translated.transformed.value())};
+  return rewritten != translated.transformed.value() &&
+         compiles_with_ecma_options(rewritten);
 }
 
 } // namespace sourcemeta::core

--- a/test/regex/regex_is_ecma_test.cc
+++ b/test/regex/regex_is_ecma_test.cc
@@ -177,6 +177,42 @@ TEST(valid_negative_lookbehind) {
   EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<!foo)bar"));
 }
 
+TEST(invalid_possessive_range_quantifier) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a{2,3}+"));
+}
+
+TEST(invalid_possessive_exact_quantifier) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a{3}+"));
+}
+
+TEST(invalid_possessive_open_quantifier) {
+  EXPECT_FALSE(sourcemeta::core::is_regex_ecma("a{3,}+"));
+}
+
+TEST(valid_plus_after_literal_brace) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a}+"));
+}
+
+TEST(valid_plus_after_escaped_brace_quantifier) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("a\\{2,3}+"));
+}
+
+TEST(valid_variable_width_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=a+)b"));
+}
+
+TEST(valid_variable_width_negative_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<!a+)b"));
+}
+
+TEST(valid_bounded_variable_width_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=a{2,5})b"));
+}
+
+TEST(valid_nested_variable_width_lookbehind) {
+  EXPECT_TRUE(sourcemeta::core::is_regex_ecma("(?<=(?<=a)b)c"));
+}
+
 TEST(valid_dot_star) { EXPECT_TRUE(sourcemeta::core::is_regex_ecma(".*")); }
 
 TEST(valid_anchored_dot_star) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

