### PR TITLE
Add OAuth authorization server metadata parsing and a cached provider

### DIFF
--- a/src/core/oauth/CMakeLists.txt
+++ b/src/core/oauth/CMakeLists.txt
@@ -1,6 +1,10 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME oauth
-  PRIVATE_HEADERS error.h profile.h pkce.h bearer.h
-  SOURCES oauth_error.cc oauth_pkce.cc oauth_bearer.cc oauth_syntax.h)
+  PRIVATE_HEADERS error.h profile.h pkce.h bearer.h random.h authorization.h
+    token.h client_authentication.h transaction.h metadata.h metadata_provider.h
+  SOURCES oauth_error.cc oauth_pkce.cc oauth_bearer.cc oauth_syntax.h
+    oauth_random.cc oauth_authorization.cc oauth_encode.h oauth_decode.h
+    oauth_token.cc oauth_client_authentication.cc oauth_transaction.cc
+    oauth_metadata.cc oauth_metadata_provider.cc)
 
 target_link_libraries(sourcemeta_core_oauth
   PUBLIC sourcemeta::core::json)

--- a/src/core/oauth/include/sourcemeta/core/oauth.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth.h
@@ -6,10 +6,17 @@
 #endif
 
 // NOLINTBEGIN(misc-include-cleaner)
+#include <sourcemeta/core/oauth_authorization.h>
 #include <sourcemeta/core/oauth_bearer.h>
+#include <sourcemeta/core/oauth_client_authentication.h>
 #include <sourcemeta/core/oauth_error.h>
+#include <sourcemeta/core/oauth_metadata.h>
+#include <sourcemeta/core/oauth_metadata_provider.h>
 #include <sourcemeta/core/oauth_pkce.h>
 #include <sourcemeta/core/oauth_profile.h>
+#include <sourcemeta/core/oauth_random.h>
+#include <sourcemeta/core/oauth_token.h>
+#include <sourcemeta/core/oauth_transaction.h>
 // NOLINTEND(misc-include-cleaner)
 
 /// @defgroup oauth OAuth

--- a/src/core/oauth/include/sourcemeta/core/oauth_authorization.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_authorization.h
@@ -1,0 +1,154 @@
+#ifndef SOURCEMETA_CORE_OAUTH_AUTHORIZATION_H_
+#define SOURCEMETA_CORE_OAUTH_AUTHORIZATION_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// A single query or form parameter as a name and value pair. Both members are
+/// non-owning views that must outlive any use of this parameter. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+///
+/// const sourcemeta::core::OAuthParameter parameter{"resource",
+///                                                  "https://api.example"};
+/// ```
+struct OAuthParameter {
+  /// The parameter name.
+  std::string_view name;
+  /// The parameter value, still in its raw unescaped form.
+  std::string_view value;
+};
+
+/// @ingroup oauth
+/// A non-owning view of the parameters of an authorization request (RFC 6749
+/// Section 4.1.1). Every field borrows from the caller and must outlive any use
+/// of this struct. An empty scalar field is treated as absent and is not
+/// emitted, and the spans carry the repeatable and extension parameters. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+/// #include <string>
+///
+/// sourcemeta::core::OAuthAuthorizationRequest request;
+/// request.client_id = "s6BhdRkqt3";
+/// request.state = "xyz";
+/// std::string url;
+/// sourcemeta::core::oauth_build_authorization_url(
+///     "https://server.example/authorize", request, url);
+/// assert(url ==
+///        "https://server.example/authorize?response_type=code"
+///        "&client_id=s6BhdRkqt3&state=xyz");
+/// ```
+struct OAuthAuthorizationRequest {
+  /// The client identifier (RFC 6749 Section 2.2).
+  std::string_view client_id;
+  /// The redirection endpoint the response is returned to (RFC 6749
+  /// Section 3.1.2).
+  std::string_view redirect_uri;
+  /// The space-delimited requested scope (RFC 6749 Section 3.3).
+  std::string_view scope;
+  /// The opaque cross-site request forgery token echoed back on the response
+  /// (RFC 6749 Section 10.12).
+  std::string_view state;
+  /// The PKCE code challenge (RFC 7636 Section 4.3).
+  std::string_view code_challenge;
+  /// The PKCE code challenge method, emitted only alongside a challenge
+  /// (RFC 7636 Section 4.3).
+  std::string_view code_challenge_method;
+  /// The reference to a pushed authorization request (RFC 9126 Section 4).
+  std::string_view request_uri;
+  /// The JWK thumbprint of the DPoP proof public key (RFC 9449 Section 10).
+  std::string_view dpop_jkt;
+  /// The repeatable resource indicators, each an absolute URI without a
+  /// fragment (RFC 8707 Section 2).
+  std::span<const OAuthParameter> resources;
+  /// The extension parameters, such as an OpenID Connect `nonce`, emitted
+  /// verbatim after the known parameters.
+  std::span<const OAuthParameter> extra;
+};
+
+/// @ingroup oauth
+/// Build an authorization request URL by appending the query to the endpoint
+/// (RFC 6749 Section 4.1.1). The `response_type` is always `code`, since the
+/// implicit grant is not represented, every value is percent-escaped, an
+/// existing query on the endpoint is honored, and the code challenge method is
+/// emitted only when a challenge is present. The sink is appended to and never
+/// cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+/// #include <string>
+///
+/// sourcemeta::core::OAuthAuthorizationRequest request;
+/// request.client_id = "s6BhdRkqt3";
+/// request.redirect_uri = "https://client.example/cb";
+/// std::string url;
+/// sourcemeta::core::oauth_build_authorization_url(
+///     "https://server.example/authorize", request, url);
+/// assert(url ==
+///        "https://server.example/authorize?response_type=code"
+///        "&client_id=s6BhdRkqt3&redirect_uri=https%3A%2F%2Fclient.example%2Fcb");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_authorization_url(const std::string_view endpoint,
+                                   const OAuthAuthorizationRequest &request,
+                                   std::string &sink) -> void;
+
+/// @ingroup oauth
+/// A non-owning view of an authorization response returned on the redirection
+/// endpoint (RFC 6749 Section 4.1.2). Each field borrows from the parsed query
+/// or the decode arena, so both must outlive the view, and an absent parameter
+/// is an empty view. A present `error` marks a failure response (RFC 6749
+/// Section 4.1.2.1).
+struct OAuthAuthorizationResponse {
+  /// The authorization code (RFC 6749 Section 4.1.2).
+  std::string_view code;
+  /// The state value echoed from the request (RFC 6749 Section 4.1.2).
+  std::string_view state;
+  /// The issuer identifier of the authorization server (RFC 9207 Section 2).
+  std::string_view iss;
+  /// The error code of a failure response (RFC 6749 Section 4.1.2.1).
+  std::string_view error;
+};
+
+/// @ingroup oauth
+/// Parse the query of an authorization response (RFC 6749 Section 4.1.2) into
+/// the result, returning whether the query is well formed. Each recognized
+/// value is form-decoded (RFC 6749 Appendix B), borrowing from the input when
+/// it carries no escape and otherwise from the storage arena, which the caller
+/// owns and which is reused across parses. A duplicated recognized parameter is
+/// a failure, and an unrecognized parameter is ignored. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+/// #include <string>
+///
+/// std::string storage;
+/// sourcemeta::core::OAuthAuthorizationResponse response;
+/// assert(sourcemeta::core::oauth_parse_authorization_response(
+///     "code=SplxlOBeZQQYbYS6WxSbIA&state=xyz", storage, response));
+/// assert(response.code == "SplxlOBeZQQYbYS6WxSbIA");
+/// assert(response.state == "xyz");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_parse_authorization_response(const std::string_view query,
+                                        std::string &storage,
+                                        OAuthAuthorizationResponse &result)
+    -> bool;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_authorization.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_authorization.h
@@ -121,6 +121,12 @@ struct OAuthAuthorizationResponse {
   std::string_view iss;
   /// The error code of a failure response (RFC 6749 Section 4.1.2.1).
   std::string_view error;
+  /// The human-readable error description of a failure response (RFC 6749
+  /// Section 4.1.2.1).
+  std::string_view error_description;
+  /// The URI of a human-readable error page for a failure response (RFC 6749
+  /// Section 4.1.2.1).
+  std::string_view error_uri;
 };
 
 /// @ingroup oauth

--- a/src/core/oauth/include/sourcemeta/core/oauth_client_authentication.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_client_authentication.h
@@ -1,0 +1,75 @@
+#ifndef SOURCEMETA_CORE_OAUTH_CLIENT_AUTHENTICATION_H_
+#define SOURCEMETA_CORE_OAUTH_CLIENT_AUTHENTICATION_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/crypto.h>
+
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// Append an HTTP `Basic` authentication credential (RFC 6749 Section 2.3.1) to
+/// the sink, for use as an `Authorization` header value. The client identifier
+/// and secret are each percent-encoded, joined with a colon, and Base64
+/// encoded. The credential is secret, so the sink is a wiping string, and it is
+/// appended to and never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString header;
+/// sourcemeta::core::oauth_client_secret_basic("s6BhdRkqt3", "gX1fBat3bV",
+///                                             header);
+/// assert(header == "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_client_secret_basic(const std::string_view client_id,
+                               const std::string_view client_secret,
+                               SecureString &sink) -> void;
+
+/// @ingroup oauth
+/// Append the `client_secret_post` client authentication parameters (RFC 6749
+/// Section 2.3.1) to a token request body. Both the identifier and the secret
+/// are emitted, so this composes into the same sink as a grant builder. The
+/// body carries a secret, so the sink is a wiping string, and it is appended to
+/// and never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_client_secret_post("id", "secret", body);
+/// assert(body == "client_id=id&client_secret=secret");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_client_secret_post(const std::string_view client_id,
+                              const std::string_view client_secret,
+                              SecureString &sink) -> void;
+
+/// @ingroup oauth
+/// Append a public client identification parameter (RFC 6749 Section 3.2.1) to
+/// a token request body, emitting the identifier alone with no secret. This
+/// composes into the same sink as a grant builder. The sink is appended to and
+/// never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_client_id_only("s6BhdRkqt3", body);
+/// assert(body == "client_id=s6BhdRkqt3");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_client_id_only(const std::string_view client_id, SecureString &sink)
+    -> void;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
@@ -67,11 +67,13 @@ auto oauth_well_known_url(const std::string_view identifier,
 /// An authorization server metadata document (RFC 8414), owning its JSON. The
 /// document is validated on construction against the issuer it was retrieved
 /// for: the issuer must match by exact code points and be a valid issuer
-/// identifier, `response_types_supported` must be present, and an
-/// authentication method that needs a signing algorithm list must carry one
-/// without `none`. Accessors apply the specification defaults, and any member
-/// without a typed accessor is reachable through the underlying document. For
-/// example:
+/// identifier, `response_types_supported` must be present and non-empty, and an
+/// authentication method that needs a signing algorithm list must carry a
+/// non-empty one without `none`. Accessors apply the specification defaults,
+/// and any member without a typed accessor is reachable through the underlying
+/// document. A string accessor returns a view into the owned document, valid
+/// for the lifetime of this object, so a view taken before the object is moved
+/// from must not be used afterward. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>

--- a/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
@@ -1,0 +1,167 @@
+#ifndef SOURCEMETA_CORE_OAUTH_METADATA_H_
+#define SOURCEMETA_CORE_OAUTH_METADATA_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/json.h>
+
+#include <cstdint>     // std::uint8_t
+#include <optional>    // std::optional
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// The kind of metadata document a well-known URL points at, which selects the
+/// suffix and whether it is inserted before the path or appended after it.
+enum class OAuthWellKnownKind : std::uint8_t {
+  /// The `oauth-authorization-server` document, inserted before the path
+  /// (RFC 8414 Section 3).
+  AuthorizationServer,
+  /// The `oauth-protected-resource` document, inserted before the path
+  /// (RFC 9728 Section 3).
+  ProtectedResource,
+  /// The `openid-configuration` document, inserted before the path (RFC 8414
+  /// Section 5).
+  OpenIDConfigurationInserted,
+  /// The `openid-configuration` document, appended after the path, the legacy
+  /// OpenID Connect Discovery form (RFC 8414 Section 5).
+  OpenIDConfigurationAppended
+};
+
+/// @ingroup oauth
+/// Derive a metadata well-known URL from an identifier and append it to the
+/// sink, returning whether the identifier is well formed (RFC 8414 Section 3,
+/// RFC 9728 Section 3). The identifier must use the `https` scheme and carry no
+/// fragment, and no query unless it is a protected resource. A terminating
+/// slash on the path is removed, and for the inserted kinds the well-known
+/// string is placed between the host and the path, preserving a protected
+/// resource query after it. The sink is appended to and never cleared. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+/// #include <string>
+///
+/// std::string url;
+/// assert(sourcemeta::core::oauth_well_known_url(
+///     "https://example.com/issuer1",
+///     sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+/// assert(url ==
+///        "https://example.com/.well-known/oauth-authorization-server/issuer1");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_well_known_url(const std::string_view identifier,
+                          const OAuthWellKnownKind kind, std::string &sink)
+    -> bool;
+
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+
+/// @ingroup oauth
+/// An authorization server metadata document (RFC 8414), owning its JSON. The
+/// document is validated on construction against the issuer it was retrieved
+/// for: the issuer must match by exact code points and be a valid issuer
+/// identifier, `response_types_supported` must be present, and an
+/// authentication method that needs a signing algorithm list must carry one
+/// without `none`. Accessors apply the specification defaults, and any member
+/// without a typed accessor is reachable through the underlying document. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+///
+/// auto document{sourcemeta::core::parse_json(
+///     R"JSON({"issuer":"https://example.com",
+///            "response_types_supported":["code"],
+///            "authorization_endpoint":"https://example.com/authorize",
+///            "token_endpoint":"https://example.com/token"})JSON")};
+/// const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+///     std::move(document), "https://example.com")};
+/// assert(metadata.has_value());
+/// assert(metadata.value().token_endpoint().value() ==
+///        "https://example.com/token");
+/// ```
+class SOURCEMETA_CORE_OAUTH_EXPORT OAuthServerMetadata {
+public:
+  /// Construct and validate a metadata document for an expected issuer,
+  /// throwing when it is invalid. The document is moved in.
+  OAuthServerMetadata(JSON &&data, const std::string_view issuer);
+
+  /// Construct and validate a metadata document for an expected issuer,
+  /// returning no value when it is invalid. The document is moved in.
+  [[nodiscard]] static auto from(JSON &&data, const std::string_view issuer)
+      -> std::optional<OAuthServerMetadata>;
+
+  /// The issuer identifier (RFC 8414 Section 2).
+  [[nodiscard]] auto issuer() const -> std::string_view;
+
+  /// The authorization endpoint (RFC 8414 Section 2).
+  [[nodiscard]] auto authorization_endpoint() const
+      -> std::optional<std::string_view>;
+
+  /// The token endpoint (RFC 8414 Section 2).
+  [[nodiscard]] auto token_endpoint() const -> std::optional<std::string_view>;
+
+  /// The dynamic client registration endpoint (RFC 8414 Section 2).
+  [[nodiscard]] auto registration_endpoint() const
+      -> std::optional<std::string_view>;
+
+  /// The token revocation endpoint (RFC 8414 Section 2).
+  [[nodiscard]] auto revocation_endpoint() const
+      -> std::optional<std::string_view>;
+
+  /// The token introspection endpoint (RFC 8414 Section 2).
+  [[nodiscard]] auto introspection_endpoint() const
+      -> std::optional<std::string_view>;
+
+  /// The JWK Set document location (RFC 8414 Section 2).
+  [[nodiscard]] auto jwks_uri() const -> std::optional<std::string_view>;
+
+  /// Whether the server signs authorization responses with an `iss` parameter,
+  /// defaulting to false when absent (RFC 9207 Section 3).
+  [[nodiscard]] auto authorization_response_iss_parameter_supported() const
+      -> bool;
+
+  /// Whether a response type is supported (RFC 8414 Section 2).
+  [[nodiscard]] auto supports_response_type(const std::string_view value) const
+      -> bool;
+
+  /// Whether a grant type is supported, defaulting to the authorization code
+  /// and implicit grants when absent (RFC 8414 Section 2).
+  [[nodiscard]] auto supports_grant_type(const std::string_view value) const
+      -> bool;
+
+  /// Whether a PKCE code challenge method is supported, defaulting to none when
+  /// absent since an omitted list means PKCE is unsupported (RFC 8414
+  /// Section 2).
+  [[nodiscard]] auto
+  supports_code_challenge_method(const std::string_view value) const -> bool;
+
+  /// Whether a token endpoint authentication method is supported, defaulting to
+  /// `client_secret_basic` when absent (RFC 8414 Section 2).
+  [[nodiscard]] auto
+  supports_token_endpoint_auth_method(const std::string_view value) const
+      -> bool;
+
+  /// The underlying document, for reaching members without a typed accessor.
+  [[nodiscard]] auto data() const -> const JSON &;
+
+private:
+  JSON data_;
+};
+
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_metadata_provider.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_metadata_provider.h
@@ -27,7 +27,11 @@ namespace sourcemeta::core {
 /// document through an injected transport, and caches it with a freshness-aware
 /// refresh. It is meant to be constructed once per issuer at startup, since a
 /// per-request instance defeats the caching. Reads take a snapshot, so a
-/// returned document is immune to a concurrent refresh. For example:
+/// returned document is immune to a concurrent refresh. The kind must be an
+/// authorization server kind, either `AuthorizationServer` or an OpenID Connect
+/// configuration form, since a protected resource document is not an
+/// authorization server metadata document and would never validate. For
+/// example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>
@@ -72,7 +76,9 @@ public:
   /// test.
   using Clock = std::function<std::chrono::system_clock::time_point()>;
 
-  /// Tunables for the caching policy.
+  /// Tunables for the caching policy. The `minimum_ttl` must not exceed the
+  /// `maximum_ttl`, since an advertised lifetime is clamped low first then
+  /// high.
   struct Options {
     /// The lifetime to assume when the transport advertises none.
     std::chrono::seconds fallback_ttl{std::chrono::hours{1}};

--- a/src/core/oauth/include/sourcemeta/core/oauth_metadata_provider.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_metadata_provider.h
@@ -1,0 +1,138 @@
+#ifndef SOURCEMETA_CORE_OAUTH_METADATA_PROVIDER_H_
+#define SOURCEMETA_CORE_OAUTH_METADATA_PROVIDER_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/oauth_metadata.h>
+
+#include <chrono>      // std::chrono::seconds, std::chrono::system_clock
+#include <functional>  // std::function
+#include <memory>      // std::shared_ptr
+#include <mutex>       // std::mutex
+#include <optional>    // std::optional
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+
+/// @ingroup oauth
+/// A long-lived, cached resolver of authorization server metadata (RFC 8414).
+/// It derives the well-known URL from an issuer, retrieves and validates the
+/// document through an injected transport, and caches it with a freshness-aware
+/// refresh. It is meant to be constructed once per issuer at startup, since a
+/// per-request instance defeats the caching. Reads take a snapshot, so a
+/// returned document is immune to a concurrent refresh. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <optional>
+///
+/// sourcemeta::core::OAuthMetadataProvider provider{
+///     "https://example.com",
+///     sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+///     [](std::string_view) -> std::optional<
+///         sourcemeta::core::OAuthMetadataProvider::FetchResult> {
+///       return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+///           .body =
+///               R"JSON({"issuer":"https://example.com",
+///                      "response_types_supported":["code"]})JSON",
+///           .max_age = std::nullopt};
+///     }};
+/// const auto metadata{provider.metadata()};
+/// ```
+class SOURCEMETA_CORE_OAUTH_EXPORT OAuthMetadataProvider {
+public:
+  /// The outcome of one metadata retrieval. The freshness hint is kept separate
+  /// from the body because only the caller that made the request can observe
+  /// the caching response header. An absent hint means no lifetime was
+  /// advertised, which is distinct from an advertised lifetime of zero.
+  struct FetchResult {
+    /// The raw metadata bytes.
+    std::string body;
+    /// The advertised freshness lifetime, absent when none was given.
+    std::optional<std::chrono::seconds> max_age;
+  };
+
+  /// A pluggable transport that turns a URL into raw metadata bytes plus an
+  /// optional freshness hint. Returns no value on a failed retrieval, such as a
+  /// transport error, an unsuccessful response, or an oversized body. Injecting
+  /// the transport keeps this module free of any networking dependency and
+  /// makes the provider substitutable for testing.
+  using Fetcher =
+      std::function<std::optional<FetchResult>(std::string_view url)>;
+
+  /// A source of the current time, defaulting to the system clock and existing
+  /// as an injection point so the refresh can be driven deterministically under
+  /// test.
+  using Clock = std::function<std::chrono::system_clock::time_point()>;
+
+  /// Tunables for the caching policy.
+  struct Options {
+    /// The lifetime to assume when the transport advertises none.
+    std::chrono::seconds fallback_ttl{std::chrono::hours{1}};
+    /// The shortest lifetime honored, clamping smaller advertised values up.
+    std::chrono::seconds minimum_ttl{std::chrono::minutes{5}};
+    /// The longest lifetime honored, clamping larger advertised values down.
+    std::chrono::seconds maximum_ttl{std::chrono::hours{24}};
+  };
+
+  /// Construct a provider for an issuer with an injected transport, using the
+  /// default policy and the system clock.
+  OAuthMetadataProvider(std::string issuer, const OAuthWellKnownKind kind,
+                        Fetcher fetcher);
+  /// Construct a provider overriding the caching policy.
+  OAuthMetadataProvider(std::string issuer, const OAuthWellKnownKind kind,
+                        Fetcher fetcher, Options options);
+  /// Construct a provider overriding the policy and the clock.
+  OAuthMetadataProvider(std::string issuer, const OAuthWellKnownKind kind,
+                        Fetcher fetcher, Options options, Clock clock);
+
+  /// The provider owns a lock guarding its cache, so it is neither copyable nor
+  /// movable. Store it behind a pointer or construct it in place.
+  OAuthMetadataProvider(const OAuthMetadataProvider &) = delete;
+  auto operator=(const OAuthMetadataProvider &)
+      -> OAuthMetadataProvider & = delete;
+  OAuthMetadataProvider(OAuthMetadataProvider &&) = delete;
+  auto operator=(OAuthMetadataProvider &&) -> OAuthMetadataProvider & = delete;
+
+  /// The cached metadata, retrieving it on the first call and refreshing it
+  /// once its freshness lifetime has elapsed. A failed refresh keeps serving
+  /// the last good document, and no value is returned only when the document
+  /// has never been retrieved successfully. The result is a snapshot immune to
+  /// a concurrent refresh.
+  [[nodiscard]] auto metadata() -> std::shared_ptr<const OAuthServerMetadata>;
+
+  /// Force an immediate retrieval regardless of freshness, serving the RFC 9728
+  /// Section 5.2 recommendation to re-retrieve on a challenge. A failed
+  /// retrieval keeps the last good document.
+  [[nodiscard]] auto refresh() -> std::shared_ptr<const OAuthServerMetadata>;
+
+private:
+  auto install_locked(const OAuthWellKnownKind kind,
+                      const std::chrono::system_clock::time_point now) -> bool;
+  auto fetch_and_install_locked(const std::chrono::system_clock::time_point now)
+      -> bool;
+
+  const std::string issuer_;
+  const OAuthWellKnownKind kind_;
+  const Fetcher fetcher_;
+  const Options options_;
+  const Clock clock_;
+  std::mutex mutex_;
+  std::shared_ptr<const OAuthServerMetadata> metadata_;
+  std::chrono::system_clock::time_point next_refresh_{};
+};
+
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_random.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_random.h
@@ -1,0 +1,33 @@
+#ifndef SOURCEMETA_CORE_OAUTH_RANDOM_H_
+#define SOURCEMETA_CORE_OAUTH_RANDOM_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <array> // std::array
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// Mint a random token, the base64url encoding of 32 cryptographically random
+/// octets, for an unguessable but non-confidential value such as a `state` or
+/// `nonce` (RFC 6749 Section 10.10). The 43 bytes are not null terminated, so
+/// pass them onward as a view of `data()` and `size()` rather than as a C
+/// string. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+/// #include <string_view>
+///
+/// const auto token{sourcemeta::core::oauth_random_token()};
+/// const std::string_view view{token.data(), token.size()};
+/// assert(view.size() == 43);
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_random_token() -> std::array<char, 43>;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_token.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_token.h
@@ -1,0 +1,149 @@
+#ifndef SOURCEMETA_CORE_OAUTH_TOKEN_H_
+#define SOURCEMETA_CORE_OAUTH_TOKEN_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth_authorization.h>
+
+#include <chrono>      // std::chrono::seconds
+#include <optional>    // std::optional
+#include <span>        // std::span
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// Append an authorization code grant token request body (RFC 6749
+/// Section 4.1.3) to the sink. The `code` is required, the `redirect_uri` is
+/// emitted only when the authorization request carried one, and the
+/// `code_verifier` is emitted only when PKCE is in use (RFC 7636 Section 4.5).
+/// No `client_id` is emitted, so the caller composes a client authentication
+/// builder into the same sink. The body carries secrets, so the sink is a
+/// wiping string, and it is appended to and never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_build_token_request_code(
+///     "SplxlOBeZQQYbYS6WxSbIA", "https://client.example/cb", "", {}, body);
+/// assert(body == "grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA"
+///                "&redirect_uri=https%3A%2F%2Fclient.example%2Fcb");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_token_request_code(
+    const std::string_view code, const std::string_view redirect_uri,
+    const std::string_view code_verifier,
+    const std::span<const OAuthParameter> resources, SecureString &sink)
+    -> void;
+
+/// @ingroup oauth
+/// Append a refresh token grant token request body (RFC 6749 Section 6) to the
+/// sink. The `refresh_token` is required, and the requested `scope` is emitted
+/// only when present and must not exceed the original grant. No `client_id` is
+/// emitted, so the caller composes a client authentication builder into the
+/// same sink. The body carries secrets, so the sink is a wiping string, and it
+/// is appended to and never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_build_token_request_refresh("tGzv3JOkF0XG5Qx2TlKWIA",
+///                                                     "read", {}, body);
+/// assert(body == "grant_type=refresh_token"
+///                "&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA&scope=read");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_token_request_refresh(
+    const std::string_view refresh_token, const std::string_view scope,
+    const std::span<const OAuthParameter> resources, SecureString &sink)
+    -> void;
+
+/// @ingroup oauth
+/// Append a client credentials grant token request body (RFC 6749
+/// Section 4.4.2) to the sink. The requested `scope` is emitted only when
+/// present. No `client_id` is emitted, so the caller composes a client
+/// authentication builder into the same sink. The sink is appended to and never
+/// cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_build_token_request_client_credentials("read", {},
+///                                                                body);
+/// assert(body == "grant_type=client_credentials&scope=read");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_token_request_client_credentials(
+    const std::string_view scope,
+    const std::span<const OAuthParameter> resources, SecureString &sink)
+    -> void;
+
+/// @ingroup oauth
+/// A non-owning view over a token endpoint success response (RFC 6749
+/// Section 5.1) held in a caller-owned JSON value. The value must outlive the
+/// view, and the token accessors return views into it, which are secret and
+/// must not be logged. Extension members such as an OpenID Connect `id_token`
+/// are reached through the underlying document. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+///
+/// const auto document{sourcemeta::core::parse_json(
+///     R"JSON({"access_token":"2YotnFZFEjr1zCsicMWpAA","token_type":"Bearer",
+///            "expires_in":3600})JSON")};
+/// const sourcemeta::core::OAuthTokenResponse response{document};
+/// assert(response.is_bearer_token_type());
+/// assert(response.access_token().value() == "2YotnFZFEjr1zCsicMWpAA");
+/// ```
+class SOURCEMETA_CORE_OAUTH_EXPORT OAuthTokenResponse {
+public:
+  /// Construct a view over a token response document, which is borrowed.
+  explicit OAuthTokenResponse(const JSON &data);
+
+  /// The issued access token (RFC 6749 Section 5.1), or no value when absent.
+  [[nodiscard]] auto access_token() const -> std::optional<std::string_view>;
+
+  /// The access token type (RFC 6749 Section 5.1), or no value when absent.
+  [[nodiscard]] auto token_type() const -> std::optional<std::string_view>;
+
+  /// Whether the token type is `Bearer`, matched case insensitively (RFC 6749
+  /// Section 5.1).
+  [[nodiscard]] auto is_bearer_token_type() const -> bool;
+
+  /// The access token lifetime in seconds (RFC 6749 Section 5.1), or no value
+  /// when absent or not a non-negative integer.
+  [[nodiscard]] auto expires_in() const -> std::optional<std::chrono::seconds>;
+
+  /// The issued refresh token (RFC 6749 Section 5.1), or no value when absent.
+  [[nodiscard]] auto refresh_token() const -> std::optional<std::string_view>;
+
+  /// The granted scope (RFC 6749 Section 5.1), or no value when absent.
+  [[nodiscard]] auto scope() const -> std::optional<std::string_view>;
+
+  /// Whether the granted scope contains a value, comparing the space-delimited
+  /// unordered set (RFC 6749 Section 3.3).
+  [[nodiscard]] auto has_scope(const std::string_view value) const -> bool;
+
+  /// The underlying document, for reaching extension members such as an OpenID
+  /// Connect `id_token`.
+  [[nodiscard]] auto data() const -> const JSON &;
+
+private:
+  const JSON *data_;
+};
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_transaction.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_transaction.h
@@ -15,8 +15,9 @@
 namespace sourcemeta::core {
 
 /// @ingroup oauth
-/// The secrets minted for one authorization code flow, each the base64url of 32
-/// random octets. Both are secret and are serialized by the caller, such as
+/// The secrets minted for one authorization code flow, each the base64url
+/// encoding of 32 random octets. Both are secret and are serialized by the
+/// caller, such as
 /// into a sealed cookie, and wiped once the flow completes. The 43 bytes of
 /// each are not null terminated.
 struct OAuthTransactionSecrets {
@@ -97,11 +98,13 @@ auto oauth_transaction_mint() -> OAuthTransactionSecrets;
 /// state in constant time, the received URI when one is supplied, the issuer,
 /// whether the server declined, and finally the presence of a code. Pass an
 /// empty `received_uri` to skip that check. The state check always defends
-/// against cross-site request forgery, but mix-up defense (RFC 9207) needs at
-/// least one of a non-empty `received_uri` or an `issuer_support` other than
-/// `NotSupported`, so a caller talking to more than one authorization server
-/// must supply one of them (RFC 8252 Section 8.10, RFC 9207 Section 2.4). For
-/// example:
+/// against cross-site request forgery. Guaranteed mix-up defense needs a
+/// non-empty `received_uri` (RFC 8252 Section 8.10) or an `issuer_support` of
+/// `Supported`, which makes a missing `iss` fatal (RFC 9207 Section 2.4). With
+/// `Unknown` the `iss` is validated only when present, so a server that omits
+/// it is not caught, and with `NotSupported` it is ignored entirely. A caller
+/// talking to more than one authorization server must therefore supply one of
+/// those two. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>

--- a/src/core/oauth/include/sourcemeta/core/oauth_transaction.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_transaction.h
@@ -1,0 +1,134 @@
+#ifndef SOURCEMETA_CORE_OAUTH_TRANSACTION_H_
+#define SOURCEMETA_CORE_OAUTH_TRANSACTION_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/oauth_authorization.h>
+
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <optional>    // std::optional
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// The secrets minted for one authorization code flow, each the base64url of 32
+/// random octets. Both are secret and are serialized by the caller, such as
+/// into a sealed cookie, and wiped once the flow completes. The 43 bytes of
+/// each are not null terminated.
+struct OAuthTransactionSecrets {
+  /// The cross-site request forgery token (RFC 6749 Section 10.12).
+  std::array<char, 43> state;
+  /// The PKCE code verifier (RFC 7636 Section 4.1).
+  std::array<char, 43> code_verifier;
+};
+
+/// @ingroup oauth
+/// A non-owning view of the state a client retains between an authorization
+/// request and its callback. Every field borrows from the caller and must
+/// outlive any use of this struct.
+struct OAuthTransaction {
+  /// The state sent with the request, compared against the callback.
+  std::string_view state;
+  /// The PKCE code verifier, carried through to the token request.
+  std::string_view code_verifier;
+  /// The issuer identifier the request was sent to (RFC 9207 Section 2).
+  std::string_view issuer;
+  /// The redirection URI the request was sent with (RFC 8252 Section 8.10).
+  std::string_view redirect_uri;
+};
+
+/// @ingroup oauth
+/// Whether the authorization server is known to support the `iss` response
+/// parameter (RFC 9207 Section 2.4). This governs how a callback missing `iss`
+/// is treated.
+enum class OAuthIssuerSupport : std::uint8_t {
+  /// The server supports `iss`, so a callback missing it is rejected.
+  Supported,
+  /// The server is known not to support `iss`, so a present `iss` is ignored.
+  NotSupported,
+  /// Support is unknown, so `iss` is validated only when present.
+  Unknown
+};
+
+/// @ingroup oauth
+/// The reason a callback was rejected, in the order the checks run. The first
+/// failing check decides the outcome (RFC 9700 Section 4).
+enum class OAuthCallbackError : std::uint8_t {
+  /// The state is missing or does not match, a possible cross-site request
+  /// forgery (RFC 6749 Section 10.12).
+  State,
+  /// The callback arrived on a URI other than the one the request was sent with
+  /// (RFC 8252 Section 8.10).
+  ReceivedURI,
+  /// The `iss` is missing when required or does not match the expected issuer,
+  /// a possible mix-up attack (RFC 9207 Section 2.4).
+  Issuer,
+  /// The authorization server returned an error rather than a code (RFC 6749
+  /// Section 4.1.2.1).
+  Declined,
+  /// The response carries neither an error nor a code.
+  MissingCode
+};
+
+/// @ingroup oauth
+/// Mint the secrets for a new authorization code flow, a random `state` and a
+/// PKCE code verifier (RFC 7636 Section 4.1, RFC 6749 Section 10.12). For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// const auto secrets{sourcemeta::core::oauth_transaction_mint()};
+/// assert(secrets.state.size() == 43);
+/// assert(secrets.code_verifier.size() == 43);
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_transaction_mint() -> OAuthTransactionSecrets;
+
+/// @ingroup oauth
+/// Validate an authorization response against the retained transaction,
+/// returning the authorization code through `code` on success or the first
+/// failing check otherwise (RFC 9700 Section 4). The checks run in order: the
+/// state in constant time, the received URI when one is supplied, the issuer,
+/// whether the server declined, and finally the presence of a code. Pass an
+/// empty `received_uri` to skip that check. The state check always defends
+/// against cross-site request forgery, but mix-up defense (RFC 9207) needs at
+/// least one of a non-empty `received_uri` or an `issuer_support` other than
+/// `NotSupported`, so a caller talking to more than one authorization server
+/// must supply one of them (RFC 8252 Section 8.10, RFC 9207 Section 2.4). For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+/// #include <string>
+///
+/// std::string storage;
+/// sourcemeta::core::OAuthAuthorizationResponse response;
+/// sourcemeta::core::oauth_parse_authorization_response(
+///     "code=SplxlOBeZQQYbYS6WxSbIA&state=xyz", storage, response);
+/// const sourcemeta::core::OAuthTransaction transaction{
+///     .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+/// std::string_view code;
+/// const auto error{sourcemeta::core::oauth_transaction_check(
+///     transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
+///     "", code)};
+/// assert(!error.has_value());
+/// assert(code == "SplxlOBeZQQYbYS6WxSbIA");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_transaction_check(const OAuthTransaction &transaction,
+                             const OAuthAuthorizationResponse &response,
+                             const OAuthIssuerSupport issuer_support,
+                             const std::string_view received_uri,
+                             std::string_view &code)
+    -> std::optional<OAuthCallbackError>;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/oauth_authorization.cc
+++ b/src/core/oauth/oauth_authorization.cc
@@ -113,6 +113,8 @@ auto oauth_parse_authorization_response(const std::string_view query,
   bool has_state{false};
   bool has_iss{false};
   bool has_error{false};
+  bool has_error_description{false};
+  bool has_error_uri{false};
   for (const auto &parameter : parsed) {
     const auto name{parameter.first};
     const auto value{parameter.second};
@@ -153,6 +155,24 @@ auto oauth_parse_authorization_response(const std::string_view query,
 
       has_error = true;
       if (!oauth_form_decode_into(value, storage, result.error)) {
+        return false;
+      }
+    } else if (name == "error_description") {
+      if (has_error_description) {
+        return false;
+      }
+
+      has_error_description = true;
+      if (!oauth_form_decode_into(value, storage, result.error_description)) {
+        return false;
+      }
+    } else if (name == "error_uri") {
+      if (has_error_uri) {
+        return false;
+      }
+
+      has_error_uri = true;
+      if (!oauth_form_decode_into(value, storage, result.error_uri)) {
         return false;
       }
     }

--- a/src/core/oauth/oauth_authorization.cc
+++ b/src/core/oauth/oauth_authorization.cc
@@ -1,0 +1,164 @@
+#include <sourcemeta/core/oauth_authorization.h>
+
+#include <sourcemeta/core/uri.h>
+
+#include "oauth_decode.h"
+
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+namespace {
+
+auto oauth_append_parameter(std::string &sink, char &separator,
+                            const std::string_view name,
+                            const std::string_view value) -> void {
+  if (separator != '\0') {
+    sink.push_back(separator);
+  }
+
+  separator = '&';
+  // RFC 6749 Section 4.1.1: the query is application/x-www-form-urlencoded, so
+  // the name is escaped too, which is a no-op for the fixed keys but keeps a
+  // caller-supplied resource or extra name from corrupting the query
+  URI::escape(name, sink);
+  sink.push_back('=');
+  URI::escape(value, sink);
+}
+
+} // namespace
+
+auto oauth_build_authorization_url(const std::string_view endpoint,
+                                   const OAuthAuthorizationRequest &request,
+                                   std::string &sink) -> void {
+  // A lower bound covering the endpoint, the known keys and separators, and the
+  // raw value lengths, over which percent-escaping only ever grows
+  sink.reserve(sink.size() + endpoint.size() + request.client_id.size() +
+               request.redirect_uri.size() + request.scope.size() +
+               request.state.size() + request.code_challenge.size() +
+               request.code_challenge_method.size() +
+               request.request_uri.size() + request.dpop_jkt.size() + 128);
+  sink.append(endpoint);
+  // The separator before the first parameter: '?' opens a query the endpoint
+  // lacks, nothing when the endpoint already ends its query with '?' or '&',
+  // and '&' continues an existing query (RFC 6749 Section 3.1)
+  char separator{'?'};
+  if (endpoint.find('?') != std::string_view::npos) {
+    separator =
+        (endpoint.empty() || endpoint.back() == '?' || endpoint.back() == '&')
+            ? '\0'
+            : '&';
+  }
+
+  // RFC 6749 Section 4.1.1: the authorization code flow is the only response
+  // type this builder emits, since the implicit grant is not represented
+  oauth_append_parameter(sink, separator, "response_type", "code");
+
+  if (!request.client_id.empty()) {
+    oauth_append_parameter(sink, separator, "client_id", request.client_id);
+  }
+
+  if (!request.redirect_uri.empty()) {
+    oauth_append_parameter(sink, separator, "redirect_uri",
+                           request.redirect_uri);
+  }
+
+  if (!request.scope.empty()) {
+    oauth_append_parameter(sink, separator, "scope", request.scope);
+  }
+
+  if (!request.state.empty()) {
+    oauth_append_parameter(sink, separator, "state", request.state);
+  }
+
+  if (!request.code_challenge.empty()) {
+    oauth_append_parameter(sink, separator, "code_challenge",
+                           request.code_challenge);
+    // RFC 7636 Section 4.3: the method qualifies a challenge, so it is
+    // meaningless and omitted when no challenge is present
+    if (!request.code_challenge_method.empty()) {
+      oauth_append_parameter(sink, separator, "code_challenge_method",
+                             request.code_challenge_method);
+    }
+  }
+
+  if (!request.request_uri.empty()) {
+    oauth_append_parameter(sink, separator, "request_uri", request.request_uri);
+  }
+
+  if (!request.dpop_jkt.empty()) {
+    oauth_append_parameter(sink, separator, "dpop_jkt", request.dpop_jkt);
+  }
+
+  for (const auto &resource : request.resources) {
+    oauth_append_parameter(sink, separator, resource.name, resource.value);
+  }
+
+  for (const auto &parameter : request.extra) {
+    oauth_append_parameter(sink, separator, parameter.name, parameter.value);
+  }
+}
+
+auto oauth_parse_authorization_response(const std::string_view query,
+                                        std::string &storage,
+                                        OAuthAuthorizationResponse &result)
+    -> bool {
+  result = {};
+  // A single up-front reserve keeps every later decode from reallocating the
+  // arena and dangling an earlier borrowed view (design convention 1)
+  storage.reserve(storage.size() + query.size());
+  const URI::Query parsed{query};
+  bool has_code{false};
+  bool has_state{false};
+  bool has_iss{false};
+  bool has_error{false};
+  for (const auto &parameter : parsed) {
+    const auto name{parameter.first};
+    const auto value{parameter.second};
+    // RFC 6749 Section 3.1: "Request and response parameters MUST NOT be
+    // included more than once", so a duplicate is malformed, while an
+    // unrecognized parameter is ignored (RFC 6749 Section 4.1.2)
+    if (name == "code") {
+      if (has_code) {
+        return false;
+      }
+
+      has_code = true;
+      if (!oauth_form_decode_into(value, storage, result.code)) {
+        return false;
+      }
+    } else if (name == "state") {
+      if (has_state) {
+        return false;
+      }
+
+      has_state = true;
+      if (!oauth_form_decode_into(value, storage, result.state)) {
+        return false;
+      }
+    } else if (name == "iss") {
+      if (has_iss) {
+        return false;
+      }
+
+      has_iss = true;
+      if (!oauth_form_decode_into(value, storage, result.iss)) {
+        return false;
+      }
+    } else if (name == "error") {
+      if (has_error) {
+        return false;
+      }
+
+      has_error = true;
+      if (!oauth_form_decode_into(value, storage, result.error)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_client_authentication.cc
+++ b/src/core/oauth/oauth_client_authentication.cc
@@ -1,0 +1,40 @@
+#include <sourcemeta/core/oauth_client_authentication.h>
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/uri.h>
+
+#include "oauth_encode.h"
+
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto oauth_client_secret_basic(const std::string_view client_id,
+                               const std::string_view client_secret,
+                               SecureString &sink) -> void {
+  // RFC 6749 Section 2.3.1: each half is percent-encoded before it is joined
+  // with a colon, so a colon inside the identifier or secret cannot be mistaken
+  // for the delimiter, and only then is the pair Base64 encoded
+  SecureString credential;
+  credential.reserve(client_id.size() + client_secret.size() + 1);
+  URI::escape(client_id, credential);
+  credential.push_back(':');
+  URI::escape(client_secret, credential);
+
+  sink.append("Basic ");
+  base64_encode(std::string_view{credential}, sink);
+}
+
+auto oauth_client_secret_post(const std::string_view client_id,
+                              const std::string_view client_secret,
+                              SecureString &sink) -> void {
+  oauth_append_form_parameter(sink, "client_id", client_id);
+  oauth_append_form_parameter(sink, "client_secret", client_secret);
+}
+
+auto oauth_client_id_only(const std::string_view client_id, SecureString &sink)
+    -> void {
+  oauth_append_form_parameter(sink, "client_id", client_id);
+}
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_decode.h
+++ b/src/core/oauth/oauth_decode.h
@@ -26,8 +26,14 @@ inline auto oauth_form_decode_into(const std::string_view value,
 
   // The caller must have reserved enough headroom for the raw value, since
   // decoding only shrinks, so this append never reallocates and a prior
-  // borrowed view into the arena stays valid
+  // borrowed view into the arena stays valid. The assert catches a violation
+  // loudly under test, and the guard fails closed rather than dangle a view if
+  // the contract is ever broken in a release build
   assert(arena.capacity() - arena.size() >= value.size());
+  if (arena.capacity() - arena.size() < value.size()) {
+    return false;
+  }
+
   const auto base{arena.size()};
   if (!URI::unescape_form(value, arena)) {
     return false;

--- a/src/core/oauth/oauth_decode.h
+++ b/src/core/oauth/oauth_decode.h
@@ -1,0 +1,37 @@
+#ifndef SOURCEMETA_CORE_OAUTH_DECODE_H_
+#define SOURCEMETA_CORE_OAUTH_DECODE_H_
+
+#include <sourcemeta/core/uri.h>
+
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+// Decode one "application/x-www-form-urlencoded" value against the caller's
+// arena following design convention 1: borrow from the input when it carries no
+// escape, otherwise append the decoded bytes to the arena and view them there.
+// The arena MUST be reserved up front to at least the total raw length of every
+// value that will be decoded into it, since decoding only shrinks, so that no
+// append reallocates and a prior borrowed view into it stays valid. Reserving
+// the whole input length once satisfies this
+inline auto oauth_form_decode_into(const std::string_view value,
+                                   std::string &arena, std::string_view &result)
+    -> bool {
+  if (value.find_first_of("+%") == std::string_view::npos) {
+    result = value;
+    return true;
+  }
+
+  const auto base{arena.size()};
+  if (!URI::unescape_form(value, arena)) {
+    return false;
+  }
+
+  result = std::string_view{arena}.substr(base);
+  return true;
+}
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/oauth_decode.h
+++ b/src/core/oauth/oauth_decode.h
@@ -3,6 +3,7 @@
 
 #include <sourcemeta/core/uri.h>
 
+#include <cassert>     // assert
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -23,6 +24,10 @@ inline auto oauth_form_decode_into(const std::string_view value,
     return true;
   }
 
+  // The caller must have reserved enough headroom for the raw value, since
+  // decoding only shrinks, so this append never reallocates and a prior
+  // borrowed view into the arena stays valid
+  assert(arena.capacity() - arena.size() >= value.size());
   const auto base{arena.size()};
   if (!URI::unescape_form(value, arena)) {
     return false;

--- a/src/core/oauth/oauth_encode.h
+++ b/src/core/oauth/oauth_encode.h
@@ -1,0 +1,30 @@
+#ifndef SOURCEMETA_CORE_OAUTH_ENCODE_H_
+#define SOURCEMETA_CORE_OAUTH_ENCODE_H_
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/uri.h>
+
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+// Append one "application/x-www-form-urlencoded" parameter to a body under
+// construction, inserting the "&" separator only between parameters so that
+// grant and client authentication builders compose into one buffer. The name
+// and value are percent-encoded through the URI escaper into the wiping sink,
+// since the body carries secrets
+inline auto oauth_append_form_parameter(SecureString &sink,
+                                        const std::string_view name,
+                                        const std::string_view value) -> void {
+  if (!sink.empty() && sink.back() != '&') {
+    sink.push_back('&');
+  }
+
+  URI::escape(name, sink);
+  sink.push_back('=');
+  URI::escape(value, sink);
+}
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -1,0 +1,310 @@
+#include <sourcemeta/core/oauth_metadata.h>
+
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth_error.h>
+
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::move
+
+namespace sourcemeta::core {
+
+namespace {
+
+using namespace std::literals::string_view_literals;
+
+const auto HASH_ISSUER{JSON::Object::hash("issuer"sv)};
+const auto HASH_AUTHORIZATION_ENDPOINT{
+    JSON::Object::hash("authorization_endpoint"sv)};
+const auto HASH_TOKEN_ENDPOINT{JSON::Object::hash("token_endpoint"sv)};
+const auto HASH_REGISTRATION_ENDPOINT{
+    JSON::Object::hash("registration_endpoint"sv)};
+const auto HASH_REVOCATION_ENDPOINT{
+    JSON::Object::hash("revocation_endpoint"sv)};
+const auto HASH_INTROSPECTION_ENDPOINT{
+    JSON::Object::hash("introspection_endpoint"sv)};
+const auto HASH_JWKS_URI{JSON::Object::hash("jwks_uri"sv)};
+const auto HASH_RESPONSE_TYPES{
+    JSON::Object::hash("response_types_supported"sv)};
+const auto HASH_GRANT_TYPES{JSON::Object::hash("grant_types_supported"sv)};
+const auto HASH_CODE_CHALLENGE_METHODS{
+    JSON::Object::hash("code_challenge_methods_supported"sv)};
+const auto HASH_TOKEN_AUTH_METHODS{
+    JSON::Object::hash("token_endpoint_auth_methods_supported"sv)};
+const auto HASH_TOKEN_AUTH_ALGS{
+    JSON::Object::hash("token_endpoint_auth_signing_alg_values_supported"sv)};
+const auto HASH_ISS_SUPPORTED{
+    JSON::Object::hash("authorization_response_iss_parameter_supported"sv)};
+
+auto is_valid_issuer(const std::string_view issuer) -> bool {
+  // RFC 8414 Section 2: the issuer is an https URL with no query or fragment
+  static constexpr std::string_view scheme{"https://"};
+  return issuer.starts_with(scheme) && issuer.size() > scheme.size() &&
+         issuer.find('#') == std::string_view::npos &&
+         issuer.find('?') == std::string_view::npos;
+}
+
+auto string_member(const JSON &data, const JSON::StringView name,
+                   const JSON::Object::hash_type hash)
+    -> std::optional<std::string_view> {
+  if (!data.is_object()) {
+    return std::nullopt;
+  }
+
+  const auto *member{data.try_at(name, hash)};
+  if (member == nullptr || !member->is_string()) {
+    return std::nullopt;
+  }
+
+  return std::string_view{member->to_string()};
+}
+
+auto array_member_contains(const JSON &data, const JSON::StringView name,
+                           const JSON::Object::hash_type hash,
+                           const JSON::StringView value) -> bool {
+  if (!data.is_object()) {
+    return false;
+  }
+
+  const auto *member{data.try_at(name, hash)};
+  return member != nullptr && member->is_array() && member->contains(value);
+}
+
+auto validated_server_metadata(JSON &&data, const std::string_view issuer)
+    -> JSON {
+  if (!data.is_object()) {
+    throw OAuthMetadataParseError{};
+  }
+
+  const auto *issuer_member{data.try_at("issuer"sv, HASH_ISSUER)};
+  if (issuer_member == nullptr || !issuer_member->is_string()) {
+    throw OAuthMetadataParseError{};
+  }
+
+  // RFC 8414 Section 3.3: the issuer in the document must be identical by code
+  // points to the one the document was retrieved for, the impersonation defense
+  const auto issuer_value{std::string_view{issuer_member->to_string()}};
+  if (issuer_value != issuer || !is_valid_issuer(issuer_value)) {
+    throw OAuthMetadataParseError{};
+  }
+
+  // RFC 8414 Section 2: response_types_supported is REQUIRED, and Section 3.2:
+  // "Claims with zero elements MUST be omitted from the response", so a
+  // present but empty array is a malformed document
+  const auto *response_types{
+      data.try_at("response_types_supported"sv, HASH_RESPONSE_TYPES)};
+  if (response_types == nullptr || !response_types->is_array() ||
+      response_types->empty()) {
+    throw OAuthMetadataParseError{};
+  }
+
+  // RFC 8414 Section 2: a signing algorithm list is REQUIRED alongside the JWT
+  // authentication methods, and "none" MUST NOT appear in it
+  if (array_member_contains(data, "token_endpoint_auth_methods_supported"sv,
+                            HASH_TOKEN_AUTH_METHODS, "private_key_jwt") ||
+      array_member_contains(data, "token_endpoint_auth_methods_supported"sv,
+                            HASH_TOKEN_AUTH_METHODS, "client_secret_jwt")) {
+    const auto *algorithms{
+        data.try_at("token_endpoint_auth_signing_alg_values_supported"sv,
+                    HASH_TOKEN_AUTH_ALGS)};
+    if (algorithms == nullptr || !algorithms->is_array() ||
+        algorithms->contains("none")) {
+      throw OAuthMetadataParseError{};
+    }
+  }
+
+  return std::move(data);
+}
+
+} // namespace
+
+auto oauth_well_known_url(const std::string_view identifier,
+                          const OAuthWellKnownKind kind, std::string &sink)
+    -> bool {
+  static constexpr std::string_view scheme{"https://"};
+  // Reject a missing scheme, a fragment, or an empty authority, where the
+  // character after the scheme already ends the host (RFC 3986 Section 3.2)
+  if (!identifier.starts_with(scheme) || identifier.size() == scheme.size() ||
+      identifier[scheme.size()] == '/' || identifier[scheme.size()] == '?' ||
+      identifier.find('#') != std::string_view::npos) {
+    return false;
+  }
+
+  const bool protected_resource{kind == OAuthWellKnownKind::ProtectedResource};
+  const auto query_position{identifier.find('?')};
+  // RFC 8414 Section 2: an issuer carries no query, unlike a protected resource
+  if (query_position != std::string_view::npos && !protected_resource) {
+    return false;
+  }
+
+  std::string_view suffix;
+  switch (kind) {
+    case OAuthWellKnownKind::AuthorizationServer:
+      suffix = "oauth-authorization-server";
+      break;
+    case OAuthWellKnownKind::ProtectedResource:
+      suffix = "oauth-protected-resource";
+      break;
+    case OAuthWellKnownKind::OpenIDConfigurationInserted:
+    case OAuthWellKnownKind::OpenIDConfigurationAppended:
+      suffix = "openid-configuration";
+      break;
+  }
+
+  static constexpr std::string_view infix{"/.well-known/"};
+  if (kind == OAuthWellKnownKind::OpenIDConfigurationAppended) {
+    // RFC 8414 Section 5: the legacy OpenID Connect form appends the well-known
+    // string after the path rather than inserting it
+    auto base{identifier};
+    if (base.ends_with('/')) {
+      base.remove_suffix(1);
+    }
+
+    sink.reserve(sink.size() + base.size() + infix.size() + suffix.size());
+    sink.append(base);
+    sink.append(infix);
+    sink.append(suffix);
+    return true;
+  }
+
+  std::string_view query;
+  auto without_query{identifier};
+  if (query_position != std::string_view::npos) {
+    query = identifier.substr(query_position);
+    without_query = identifier.substr(0, query_position);
+  }
+
+  // RFC 8414 Section 3.1: the well-known string is inserted between the host
+  // and the path, with any terminating slash on the path removed first
+  auto authority{without_query};
+  std::string_view path;
+  const auto path_position{without_query.find('/', scheme.size())};
+  if (path_position != std::string_view::npos) {
+    authority = without_query.substr(0, path_position);
+    path = without_query.substr(path_position);
+  }
+
+  if (path.ends_with('/')) {
+    path.remove_suffix(1);
+  }
+
+  sink.reserve(sink.size() + authority.size() + infix.size() + suffix.size() +
+               path.size() + query.size());
+  sink.append(authority);
+  sink.append(infix);
+  sink.append(suffix);
+  sink.append(path);
+  sink.append(query);
+  return true;
+}
+
+OAuthServerMetadata::OAuthServerMetadata(JSON &&data,
+                                         const std::string_view issuer)
+    : data_{validated_server_metadata(std::move(data), issuer)} {}
+
+auto OAuthServerMetadata::from(JSON &&data, const std::string_view issuer)
+    -> std::optional<OAuthServerMetadata> {
+  try {
+    return OAuthServerMetadata{std::move(data), issuer};
+  } catch (const OAuthMetadataParseError &) {
+    return std::nullopt;
+  }
+}
+
+auto OAuthServerMetadata::issuer() const -> std::string_view {
+  return string_member(this->data_, "issuer"sv, HASH_ISSUER).value();
+}
+
+auto OAuthServerMetadata::authorization_endpoint() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "authorization_endpoint"sv,
+                       HASH_AUTHORIZATION_ENDPOINT);
+}
+
+auto OAuthServerMetadata::token_endpoint() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "token_endpoint"sv, HASH_TOKEN_ENDPOINT);
+}
+
+auto OAuthServerMetadata::registration_endpoint() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "registration_endpoint"sv,
+                       HASH_REGISTRATION_ENDPOINT);
+}
+
+auto OAuthServerMetadata::revocation_endpoint() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "revocation_endpoint"sv,
+                       HASH_REVOCATION_ENDPOINT);
+}
+
+auto OAuthServerMetadata::introspection_endpoint() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "introspection_endpoint"sv,
+                       HASH_INTROSPECTION_ENDPOINT);
+}
+
+auto OAuthServerMetadata::jwks_uri() const -> std::optional<std::string_view> {
+  return string_member(this->data_, "jwks_uri"sv, HASH_JWKS_URI);
+}
+
+auto OAuthServerMetadata::authorization_response_iss_parameter_supported() const
+    -> bool {
+  if (!this->data_.is_object()) {
+    return false;
+  }
+
+  const auto *member{this->data_.try_at(
+      "authorization_response_iss_parameter_supported"sv, HASH_ISS_SUPPORTED)};
+  return member != nullptr && member->is_boolean() && member->to_boolean();
+}
+
+auto OAuthServerMetadata::supports_response_type(
+    const std::string_view value) const -> bool {
+  return array_member_contains(this->data_, "response_types_supported"sv,
+                               HASH_RESPONSE_TYPES, value);
+}
+
+auto OAuthServerMetadata::supports_grant_type(
+    const std::string_view value) const -> bool {
+  const auto *member{
+      this->data_.is_object()
+          ? this->data_.try_at("grant_types_supported"sv, HASH_GRANT_TYPES)
+          : nullptr};
+  if (member == nullptr || !member->is_array()) {
+    // RFC 8414 Section 2: the default is the authorization code and implicit
+    // grants
+    return value == "authorization_code" || value == "implicit";
+  }
+
+  return member->contains(value);
+}
+
+auto OAuthServerMetadata::supports_code_challenge_method(
+    const std::string_view value) const -> bool {
+  // RFC 8414 Section 2: an omitted list means PKCE is not supported, so there
+  // is no default to fall back to
+  return array_member_contains(this->data_,
+                               "code_challenge_methods_supported"sv,
+                               HASH_CODE_CHALLENGE_METHODS, value);
+}
+
+auto OAuthServerMetadata::supports_token_endpoint_auth_method(
+    const std::string_view value) const -> bool {
+  const auto *member{
+      this->data_.is_object()
+          ? this->data_.try_at("token_endpoint_auth_methods_supported"sv,
+                               HASH_TOKEN_AUTH_METHODS)
+          : nullptr};
+  if (member == nullptr || !member->is_array()) {
+    // RFC 8414 Section 2: the default is client_secret_basic
+    return value == "client_secret_basic";
+  }
+
+  return member->contains(value);
+}
+
+auto OAuthServerMetadata::data() const -> const JSON & { return this->data_; }
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -38,9 +38,12 @@ const auto HASH_ISS_SUPPORTED{
     JSON::Object::hash("authorization_response_iss_parameter_supported"sv)};
 
 auto is_valid_issuer(const std::string_view issuer) -> bool {
-  // RFC 8414 Section 2: the issuer is an https URL with no query or fragment
+  // RFC 8414 Section 2: the issuer is an https URL with no query or fragment,
+  // and a non-empty authority (RFC 3986 Section 3.2), so the character after
+  // the scheme must not already end the host
   static constexpr std::string_view scheme{"https://"};
   return issuer.starts_with(scheme) && issuer.size() > scheme.size() &&
+         issuer[scheme.size()] != '/' &&
          issuer.find('#') == std::string_view::npos &&
          issuer.find('?') == std::string_view::npos;
 }
@@ -100,7 +103,8 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
   }
 
   // RFC 8414 Section 2: a signing algorithm list is REQUIRED alongside the JWT
-  // authentication methods, and "none" MUST NOT appear in it
+  // authentication methods, "none" MUST NOT appear in it, and Section 3.2
+  // forbids a zero-element array, so an empty list is also invalid
   if (array_member_contains(data, "token_endpoint_auth_methods_supported"sv,
                             HASH_TOKEN_AUTH_METHODS, "private_key_jwt") ||
       array_member_contains(data, "token_endpoint_auth_methods_supported"sv,
@@ -109,7 +113,7 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
         data.try_at("token_endpoint_auth_signing_alg_values_supported"sv,
                     HASH_TOKEN_AUTH_ALGS)};
     if (algorithms == nullptr || !algorithms->is_array() ||
-        algorithms->contains("none")) {
+        algorithms->empty() || algorithms->contains("none")) {
       throw OAuthMetadataParseError{};
     }
   }

--- a/src/core/oauth/oauth_metadata_provider.cc
+++ b/src/core/oauth/oauth_metadata_provider.cc
@@ -4,9 +4,11 @@
 #include <sourcemeta/core/oauth_metadata.h>
 
 #include <algorithm> // std::max, std::min
+#include <cassert>   // assert
 #include <chrono>    // std::chrono::seconds, std::chrono::system_clock
 #include <memory>    // std::make_shared, std::shared_ptr
 #include <mutex>     // std::scoped_lock
+#include <optional>  // std::optional
 #include <string>    // std::string
 #include <utility>   // std::move
 
@@ -44,7 +46,11 @@ OAuthMetadataProvider::OAuthMetadataProvider(std::string issuer,
                                              Fetcher fetcher, Options options,
                                              Clock clock)
     : issuer_{std::move(issuer)}, kind_{kind}, fetcher_{std::move(fetcher)},
-      options_{options}, clock_{std::move(clock)} {}
+      options_{options}, clock_{std::move(clock)} {
+  // A protected resource document is not authorization server metadata, so it
+  // would never validate and the provider would permanently return no value
+  assert(kind != OAuthWellKnownKind::ProtectedResource);
+}
 
 auto OAuthMetadataProvider::install_locked(
     const OAuthWellKnownKind kind,
@@ -54,7 +60,16 @@ auto OAuthMetadataProvider::install_locked(
     return false;
   }
 
-  const auto fetched{this->fetcher_(url)};
+  std::optional<FetchResult> fetched;
+  try {
+    fetched = this->fetcher_(url);
+  } catch (...) {
+    // A fetcher signals failure by returning no value, but a throwing transport
+    // is treated as just another failed retrieval, so a misbehaving fetcher can
+    // never escape a metadata lookup
+    return false;
+  }
+
   if (!fetched.has_value()) {
     return false;
   }

--- a/src/core/oauth/oauth_metadata_provider.cc
+++ b/src/core/oauth/oauth_metadata_provider.cc
@@ -97,10 +97,13 @@ auto OAuthMetadataProvider::metadata()
     -> std::shared_ptr<const OAuthServerMetadata> {
   const auto now{this->clock_()};
   const std::scoped_lock lock{this->mutex_};
-  if (this->metadata_ == nullptr || now >= this->next_refresh_) {
-    // A failed refresh leaves the last good document in place, so a stale
-    // snapshot is served rather than none
-    if (!this->fetch_and_install_locked(now) && this->metadata_ != nullptr) {
+  // The refresh deadline starts at the epoch, so the first call always
+  // retrieves. Gating solely on it, rather than also on an absent document,
+  // means a failed retrieval backs off for the minimum lifetime instead of
+  // being retried on every call during an outage, whether or not a prior good
+  // document exists to serve meanwhile
+  if (now >= this->next_refresh_) {
+    if (!this->fetch_and_install_locked(now)) {
       this->next_refresh_ = now + this->options_.minimum_ttl;
     }
   }

--- a/src/core/oauth/oauth_metadata_provider.cc
+++ b/src/core/oauth/oauth_metadata_provider.cc
@@ -1,0 +1,119 @@
+#include <sourcemeta/core/oauth_metadata_provider.h>
+
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth_metadata.h>
+
+#include <algorithm> // std::max, std::min
+#include <chrono>    // std::chrono::seconds, std::chrono::system_clock
+#include <memory>    // std::make_shared, std::shared_ptr
+#include <mutex>     // std::scoped_lock
+#include <string>    // std::string
+#include <utility>   // std::move
+
+namespace sourcemeta::core {
+
+namespace {
+
+auto clamp_ttl(const std::optional<std::chrono::seconds> max_age,
+               const OAuthMetadataProvider::Options &options)
+    -> std::chrono::seconds {
+  if (max_age.has_value()) {
+    return std::max(options.minimum_ttl,
+                    std::min(max_age.value(), options.maximum_ttl));
+  }
+
+  return options.fallback_ttl;
+}
+
+} // namespace
+
+OAuthMetadataProvider::OAuthMetadataProvider(std::string issuer,
+                                             const OAuthWellKnownKind kind,
+                                             Fetcher fetcher)
+    : OAuthMetadataProvider{std::move(issuer), kind, std::move(fetcher),
+                            Options{}} {}
+
+OAuthMetadataProvider::OAuthMetadataProvider(std::string issuer,
+                                             const OAuthWellKnownKind kind,
+                                             Fetcher fetcher, Options options)
+    : OAuthMetadataProvider{std::move(issuer), kind, std::move(fetcher),
+                            options, Clock{&std::chrono::system_clock::now}} {}
+
+OAuthMetadataProvider::OAuthMetadataProvider(std::string issuer,
+                                             const OAuthWellKnownKind kind,
+                                             Fetcher fetcher, Options options,
+                                             Clock clock)
+    : issuer_{std::move(issuer)}, kind_{kind}, fetcher_{std::move(fetcher)},
+      options_{options}, clock_{std::move(clock)} {}
+
+auto OAuthMetadataProvider::install_locked(
+    const OAuthWellKnownKind kind,
+    const std::chrono::system_clock::time_point now) -> bool {
+  std::string url;
+  if (!oauth_well_known_url(this->issuer_, kind, url)) {
+    return false;
+  }
+
+  const auto fetched{this->fetcher_(url)};
+  if (!fetched.has_value()) {
+    return false;
+  }
+
+  auto document{try_parse_json(fetched.value().body)};
+  if (!document.has_value()) {
+    return false;
+  }
+
+  auto parsed{
+      OAuthServerMetadata::from(std::move(document).value(), this->issuer_)};
+  if (!parsed.has_value()) {
+    return false;
+  }
+
+  this->metadata_ =
+      std::make_shared<const OAuthServerMetadata>(std::move(parsed).value());
+  this->next_refresh_ =
+      now + clamp_ttl(fetched.value().max_age, this->options_);
+  return true;
+}
+
+auto OAuthMetadataProvider::fetch_and_install_locked(
+    const std::chrono::system_clock::time_point now) -> bool {
+  if (this->install_locked(this->kind_, now)) {
+    return true;
+  }
+
+  // RFC 8414 Section 5: the inserted openid-configuration form is tried first
+  // and the legacy appended form only as a fallback
+  if (this->kind_ == OAuthWellKnownKind::OpenIDConfigurationInserted) {
+    return this->install_locked(OAuthWellKnownKind::OpenIDConfigurationAppended,
+                                now);
+  }
+
+  return false;
+}
+
+auto OAuthMetadataProvider::metadata()
+    -> std::shared_ptr<const OAuthServerMetadata> {
+  const auto now{this->clock_()};
+  const std::scoped_lock lock{this->mutex_};
+  if (this->metadata_ == nullptr || now >= this->next_refresh_) {
+    // A failed refresh leaves the last good document in place, so a stale
+    // snapshot is served rather than none
+    if (!this->fetch_and_install_locked(now) && this->metadata_ != nullptr) {
+      this->next_refresh_ = now + this->options_.minimum_ttl;
+    }
+  }
+
+  return this->metadata_;
+}
+
+auto OAuthMetadataProvider::refresh()
+    -> std::shared_ptr<const OAuthServerMetadata> {
+  const auto now{this->clock_()};
+  const std::scoped_lock lock{this->mutex_};
+  this->fetch_and_install_locked(now);
+  return this->metadata_;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_random.cc
+++ b/src/core/oauth/oauth_random.cc
@@ -1,0 +1,26 @@
+#include <sourcemeta/core/oauth_random.h>
+
+#include <sourcemeta/core/crypto.h>
+
+#include <algorithm>   // std::ranges::copy
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto oauth_random_token() -> std::array<char, 43> {
+  // The token is not secret, so unlike the PKCE verifier the entropy needs no
+  // wiping storage, matching the state and nonce classification of the design
+  std::array<std::uint8_t, 32> entropy{};
+  random_bytes(entropy);
+  const auto encoded{base64url_encode(
+      std::string_view{reinterpret_cast<const char *>(entropy.data()), // NOLINT
+                       entropy.size()})};
+
+  std::array<char, 43> result{};
+  std::ranges::copy(encoded, result.begin());
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_token.cc
+++ b/src/core/oauth/oauth_token.cc
@@ -1,0 +1,170 @@
+#include <sourcemeta/core/oauth_token.h>
+
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/text.h>
+
+#include "oauth_encode.h"
+
+#include <chrono>      // std::chrono::seconds
+#include <cstddef>     // std::size_t
+#include <optional>    // std::optional, std::nullopt
+#include <span>        // std::span
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+namespace {
+
+using namespace std::literals::string_view_literals;
+
+const auto HASH_ACCESS_TOKEN{JSON::Object::hash("access_token"sv)};
+const auto HASH_TOKEN_TYPE{JSON::Object::hash("token_type"sv)};
+const auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
+const auto HASH_REFRESH_TOKEN{JSON::Object::hash("refresh_token"sv)};
+const auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
+
+auto string_member(const JSON &data, const JSON::StringView name,
+                   const JSON::Object::hash_type hash)
+    -> std::optional<std::string_view> {
+  if (!data.is_object()) {
+    return std::nullopt;
+  }
+
+  const auto *member{data.try_at(name, hash)};
+  if (member == nullptr || !member->is_string()) {
+    return std::nullopt;
+  }
+
+  return std::string_view{member->to_string()};
+}
+
+auto oauth_append_resources(SecureString &sink,
+                            const std::span<const OAuthParameter> resources)
+    -> void {
+  for (const auto &resource : resources) {
+    oauth_append_form_parameter(sink, resource.name, resource.value);
+  }
+}
+
+} // namespace
+
+auto oauth_build_token_request_code(
+    const std::string_view code, const std::string_view redirect_uri,
+    const std::string_view code_verifier,
+    const std::span<const OAuthParameter> resources, SecureString &sink)
+    -> void {
+  oauth_append_form_parameter(sink, "grant_type", "authorization_code");
+  oauth_append_form_parameter(sink, "code", code);
+  if (!redirect_uri.empty()) {
+    oauth_append_form_parameter(sink, "redirect_uri", redirect_uri);
+  }
+
+  if (!code_verifier.empty()) {
+    oauth_append_form_parameter(sink, "code_verifier", code_verifier);
+  }
+
+  oauth_append_resources(sink, resources);
+}
+
+auto oauth_build_token_request_refresh(
+    const std::string_view refresh_token, const std::string_view scope,
+    const std::span<const OAuthParameter> resources, SecureString &sink)
+    -> void {
+  oauth_append_form_parameter(sink, "grant_type", "refresh_token");
+  oauth_append_form_parameter(sink, "refresh_token", refresh_token);
+  if (!scope.empty()) {
+    oauth_append_form_parameter(sink, "scope", scope);
+  }
+
+  oauth_append_resources(sink, resources);
+}
+
+auto oauth_build_token_request_client_credentials(
+    const std::string_view scope,
+    const std::span<const OAuthParameter> resources, SecureString &sink)
+    -> void {
+  oauth_append_form_parameter(sink, "grant_type", "client_credentials");
+  if (!scope.empty()) {
+    oauth_append_form_parameter(sink, "scope", scope);
+  }
+
+  oauth_append_resources(sink, resources);
+}
+
+OAuthTokenResponse::OAuthTokenResponse(const JSON &data) : data_{&data} {}
+
+auto OAuthTokenResponse::access_token() const
+    -> std::optional<std::string_view> {
+  return string_member(*this->data_, "access_token"sv, HASH_ACCESS_TOKEN);
+}
+
+auto OAuthTokenResponse::token_type() const -> std::optional<std::string_view> {
+  return string_member(*this->data_, "token_type"sv, HASH_TOKEN_TYPE);
+}
+
+auto OAuthTokenResponse::is_bearer_token_type() const -> bool {
+  const auto type{this->token_type()};
+  // RFC 6749 Section 5.1: the token type value is compared case insensitively
+  return type.has_value() && equals_ignore_case(type.value(), "Bearer");
+}
+
+auto OAuthTokenResponse::expires_in() const
+    -> std::optional<std::chrono::seconds> {
+  if (!this->data_->is_object()) {
+    return std::nullopt;
+  }
+
+  const auto *member{this->data_->try_at("expires_in"sv, HASH_EXPIRES_IN)};
+  if (member == nullptr || !member->is_integer()) {
+    return std::nullopt;
+  }
+
+  const auto value{member->to_integer()};
+  if (value < 0) {
+    return std::nullopt;
+  }
+
+  return std::chrono::seconds{value};
+}
+
+auto OAuthTokenResponse::refresh_token() const
+    -> std::optional<std::string_view> {
+  return string_member(*this->data_, "refresh_token"sv, HASH_REFRESH_TOKEN);
+}
+
+auto OAuthTokenResponse::scope() const -> std::optional<std::string_view> {
+  return string_member(*this->data_, "scope"sv, HASH_SCOPE);
+}
+
+auto OAuthTokenResponse::has_scope(const std::string_view value) const -> bool {
+  const auto granted{this->scope()};
+  if (!granted.has_value() || value.empty()) {
+    return false;
+  }
+
+  // RFC 6749 Section 3.3: scope is a space-delimited, unordered set of tokens,
+  // scanned without allocation
+  const auto text{granted.value()};
+  std::size_t position{0};
+  while (position < text.size()) {
+    const auto next{text.find(' ', position)};
+    const auto token{text.substr(position, next == std::string_view::npos
+                                               ? std::string_view::npos
+                                               : next - position)};
+    if (token == value) {
+      return true;
+    }
+
+    if (next == std::string_view::npos) {
+      break;
+    }
+
+    position = next + 1;
+  }
+
+  return false;
+}
+
+auto OAuthTokenResponse::data() const -> const JSON & { return *this->data_; }
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_transaction.cc
+++ b/src/core/oauth/oauth_transaction.cc
@@ -1,0 +1,69 @@
+#include <sourcemeta/core/oauth_transaction.h>
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/oauth_pkce.h>
+#include <sourcemeta/core/oauth_random.h>
+
+#include <optional>    // std::optional, std::nullopt
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+auto oauth_transaction_mint() -> OAuthTransactionSecrets {
+  return {.state = oauth_random_token(),
+          .code_verifier = oauth_pkce_verifier()};
+}
+
+auto oauth_transaction_check(const OAuthTransaction &transaction,
+                             const OAuthAuthorizationResponse &response,
+                             const OAuthIssuerSupport issuer_support,
+                             const std::string_view received_uri,
+                             std::string_view &code)
+    -> std::optional<OAuthCallbackError> {
+  // RFC 6749 Section 10.12: the state binds the callback to this user agent, so
+  // it is checked first and in constant time to avoid leaking a match position,
+  // even though the value itself is not confidential
+  if (response.state.empty() ||
+      !secure_equals(response.state, transaction.state)) {
+    return OAuthCallbackError::State;
+  }
+
+  // RFC 8252 Section 8.10: when the caller knows the URI the response arrived
+  // on, it must be the one the request was sent with
+  if (!received_uri.empty() && received_uri != transaction.redirect_uri) {
+    return OAuthCallbackError::ReceivedURI;
+  }
+
+  // RFC 9207 Section 2.4: the issuer defends against a mix-up attack
+  switch (issuer_support) {
+    case OAuthIssuerSupport::Supported:
+      if (response.iss.empty() || response.iss != transaction.issuer) {
+        return OAuthCallbackError::Issuer;
+      }
+
+      break;
+    case OAuthIssuerSupport::Unknown:
+      if (!response.iss.empty() && response.iss != transaction.issuer) {
+        return OAuthCallbackError::Issuer;
+      }
+
+      break;
+    case OAuthIssuerSupport::NotSupported:
+      break;
+  }
+
+  // RFC 6749 Section 4.1.2.1: an authenticated error response is a decline, and
+  // it is distinguished from a missing code only after the checks above pass
+  if (!response.error.empty()) {
+    return OAuthCallbackError::Declined;
+  }
+
+  if (response.code.empty()) {
+    return OAuthCallbackError::MissingCode;
+  }
+
+  code = response.code;
+  return std::nullopt;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/uri/CMakeLists.txt
+++ b/src/core/uri/CMakeLists.txt
@@ -13,6 +13,6 @@ target_link_libraries(sourcemeta_core_uri
 target_link_libraries(sourcemeta_core_uri
   PRIVATE sourcemeta::core::ip)
 target_link_libraries(sourcemeta_core_uri
-  PRIVATE sourcemeta::core::text)
+  PUBLIC sourcemeta::core::text)
 target_link_libraries(sourcemeta_core_uri
   PRIVATE sourcemeta::core::unicode)

--- a/src/core/uri/escape.cc
+++ b/src/core/uri/escape.cc
@@ -11,49 +11,6 @@
 
 namespace sourcemeta::core {
 
-auto URI::escape(const std::string_view input, std::string &output,
-                 const bool maybe_encoded) -> void {
-  output.reserve(output.size() + input.size() * 3);
-  if (!maybe_encoded) {
-    for (const auto character : input) {
-      if (uri_is_unreserved(character)) {
-        output += character;
-      } else {
-        uri_percent_encode_byte(output, static_cast<unsigned char>(character));
-      }
-    }
-
-    return;
-  }
-
-  // Treat the input as possibly already encoded, decoding each octet before
-  // re-encoding so that a valid escape survives and a needlessly encoded
-  // unreserved octet is decoded
-  for (std::size_t position = 0; position < input.size();) {
-    const auto high{input[position] == URI_PERCENT &&
-                            position + 2 < input.size()
-                        ? hex_digit_value(input[position + 1])
-                        : static_cast<std::int8_t>(-1)};
-    const auto low{high < 0 ? static_cast<std::int8_t>(-1)
-                            : hex_digit_value(input[position + 2])};
-
-    unsigned char byte{};
-    if (low < 0) {
-      byte = static_cast<unsigned char>(input[position]);
-      position += 1;
-    } else {
-      byte = static_cast<unsigned char>((high << 4) | low);
-      position += 3;
-    }
-
-    if (uri_is_unreserved(static_cast<char>(byte))) {
-      output += static_cast<char>(byte);
-    } else {
-      uri_percent_encode_byte(output, byte);
-    }
-  }
-}
-
 auto URI::escape(const std::string_view input, const bool maybe_encoded)
     -> std::string {
   std::string result;

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -5,6 +5,8 @@
 #include <sourcemeta/core/uri_export.h>
 #endif
 
+#include <sourcemeta/core/text.h>
+
 // NOLINTBEGIN(misc-include-cleaner)
 #include <sourcemeta/core/uri_error.h>
 // NOLINTEND(misc-include-cleaner)
@@ -778,10 +780,11 @@ public:
   [[nodiscard]] static auto escape(std::string_view input,
                                    bool maybe_encoded = false) -> std::string;
 
-  /// Percent-encode a string per RFC 3986, appending the result to an existing
-  /// string rather than allocating a new one, optionally treating the input as
-  /// possibly already encoded. The output must not alias the input. For
-  /// example:
+  /// Percent-encode a string per RFC 3986, appending the result to a string
+  /// like output sink rather than allocating a new string. Besides a
+  /// `std::string` the sink can be a wiping string for secret material. The
+  /// input can optionally be treated as possibly already encoded. The output
+  /// must not alias the input. For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>
@@ -792,8 +795,44 @@ public:
   /// sourcemeta::core::URI::escape("foo bar", output);
   /// assert(output == "key=foo%20bar");
   /// ```
-  static auto escape(std::string_view input, std::string &output,
-                     bool maybe_encoded = false) -> void;
+  template <typename Output>
+  static auto escape(const std::string_view input, Output &output,
+                     const bool maybe_encoded = false) -> void {
+    output.reserve(output.size() + input.size() * 3);
+    for (std::size_t position = 0; position < input.size();) {
+      auto byte{static_cast<unsigned char>(input[position])};
+      std::size_t advance{1};
+      // Treat the input as possibly already encoded by decoding each valid
+      // escape before re-encoding, so a valid escape survives and a needlessly
+      // encoded unreserved octet is decoded
+      if (maybe_encoded && input[position] == '%' &&
+          position + 2 < input.size()) {
+        const auto high{hex_digit_value(input[position + 1])};
+        const auto low{high < 0 ? static_cast<std::int8_t>(-1)
+                                : hex_digit_value(input[position + 2])};
+        if (low >= 0) {
+          byte = static_cast<unsigned char>((high << 4) | low);
+          advance = 3;
+        }
+      }
+
+      position += advance;
+      // RFC 3986 Section 2.3: the unreserved set passes through unescaped
+      if (is_alphanum(static_cast<char>(byte)) || byte == '-' || byte == '.' ||
+          byte == '_' || byte == '~') {
+        output.push_back(static_cast<char>(byte));
+      } else {
+        // RFC 3986 Section 2.1: percent-encode with uppercase hexadecimal
+        const auto high{static_cast<unsigned char>((byte >> 4U) & 0x0FU)};
+        const auto low{static_cast<unsigned char>(byte & 0x0FU)};
+        output.push_back('%');
+        output.push_back(
+            static_cast<char>(high < 10 ? '0' + high : 'A' + high - 10));
+        output.push_back(
+            static_cast<char>(low < 10 ? '0' + low : 'A' + low - 10));
+      }
+    }
+  }
 
   /// Percent-decode every escape sequence in a string per RFC 3986, leaving
   /// malformed sequences untouched. For example:

--- a/test/oauth/CMakeLists.txt
+++ b/test/oauth/CMakeLists.txt
@@ -1,5 +1,8 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME oauth
-  SOURCES oauth_error_test.cc oauth_pkce_test.cc oauth_bearer_test.cc)
+  SOURCES oauth_error_test.cc oauth_pkce_test.cc oauth_bearer_test.cc
+    oauth_random_test.cc oauth_authorization_test.cc oauth_token_test.cc
+    oauth_client_authentication_test.cc oauth_transaction_test.cc
+    oauth_metadata_test.cc oauth_metadata_provider_test.cc)
 
 target_link_libraries(sourcemeta_core_oauth_unit
   PRIVATE sourcemeta::core::oauth)

--- a/test/oauth/oauth_authorization_test.cc
+++ b/test/oauth/oauth_authorization_test.cc
@@ -357,3 +357,22 @@ TEST(parse_authorization_response_bare_key_without_equals) {
   EXPECT_TRUE(response.code.empty());
   EXPECT_EQ(response.state, "x");
 }
+
+TEST(parse_authorization_response_reads_error_details) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "error=access_denied&error_description=User%20denied"
+      "&error_uri=https%3A%2F%2Fx%2Fe&state=xyz",
+      storage, response));
+  EXPECT_EQ(response.error, "access_denied");
+  EXPECT_EQ(response.error_description, "User denied");
+  EXPECT_EQ(response.error_uri, "https://x/e");
+}
+
+TEST(parse_authorization_response_rejects_a_duplicate_error_description) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_FALSE(sourcemeta::core::oauth_parse_authorization_response(
+      "error_description=a&error_description=b", storage, response));
+}

--- a/test/oauth/oauth_authorization_test.cc
+++ b/test/oauth/oauth_authorization_test.cc
@@ -1,0 +1,359 @@
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>  // std::array
+#include <string> // std::string
+
+TEST(build_url_minimal_emits_response_type_and_client_id) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "s6BhdRkqt3";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url(
+      "https://server.example/authorize", request, url);
+  EXPECT_EQ(url, "https://server.example/authorize?response_type=code"
+                 "&client_id=s6BhdRkqt3");
+}
+
+TEST(build_url_full_code_flow_with_pkce) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "s6BhdRkqt3";
+  request.redirect_uri = "https://client.example/cb";
+  request.scope = "openid profile";
+  request.state = "xyz";
+  request.code_challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+  request.code_challenge_method = "S256";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url(
+      "https://server.example/authorize", request, url);
+  EXPECT_EQ(
+      url,
+      "https://server.example/authorize?response_type=code"
+      "&client_id=s6BhdRkqt3&redirect_uri=https%3A%2F%2Fclient.example%2Fcb"
+      "&scope=openid%20profile&state=xyz"
+      "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+      "&code_challenge_method=S256");
+}
+
+TEST(build_url_escapes_the_redirect_uri) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.redirect_uri = "https://client.example/cb?x=1";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&redirect_uri=https%3A%2F%2Fclient.example%2Fcb%3Fx%3D1");
+}
+
+TEST(build_url_escapes_spaces_in_scope) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.scope = "read write";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&scope=read%20write");
+}
+
+TEST(build_url_omits_empty_fields) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.redirect_uri = "";
+  request.scope = "";
+  request.state = "";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=code&client_id=abc");
+}
+
+TEST(build_url_omits_the_method_without_a_challenge) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.code_challenge_method = "S256";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=code&client_id=abc");
+}
+
+TEST(build_url_honors_an_existing_query) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url(
+      "https://server.example/auth?foo=bar", request, url);
+  EXPECT_EQ(url, "https://server.example/auth?foo=bar&response_type=code"
+                 "&client_id=abc");
+}
+
+TEST(build_url_emits_repeatable_resources) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  const std::array<sourcemeta::core::OAuthParameter, 2> resources{
+      {{"resource", "https://api.a"}, {"resource", "https://api.b"}}};
+  request.resources = resources;
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&resource=https%3A%2F%2Fapi.a&resource=https%3A%2F%2Fapi.b");
+}
+
+TEST(build_url_emits_extra_parameters) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  const std::array<sourcemeta::core::OAuthParameter, 1> extra{
+      {{"nonce", "n-0S6_WzA2Mj"}}};
+  request.extra = extra;
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&nonce=n-0S6_WzA2Mj");
+}
+
+TEST(build_url_emits_a_request_uri_reference) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.request_uri = "urn:ietf:params:oauth:request_uri:6esc";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=code&client_id=abc"
+            "&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3A6esc");
+}
+
+TEST(build_url_emits_a_dpop_jkt) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.dpop_jkt = "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&dpop_jkt=NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs");
+}
+
+TEST(build_url_appends_to_an_existing_sink) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  std::string url{"redirect: "};
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "redirect: https://server.example/auth?response_type=code"
+                 "&client_id=abc");
+}
+
+TEST(parse_authorization_response_reads_code_and_state) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=SplxlOBeZQQYbYS6WxSbIA&state=xyz", storage, response));
+  EXPECT_EQ(response.code, "SplxlOBeZQQYbYS6WxSbIA");
+  EXPECT_EQ(response.state, "xyz");
+  EXPECT_TRUE(response.iss.empty());
+  EXPECT_TRUE(response.error.empty());
+}
+
+TEST(parse_authorization_response_reads_iss) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=abc&state=xyz&iss=https%3A%2F%2Fserver.example", storage,
+      response));
+  EXPECT_EQ(response.iss, "https://server.example");
+}
+
+TEST(parse_authorization_response_reads_an_error) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "error=access_denied&state=xyz", storage, response));
+  EXPECT_EQ(response.error, "access_denied");
+  EXPECT_TRUE(response.code.empty());
+}
+
+TEST(parse_authorization_response_decodes_plus_as_space) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=a+b&state=x", storage, response));
+  EXPECT_EQ(response.code, "a b");
+}
+
+TEST(parse_authorization_response_borrows_an_unencoded_value) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  const std::string query{"code=plain&state=xyz"};
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      query, storage, response));
+  // A value with no escape borrows from the input rather than the arena
+  EXPECT_TRUE(response.code.data() >= query.data());
+  EXPECT_TRUE(response.code.data() < query.data() + query.size());
+}
+
+TEST(parse_authorization_response_rejects_a_duplicate_parameter) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_FALSE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=a&code=b", storage, response));
+}
+
+TEST(parse_authorization_response_ignores_an_unknown_parameter) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=abc&extra=ignored&state=xyz", storage, response));
+  EXPECT_EQ(response.code, "abc");
+  EXPECT_EQ(response.state, "xyz");
+}
+
+TEST(parse_authorization_response_rejects_a_malformed_escape) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_FALSE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=a%2", storage, response));
+}
+
+TEST(parse_authorization_response_accepts_an_empty_query) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response("", storage,
+                                                                   response));
+  EXPECT_TRUE(response.code.empty());
+}
+
+TEST(build_url_escapes_an_extra_parameter_name) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  const std::array<sourcemeta::core::OAuthParameter, 1> extra{{{"a b", "c"}}};
+  request.extra = extra;
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&a%20b=c");
+}
+
+TEST(build_url_endpoint_ending_in_question_mark) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url(
+      "https://server.example/auth?", request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=code&client_id=abc");
+}
+
+TEST(build_url_endpoint_ending_in_ampersand) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url(
+      "https://server.example/auth?foo=bar&", request, url);
+  EXPECT_EQ(url, "https://server.example/auth?foo=bar&response_type=code"
+                 "&client_id=abc");
+}
+
+TEST(build_url_challenge_without_a_method) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.code_challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code&client_id=abc"
+                 "&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+}
+
+TEST(build_url_with_no_client_id_still_emits_response_type) {
+  const sourcemeta::core::OAuthAuthorizationRequest request;
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth?response_type=code");
+}
+
+TEST(parse_authorization_response_empty_value) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=&state=x", storage, response));
+  EXPECT_TRUE(response.code.empty());
+  EXPECT_EQ(response.state, "x");
+}
+
+TEST(parse_authorization_response_rejects_a_duplicate_iss) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_FALSE(sourcemeta::core::oauth_parse_authorization_response(
+      "iss=a&iss=b", storage, response));
+}
+
+TEST(parse_authorization_response_rejects_a_duplicate_error) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_FALSE(sourcemeta::core::oauth_parse_authorization_response(
+      "error=a&error=b", storage, response));
+}
+
+TEST(parse_authorization_response_rejects_a_duplicate_state) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_FALSE(sourcemeta::core::oauth_parse_authorization_response(
+      "state=a&state=b", storage, response));
+}
+
+TEST(parse_authorization_response_keeps_encoded_delimiters) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=a%26b%3Dc&state=x", storage, response));
+  EXPECT_EQ(response.code, "a&b=c");
+  EXPECT_EQ(response.state, "x");
+}
+
+TEST(parse_authorization_response_tolerates_empty_pairs) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "&code=x&&state=y", storage, response));
+  EXPECT_EQ(response.code, "x");
+  EXPECT_EQ(response.state, "y");
+}
+
+TEST(parse_authorization_response_captures_both_code_and_error) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=x&error=access_denied&state=y", storage, response));
+  EXPECT_EQ(response.code, "x");
+  EXPECT_EQ(response.error, "access_denied");
+}
+
+TEST(parse_authorization_response_reuses_the_storage_arena) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse first;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=a%20b&state=x", storage, first));
+  EXPECT_EQ(first.code, "a b");
+  sourcemeta::core::OAuthAuthorizationResponse second;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code=c%20d&state=y", storage, second));
+  EXPECT_EQ(second.code, "c d");
+  EXPECT_EQ(second.state, "y");
+}
+
+TEST(parse_authorization_response_bare_key_without_equals) {
+  std::string storage;
+  sourcemeta::core::OAuthAuthorizationResponse response;
+  EXPECT_TRUE(sourcemeta::core::oauth_parse_authorization_response(
+      "code&state=x", storage, response));
+  EXPECT_TRUE(response.code.empty());
+  EXPECT_EQ(response.state, "x");
+}

--- a/test/oauth/oauth_client_authentication_test.cc
+++ b/test/oauth/oauth_client_authentication_test.cc
@@ -1,0 +1,44 @@
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+TEST(client_secret_basic_encodes_the_credential) {
+  sourcemeta::core::SecureString header;
+  sourcemeta::core::oauth_client_secret_basic("s6BhdRkqt3", "gX1fBat3bV",
+                                              header);
+  EXPECT_TRUE(header == "Basic czZCaGRSa3F0MzpnWDFmQmF0M2JW");
+}
+
+TEST(client_secret_basic_percent_encodes_each_half) {
+  // RFC 6749 Section 2.3.1: the colon in the identifier and the space in the
+  // secret are percent-encoded before the halves are joined and Base64 encoded
+  sourcemeta::core::SecureString header;
+  sourcemeta::core::oauth_client_secret_basic("a:b", "c d", header);
+  EXPECT_TRUE(header == "Basic YSUzQWI6YyUyMGQ=");
+}
+
+TEST(client_secret_post_emits_both_parameters) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_client_secret_post("s6BhdRkqt3", "gX1fBat3bV", body);
+  EXPECT_TRUE(body == "client_id=s6BhdRkqt3&client_secret=gX1fBat3bV");
+}
+
+TEST(client_secret_post_escapes_the_secret) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_client_secret_post("abc", "s p@ce", body);
+  EXPECT_TRUE(body == "client_id=abc&client_secret=s%20p%40ce");
+}
+
+TEST(client_id_only_emits_the_identifier) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_client_id_only("s6BhdRkqt3", body);
+  EXPECT_TRUE(body == "client_id=s6BhdRkqt3");
+}
+
+TEST(client_id_only_composes_after_a_grant) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_code("abc", "", "verifier", {},
+                                                   body);
+  sourcemeta::core::oauth_client_id_only("s6BhdRkqt3", body);
+  EXPECT_TRUE(body == "grant_type=authorization_code&code=abc"
+                      "&code_verifier=verifier&client_id=s6BhdRkqt3");
+}

--- a/test/oauth/oauth_metadata_provider_test.cc
+++ b/test/oauth/oauth_metadata_provider_test.cc
@@ -309,3 +309,29 @@ TEST(metadata_provider_returns_the_same_snapshot_within_the_ttl) {
   const auto second{provider.metadata()};
   EXPECT_TRUE(first == second);
 }
+
+TEST(metadata_provider_backs_off_after_a_failed_fetch) {
+  int fetch_count{0};
+  const auto clock_now{std::make_shared<std::chrono::system_clock::time_point>(
+      std::chrono::system_clock::time_point{})};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return std::nullopt;
+      },
+      sourcemeta::core::OAuthMetadataProvider::Options{},
+      [clock_now]() { return *clock_now; }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+  EXPECT_EQ(fetch_count, 1);
+  // A second call within the minimum lifetime does not re-fetch during the
+  // outage, even though the document has never been retrieved
+  *clock_now += std::chrono::seconds{10};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+  EXPECT_EQ(fetch_count, 1);
+  // Once the minimum lifetime elapses the fetch is retried
+  *clock_now += std::chrono::minutes{6};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+  EXPECT_EQ(fetch_count, 2);
+}

--- a/test/oauth/oauth_metadata_provider_test.cc
+++ b/test/oauth/oauth_metadata_provider_test.cc
@@ -1,0 +1,311 @@
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <chrono>      // std::chrono
+#include <memory>      // std::make_shared
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace {
+
+using Fetch =
+    std::optional<sourcemeta::core::OAuthMetadataProvider::FetchResult>;
+
+constexpr std::string_view SERVER_DOCUMENT{R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https://example.com/token"
+  })JSON"};
+
+} // namespace
+
+TEST(metadata_provider_fetches_on_first_call) {
+  int fetch_count{0};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      }};
+  const auto metadata{provider.metadata()};
+  EXPECT_TRUE(metadata != nullptr);
+  EXPECT_EQ(metadata->issuer(), "https://example.com");
+  EXPECT_EQ(metadata->token_endpoint().value(), "https://example.com/token");
+  EXPECT_EQ(fetch_count, 1);
+}
+
+TEST(metadata_provider_derives_the_authorization_server_url) {
+  std::string seen;
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&seen](std::string_view url) -> Fetch {
+        seen = std::string{url};
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      }};
+  const auto metadata{provider.metadata()};
+  EXPECT_TRUE(metadata != nullptr);
+  EXPECT_EQ(seen, "https://example.com/.well-known/oauth-authorization-server");
+}
+
+TEST(metadata_provider_caches_within_the_ttl) {
+  int fetch_count{0};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      }};
+  const auto first{provider.metadata()};
+  const auto second{provider.metadata()};
+  EXPECT_TRUE(first != nullptr);
+  EXPECT_TRUE(second != nullptr);
+  EXPECT_EQ(fetch_count, 1);
+}
+
+TEST(metadata_provider_refreshes_after_the_ttl) {
+  int fetch_count{0};
+  const auto clock_now{std::make_shared<std::chrono::system_clock::time_point>(
+      std::chrono::system_clock::time_point{})};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      },
+      sourcemeta::core::OAuthMetadataProvider::Options{},
+      [clock_now]() { return *clock_now; }};
+  const auto first{provider.metadata()};
+  EXPECT_EQ(fetch_count, 1);
+  *clock_now += std::chrono::hours{2};
+  const auto second{provider.metadata()};
+  EXPECT_TRUE(second != nullptr);
+  EXPECT_EQ(fetch_count, 2);
+}
+
+TEST(metadata_provider_refresh_forces_a_refetch) {
+  int fetch_count{0};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      }};
+  const auto first{provider.metadata()};
+  EXPECT_EQ(fetch_count, 1);
+  const auto refreshed{provider.refresh()};
+  EXPECT_TRUE(refreshed != nullptr);
+  EXPECT_EQ(fetch_count, 2);
+}
+
+TEST(metadata_provider_returns_null_when_the_fetch_fails) {
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [](std::string_view) -> Fetch { return std::nullopt; }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+}
+
+TEST(metadata_provider_serves_stale_after_a_failed_refresh) {
+  bool succeed{true};
+  const auto clock_now{std::make_shared<std::chrono::system_clock::time_point>(
+      std::chrono::system_clock::time_point{})};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&succeed](std::string_view) -> Fetch {
+        if (!succeed) {
+          return std::nullopt;
+        }
+
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      },
+      sourcemeta::core::OAuthMetadataProvider::Options{},
+      [clock_now]() { return *clock_now; }};
+  const auto first{provider.metadata()};
+  EXPECT_TRUE(first != nullptr);
+  succeed = false;
+  *clock_now += std::chrono::hours{2};
+  const auto stale{provider.metadata()};
+  EXPECT_TRUE(stale != nullptr);
+  EXPECT_EQ(stale->issuer(), "https://example.com");
+}
+
+TEST(metadata_provider_returns_null_on_a_validation_failure) {
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [](std::string_view) -> Fetch {
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = R"JSON({
+              "issuer": "https://evil.example",
+              "response_types_supported": [ "code" ]
+            })JSON",
+            .max_age = std::nullopt};
+      }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+}
+
+TEST(metadata_provider_falls_back_to_the_appended_openid_form) {
+  std::string appended_url;
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com/issuer1",
+      sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationInserted,
+      [&appended_url](std::string_view url) -> Fetch {
+        // The inserted form is tried first and fails, so only the appended
+        // form yields a document
+        if (url ==
+            "https://example.com/issuer1/.well-known/openid-configuration") {
+          appended_url = std::string{url};
+          return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+              .body = R"JSON({
+                "issuer": "https://example.com/issuer1",
+                "response_types_supported": [ "code" ]
+              })JSON",
+              .max_age = std::nullopt};
+        }
+
+        return std::nullopt;
+      }};
+  const auto metadata{provider.metadata()};
+  EXPECT_TRUE(metadata != nullptr);
+  EXPECT_EQ(metadata->issuer(), "https://example.com/issuer1");
+  EXPECT_EQ(appended_url,
+            "https://example.com/issuer1/.well-known/openid-configuration");
+}
+
+TEST(metadata_provider_clamps_a_tiny_ttl_to_the_minimum) {
+  int fetch_count{0};
+  const auto clock_now{std::make_shared<std::chrono::system_clock::time_point>(
+      std::chrono::system_clock::time_point{})};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT},
+            .max_age = std::chrono::seconds{1}};
+      },
+      sourcemeta::core::OAuthMetadataProvider::Options{},
+      [clock_now]() { return *clock_now; }};
+  const auto first{provider.metadata()};
+  EXPECT_EQ(fetch_count, 1);
+  // The advertised one second is clamped up to the five minute minimum, so a
+  // read ten seconds later is still cached
+  *clock_now += std::chrono::seconds{10};
+  const auto second{provider.metadata()};
+  EXPECT_TRUE(second != nullptr);
+  EXPECT_EQ(fetch_count, 1);
+}
+
+TEST(metadata_provider_openid_inserted_success_skips_appended) {
+  int fetch_count{0};
+  std::string seen;
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com/issuer1",
+      sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationInserted,
+      [&fetch_count, &seen](std::string_view url) -> Fetch {
+        fetch_count += 1;
+        seen = std::string{url};
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = R"JSON({
+              "issuer": "https://example.com/issuer1",
+              "response_types_supported": [ "code" ]
+            })JSON",
+            .max_age = std::nullopt};
+      }};
+  const auto metadata{provider.metadata()};
+  EXPECT_TRUE(metadata != nullptr);
+  EXPECT_EQ(fetch_count, 1);
+  EXPECT_EQ(seen,
+            "https://example.com/.well-known/openid-configuration/issuer1");
+}
+
+TEST(metadata_provider_openid_both_forms_fail) {
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com/issuer1",
+      sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationInserted,
+      [](std::string_view) -> Fetch { return std::nullopt; }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+}
+
+TEST(metadata_provider_clamps_a_huge_ttl_to_the_maximum) {
+  int fetch_count{0};
+  const auto clock_now{std::make_shared<std::chrono::system_clock::time_point>(
+      std::chrono::system_clock::time_point{})};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&fetch_count](std::string_view) -> Fetch {
+        fetch_count += 1;
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT},
+            .max_age = std::chrono::hours{24 * 365}};
+      },
+      sourcemeta::core::OAuthMetadataProvider::Options{},
+      [clock_now]() { return *clock_now; }};
+  const auto first{provider.metadata()};
+  EXPECT_EQ(fetch_count, 1);
+  // A one-year advertised lifetime is clamped to the 24 hour maximum, so 25
+  // hours later a refresh is due
+  *clock_now += std::chrono::hours{25};
+  const auto second{provider.metadata()};
+  EXPECT_TRUE(second != nullptr);
+  EXPECT_EQ(fetch_count, 2);
+}
+
+TEST(metadata_provider_rejects_a_malformed_json_body) {
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [](std::string_view) -> Fetch {
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = "{not valid json", .max_age = std::nullopt};
+      }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+}
+
+TEST(metadata_provider_recovers_after_a_failure) {
+  bool succeed{false};
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [&succeed](std::string_view) -> Fetch {
+        if (!succeed) {
+          return std::nullopt;
+        }
+
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
+  succeed = true;
+  const auto recovered{provider.refresh()};
+  EXPECT_TRUE(recovered != nullptr);
+  EXPECT_EQ(recovered->issuer(), "https://example.com");
+}
+
+TEST(metadata_provider_returns_the_same_snapshot_within_the_ttl) {
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [](std::string_view) -> Fetch {
+        return sourcemeta::core::OAuthMetadataProvider::FetchResult{
+            .body = std::string{SERVER_DOCUMENT}, .max_age = std::nullopt};
+      }};
+  const auto first{provider.metadata()};
+  const auto second{provider.metadata()};
+  EXPECT_TRUE(first == second);
+}

--- a/test/oauth/oauth_metadata_provider_test.cc
+++ b/test/oauth/oauth_metadata_provider_test.cc
@@ -4,6 +4,7 @@
 #include <chrono>      // std::chrono
 #include <memory>      // std::make_shared
 #include <optional>    // std::optional, std::nullopt
+#include <stdexcept>   // std::runtime_error
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -334,4 +335,14 @@ TEST(metadata_provider_backs_off_after_a_failed_fetch) {
   *clock_now += std::chrono::minutes{6};
   EXPECT_TRUE(provider.metadata() == nullptr);
   EXPECT_EQ(fetch_count, 2);
+}
+
+TEST(metadata_provider_treats_a_throwing_fetcher_as_a_failure) {
+  sourcemeta::core::OAuthMetadataProvider provider{
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer,
+      [](std::string_view) -> Fetch {
+        throw std::runtime_error{"transport failure"};
+      }};
+  EXPECT_TRUE(provider.metadata() == nullptr);
 }

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -1,0 +1,448 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <string>  // std::string
+#include <utility> // std::move
+
+TEST(well_known_url_authorization_server_without_a_path) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_EQ(url, "https://example.com/.well-known/oauth-authorization-server");
+}
+
+TEST(well_known_url_authorization_server_with_a_path) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/issuer1",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_EQ(
+      url,
+      "https://example.com/.well-known/oauth-authorization-server/issuer1");
+}
+
+TEST(well_known_url_strips_a_terminating_slash) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_EQ(url, "https://example.com/.well-known/oauth-authorization-server");
+}
+
+TEST(well_known_url_protected_resource) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/resource1",
+      sourcemeta::core::OAuthWellKnownKind::ProtectedResource, url));
+  EXPECT_EQ(
+      url,
+      "https://example.com/.well-known/oauth-protected-resource/resource1");
+}
+
+TEST(well_known_url_protected_resource_preserves_a_query) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/path?tenant=a",
+      sourcemeta::core::OAuthWellKnownKind::ProtectedResource, url));
+  EXPECT_EQ(
+      url,
+      "https://example.com/.well-known/oauth-protected-resource/path?tenant=a");
+}
+
+TEST(well_known_url_openid_configuration_inserted) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/issuer1",
+      sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationInserted, url));
+  EXPECT_EQ(url,
+            "https://example.com/.well-known/openid-configuration/issuer1");
+}
+
+TEST(well_known_url_openid_configuration_appended) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/issuer1",
+      sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationAppended, url));
+  EXPECT_EQ(url,
+            "https://example.com/issuer1/.well-known/openid-configuration");
+}
+
+TEST(well_known_url_openid_configuration_appended_without_a_path) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::OpenIDConfigurationAppended, url));
+  EXPECT_EQ(url, "https://example.com/.well-known/openid-configuration");
+}
+
+TEST(well_known_url_rejects_a_non_https_scheme) {
+  std::string url;
+  EXPECT_FALSE(sourcemeta::core::oauth_well_known_url(
+      "http://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_TRUE(url.empty());
+}
+
+TEST(well_known_url_rejects_a_fragment) {
+  std::string url;
+  EXPECT_FALSE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/issuer#x",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+}
+
+TEST(well_known_url_rejects_a_query_for_an_issuer) {
+  std::string url;
+  EXPECT_FALSE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/issuer?x=1",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+}
+
+TEST(well_known_url_appends_to_an_existing_sink) {
+  std::string url{"GET "};
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_EQ(url,
+            "GET https://example.com/.well-known/oauth-authorization-server");
+}
+
+TEST(server_metadata_parses_a_valid_document) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "registration_endpoint": "https://example.com/register",
+    "jwks_uri": "https://example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://example.com/authorize");
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://example.com/token");
+  EXPECT_EQ(metadata.value().registration_endpoint().value(),
+            "https://example.com/register");
+  EXPECT_EQ(metadata.value().jwks_uri().value(), "https://example.com/jwks");
+}
+
+TEST(server_metadata_rejects_an_issuer_mismatch) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://evil.example")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_missing_issuer) {
+  auto document{sourcemeta::core::parse_json(
+      R"JSON({ "response_types_supported": [ "code" ] })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_missing_response_types) {
+  auto document{sourcemeta::core::parse_json(
+      R"JSON({ "issuer": "https://example.com" })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_non_https_issuer) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "http://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "http://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_non_object) {
+  auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_requires_signing_algs_for_private_key_jwt) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint_auth_methods_supported": [ "private_key_jwt" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_accepts_signing_algs_for_private_key_jwt) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint_auth_methods_supported": [ "private_key_jwt" ],
+    "token_endpoint_auth_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_none_in_signing_algs) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint_auth_methods_supported": [ "client_secret_jwt" ],
+    "token_endpoint_auth_signing_alg_values_supported": [ "none" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_iss_parameter_supported_defaults_to_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+}
+
+TEST(server_metadata_iss_parameter_supported_reads_true) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_response_iss_parameter_supported": true
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(
+      metadata.value().authorization_response_iss_parameter_supported());
+}
+
+TEST(server_metadata_grant_types_default) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("refresh_token"));
+}
+
+TEST(server_metadata_grant_types_explicit) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "grant_types_supported": [ "authorization_code", "refresh_token" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("refresh_token"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("implicit"));
+}
+
+TEST(server_metadata_code_challenge_methods_absent_is_unsupported) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+}
+
+TEST(server_metadata_code_challenge_methods_present) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "code_challenge_methods_supported": [ "S256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+}
+
+TEST(server_metadata_token_auth_method_default) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_post"));
+}
+
+TEST(server_metadata_supports_response_type) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code", "token" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_TRUE(metadata.value().supports_response_type("token"));
+  EXPECT_FALSE(metadata.value().supports_response_type("id_token"));
+}
+
+TEST(server_metadata_absent_endpoints_are_empty) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+}
+
+TEST(server_metadata_passthrough) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "service_documentation": "https://example.com/docs"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  const auto *documentation{
+      metadata.value().data().try_at("service_documentation")};
+  EXPECT_TRUE(documentation != nullptr);
+  EXPECT_EQ(documentation->to_string(), "https://example.com/docs");
+}
+
+TEST(server_metadata_rejects_an_empty_response_types) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(well_known_url_rejects_an_empty_authority) {
+  std::string url;
+  EXPECT_FALSE(sourcemeta::core::oauth_well_known_url(
+      "https:///path",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_TRUE(url.empty());
+}
+
+TEST(well_known_url_rejects_an_empty_authority_with_query) {
+  std::string url;
+  EXPECT_FALSE(sourcemeta::core::oauth_well_known_url(
+      "https://?tenant=a",
+      sourcemeta::core::OAuthWellKnownKind::ProtectedResource, url));
+}
+
+TEST(server_metadata_accepts_an_issuer_with_a_path) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com/tenant",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com/tenant")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com/tenant");
+}
+
+TEST(server_metadata_accepts_an_issuer_with_a_trailing_slash) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com/",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com/")};
+  EXPECT_TRUE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_an_empty_issuer) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthServerMetadata::from(std::move(document), "")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_grant_types_wrong_type_falls_back_to_default) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "grant_types_supported": "authorization_code"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+}
+
+TEST(server_metadata_iss_parameter_supported_wrong_type_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_response_iss_parameter_supported": "true"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+}
+
+TEST(server_metadata_non_string_response_type_elements_do_not_match) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ 123 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_response_type("code"));
+}
+
+TEST(well_known_url_authorization_server_with_a_port) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com:8443/tenant",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_EQ(
+      url,
+      "https://example.com:8443/.well-known/oauth-authorization-server/tenant");
+}
+
+TEST(well_known_url_multi_segment_path) {
+  std::string url;
+  EXPECT_TRUE(sourcemeta::core::oauth_well_known_url(
+      "https://example.com/a/b/c",
+      sourcemeta::core::OAuthWellKnownKind::AuthorizationServer, url));
+  EXPECT_EQ(url,
+            "https://example.com/.well-known/oauth-authorization-server/a/b/c");
+}

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -446,3 +446,25 @@ TEST(well_known_url_multi_segment_path) {
   EXPECT_EQ(url,
             "https://example.com/.well-known/oauth-authorization-server/a/b/c");
 }
+
+TEST(server_metadata_rejects_an_empty_authority_issuer) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https:///path",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https:///path")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_an_empty_signing_alg_list) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint_auth_methods_supported": [ "private_key_jwt" ],
+    "token_endpoint_auth_signing_alg_values_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}

--- a/test/oauth/oauth_random_test.cc
+++ b/test/oauth/oauth_random_test.cc
@@ -1,0 +1,24 @@
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <string_view> // std::string_view
+
+TEST(random_token_is_43_characters) {
+  const auto token{sourcemeta::core::oauth_random_token()};
+  EXPECT_EQ((std::string_view{token.data(), token.size()}).size(), 43);
+}
+
+TEST(random_token_carries_no_base64_padding) {
+  // The base64url of 32 octets is 43 characters with no "=" padding, which is
+  // exactly what makes the array-sized mint allocation free
+  const auto token{sourcemeta::core::oauth_random_token()};
+  EXPECT_TRUE((std::string_view{token.data(), token.size()}).find('=') ==
+              std::string_view::npos);
+}
+
+TEST(random_tokens_differ_between_calls) {
+  const auto first{sourcemeta::core::oauth_random_token()};
+  const auto second{sourcemeta::core::oauth_random_token()};
+  EXPECT_FALSE((std::string_view{first.data(), first.size()}) ==
+               (std::string_view{second.data(), second.size()}));
+}

--- a/test/oauth/oauth_token_test.cc
+++ b/test/oauth/oauth_token_test.cc
@@ -1,0 +1,246 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>  // std::array
+#include <chrono> // std::chrono::seconds
+
+TEST(build_token_request_code_minimal) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_code("SplxlOBeZQQYbYS6WxSbIA", "",
+                                                   "", {}, body);
+  EXPECT_TRUE(body ==
+              "grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA");
+}
+
+TEST(build_token_request_code_with_redirect_and_verifier) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_code(
+      "SplxlOBeZQQYbYS6WxSbIA", "https://client.example/cb",
+      "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk", {}, body);
+  EXPECT_TRUE(body ==
+              "grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA"
+              "&redirect_uri=https%3A%2F%2Fclient.example%2Fcb"
+              "&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
+}
+
+TEST(build_token_request_code_escapes_the_code) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_code("a/b+c", "", "", {}, body);
+  EXPECT_TRUE(body == "grant_type=authorization_code&code=a%2Fb%2Bc");
+}
+
+TEST(build_token_request_code_with_resources) {
+  const std::array<sourcemeta::core::OAuthParameter, 1> resources{
+      {{"resource", "https://api.example"}}};
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_code("abc", "", "", resources,
+                                                   body);
+  EXPECT_TRUE(body == "grant_type=authorization_code&code=abc"
+                      "&resource=https%3A%2F%2Fapi.example");
+}
+
+TEST(build_token_request_refresh_minimal) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_refresh("tGzv3JOkF0XG5Qx2TlKWIA",
+                                                      "", {}, body);
+  EXPECT_TRUE(body ==
+              "grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA");
+}
+
+TEST(build_token_request_refresh_with_scope) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_refresh("tGzv3JOkF0XG5Qx2TlKWIA",
+                                                      "read write", {}, body);
+  EXPECT_TRUE(body ==
+              "grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA"
+              "&scope=read%20write");
+}
+
+TEST(build_token_request_client_credentials_minimal) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_client_credentials("", {}, body);
+  EXPECT_TRUE(body == "grant_type=client_credentials");
+}
+
+TEST(build_token_request_client_credentials_with_scope) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_client_credentials("read", {},
+                                                                 body);
+  EXPECT_TRUE(body == "grant_type=client_credentials&scope=read");
+}
+
+TEST(build_token_request_composes_with_client_secret_post) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_code(
+      "SplxlOBeZQQYbYS6WxSbIA", "https://client.example/cb", "", {}, body);
+  sourcemeta::core::oauth_client_secret_post("s6BhdRkqt3", "gX1fBat3bV", body);
+  EXPECT_TRUE(body ==
+              "grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA"
+              "&redirect_uri=https%3A%2F%2Fclient.example%2Fcb"
+              "&client_id=s6BhdRkqt3&client_secret=gX1fBat3bV");
+}
+
+TEST(token_response_reads_the_rfc6749_example) {
+  const auto document{sourcemeta::core::parse_json(R"JSON({
+    "access_token": "2YotnFZFEjr1zCsicMWpAA",
+    "token_type": "Bearer",
+    "expires_in": 3600,
+    "refresh_token": "tGzv3JOkF0XG5Qx2TlKWIA"
+  })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.access_token().has_value());
+  EXPECT_EQ(response.access_token().value(), "2YotnFZFEjr1zCsicMWpAA");
+  EXPECT_TRUE(response.token_type().has_value());
+  EXPECT_EQ(response.token_type().value(), "Bearer");
+  EXPECT_TRUE(response.expires_in().has_value());
+  EXPECT_TRUE(response.expires_in().value() == std::chrono::seconds{3600});
+  EXPECT_TRUE(response.refresh_token().has_value());
+  EXPECT_EQ(response.refresh_token().value(), "tGzv3JOkF0XG5Qx2TlKWIA");
+}
+
+TEST(token_response_bearer_type_is_case_insensitive) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "token_type": "bearer" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.is_bearer_token_type());
+}
+
+TEST(token_response_non_bearer_type) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "token_type": "DPoP" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.is_bearer_token_type());
+}
+
+TEST(token_response_absent_fields_are_empty) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "access_token": "abc" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.token_type().has_value());
+  EXPECT_FALSE(response.expires_in().has_value());
+  EXPECT_FALSE(response.refresh_token().has_value());
+  EXPECT_FALSE(response.scope().has_value());
+  EXPECT_FALSE(response.is_bearer_token_type());
+}
+
+TEST(token_response_rejects_a_negative_expires_in) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "expires_in": -1 })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.expires_in().has_value());
+}
+
+TEST(token_response_rejects_a_non_integer_expires_in) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "expires_in": "3600" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.expires_in().has_value());
+}
+
+TEST(token_response_on_a_non_object_is_empty) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.access_token().has_value());
+}
+
+TEST(token_response_scope_membership) {
+  const auto document{sourcemeta::core::parse_json(
+      R"JSON({ "scope": "read write admin" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.scope().has_value());
+  EXPECT_EQ(response.scope().value(), "read write admin");
+  EXPECT_TRUE(response.has_scope("read"));
+  EXPECT_TRUE(response.has_scope("write"));
+  EXPECT_TRUE(response.has_scope("admin"));
+  EXPECT_FALSE(response.has_scope("delete"));
+  EXPECT_FALSE(response.has_scope("wri"));
+  EXPECT_FALSE(response.has_scope(""));
+}
+
+TEST(token_response_scope_membership_single_value) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "scope": "read" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.has_scope("read"));
+  EXPECT_FALSE(response.has_scope("write"));
+}
+
+TEST(token_response_id_token_via_passthrough) {
+  const auto document{sourcemeta::core::parse_json(R"JSON({
+    "access_token": "abc",
+    "id_token": "header.payload.signature"
+  })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  const auto *id_token{response.data().try_at("id_token")};
+  EXPECT_TRUE(id_token != nullptr);
+  EXPECT_TRUE(id_token->is_string());
+  EXPECT_EQ(id_token->to_string(), "header.payload.signature");
+}
+
+TEST(token_response_expires_in_zero_is_valid) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "expires_in": 0 })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.expires_in().has_value());
+  EXPECT_TRUE(response.expires_in().value() == std::chrono::seconds{0});
+}
+
+TEST(token_response_rejects_a_fractional_expires_in) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "expires_in": 3600.5 })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.expires_in().has_value());
+}
+
+TEST(token_response_empty_token_type_is_not_bearer) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "token_type": "" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.token_type().has_value());
+  EXPECT_FALSE(response.is_bearer_token_type());
+}
+
+TEST(token_response_non_string_access_token_is_empty) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "access_token": 123 })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_FALSE(response.access_token().has_value());
+}
+
+TEST(token_response_empty_scope_has_no_membership) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "scope": "" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.scope().has_value());
+  EXPECT_FALSE(response.has_scope("read"));
+}
+
+TEST(token_response_scope_with_trailing_and_double_spaces) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "scope": "read  write " })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.has_scope("read"));
+  EXPECT_TRUE(response.has_scope("write"));
+  EXPECT_FALSE(response.has_scope(""));
+}
+
+TEST(build_token_request_refresh_with_resources) {
+  const std::array<sourcemeta::core::OAuthParameter, 1> resources{
+      {{"resource", "https://api.example"}}};
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_refresh("rt", "", resources,
+                                                      body);
+  EXPECT_TRUE(body == "grant_type=refresh_token&refresh_token=rt"
+                      "&resource=https%3A%2F%2Fapi.example");
+}
+
+TEST(build_token_request_client_credentials_with_two_resources) {
+  const std::array<sourcemeta::core::OAuthParameter, 2> resources{
+      {{"resource", "https://a"}, {"resource", "https://b"}}};
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_client_credentials(
+      "read", resources, body);
+  EXPECT_TRUE(body == "grant_type=client_credentials&scope=read"
+                      "&resource=https%3A%2F%2Fa&resource=https%3A%2F%2Fb");
+}

--- a/test/oauth/oauth_transaction_test.cc
+++ b/test/oauth/oauth_transaction_test.cc
@@ -1,0 +1,285 @@
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <string_view> // std::string_view
+
+TEST(transaction_mint_produces_distinct_secrets) {
+  const auto secrets{sourcemeta::core::oauth_transaction_mint()};
+  const std::string_view state{secrets.state.data(), secrets.state.size()};
+  const std::string_view verifier{secrets.code_verifier.data(),
+                                  secrets.code_verifier.size()};
+  EXPECT_EQ(state.size(), 43);
+  EXPECT_EQ(verifier.size(), 43);
+  EXPECT_FALSE(state == verifier);
+}
+
+TEST(transaction_mint_differs_between_calls) {
+  const auto first{sourcemeta::core::oauth_transaction_mint()};
+  const auto second{sourcemeta::core::oauth_transaction_mint()};
+  EXPECT_FALSE((std::string_view{first.state.data(), first.state.size()}) ==
+               (std::string_view{second.state.data(), second.state.size()}));
+}
+
+TEST(transaction_check_accepts_a_valid_callback) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "SplxlOBeZQQYbYS6WxSbIA", .state = "xyz", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(code, "SplxlOBeZQQYbYS6WxSbIA");
+}
+
+TEST(transaction_check_rejects_a_state_mismatch) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "different", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+}
+
+TEST(transaction_check_rejects_a_missing_state) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+}
+
+TEST(transaction_check_accepts_a_matching_received_uri) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "",
+      .redirect_uri = "https://client.example/cb"};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
+      "https://client.example/cb", code)};
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(code, "abc");
+}
+
+TEST(transaction_check_rejects_a_received_uri_mismatch) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "",
+      .redirect_uri = "https://client.example/cb"};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
+      "https://client.example/other", code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() ==
+              sourcemeta::core::OAuthCallbackError::ReceivedURI);
+}
+
+TEST(transaction_check_requires_iss_when_supported) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "https://server.example",
+      .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
+      "", code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Issuer);
+}
+
+TEST(transaction_check_accepts_a_matching_iss_when_supported) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "https://server.example",
+      .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc",
+      .state = "xyz",
+      .iss = "https://server.example",
+      .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
+      "", code)};
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(code, "abc");
+}
+
+TEST(transaction_check_rejects_a_mismatched_iss_when_supported) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "https://server.example",
+      .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc",
+      .state = "xyz",
+      .iss = "https://evil.example",
+      .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
+      "", code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Issuer);
+}
+
+TEST(transaction_check_validates_a_present_iss_when_unknown) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "https://server.example",
+      .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc",
+      .state = "xyz",
+      .iss = "https://evil.example",
+      .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Issuer);
+}
+
+TEST(transaction_check_ignores_an_absent_iss_when_unknown) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "https://server.example",
+      .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(code, "abc");
+}
+
+TEST(transaction_check_ignores_a_present_iss_when_not_supported) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "https://server.example",
+      .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc",
+      .state = "xyz",
+      .iss = "https://evil.example",
+      .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::NotSupported,
+      "", code)};
+  EXPECT_FALSE(error.has_value());
+  EXPECT_EQ(code, "abc");
+}
+
+TEST(transaction_check_reports_a_decline) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "", .state = "xyz", .iss = "", .error = "access_denied"};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Declined);
+}
+
+TEST(transaction_check_reports_a_missing_code) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "", .state = "xyz", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() ==
+              sourcemeta::core::OAuthCallbackError::MissingCode);
+}
+
+TEST(transaction_check_validates_state_before_a_decline) {
+  // A crafted error response with a wrong state is a forgery, not a genuine
+  // decline, so the state check takes precedence
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "", .state = "wrong", .iss = "", .error = "access_denied"};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+}
+
+TEST(transaction_check_state_of_a_different_length_fails) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "xy", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+}
+
+TEST(transaction_check_empty_transaction_state_rejects) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "", .code_verifier = "", .issuer = "", .redirect_uri = ""};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "anything", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
+      code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+}
+
+TEST(transaction_check_state_takes_precedence_over_received_uri) {
+  const sourcemeta::core::OAuthTransaction transaction{
+      .state = "xyz",
+      .code_verifier = "",
+      .issuer = "",
+      .redirect_uri = "https://client.example/cb"};
+  const sourcemeta::core::OAuthAuthorizationResponse response{
+      .code = "abc", .state = "wrong", .iss = "", .error = ""};
+  std::string_view code;
+  const auto error{sourcemeta::core::oauth_transaction_check(
+      transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
+      "https://client.example/other", code)};
+  EXPECT_TRUE(error.has_value());
+  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+}

--- a/test/oauth/oauth_transaction_test.cc
+++ b/test/oauth/oauth_transaction_test.cc
@@ -24,7 +24,12 @@ TEST(transaction_check_accepts_a_valid_callback) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "SplxlOBeZQQYbYS6WxSbIA", .state = "xyz", .iss = "", .error = ""};
+      .code = "SplxlOBeZQQYbYS6WxSbIA",
+      .state = "xyz",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -37,7 +42,12 @@ TEST(transaction_check_rejects_a_state_mismatch) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "different", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "different",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -50,7 +60,12 @@ TEST(transaction_check_rejects_a_missing_state) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -66,7 +81,12 @@ TEST(transaction_check_accepts_a_matching_received_uri) {
       .issuer = "",
       .redirect_uri = "https://client.example/cb"};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "xyz",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
@@ -82,7 +102,12 @@ TEST(transaction_check_rejects_a_received_uri_mismatch) {
       .issuer = "",
       .redirect_uri = "https://client.example/cb"};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "xyz",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
@@ -98,7 +123,12 @@ TEST(transaction_check_requires_iss_when_supported) {
       .issuer = "https://server.example",
       .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "xyz",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
@@ -117,7 +147,9 @@ TEST(transaction_check_accepts_a_matching_iss_when_supported) {
       .code = "abc",
       .state = "xyz",
       .iss = "https://server.example",
-      .error = ""};
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
@@ -136,7 +168,9 @@ TEST(transaction_check_rejects_a_mismatched_iss_when_supported) {
       .code = "abc",
       .state = "xyz",
       .iss = "https://evil.example",
-      .error = ""};
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
@@ -155,7 +189,9 @@ TEST(transaction_check_validates_a_present_iss_when_unknown) {
       .code = "abc",
       .state = "xyz",
       .iss = "https://evil.example",
-      .error = ""};
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -171,7 +207,12 @@ TEST(transaction_check_ignores_an_absent_iss_when_unknown) {
       .issuer = "https://server.example",
       .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "xyz", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "xyz",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -190,7 +231,9 @@ TEST(transaction_check_ignores_a_present_iss_when_not_supported) {
       .code = "abc",
       .state = "xyz",
       .iss = "https://evil.example",
-      .error = ""};
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::NotSupported,
@@ -203,7 +246,12 @@ TEST(transaction_check_reports_a_decline) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "", .state = "xyz", .iss = "", .error = "access_denied"};
+      .code = "",
+      .state = "xyz",
+      .iss = "",
+      .error = "access_denied",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -216,7 +264,12 @@ TEST(transaction_check_reports_a_missing_code) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "", .state = "xyz", .iss = "", .error = ""};
+      .code = "",
+      .state = "xyz",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -231,7 +284,12 @@ TEST(transaction_check_validates_state_before_a_decline) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "", .state = "wrong", .iss = "", .error = "access_denied"};
+      .code = "",
+      .state = "wrong",
+      .iss = "",
+      .error = "access_denied",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -244,7 +302,12 @@ TEST(transaction_check_state_of_a_different_length_fails) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "xyz", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "xy", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "xy",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -257,7 +320,12 @@ TEST(transaction_check_empty_transaction_state_rejects) {
   const sourcemeta::core::OAuthTransaction transaction{
       .state = "", .code_verifier = "", .issuer = "", .redirect_uri = ""};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "anything", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "anything",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
@@ -273,7 +341,12 @@ TEST(transaction_check_state_takes_precedence_over_received_uri) {
       .issuer = "",
       .redirect_uri = "https://client.example/cb"};
   const sourcemeta::core::OAuthAuthorizationResponse response{
-      .code = "abc", .state = "wrong", .iss = "", .error = ""};
+      .code = "abc",
+      .state = "wrong",
+      .iss = "",
+      .error = "",
+      .error_description = "",
+      .error_uri = ""};
   std::string_view code;
   const auto error{sourcemeta::core::oauth_transaction_check(
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,

--- a/test/oauth/oauth_transaction_test.cc
+++ b/test/oauth/oauth_transaction_test.cc
@@ -43,7 +43,7 @@ TEST(transaction_check_rejects_a_state_mismatch) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::State);
 }
 
 TEST(transaction_check_rejects_a_missing_state) {
@@ -56,7 +56,7 @@ TEST(transaction_check_rejects_a_missing_state) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::State);
 }
 
 TEST(transaction_check_accepts_a_matching_received_uri) {
@@ -88,8 +88,7 @@ TEST(transaction_check_rejects_a_received_uri_mismatch) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
       "https://client.example/other", code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() ==
-              sourcemeta::core::OAuthCallbackError::ReceivedURI);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::ReceivedURI);
 }
 
 TEST(transaction_check_requires_iss_when_supported) {
@@ -105,7 +104,7 @@ TEST(transaction_check_requires_iss_when_supported) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
       "", code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Issuer);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::Issuer);
 }
 
 TEST(transaction_check_accepts_a_matching_iss_when_supported) {
@@ -143,7 +142,7 @@ TEST(transaction_check_rejects_a_mismatched_iss_when_supported) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Supported,
       "", code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Issuer);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::Issuer);
 }
 
 TEST(transaction_check_validates_a_present_iss_when_unknown) {
@@ -162,7 +161,7 @@ TEST(transaction_check_validates_a_present_iss_when_unknown) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Issuer);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::Issuer);
 }
 
 TEST(transaction_check_ignores_an_absent_iss_when_unknown) {
@@ -210,7 +209,7 @@ TEST(transaction_check_reports_a_decline) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::Declined);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::Declined);
 }
 
 TEST(transaction_check_reports_a_missing_code) {
@@ -223,8 +222,7 @@ TEST(transaction_check_reports_a_missing_code) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() ==
-              sourcemeta::core::OAuthCallbackError::MissingCode);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::MissingCode);
 }
 
 TEST(transaction_check_validates_state_before_a_decline) {
@@ -239,7 +237,7 @@ TEST(transaction_check_validates_state_before_a_decline) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::State);
 }
 
 TEST(transaction_check_state_of_a_different_length_fails) {
@@ -252,7 +250,7 @@ TEST(transaction_check_state_of_a_different_length_fails) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::State);
 }
 
 TEST(transaction_check_empty_transaction_state_rejects) {
@@ -265,7 +263,7 @@ TEST(transaction_check_empty_transaction_state_rejects) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown, "",
       code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::State);
 }
 
 TEST(transaction_check_state_takes_precedence_over_received_uri) {
@@ -281,5 +279,5 @@ TEST(transaction_check_state_takes_precedence_over_received_uri) {
       transaction, response, sourcemeta::core::OAuthIssuerSupport::Unknown,
       "https://client.example/other", code)};
   EXPECT_TRUE(error.has_value());
-  EXPECT_TRUE(error.value() == sourcemeta::core::OAuthCallbackError::State);
+  EXPECT_EQ(error.value(), sourcemeta::core::OAuthCallbackError::State);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

