### PR TITLE
Add a `SecureString` overload for `base64_encode`

### DIFF
--- a/src/core/crypto/crypto_base64.cc
+++ b/src/core/crypto/crypto_base64.cc
@@ -171,6 +171,14 @@ auto base64_encode(const std::string_view input) -> std::string {
   return result;
 }
 
+auto base64_encode(const std::string_view input, SecureString &output) -> void {
+  // The input is copied first so that growing the output cannot invalidate it
+  // when the two alias the same storage
+  const SecureString input_copy{input};
+  output.reserve(output.size() + ((input_copy.size() + 2) / 3) * 4);
+  encode(std::string_view{input_copy}, BASE64_ALPHABET, true, output);
+}
+
 auto base64_decode(const std::string_view input) -> std::optional<std::string> {
   return decode(input, BASE64_DECODE_TABLE, true);
 }

--- a/src/core/crypto/include/sourcemeta/core/crypto_base64.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_base64.h
@@ -43,6 +43,22 @@ auto SOURCEMETA_CORE_CRYPTO_EXPORT base64_encode(const std::string_view input)
     -> std::string;
 
 /// @ingroup crypto
+/// Encode a byte sequence using Base64 (RFC 4648 Section 4), appending to a
+/// wiping string so that an encoded secret is never held in ordinary storage.
+/// The output must not alias the input. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/crypto.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString result;
+/// sourcemeta::core::base64_encode("foobar", result);
+/// assert(result == "Zm9vYmFy");
+/// ```
+auto SOURCEMETA_CORE_CRYPTO_EXPORT base64_encode(const std::string_view input,
+                                                 SecureString &output) -> void;
+
+/// @ingroup crypto
 /// Decode a Base64 string (RFC 4648 Section 4), returning no value unless the
 /// input is a canonical padded encoding. For example:
 ///

--- a/test/crypto/crypto_base64_test.cc
+++ b/test/crypto/crypto_base64_test.cc
@@ -181,3 +181,33 @@ TEST(decode_rejects_nonzero_pad_bits_two_characters) {
 TEST(decode_rejects_nonzero_pad_bits_three_characters) {
   EXPECT_FALSE(sourcemeta::core::base64_decode("Zm9=").has_value());
 }
+
+TEST(encode_secure_string_overload_appends) {
+  sourcemeta::core::SecureString output{"prefix:"};
+  sourcemeta::core::base64_encode("foobar", output);
+  EXPECT_TRUE(output == "prefix:Zm9vYmFy");
+}
+
+TEST(encode_secure_string_overload_pads) {
+  sourcemeta::core::SecureString output;
+  sourcemeta::core::base64_encode("foo", output);
+  EXPECT_TRUE(output == "Zm9v");
+}
+
+TEST(encode_secure_string_overload_single_padding) {
+  sourcemeta::core::SecureString output;
+  sourcemeta::core::base64_encode("fooba", output);
+  EXPECT_TRUE(output == "Zm9vYmE=");
+}
+
+TEST(encode_secure_string_overload_double_padding) {
+  sourcemeta::core::SecureString output;
+  sourcemeta::core::base64_encode("foob", output);
+  EXPECT_TRUE(output == "Zm9vYg==");
+}
+
+TEST(encode_secure_string_overload_empty) {
+  sourcemeta::core::SecureString output;
+  sourcemeta::core::base64_encode("", output);
+  EXPECT_TRUE(output.empty());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

