### PR TITLE
Implement DPoP proofs, verification, and replay protection for OAuth

### DIFF
--- a/src/core/jose/include/sourcemeta/core/jose_algorithm.h
+++ b/src/core/jose/include/sourcemeta/core/jose_algorithm.h
@@ -61,6 +61,38 @@ SOURCEMETA_CORE_JOSE_EXPORT
 auto to_jws_algorithm(const std::string_view value) noexcept
     -> std::optional<JWSAlgorithm>;
 
+/// @ingroup jose
+/// Map a JSON Web Signature algorithm to its `alg` value, the inverse of
+/// parsing (RFC 7515 Section 4.1.1). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/jose.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::jws_algorithm_name(
+///            sourcemeta::core::JWSAlgorithm::ES256) == "ES256");
+/// ```
+SOURCEMETA_CORE_JOSE_EXPORT
+auto jws_algorithm_name(const JWSAlgorithm algorithm) noexcept
+    -> std::string_view;
+
+/// @ingroup jose
+/// Whether an algorithm is an asymmetric digital signature algorithm rather
+/// than a symmetric message authentication code (RFC 7518 Section 3.1). For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/jose.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::jws_algorithm_is_asymmetric(
+///            sourcemeta::core::JWSAlgorithm::ES256));
+/// assert(!sourcemeta::core::jws_algorithm_is_asymmetric(
+///            sourcemeta::core::JWSAlgorithm::HS256));
+/// ```
+SOURCEMETA_CORE_JOSE_EXPORT
+auto jws_algorithm_is_asymmetric(const JWSAlgorithm algorithm) noexcept -> bool;
+
 } // namespace sourcemeta::core
 
 #endif

--- a/src/core/jose/jose_algorithm.cc
+++ b/src/core/jose/jose_algorithm.cc
@@ -2,6 +2,7 @@
 
 #include <optional>    // std::optional, std::nullopt
 #include <string_view> // std::string_view
+#include <utility>     // std::unreachable
 
 namespace sourcemeta::core {
 
@@ -36,6 +37,63 @@ auto to_jws_algorithm(const std::string_view value) noexcept
   } else {
     return std::nullopt;
   }
+}
+
+auto jws_algorithm_name(const JWSAlgorithm algorithm) noexcept
+    -> std::string_view {
+  switch (algorithm) {
+    case JWSAlgorithm::RS256:
+      return "RS256";
+    case JWSAlgorithm::RS384:
+      return "RS384";
+    case JWSAlgorithm::RS512:
+      return "RS512";
+    case JWSAlgorithm::PS256:
+      return "PS256";
+    case JWSAlgorithm::PS384:
+      return "PS384";
+    case JWSAlgorithm::PS512:
+      return "PS512";
+    case JWSAlgorithm::ES256:
+      return "ES256";
+    case JWSAlgorithm::ES384:
+      return "ES384";
+    case JWSAlgorithm::ES512:
+      return "ES512";
+    case JWSAlgorithm::EdDSA:
+      return "EdDSA";
+    case JWSAlgorithm::HS256:
+      return "HS256";
+    case JWSAlgorithm::HS384:
+      return "HS384";
+    case JWSAlgorithm::HS512:
+      return "HS512";
+  }
+
+  std::unreachable();
+}
+
+auto jws_algorithm_is_asymmetric(const JWSAlgorithm algorithm) noexcept
+    -> bool {
+  switch (algorithm) {
+    case JWSAlgorithm::RS256:
+    case JWSAlgorithm::RS384:
+    case JWSAlgorithm::RS512:
+    case JWSAlgorithm::PS256:
+    case JWSAlgorithm::PS384:
+    case JWSAlgorithm::PS512:
+    case JWSAlgorithm::ES256:
+    case JWSAlgorithm::ES384:
+    case JWSAlgorithm::ES512:
+    case JWSAlgorithm::EdDSA:
+      return true;
+    case JWSAlgorithm::HS256:
+    case JWSAlgorithm::HS384:
+    case JWSAlgorithm::HS512:
+      return false;
+  }
+
+  std::unreachable();
 }
 
 } // namespace sourcemeta::core

--- a/src/core/jose/jose_jwt.cc
+++ b/src/core/jose/jose_jwt.cc
@@ -38,6 +38,19 @@ auto string_claim(const sourcemeta::core::JSON &object,
   return std::string_view{member->to_string()};
 }
 
+// The JSON layer preserves repeated members rather than collapsing them, so
+// uniqueness is checked here
+auto has_unique_members(const sourcemeta::core::JSON &object) -> bool {
+  std::unordered_set<std::string_view> names;
+  for (const auto &entry : object.as_object()) {
+    if (!names.emplace(entry.first).second) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 auto date_claim(const sourcemeta::core::JSON &object,
                 const sourcemeta::core::JSON::StringView name,
                 const sourcemeta::core::JSON::Object::hash_type hash)
@@ -101,14 +114,12 @@ auto JWT::parse(const std::string_view input, JWT &result) -> bool {
     return false;
   }
 
-  // RFC 7515 Section 4: the header parameter names must be unique, so a header
-  // with a duplicate is rejected, since the JSON layer preserves repeated
-  // members rather than collapsing them
-  std::unordered_set<std::string_view> header_parameters;
-  for (const auto &parameter : header_json.value().as_object()) {
-    if (!header_parameters.emplace(parameter.first).second) {
-      return false;
-    }
+  // RFC 7515 Section 4: the header parameter names must be unique, and RFC 7519
+  // Section 4: the claim names must be unique, so a duplicate in either the
+  // header or the payload is rejected (RFC 8725 Section 2.4)
+  if (!has_unique_members(header_json.value()) ||
+      !has_unique_members(payload_json.value())) {
+    return false;
   }
 
   // The algorithm header parameter is required and must be a string (RFC 7515

--- a/src/core/oauth/CMakeLists.txt
+++ b/src/core/oauth/CMakeLists.txt
@@ -1,13 +1,13 @@
 sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME oauth
   PRIVATE_HEADERS error.h profile.h pkce.h bearer.h random.h authorization.h
     token.h client_authentication.h transaction.h metadata.h metadata_provider.h
-    token_exchange.h revocation.h introspection.h device.h
+    token_exchange.h revocation.h introspection.h device.h dpop.h
   SOURCES oauth_error.cc oauth_pkce.cc oauth_bearer.cc oauth_syntax.h
     oauth_random.cc oauth_authorization.cc oauth_encode.h oauth_decode.h
     oauth_json.h oauth_token.cc oauth_client_authentication.cc
     oauth_transaction.cc oauth_metadata.cc oauth_metadata_provider.cc
     oauth_ttl.h oauth_token_exchange.cc oauth_revocation.cc
-    oauth_introspection.cc oauth_device.cc)
+    oauth_introspection.cc oauth_device.cc oauth_dpop.cc)
 
 target_link_libraries(sourcemeta_core_oauth
   PUBLIC sourcemeta::core::json)

--- a/src/core/oauth/include/sourcemeta/core/oauth.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth.h
@@ -10,6 +10,7 @@
 #include <sourcemeta/core/oauth_bearer.h>
 #include <sourcemeta/core/oauth_client_authentication.h>
 #include <sourcemeta/core/oauth_device.h>
+#include <sourcemeta/core/oauth_dpop.h>
 #include <sourcemeta/core/oauth_error.h>
 #include <sourcemeta/core/oauth_introspection.h>
 #include <sourcemeta/core/oauth_metadata.h>

--- a/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
@@ -120,8 +120,8 @@ private:
 /// assert(confirmation.at("jkt").to_string() ==
 ///        "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I");
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_dpop_confirmation(const std::string_view thumbprint) -> JSON;
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto
+oauth_dpop_confirmation(const std::string_view thumbprint) -> JSON;
 
 /// @ingroup oauth
 /// The JSON Web Key thumbprint of the key a DPoP proof is signed with (RFC 9449
@@ -136,8 +136,8 @@ auto oauth_dpop_confirmation(const std::string_view thumbprint) -> JSON;
 /// const auto thumbprint{sourcemeta::core::oauth_dpop_proof_thumbprint(proof)};
 /// assert(!thumbprint.has_value() || !thumbprint.value().empty());
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_dpop_proof_thumbprint(const std::string_view proof)
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto
+oauth_dpop_proof_thumbprint(const std::string_view proof)
     -> std::optional<std::string>;
 
 /// @ingroup oauth
@@ -227,13 +227,10 @@ struct OAuthDPoPVerifyOptions {
 /// assert(!error.has_value() ||
 ///        error.value() == sourcemeta::core::OAuthDPoPError::Expired);
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_dpop_verify(const std::string_view proof,
-                       const std::string_view method,
-                       const std::string_view url,
-                       const std::chrono::system_clock::time_point now,
-                       const OAuthDPoPVerifyOptions &options)
-    -> std::optional<OAuthDPoPError>;
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto oauth_dpop_verify(
+    const std::string_view proof, const std::string_view method,
+    const std::string_view url, const std::chrono::system_clock::time_point now,
+    const OAuthDPoPVerifyOptions &options) -> std::optional<OAuthDPoPError>;
 
 /// @ingroup oauth
 /// An in-memory store of the proof identifiers seen within their acceptance
@@ -321,8 +318,8 @@ private:
 /// assert(sourcemeta::core::oauth_is_valid_dpop_nonce("eyJ7S_zG.eyJH0-Z.HX4w"));
 /// assert(!sourcemeta::core::oauth_is_valid_dpop_nonce(""));
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_is_valid_dpop_nonce(const std::string_view value) noexcept -> bool;
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto
+oauth_is_valid_dpop_nonce(const std::string_view value) noexcept -> bool;
 
 } // namespace sourcemeta::core
 

--- a/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
@@ -81,7 +81,8 @@ public:
       -> bool;
 
   /// Record the most recent nonce a server issued through its response header,
-  /// to be included in later proofs to that server (RFC 9449 Section 8).
+  /// to be included in later proofs to that server, ignoring a malformed nonce
+  /// rather than echoing it (RFC 9449 Section 8).
   auto observe(const std::string_view server, const std::string_view nonce)
       -> void;
 
@@ -120,8 +121,7 @@ private:
 ///        "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I");
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
-[[nodiscard]] auto oauth_dpop_confirmation(const std::string_view thumbprint)
-    -> JSON;
+auto oauth_dpop_confirmation(const std::string_view thumbprint) -> JSON;
 
 /// @ingroup oauth
 /// The JSON Web Key thumbprint of the key a DPoP proof is signed with (RFC 9449
@@ -137,7 +137,7 @@ SOURCEMETA_CORE_OAUTH_EXPORT
 /// assert(!thumbprint.has_value() || !thumbprint.value().empty());
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
-[[nodiscard]] auto oauth_dpop_proof_thumbprint(const std::string_view proof)
+auto oauth_dpop_proof_thumbprint(const std::string_view proof)
     -> std::optional<std::string>;
 
 /// @ingroup oauth
@@ -228,10 +228,12 @@ struct OAuthDPoPVerifyOptions {
 ///        error.value() == sourcemeta::core::OAuthDPoPError::Expired);
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
-[[nodiscard]] auto oauth_dpop_verify(
-    const std::string_view proof, const std::string_view method,
-    const std::string_view url, const std::chrono::system_clock::time_point now,
-    const OAuthDPoPVerifyOptions &options) -> std::optional<OAuthDPoPError>;
+auto oauth_dpop_verify(const std::string_view proof,
+                       const std::string_view method,
+                       const std::string_view url,
+                       const std::chrono::system_clock::time_point now,
+                       const OAuthDPoPVerifyOptions &options)
+    -> std::optional<OAuthDPoPError>;
 
 /// @ingroup oauth
 /// An in-memory store of the proof identifiers seen within their acceptance
@@ -276,8 +278,9 @@ public:
                    const std::chrono::system_clock::time_point now,
                    const std::chrono::seconds window) -> bool;
 
-  /// The number of live entries, after pruning those whose window has elapsed
-  /// by the given time.
+  /// The number of entries whose window has not elapsed by the given time,
+  /// counted without modifying the store, since expired entries are pruned when
+  /// the next one is recorded.
   [[nodiscard]] auto size(const std::chrono::system_clock::time_point now) const
       -> std::size_t;
 
@@ -310,8 +313,7 @@ private:
 /// assert(!sourcemeta::core::oauth_is_valid_dpop_nonce(""));
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
-[[nodiscard]] auto
-oauth_is_valid_dpop_nonce(const std::string_view value) noexcept -> bool;
+auto oauth_is_valid_dpop_nonce(const std::string_view value) noexcept -> bool;
 
 } // namespace sourcemeta::core
 

--- a/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
@@ -1,0 +1,318 @@
+#ifndef SOURCEMETA_CORE_OAUTH_DPOP_H_
+#define SOURCEMETA_CORE_OAUTH_DPOP_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/jose_algorithm.h>
+#include <sourcemeta/core/jose_jwk_private.h>
+
+#include <sourcemeta/core/json.h>
+
+#include <array>       // std::array
+#include <chrono>      // std::chrono::seconds, std::chrono::system_clock
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <map>         // std::map
+#include <mutex>       // std::mutex
+#include <optional>    // std::optional
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <vector>      // std::vector
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// The token type of a DPoP-bound access token (RFC 9449 Section 5), the value
+/// a bound token response carries and a client confirms before use.
+inline constexpr std::string_view OAUTH_TOKEN_TYPE_DPOP{"DPoP"};
+
+/// @ingroup oauth
+/// A client-side minter of DPoP proof JSON Web Tokens (RFC 9449 Section 4.2)
+/// that holds one proof-of-possession key and the most recent nonce each server
+/// has issued. Nonces are tracked per server because a nonce is only accepted
+/// by the server that issued it (RFC 9449 Section 9), so a caller keys the
+/// authorization server by its issuer and each resource server by its origin.
+/// For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/jose.h>
+/// #include <chrono>
+/// #include <string>
+/// #include <cassert>
+///
+/// auto key{sourcemeta::core::JWKPrivate::from_pem(pem)};
+/// assert(key.has_value());
+/// sourcemeta::core::OAuthDPoPProofer proofer{
+///     std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+/// std::string header;
+/// assert(proofer.proof("https://server.example.com", "POST",
+///                      "https://server.example.com/token", "",
+///                      std::chrono::system_clock::now(), header));
+/// ```
+class SOURCEMETA_CORE_OAUTH_EXPORT OAuthDPoPProofer {
+public:
+  /// Construct a proofer bound to a proof-of-possession key and the asymmetric
+  /// signature algorithm to sign proofs with (RFC 9449 Section 4.2).
+  OAuthDPoPProofer(JWKPrivate key, const JWSAlgorithm algorithm);
+
+  /// A proofer owns a private key and a mutex, so it is neither copied nor
+  /// moved.
+  OAuthDPoPProofer(const OAuthDPoPProofer &) = delete;
+  auto operator=(const OAuthDPoPProofer &) -> OAuthDPoPProofer & = delete;
+  OAuthDPoPProofer(OAuthDPoPProofer &&) = delete;
+  auto operator=(OAuthDPoPProofer &&) -> OAuthDPoPProofer & = delete;
+  ~OAuthDPoPProofer() = default;
+
+  /// Append a DPoP proof for a request to the sink, returning whether it could
+  /// be built and signed. The method and target URI are covered by the proof,
+  /// the access token binds the proof through its hash when it is presented to
+  /// a protected resource and is omitted otherwise (RFC 9449 Section 7), and
+  /// the most recent nonce the server issued is included when one is known. The
+  /// creation time is taken from the given clock reading (RFC 9449
+  /// Section 4.2).
+  [[nodiscard]] auto
+  proof(const std::string_view server, const std::string_view method,
+        const std::string_view url, const std::string_view access_token,
+        const std::chrono::system_clock::time_point now, std::string &sink)
+      -> bool;
+
+  /// Record the most recent nonce a server issued through its response header,
+  /// to be included in later proofs to that server (RFC 9449 Section 8).
+  auto observe(const std::string_view server, const std::string_view nonce)
+      -> void;
+
+  /// The JSON Web Key thumbprint of the proof-of-possession key (RFC 9449
+  /// Section 6.1), the value a client sends to bind an authorization code to
+  /// the key (RFC 9449 Section 10), or no value when the public part cannot be
+  /// recovered.
+  [[nodiscard]] auto thumbprint() const -> std::optional<std::string>;
+
+private:
+  JWKPrivate key_;
+  JWSAlgorithm algorithm_;
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+  mutable std::mutex mutex_;
+  std::map<std::string, std::string, std::less<>> nonces_;
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
+};
+
+/// @ingroup oauth
+/// Build the confirmation value that binds an access token to a DPoP key
+/// (RFC 9449 Section 6.1), for a server to assign under the `cnf` claim of a
+/// JSON Web Token access token or a top-level `cnf` of a token introspection
+/// response (RFC 9449 Section 6.2). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// const auto confirmation{sourcemeta::core::oauth_dpop_confirmation(
+///     "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I")};
+/// assert(confirmation.at("jkt").to_string() ==
+///        "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+[[nodiscard]] auto oauth_dpop_confirmation(const std::string_view thumbprint)
+    -> JSON;
+
+/// @ingroup oauth
+/// The JSON Web Key thumbprint of the key a DPoP proof is signed with (RFC 9449
+/// Section 6.1), the value a server matches against an authorization code
+/// binding (RFC 9449 Section 10) or binds an issued token to, or no value when
+/// the proof or its embedded key cannot be read. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// const auto thumbprint{sourcemeta::core::oauth_dpop_proof_thumbprint(proof)};
+/// assert(!thumbprint.has_value() || !thumbprint.value().empty());
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+[[nodiscard]] auto oauth_dpop_proof_thumbprint(const std::string_view proof)
+    -> std::optional<std::string>;
+
+/// @ingroup oauth
+/// The reason a DPoP proof failed verification (RFC 9449 Section 4.3), one per
+/// check performed, with a missing nonce kept distinct from a mismatched one
+/// because a server resupplies a nonce for the former (RFC 9449 Section 9).
+enum class OAuthDPoPError : std::uint8_t {
+  /// More or fewer than one DPoP header field was present (check 1).
+  ProofCount,
+  /// The header value was not a single well-formed JSON Web Token (check 2).
+  Malformed,
+  /// A required header parameter or claim was absent (check 3).
+  MissingClaim,
+  /// The token type header parameter was not `dpop+jwt` (check 4).
+  UnexpectedType,
+  /// The algorithm was absent, symmetric, or outside the accepted set
+  /// (check 5).
+  UnsupportedAlgorithm,
+  /// The embedded key carried private material (check 7).
+  PrivateKey,
+  /// The signature did not verify with the embedded key (check 6).
+  Signature,
+  /// The method claim did not match the request method (check 8).
+  MethodMismatch,
+  /// The target claim did not match the request target (check 9).
+  TargetMismatch,
+  /// A nonce was required but absent, the downgrade the server must reject
+  /// (check 10, RFC 9449 Section 11.3).
+  MissingNonce,
+  /// The nonce claim did not match the nonce the server issued (check 10).
+  NonceMismatch,
+  /// The creation time was outside the acceptable window (check 11).
+  Expired,
+  /// The access token hash was absent or did not match the presented token
+  /// (check 12).
+  AccessTokenMismatch,
+  /// The proof key did not match the key the access token is bound to, or a
+  /// token was presented with no binding to confirm it against (check 12).
+  KeyMismatch
+};
+
+/// @ingroup oauth
+/// The inputs to DPoP proof verification a caller supplies beyond the request
+/// (RFC 9449 Section 4.3). Every field has a safe default, so a token endpoint
+/// verifying a proof with no bound token leaves the token and thumbprint unset,
+/// and a protected resource sets both.
+struct OAuthDPoPVerifyOptions {
+  /// The number of DPoP header fields the request carried, checked to be
+  /// exactly one (RFC 9449 Section 4.3 check 1).
+  std::size_t proof_count{1};
+  /// The asymmetric algorithms accepted per local policy, every asymmetric
+  /// algorithm when empty (RFC 9449 Section 4.3 check 5).
+  std::span<const JWSAlgorithm> allowed_algorithms{};
+  /// How far in the past a creation time may be (RFC 9449 Section 11.1).
+  std::chrono::seconds past_window{std::chrono::seconds{300}};
+  /// How far in the future a creation time may be, to tolerate clock offset
+  /// (RFC 9449 Section 11.1).
+  std::chrono::seconds future_window{std::chrono::seconds{5}};
+  /// The nonce the server issued to the client, requiring a matching nonce
+  /// claim when set (RFC 9449 Section 9).
+  std::optional<std::string_view> expected_nonce{std::nullopt};
+  /// The access token presented alongside the proof, requiring a matching hash
+  /// claim when set, and requiring the bound thumbprint to also be set so the
+  /// key binding is confirmed rather than skipped (RFC 9449 Section 7).
+  std::optional<std::string_view> access_token{std::nullopt};
+  /// The thumbprint the access token is bound to, requiring a matching proof
+  /// key when set (RFC 9449 Section 4.3 check 12).
+  std::optional<std::string_view> bound_thumbprint{std::nullopt};
+};
+
+/// @ingroup oauth
+/// Verify a DPoP proof against the request it accompanies (RFC 9449
+/// Section 4.3), returning the first failing check or no value when every check
+/// passes. The checks are run in a fixed order though the specification permits
+/// any order, and replay is a separate concern the caller enforces after this
+/// passes. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <chrono>
+/// #include <cassert>
+///
+/// sourcemeta::core::OAuthDPoPVerifyOptions options;
+/// const auto error{sourcemeta::core::oauth_dpop_verify(
+///     proof, "POST", "https://server.example.com/token",
+///     std::chrono::system_clock::now(), options)};
+/// assert(!error.has_value() ||
+///        error.value() == sourcemeta::core::OAuthDPoPError::Expired);
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+[[nodiscard]] auto oauth_dpop_verify(
+    const std::string_view proof, const std::string_view method,
+    const std::string_view url, const std::chrono::system_clock::time_point now,
+    const OAuthDPoPVerifyOptions &options) -> std::optional<OAuthDPoPError>;
+
+/// @ingroup oauth
+/// An in-memory store of the proof identifiers seen within their acceptance
+/// window, to reject a replayed DPoP proof at one target (RFC 9449
+/// Section 11.1). A store instance is safe to share across threads, and it
+/// holds a hash of each identifier rather than the identifier itself. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <chrono>
+/// #include <cassert>
+///
+/// sourcemeta::core::OAuthDPoPReplayStore store;
+/// const auto now{std::chrono::system_clock::now()};
+/// assert(store.check_and_insert("id", "https://server.example.com/token", now,
+///                               std::chrono::seconds{300}));
+/// assert(!store.check_and_insert("id", "https://server.example.com/token",
+/// now,
+///                                std::chrono::seconds{300}));
+/// ```
+class SOURCEMETA_CORE_OAUTH_EXPORT OAuthDPoPReplayStore {
+public:
+  /// Construct an empty store.
+  OAuthDPoPReplayStore() = default;
+
+  /// A store owns a mutex, so it is neither copied nor moved.
+  OAuthDPoPReplayStore(const OAuthDPoPReplayStore &) = delete;
+  auto operator=(const OAuthDPoPReplayStore &)
+      -> OAuthDPoPReplayStore & = delete;
+  OAuthDPoPReplayStore(OAuthDPoPReplayStore &&) = delete;
+  auto operator=(OAuthDPoPReplayStore &&) -> OAuthDPoPReplayStore & = delete;
+  ~OAuthDPoPReplayStore() = default;
+
+  /// Record a proof identifier at a target and report whether it is new,
+  /// returning false for one already seen within its window, which is a replay
+  /// (RFC 9449 Section 11.1). Entries whose window has elapsed by the given
+  /// time are pruned.
+  [[nodiscard]] auto
+  check_and_insert(const std::string_view identifier,
+                   const std::string_view target,
+                   const std::chrono::system_clock::time_point now,
+                   const std::chrono::seconds window) -> bool;
+
+  /// The number of live entries, after pruning those whose window has elapsed
+  /// by the given time.
+  [[nodiscard]] auto size(const std::chrono::system_clock::time_point now) const
+      -> std::size_t;
+
+private:
+  struct Entry {
+    std::array<std::uint8_t, 32> digest;
+    std::chrono::system_clock::time_point expiry;
+  };
+
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#endif
+  mutable std::mutex mutex_;
+  std::vector<Entry> entries_;
+#if defined(_MSC_VER)
+#pragma warning(default : 4251)
+#endif
+};
+
+/// @ingroup oauth
+/// Whether a value is a well-formed DPoP nonce, a non-empty string of the nonce
+/// character set (RFC 9449 Section 8.1, RFC 6749 Appendix A), so a client
+/// validates a received nonce before echoing it. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::oauth_is_valid_dpop_nonce("eyJ7S_zG.eyJH0-Z.HX4w"));
+/// assert(!sourcemeta::core::oauth_is_valid_dpop_nonce(""));
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+[[nodiscard]] auto
+oauth_is_valid_dpop_nonce(const std::string_view value) noexcept -> bool;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
@@ -238,9 +238,11 @@ auto oauth_dpop_verify(const std::string_view proof,
 /// @ingroup oauth
 /// An in-memory store of the proof identifiers seen within their acceptance
 /// window, to reject a replayed DPoP proof at one target (RFC 9449
-/// Section 11.1). A store instance is safe to share across threads, and it
-/// holds a hash of each identifier rather than the identifier itself. For
-/// example:
+/// Section 11.1). A store instance is safe to share across threads, it holds a
+/// hash of each identifier rather than the identifier itself, and it is bounded
+/// to a fixed capacity so an attacker minting distinct proofs cannot exhaust
+/// memory. When full, the entry closest to expiry is evicted, which the
+/// acceptance window backstops (RFC 9449 Section 4.3 check 11). For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>
@@ -257,8 +259,14 @@ auto oauth_dpop_verify(const std::string_view proof,
 /// ```
 class SOURCEMETA_CORE_OAUTH_EXPORT OAuthDPoPReplayStore {
 public:
-  /// Construct an empty store.
-  OAuthDPoPReplayStore() = default;
+  /// The default maximum number of live entries a store retains.
+  static constexpr std::size_t DEFAULT_CAPACITY{131072};
+
+  /// Construct an empty store with the given maximum number of live entries,
+  /// beyond which the entry closest to expiry is evicted to make room.
+  explicit OAuthDPoPReplayStore(
+      const std::size_t capacity = DEFAULT_CAPACITY) noexcept
+      : capacity_{capacity == 0 ? DEFAULT_CAPACITY : capacity} {}
 
   /// A store owns a mutex, so it is neither copied nor moved.
   OAuthDPoPReplayStore(const OAuthDPoPReplayStore &) = delete;
@@ -271,7 +279,7 @@ public:
   /// Record a proof identifier at a target and report whether it is new,
   /// returning false for one already seen within its window, which is a replay
   /// (RFC 9449 Section 11.1). Entries whose window has elapsed by the given
-  /// time are pruned.
+  /// time are pruned, and at capacity the entry closest to expiry is evicted.
   [[nodiscard]] auto
   check_and_insert(const std::string_view identifier,
                    const std::string_view target,
@@ -290,6 +298,7 @@ private:
     std::chrono::system_clock::time_point expiry;
   };
 
+  std::size_t capacity_;
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -1,0 +1,458 @@
+#include <sourcemeta/core/oauth_dpop.h>
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/jose_jwk.h>
+#include <sourcemeta/core/jose_jwt.h>
+#include <sourcemeta/core/jose_sign.h>
+#include <sourcemeta/core/jose_verify.h>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth_random.h>
+
+#include "oauth_json.h"
+#include "oauth_syntax.h"
+
+#include <algorithm> // std::ranges::find, std::ranges::all_of, std::ranges::count_if
+#include <array>       // std::array
+#include <chrono>      // std::chrono::seconds, std::chrono::duration_cast
+#include <cstdint>     // std::int64_t, std::uint8_t
+#include <mutex>       // std::scoped_lock
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::move, std::unreachable
+#include <vector>      // std::erase_if
+
+namespace sourcemeta::core {
+
+namespace {
+
+using namespace std::literals::string_view_literals;
+
+const auto HASH_TYP{JSON::Object::hash("typ"sv)};
+const auto HASH_ALG{JSON::Object::hash("alg"sv)};
+const auto HASH_JWK{JSON::Object::hash("jwk"sv)};
+const auto HASH_JTI{JSON::Object::hash("jti"sv)};
+const auto HASH_HTM{JSON::Object::hash("htm"sv)};
+const auto HASH_HTU{JSON::Object::hash("htu"sv)};
+const auto HASH_IAT{JSON::Object::hash("iat"sv)};
+const auto HASH_ATH{JSON::Object::hash("ath"sv)};
+const auto HASH_NONCE{JSON::Object::hash("nonce"sv)};
+const auto HASH_JKT{JSON::Object::hash("jkt"sv)};
+
+// RFC 7515 Section 4.1.1: the "alg" header value each algorithm serializes to
+auto dpop_algorithm_name(const JWSAlgorithm algorithm) -> std::string_view {
+  switch (algorithm) {
+    case JWSAlgorithm::RS256:
+      return "RS256";
+    case JWSAlgorithm::RS384:
+      return "RS384";
+    case JWSAlgorithm::RS512:
+      return "RS512";
+    case JWSAlgorithm::PS256:
+      return "PS256";
+    case JWSAlgorithm::PS384:
+      return "PS384";
+    case JWSAlgorithm::PS512:
+      return "PS512";
+    case JWSAlgorithm::ES256:
+      return "ES256";
+    case JWSAlgorithm::ES384:
+      return "ES384";
+    case JWSAlgorithm::ES512:
+      return "ES512";
+    case JWSAlgorithm::EdDSA:
+      return "EdDSA";
+    case JWSAlgorithm::HS256:
+      return "HS256";
+    case JWSAlgorithm::HS384:
+      return "HS384";
+    case JWSAlgorithm::HS512:
+      return "HS512";
+  }
+
+  std::unreachable();
+}
+
+// RFC 9449 Section 4.2: the DPoP algorithm MUST NOT be a symmetric one, so the
+// message authentication code algorithms are the ones to exclude
+auto dpop_is_asymmetric(const JWSAlgorithm algorithm) noexcept -> bool {
+  switch (algorithm) {
+    case JWSAlgorithm::RS256:
+    case JWSAlgorithm::RS384:
+    case JWSAlgorithm::RS512:
+    case JWSAlgorithm::PS256:
+    case JWSAlgorithm::PS384:
+    case JWSAlgorithm::PS512:
+    case JWSAlgorithm::ES256:
+    case JWSAlgorithm::ES384:
+    case JWSAlgorithm::ES512:
+    case JWSAlgorithm::EdDSA:
+      return true;
+    case JWSAlgorithm::HS256:
+    case JWSAlgorithm::HS384:
+    case JWSAlgorithm::HS512:
+      return false;
+  }
+
+  std::unreachable();
+}
+
+// RFC 9449 Section 4.2: the HTTP target URI without query and fragment, with
+// the syntax and scheme normalization Section 4.3 recommends applied so the
+// same request compares equal on both sides, and an empty path treated as "/"
+// (RFC 3986 Section 6.2.3)
+auto dpop_normalize_target(const std::string_view url)
+    -> std::optional<std::string> {
+  auto uri{oauth_try_parse_uri(url)};
+  if (!uri.has_value()) {
+    return std::nullopt;
+  }
+
+  uri->canonicalize();
+  const auto scheme{uri->scheme()};
+  const auto authority{uri->authority()};
+  if (!scheme.has_value() || !authority.has_value()) {
+    return std::nullopt;
+  }
+
+  // RFC 9110 Section 4.2.1: an "http" or "https" target URI carries no
+  // userinfo, so any is dropped rather than signed into the proof or compared,
+  // keeping the host and port (with the IPv6 brackets the authority already
+  // carries)
+  std::string_view host_and_port{authority.value()};
+  const auto userinfo_end{host_and_port.find('@')};
+  if (userinfo_end != std::string_view::npos) {
+    host_and_port.remove_prefix(userinfo_end + 1);
+  }
+
+  const auto path{uri->path()};
+  const auto has_path{path.has_value() && !path.value().empty()};
+  std::string result;
+  result.reserve(scheme.value().size() + 3 + host_and_port.size() +
+                 (has_path ? path.value().size() : 1));
+  result.append(scheme.value());
+  result.append("://");
+  result.append(host_and_port);
+  if (has_path) {
+    result.append(path.value());
+  } else {
+    result.push_back('/');
+  }
+
+  return result;
+}
+
+// RFC 9449 Section 4.2 and Section 7: the base64url-encoded SHA-256 hash of the
+// access token, the value bound into a proof through the hash claim
+auto dpop_access_token_hash(const std::string_view access_token)
+    -> std::string {
+  const auto digest{sha256_digest(access_token)};
+  return base64url_encode(std::string_view{
+      reinterpret_cast<const char *>(digest.data()), digest.size()});
+}
+
+// RFC 9449 Section 4.3 check 7: the public key MUST NOT contain a private key,
+// whose presence is marked by any private JSON Web Key member (RFC 7518
+// Sections 6.2.2 and 6.3.2, RFC 8037 Section 2, RFC 7518 Section 6.4)
+auto dpop_has_private_material(const JSON &key) -> bool {
+  return key.defines("d") || key.defines("p") || key.defines("q") ||
+         key.defines("dp") || key.defines("dq") || key.defines("qi") ||
+         key.defines("oth") || key.defines("k");
+}
+
+} // namespace
+
+OAuthDPoPProofer::OAuthDPoPProofer(JWKPrivate key, const JWSAlgorithm algorithm)
+    : key_{std::move(key)}, algorithm_{algorithm} {}
+
+auto OAuthDPoPProofer::proof(const std::string_view server,
+                             const std::string_view method,
+                             const std::string_view url,
+                             const std::string_view access_token,
+                             const std::chrono::system_clock::time_point now,
+                             std::string &sink) -> bool {
+  auto target{dpop_normalize_target(url)};
+  if (!target.has_value()) {
+    return false;
+  }
+
+  auto public_key{this->key_.public_jwk()};
+  if (!public_key.has_value()) {
+    return false;
+  }
+
+  auto header{JSON::make_object()};
+  header.assign_assume_new("typ", JSON{"dpop+jwt"}, HASH_TYP);
+  header.assign_assume_new("alg", JSON{dpop_algorithm_name(this->algorithm_)},
+                           HASH_ALG);
+  header.assign_assume_new("jwk", std::move(public_key.value()), HASH_JWK);
+
+  auto payload{JSON::make_object()};
+  const auto identifier{oauth_random_token()};
+  payload.assign_assume_new(
+      "jti", JSON{std::string_view{identifier.data(), identifier.size()}},
+      HASH_JTI);
+  payload.assign_assume_new("htm", JSON{method}, HASH_HTM);
+  payload.assign_assume_new("htu", JSON{std::move(target.value())}, HASH_HTU);
+  payload.assign_assume_new(
+      "iat",
+      JSON{static_cast<std::int64_t>(
+          std::chrono::duration_cast<std::chrono::seconds>(
+              now.time_since_epoch())
+              .count())},
+      HASH_IAT);
+  if (!access_token.empty()) {
+    payload.assign_assume_new("ath", JSON{dpop_access_token_hash(access_token)},
+                              HASH_ATH);
+  }
+
+  {
+    const std::scoped_lock lock{this->mutex_};
+    const auto iterator{this->nonces_.find(server)};
+    if (iterator != this->nonces_.end()) {
+      payload.assign_assume_new("nonce", JSON{iterator->second}, HASH_NONCE);
+    }
+  }
+
+  const auto token{jwt_sign(header, payload, this->key_)};
+  if (!token.has_value()) {
+    return false;
+  }
+
+  sink.append(token.value());
+  return true;
+}
+
+auto OAuthDPoPProofer::observe(const std::string_view server,
+                               const std::string_view nonce) -> void {
+  const std::scoped_lock lock{this->mutex_};
+  this->nonces_.insert_or_assign(std::string{server}, std::string{nonce});
+}
+
+auto OAuthDPoPProofer::thumbprint() const -> std::optional<std::string> {
+  return this->key_.thumbprint();
+}
+
+auto oauth_dpop_confirmation(const std::string_view thumbprint) -> JSON {
+  auto confirmation{JSON::make_object()};
+  confirmation.assign_assume_new("jkt", JSON{thumbprint}, HASH_JKT);
+  return confirmation;
+}
+
+auto oauth_dpop_proof_thumbprint(const std::string_view proof)
+    -> std::optional<std::string> {
+  const auto token{JWT::from(proof)};
+  if (!token.has_value()) {
+    return std::nullopt;
+  }
+
+  const auto &header{token.value().header()};
+  if (!header.is_object()) {
+    return std::nullopt;
+  }
+
+  const auto *key{header.try_at("jwk"sv, HASH_JWK)};
+  if (key == nullptr || !key->is_object()) {
+    return std::nullopt;
+  }
+
+  const auto parsed{JWK::from(*key)};
+  if (!parsed.has_value()) {
+    return std::nullopt;
+  }
+
+  return parsed.value().thumbprint();
+}
+
+auto oauth_dpop_verify(const std::string_view proof,
+                       const std::string_view method,
+                       const std::string_view url,
+                       const std::chrono::system_clock::time_point now,
+                       const OAuthDPoPVerifyOptions &options)
+    -> std::optional<OAuthDPoPError> {
+  // RFC 9449 Section 4.3 check 1: exactly one DPoP header field
+  if (options.proof_count != 1) {
+    return OAuthDPoPError::ProofCount;
+  }
+
+  // Check 2: a single well-formed JSON Web Token
+  const auto token{JWT::from(proof)};
+  if (!token.has_value()) {
+    return OAuthDPoPError::Malformed;
+  }
+
+  const auto &parsed{token.value()};
+
+  // Check 4: the token type is dpop+jwt
+  const auto type{parsed.type()};
+  if (!type.has_value() || type.value() != "dpop+jwt") {
+    return OAuthDPoPError::UnexpectedType;
+  }
+
+  // Check 5: an asymmetric algorithm, not none, within local policy
+  const auto algorithm{parsed.algorithm()};
+  if (!algorithm.has_value() || !dpop_is_asymmetric(algorithm.value())) {
+    return OAuthDPoPError::UnsupportedAlgorithm;
+  }
+
+  if (!options.allowed_algorithms.empty() &&
+      std::ranges::find(options.allowed_algorithms, algorithm.value()) ==
+          options.allowed_algorithms.end()) {
+    return OAuthDPoPError::UnsupportedAlgorithm;
+  }
+
+  // Check 3: all required header parameters and claims are present
+  const auto &header{parsed.header()};
+  const auto *key{header.is_object() ? header.try_at("jwk"sv, HASH_JWK)
+                                     : nullptr};
+  if (key == nullptr || !key->is_object()) {
+    return OAuthDPoPError::MissingClaim;
+  }
+
+  const auto identifier{parsed.token_id()};
+  const auto method_claim{
+      oauth_json_string_member(parsed.payload(), "htm"sv, HASH_HTM)};
+  const auto target_claim{
+      oauth_json_string_member(parsed.payload(), "htu"sv, HASH_HTU)};
+  const auto issued{parsed.issued_at()};
+  if (!identifier.has_value() || !method_claim.has_value() ||
+      !target_claim.has_value() || !issued.has_value()) {
+    return OAuthDPoPError::MissingClaim;
+  }
+
+  // Check 7: the embedded key carries no private material
+  if (dpop_has_private_material(*key)) {
+    return OAuthDPoPError::PrivateKey;
+  }
+
+  // Check 6: the signature verifies with the embedded key
+  const auto public_key{JWK::from(*key)};
+  if (!public_key.has_value() ||
+      !jwt_verify_signature(parsed, public_key.value())) {
+    return OAuthDPoPError::Signature;
+  }
+
+  // Check 8: the method claim matches the request method
+  if (method_claim.value() != method) {
+    return OAuthDPoPError::MethodMismatch;
+  }
+
+  // Check 9: the target claim matches the request target
+  const auto normalized_claim{dpop_normalize_target(target_claim.value())};
+  const auto normalized_request{dpop_normalize_target(url)};
+  if (!normalized_claim.has_value() || !normalized_request.has_value() ||
+      normalized_claim.value() != normalized_request.value()) {
+    return OAuthDPoPError::TargetMismatch;
+  }
+
+  // Check 10: the nonce claim matches the nonce the server issued
+  const auto nonce_claim{
+      oauth_json_string_member(parsed.payload(), "nonce"sv, HASH_NONCE)};
+  if (options.expected_nonce.has_value()) {
+    if (!nonce_claim.has_value()) {
+      return OAuthDPoPError::MissingNonce;
+    }
+
+    if (!secure_equals(nonce_claim.value(), options.expected_nonce.value())) {
+      return OAuthDPoPError::NonceMismatch;
+    }
+  }
+
+  // Check 11: the creation time is within the acceptable window
+  if (issued.value() < now - options.past_window ||
+      issued.value() > now + options.future_window) {
+    return OAuthDPoPError::Expired;
+  }
+
+  // Check 12: the access token hash and the key binding, when a token is
+  // presented
+  if (options.access_token.has_value()) {
+    const auto hash_claim{
+        oauth_json_string_member(parsed.payload(), "ath"sv, HASH_ATH)};
+    if (!hash_claim.has_value()) {
+      return OAuthDPoPError::AccessTokenMismatch;
+    }
+
+    const auto expected{dpop_access_token_hash(options.access_token.value())};
+    if (!secure_equals(hash_claim.value(), expected)) {
+      return OAuthDPoPError::AccessTokenMismatch;
+    }
+
+    // RFC 9449 Section 7.1: a protected resource MUST confirm the proof key
+    // matches the key the token is bound to, so presenting a token without a
+    // binding to check against fails closed rather than skipping that
+    // confirmation
+    if (!options.bound_thumbprint.has_value()) {
+      return OAuthDPoPError::KeyMismatch;
+    }
+  }
+
+  if (options.bound_thumbprint.has_value()) {
+    const auto proof_thumbprint{public_key.value().thumbprint()};
+    if (!proof_thumbprint.has_value() ||
+        !secure_equals(proof_thumbprint.value(),
+                       options.bound_thumbprint.value())) {
+      return OAuthDPoPError::KeyMismatch;
+    }
+  }
+
+  return std::nullopt;
+}
+
+auto OAuthDPoPReplayStore::check_and_insert(
+    const std::string_view identifier, const std::string_view target,
+    const std::chrono::system_clock::time_point now,
+    const std::chrono::seconds window) -> bool {
+  // RFC 9449 Section 11.1: the identifier is tracked in the context of the
+  // target URI, so the digest covers both and one store safely spans targets.
+  // The target is normalized the same way the verifier compares the htu claim
+  // (Section 4.3 check 9), so a replay to an equivalent but differently spelled
+  // target is still detected rather than admitted as a fresh identifier
+  const auto normalized{dpop_normalize_target(target)};
+  const std::string_view effective{
+      normalized.has_value() ? std::string_view{normalized.value()} : target};
+  std::string material;
+  material.reserve(identifier.size() + 1 + effective.size());
+  material.append(identifier);
+  material.push_back('\0');
+  material.append(effective);
+  const auto digest{sha256_digest(material)};
+
+  const std::scoped_lock lock{this->mutex_};
+  std::erase_if(this->entries_, [now](const Entry &entry) -> bool {
+    return entry.expiry <= now;
+  });
+  for (const auto &entry : this->entries_) {
+    if (entry.digest == digest) {
+      return false;
+    }
+  }
+
+  this->entries_.push_back(Entry{.digest = digest, .expiry = now + window});
+  return true;
+}
+
+auto OAuthDPoPReplayStore::size(
+    const std::chrono::system_clock::time_point now) const -> std::size_t {
+  const std::scoped_lock lock{this->mutex_};
+  return static_cast<std::size_t>(
+      std::ranges::count_if(this->entries_, [now](const Entry &entry) -> bool {
+        return entry.expiry > now;
+      }));
+}
+
+auto oauth_is_valid_dpop_nonce(const std::string_view value) noexcept -> bool {
+  if (value.empty()) {
+    return false;
+  }
+
+  // RFC 6749 Appendix A: NQCHAR = %x21 / %x23-5B / %x5D-7E, the printable ASCII
+  // set excluding the space, the double quote, and the backslash
+  return std::ranges::all_of(value, [](const char character) -> bool {
+    const auto byte{static_cast<unsigned char>(character)};
+    return byte == 0x21 || (byte >= 0x23 && byte <= 0x5B) ||
+           (byte >= 0x5D && byte <= 0x7E);
+  });
+}
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -99,8 +99,7 @@ auto dpop_is_asymmetric(const JWSAlgorithm algorithm) noexcept -> bool {
 
 // RFC 9449 Section 4.2: the HTTP target URI without query and fragment, with
 // the syntax and scheme normalization Section 4.3 recommends applied so the
-// same request compares equal on both sides, and an empty path treated as "/"
-// (RFC 3986 Section 6.2.3)
+// same request compares equal on both sides
 auto dpop_normalize_target(const std::string_view url)
     -> std::optional<std::string> {
   auto uri{oauth_try_parse_uri(url)};
@@ -108,38 +107,25 @@ auto dpop_normalize_target(const std::string_view url)
     return std::nullopt;
   }
 
+  // RFC 9449 Section 4.3 recommends the syntax and scheme normalization of
+  // RFC 3986 Sections 6.2.2 and 6.2.3, and Section 4.2 excludes the query and
+  // fragment. RFC 9110 Section 4.2.1 gives an "http" or "https" target URI no
+  // userinfo, so it is dropped rather than signed into the proof or compared
   uri->canonicalize();
-  const auto scheme{uri->scheme()};
-  const auto authority{uri->authority()};
-  if (!scheme.has_value() || !authority.has_value()) {
+  uri->query("");
+  uri->userinfo("");
+  if (!uri->scheme().has_value() || !uri->host().has_value()) {
     return std::nullopt;
   }
 
-  // RFC 9110 Section 4.2.1: an "http" or "https" target URI carries no
-  // userinfo, so any is dropped rather than signed into the proof or compared,
-  // keeping the host and port (with the IPv6 brackets the authority already
-  // carries)
-  std::string_view host_and_port{authority.value()};
-  const auto userinfo_end{host_and_port.find('@')};
-  if (userinfo_end != std::string_view::npos) {
-    host_and_port.remove_prefix(userinfo_end + 1);
+  // RFC 3986 Section 6.2.3: an authority with an empty path is equivalent to
+  // one with a path of "/", a scheme-based normalization the general
+  // canonicalizer leaves to the caller
+  if (!uri->path().has_value() || uri->path().value().empty()) {
+    uri->path(std::string{"/"});
   }
 
-  const auto path{uri->path()};
-  const auto has_path{path.has_value() && !path.value().empty()};
-  std::string result;
-  result.reserve(scheme.value().size() + 3 + host_and_port.size() +
-                 (has_path ? path.value().size() : 1));
-  result.append(scheme.value());
-  result.append("://");
-  result.append(host_and_port);
-  if (has_path) {
-    result.append(path.value());
-  } else {
-    result.push_back('/');
-  }
-
-  return result;
+  return uri->recompose_without_fragment();
 }
 
 // RFC 9449 Section 4.2 and Section 7: the base64url-encoded SHA-256 hash of the

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -385,13 +385,29 @@ auto OAuthDPoPReplayStore::check_and_insert(
   std::erase_if(this->entries_, [now](const Entry &entry) -> bool {
     return entry.expiry <= now;
   });
-  for (const auto &entry : this->entries_) {
-    if (entry.digest == digest) {
+
+  // Scan once for a replay, tracking the entry closest to expiry so it can be
+  // evicted if the store is at capacity and this identifier is new
+  std::size_t earliest{0};
+  for (std::size_t index{0}; index < this->entries_.size(); index += 1) {
+    if (this->entries_[index].digest == digest) {
       return false;
+    }
+
+    if (this->entries_[index].expiry < this->entries_[earliest].expiry) {
+      earliest = index;
     }
   }
 
-  this->entries_.push_back(Entry{.digest = digest, .expiry = now + window});
+  const Entry entry{.digest = digest, .expiry = now + window};
+  // A bounded store cannot grow without limit, so at capacity the entry closest
+  // to expiry, with the least replay protection left, gives up its slot
+  if (this->entries_.size() >= this->capacity_ && !this->entries_.empty()) {
+    this->entries_[earliest] = entry;
+  } else {
+    this->entries_.push_back(entry);
+  }
+
   return true;
 }
 

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -1,6 +1,7 @@
 #include <sourcemeta/core/oauth_dpop.h>
 
 #include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/jose_algorithm.h>
 #include <sourcemeta/core/jose_jwk.h>
 #include <sourcemeta/core/jose_jwt.h>
 #include <sourcemeta/core/jose_sign.h>
@@ -19,7 +20,7 @@
 #include <optional>    // std::optional, std::nullopt
 #include <string>      // std::string
 #include <string_view> // std::string_view
-#include <utility>     // std::move, std::unreachable
+#include <utility>     // std::move
 #include <vector>      // std::erase_if
 
 namespace sourcemeta::core {
@@ -39,63 +40,16 @@ const auto HASH_ATH{JSON::Object::hash("ath"sv)};
 const auto HASH_NONCE{JSON::Object::hash("nonce"sv)};
 const auto HASH_JKT{JSON::Object::hash("jkt"sv)};
 
-// RFC 7515 Section 4.1.1: the "alg" header value each algorithm serializes to
-auto dpop_algorithm_name(const JWSAlgorithm algorithm) -> std::string_view {
-  switch (algorithm) {
-    case JWSAlgorithm::RS256:
-      return "RS256";
-    case JWSAlgorithm::RS384:
-      return "RS384";
-    case JWSAlgorithm::RS512:
-      return "RS512";
-    case JWSAlgorithm::PS256:
-      return "PS256";
-    case JWSAlgorithm::PS384:
-      return "PS384";
-    case JWSAlgorithm::PS512:
-      return "PS512";
-    case JWSAlgorithm::ES256:
-      return "ES256";
-    case JWSAlgorithm::ES384:
-      return "ES384";
-    case JWSAlgorithm::ES512:
-      return "ES512";
-    case JWSAlgorithm::EdDSA:
-      return "EdDSA";
-    case JWSAlgorithm::HS256:
-      return "HS256";
-    case JWSAlgorithm::HS384:
-      return "HS384";
-    case JWSAlgorithm::HS512:
-      return "HS512";
-  }
-
-  std::unreachable();
-}
-
-// RFC 9449 Section 4.2: the DPoP algorithm MUST NOT be a symmetric one, so the
-// message authentication code algorithms are the ones to exclude
-auto dpop_is_asymmetric(const JWSAlgorithm algorithm) noexcept -> bool {
-  switch (algorithm) {
-    case JWSAlgorithm::RS256:
-    case JWSAlgorithm::RS384:
-    case JWSAlgorithm::RS512:
-    case JWSAlgorithm::PS256:
-    case JWSAlgorithm::PS384:
-    case JWSAlgorithm::PS512:
-    case JWSAlgorithm::ES256:
-    case JWSAlgorithm::ES384:
-    case JWSAlgorithm::ES512:
-    case JWSAlgorithm::EdDSA:
-      return true;
-    case JWSAlgorithm::HS256:
-    case JWSAlgorithm::HS384:
-    case JWSAlgorithm::HS512:
-      return false;
-  }
-
-  std::unreachable();
-}
+// The private JSON Web Key members whose presence marks a private key (RFC 7518
+// Sections 6.2.2 and 6.3.2, RFC 8037 Section 2, RFC 7518 Section 6.4)
+const auto HASH_D{JSON::Object::hash("d"sv)};
+const auto HASH_P{JSON::Object::hash("p"sv)};
+const auto HASH_Q{JSON::Object::hash("q"sv)};
+const auto HASH_DP{JSON::Object::hash("dp"sv)};
+const auto HASH_DQ{JSON::Object::hash("dq"sv)};
+const auto HASH_QI{JSON::Object::hash("qi"sv)};
+const auto HASH_OTH{JSON::Object::hash("oth"sv)};
+const auto HASH_K{JSON::Object::hash("k"sv)};
 
 // RFC 9449 Section 4.2: the HTTP target URI without query and fragment, with
 // the syntax and scheme normalization Section 4.3 recommends applied so the
@@ -138,12 +92,16 @@ auto dpop_access_token_hash(const std::string_view access_token)
 }
 
 // RFC 9449 Section 4.3 check 7: the public key MUST NOT contain a private key,
-// whose presence is marked by any private JSON Web Key member (RFC 7518
-// Sections 6.2.2 and 6.3.2, RFC 8037 Section 2, RFC 7518 Section 6.4)
+// whose presence is marked by any private JSON Web Key member
 auto dpop_has_private_material(const JSON &key) -> bool {
-  return key.defines("d") || key.defines("p") || key.defines("q") ||
-         key.defines("dp") || key.defines("dq") || key.defines("qi") ||
-         key.defines("oth") || key.defines("k");
+  return key.try_at("d"sv, HASH_D) != nullptr ||
+         key.try_at("p"sv, HASH_P) != nullptr ||
+         key.try_at("q"sv, HASH_Q) != nullptr ||
+         key.try_at("dp"sv, HASH_DP) != nullptr ||
+         key.try_at("dq"sv, HASH_DQ) != nullptr ||
+         key.try_at("qi"sv, HASH_QI) != nullptr ||
+         key.try_at("oth"sv, HASH_OTH) != nullptr ||
+         key.try_at("k"sv, HASH_K) != nullptr;
 }
 
 } // namespace
@@ -157,6 +115,12 @@ auto OAuthDPoPProofer::proof(const std::string_view server,
                              const std::string_view access_token,
                              const std::chrono::system_clock::time_point now,
                              std::string &sink) -> bool {
+  // RFC 9449 Section 4.2: a DPoP proof MUST be signed with an asymmetric
+  // algorithm, so a symmetric one yields no proof rather than an invalid one
+  if (!jws_algorithm_is_asymmetric(this->algorithm_)) {
+    return false;
+  }
+
   auto target{dpop_normalize_target(url)};
   if (!target.has_value()) {
     return false;
@@ -169,7 +133,7 @@ auto OAuthDPoPProofer::proof(const std::string_view server,
 
   auto header{JSON::make_object()};
   header.assign_assume_new("typ", JSON{"dpop+jwt"}, HASH_TYP);
-  header.assign_assume_new("alg", JSON{dpop_algorithm_name(this->algorithm_)},
+  header.assign_assume_new("alg", JSON{jws_algorithm_name(this->algorithm_)},
                            HASH_ALG);
   header.assign_assume_new("jwk", std::move(public_key.value()), HASH_JWK);
 
@@ -211,6 +175,12 @@ auto OAuthDPoPProofer::proof(const std::string_view server,
 
 auto OAuthDPoPProofer::observe(const std::string_view server,
                                const std::string_view nonce) -> void {
+  // RFC 9449 Section 8.1: a nonce is a non-empty string of the nonce character
+  // set, so a malformed one is dropped rather than echoed into a later proof
+  if (!oauth_is_valid_dpop_nonce(nonce)) {
+    return;
+  }
+
   const std::scoped_lock lock{this->mutex_};
   this->nonces_.insert_or_assign(std::string{server}, std::string{nonce});
 }
@@ -239,6 +209,12 @@ auto oauth_dpop_proof_thumbprint(const std::string_view proof)
 
   const auto *key{header.try_at("jwk"sv, HASH_JWK)};
   if (key == nullptr || !key->is_object()) {
+    return std::nullopt;
+  }
+
+  // RFC 9449 Section 4.3 check 7: a proof whose embedded key carries private
+  // material is invalid, so no thumbprint is derived to bind or match against
+  if (dpop_has_private_material(*key)) {
     return std::nullopt;
   }
 
@@ -277,7 +253,8 @@ auto oauth_dpop_verify(const std::string_view proof,
 
   // Check 5: an asymmetric algorithm, not none, within local policy
   const auto algorithm{parsed.algorithm()};
-  if (!algorithm.has_value() || !dpop_is_asymmetric(algorithm.value())) {
+  if (!algorithm.has_value() ||
+      !jws_algorithm_is_asymmetric(algorithm.value())) {
     return OAuthDPoPError::UnsupportedAlgorithm;
   }
 

--- a/test/jose/jose_algorithm_test.cc
+++ b/test/jose/jose_algorithm_test.cc
@@ -55,25 +55,43 @@ TEST(to_jws_algorithm_hs512) {
   EXPECT_EQ(result.value(), sourcemeta::core::JWSAlgorithm::HS512);
 }
 
-TEST(jws_algorithm_name_rs256) {
+TEST(jws_algorithm_name_covers_every_algorithm) {
   EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
                 sourcemeta::core::JWSAlgorithm::RS256),
             "RS256");
-}
-
-TEST(jws_algorithm_name_es256) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::RS384),
+            "RS384");
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::RS512),
+            "RS512");
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::PS256),
+            "PS256");
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::PS384),
+            "PS384");
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::PS512),
+            "PS512");
   EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
                 sourcemeta::core::JWSAlgorithm::ES256),
             "ES256");
-}
-
-TEST(jws_algorithm_name_eddsa) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::ES384),
+            "ES384");
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::ES512),
+            "ES512");
   EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
                 sourcemeta::core::JWSAlgorithm::EdDSA),
             "EdDSA");
-}
-
-TEST(jws_algorithm_name_hs512) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::HS256),
+            "HS256");
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::HS384),
+            "HS384");
   EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
                 sourcemeta::core::JWSAlgorithm::HS512),
             "HS512");
@@ -87,24 +105,27 @@ TEST(jws_algorithm_name_round_trips) {
             sourcemeta::core::JWSAlgorithm::PS384);
 }
 
-TEST(jws_algorithm_is_asymmetric_ec) {
-  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
-      sourcemeta::core::JWSAlgorithm::ES256));
-}
-
-TEST(jws_algorithm_is_asymmetric_rsa) {
+TEST(jws_algorithm_is_asymmetric_covers_every_algorithm) {
   EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
       sourcemeta::core::JWSAlgorithm::RS256));
   EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::RS384));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::RS512));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::PS256));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::PS384));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
       sourcemeta::core::JWSAlgorithm::PS512));
-}
-
-TEST(jws_algorithm_is_asymmetric_eddsa) {
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::ES256));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::ES384));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::ES512));
   EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
       sourcemeta::core::JWSAlgorithm::EdDSA));
-}
-
-TEST(jws_algorithm_is_asymmetric_rejects_mac) {
   EXPECT_FALSE(sourcemeta::core::jws_algorithm_is_asymmetric(
       sourcemeta::core::JWSAlgorithm::HS256));
   EXPECT_FALSE(sourcemeta::core::jws_algorithm_is_asymmetric(

--- a/test/jose/jose_algorithm_test.cc
+++ b/test/jose/jose_algorithm_test.cc
@@ -54,3 +54,61 @@ TEST(to_jws_algorithm_hs512) {
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), sourcemeta::core::JWSAlgorithm::HS512);
 }
+
+TEST(jws_algorithm_name_rs256) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::RS256),
+            "RS256");
+}
+
+TEST(jws_algorithm_name_es256) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::ES256),
+            "ES256");
+}
+
+TEST(jws_algorithm_name_eddsa) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::EdDSA),
+            "EdDSA");
+}
+
+TEST(jws_algorithm_name_hs512) {
+  EXPECT_EQ(sourcemeta::core::jws_algorithm_name(
+                sourcemeta::core::JWSAlgorithm::HS512),
+            "HS512");
+}
+
+TEST(jws_algorithm_name_round_trips) {
+  EXPECT_EQ(sourcemeta::core::to_jws_algorithm(
+                sourcemeta::core::jws_algorithm_name(
+                    sourcemeta::core::JWSAlgorithm::PS384))
+                .value(),
+            sourcemeta::core::JWSAlgorithm::PS384);
+}
+
+TEST(jws_algorithm_is_asymmetric_ec) {
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::ES256));
+}
+
+TEST(jws_algorithm_is_asymmetric_rsa) {
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::RS256));
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::PS512));
+}
+
+TEST(jws_algorithm_is_asymmetric_eddsa) {
+  EXPECT_TRUE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::EdDSA));
+}
+
+TEST(jws_algorithm_is_asymmetric_rejects_mac) {
+  EXPECT_FALSE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::HS256));
+  EXPECT_FALSE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::HS384));
+  EXPECT_FALSE(sourcemeta::core::jws_algorithm_is_asymmetric(
+      sourcemeta::core::JWSAlgorithm::HS512));
+}

--- a/test/jose/jose_jwt_test.cc
+++ b/test/jose/jose_jwt_test.cc
@@ -41,6 +41,19 @@ TEST(rejects_duplicate_header_parameter_non_alg) {
   EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
 }
 
+TEST(rejects_duplicate_payload_claim) {
+  // RFC 7519 Section 4: the claim names must be unique
+  const auto input{make_token(R"({ "alg": "RS256" })",
+                              R"({ "iss": "a", "iss": "b" })", "sig")};
+  EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
+}
+
+TEST(rejects_duplicate_unregistered_payload_claim) {
+  const auto input{make_token(R"({ "alg": "RS256" })",
+                              R"({ "htu": "a", "htu": "b" })", "sig")};
+  EXPECT_FALSE(sourcemeta::core::JWT::from(input).has_value());
+}
+
 TEST(signing_input_is_verbatim) {
   const auto input{
       make_token(R"({ "alg": "RS256" })", R"({ "iss": "acme" })", "sig")};

--- a/test/oauth/CMakeLists.txt
+++ b/test/oauth/CMakeLists.txt
@@ -4,7 +4,8 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME oauth
     oauth_client_authentication_test.cc oauth_transaction_test.cc
     oauth_metadata_test.cc oauth_metadata_provider_test.cc
     oauth_conformance_test.cc oauth_token_exchange_test.cc
-    oauth_revocation_test.cc oauth_introspection_test.cc oauth_device_test.cc)
+    oauth_revocation_test.cc oauth_introspection_test.cc oauth_device_test.cc
+    oauth_dpop_test.cc)
 
 target_link_libraries(sourcemeta_core_oauth_unit
   PRIVATE sourcemeta::core::oauth)

--- a/test/oauth/oauth_dpop_test.cc
+++ b/test/oauth/oauth_dpop_test.cc
@@ -212,7 +212,8 @@ TEST(verify_accepts_an_allowed_algorithm) {
                             "https://server.example.com/token", "", FIXED_TIME,
                             proof));
 
-  const std::array allowed{sourcemeta::core::JWSAlgorithm::ES256};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
+      {sourcemeta::core::JWSAlgorithm::ES256}};
   sourcemeta::core::OAuthDPoPVerifyOptions options;
   options.allowed_algorithms = allowed;
   EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
@@ -419,7 +420,8 @@ TEST(verify_rejects_an_algorithm_outside_policy) {
                             "https://server.example.com/token", "", FIXED_TIME,
                             proof));
 
-  const std::array allowed{sourcemeta::core::JWSAlgorithm::ES384};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
+      {sourcemeta::core::JWSAlgorithm::ES384}};
   sourcemeta::core::OAuthDPoPVerifyOptions options;
   options.allowed_algorithms = allowed;
   EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
@@ -966,4 +968,48 @@ TEST(proofer_rejects_an_unparseable_target) {
   std::string proof;
   EXPECT_FALSE(proofer.proof("https://server.example.com", "POST", "not a url",
                              "", FIXED_TIME, proof));
+}
+
+TEST(proofer_rejects_a_symmetric_algorithm) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::HS256};
+  std::string proof;
+  EXPECT_FALSE(proofer.proof("https://server.example.com", "POST",
+                             "https://server.example.com/token", "", FIXED_TIME,
+                             proof));
+  EXPECT_TRUE(proof.empty());
+}
+
+TEST(proofer_ignores_a_malformed_observed_nonce) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  proofer.observe("https://server.example.com", "bad nonce");
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_FALSE(token.value().payload().defines("nonce"));
+}
+
+TEST(proof_thumbprint_rejects_a_private_key_in_the_header) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PRIVATE_JWK));
+  const auto payload{sourcemeta::core::parse_json(R"({"jti":"x"})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_dpop_proof_thumbprint(proof.value()).has_value());
 }

--- a/test/oauth/oauth_dpop_test.cc
+++ b/test/oauth/oauth_dpop_test.cc
@@ -1,0 +1,969 @@
+#include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>    // std::array
+#include <chrono>   // std::chrono::system_clock, std::chrono::seconds
+#include <optional> // std::optional
+#include <string>   // std::string
+#include <utility>  // std::move
+
+static constexpr std::string_view EC_PRIVATE_JWK{
+    R"({"kty":"EC","crv":"P-256",)"
+    R"("x":"2TARGSWq8F97iq3Ng48wCEN26cxzy8OCzbFa-6ZfnaI",)"
+    R"("y":"5lkzZqhWOkc2m2zJOotl6K3_x6-TSs9OnzQKwb35DxQ",)"
+    R"("d":"ttepxcp-OwXCj4-v4sGcxRxQRXA8D5Svu02yhcHvbd0"})"};
+
+static constexpr std::string_view EC_PUBLIC_JWK{
+    R"({"kty":"EC","crv":"P-256",)"
+    R"("x":"2TARGSWq8F97iq3Ng48wCEN26cxzy8OCzbFa-6ZfnaI",)"
+    R"("y":"5lkzZqhWOkc2m2zJOotl6K3_x6-TSs9OnzQKwb35DxQ"})"};
+
+static constexpr std::string_view OTHER_PUBLIC_JWK{
+    R"({"kty":"EC","crv":"P-256",)"
+    R"("x":"l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",)"
+    R"("y":"9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA"})"};
+
+static constexpr std::string_view OCT_JWK{
+    R"({"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T)"
+    R"(-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"})"};
+
+// RFC 9449 Section 6.1: the thumbprint of the Section 5 example public key
+static constexpr std::string_view OTHER_THUMBPRINT{
+    "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"};
+
+static const std::string RSA_PRIVATE_JWK{
+    R"({"kty":"RSA",)"
+    R"("n":"n-ivWLN0CTSLXc7GNcHGOuZHdu6QcGT3SlFTaf2ckxLVEDcAU4fIez7rKtvZaCzp)"
+    R"(KJ6cb5KZnDcIn-gOCrE0FI6OZdCvgAGNqoFH6D1AANk8lWSFc1bWoti5xzXls2IN4fDRDa)"
+    R"(BoXeXBniurOF8zTMlpyFiX4sgmaPpaJuKGH97AyXkHg4AYAFOUxOMPDM4EglexkzWRo0z_)"
+    R"(qwRfj4qKbaNqF2P24dLOclnojEqD1i-ZKZn4PzD4plw85DSjc6Sm90OOpFW54zxiX2Eff5)"
+    R"(9ez46j91_2d6SlSzFhNwrvaZYKBJl-vNegJzxsHWPwrGcNR31jEXa6kepjbAsp0FOBJw",)"
+    R"("e":"AQAB",)"
+    R"("d":"DdJY8FEijcvNjWAwCw7NXuNEo2e0yGI8awoN1wglc85EPaXjZf-YjpPo_nKzn1OHx)"
+    R"(mEJ-ILdZX6Zmj4T6KIEdGUWCIA54ICXNCOp3s2x2IuZDE38qEmF59wqbVOf9RoGmn7sMuy)"
+    R"(og2U2j8C1M1GB56Mz0i4GLYNLU_Y_u0NdKyfnhYRijuGOIb_TcC0MOy269XhsAVr-Ntat0)"
+    R"(OzlITbaGKGW0yOr96hUY2Ocax99xbtjMyiYhB5Hu99yHn7ZPRtfATnmAujjWPV7Knd9n1e)"
+    R"(O-hC6X8f-eKl9v-iqLuhNnFBGHhd3So_FZ0W3qXTXfC0Oq4TUsRjf4k4EtOcGf80SoQ",)"
+    R"("p":"zYCJC70qUjNIlxUZ4u_XmDF8FiIsEo5A09eRNQchLnGClp_pVQ9z77mSicWsyUJOt)"
+    R"(I9YTKWKCwniN0RIPZM2O3cV4ZC8hdWP5noTxitnbLYeyfoZDr-i8uPqHHu3vaW-VJhGeJj)"
+    R"(5yELFrOxXAlikA2QQkecn94hs3iQ9tdFFc-8",)"
+    R"("q":"xzQIWpdrkeQnOk3_YoO7XY8ZyRiQwv-8kqQ8oae3Njo06oMWC0VbV8o5HPj-pCMWB)"
+    R"(vwAfMdZznOhMGjV2Ajla-z2ANteWebFVYt1xu2bxsMDIPqMfXTxWUftHtmFi6PSS9ZN5mI)"
+    R"(22AarR0nLDuFHr3KG3lWm173-RfgvhH_Xrkk",)"
+    R"("dp":"WSWfTfZbu5j_rnq65hWBg0ZEPB3K3KnVOZDULxrOrCUVr13jjMDNXHs2NIoKMKyR)"
+    R"(FAbzGRzey3cYKT130S5hYl6AoX92KODCMgtXNKpzjVdb9-aEpD9B4vg4AO8ygBS8glokiA)"
+    R"(Bkqxk8Q42rGRt22vm3rnOGhP0rrRovowYLiQU",)"
+    R"("dq":"o08lCh_ZMGG7RzFqjXkxwiHvIc3h3_uIvS-oBV9Z9DsD5r5Q9CyIFhDTgc0f9bBN)"
+    R"(_qvaOnG0Tmy9WNKZfeLNMw2xIEK3tzxZyyfqBowFiY2WoxLE2pVkx60P2Jq7wR8s6L9oXd)"
+    R"(dm3vOYt3jn3-sQueVKbDwL7BL2wqYVTqsARwE",)"
+    R"("qi":"qNjXTrOsMEqKYSJNsk6Z0sjDB2yuHS47CbkWZjikg4TIR4WmpYVY7EOfidoboen5)"
+    R"(jGKFMuXAJo4pz6IBgS5eN6uzPvfvqJUiMGc6lG_zBFKsc-WnveUIzYqqz3gNrA_gwN872o)"
+    R"(JCzSsEiFwMKFkui2fIAH8-c7Z5Tpo63qroRxk"})"};
+
+static const auto FIXED_TIME{
+    std::chrono::system_clock::from_time_t(1562262616)};
+
+TEST(dpop_token_type_constant) {
+  EXPECT_EQ(sourcemeta::core::OAUTH_TOKEN_TYPE_DPOP, "DPoP");
+}
+
+TEST(proofer_builds_a_verifiable_proof) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "https://server.example.com/token",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(proof_carries_the_expected_header_and_claims) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().type().value(), "dpop+jwt");
+  EXPECT_EQ(token.value().algorithm().value(),
+            sourcemeta::core::JWSAlgorithm::ES256);
+  EXPECT_TRUE(token.value().header().defines("jwk"));
+  EXPECT_TRUE(token.value().token_id().has_value());
+  EXPECT_TRUE(token.value().issued_at().has_value());
+  EXPECT_EQ(token.value().payload().at("htm").to_string(), "POST");
+  EXPECT_EQ(token.value().payload().at("htu").to_string(),
+            "https://server.example.com/token");
+  EXPECT_FALSE(token.value().payload().defines("ath"));
+  EXPECT_FALSE(token.value().payload().defines("nonce"));
+}
+
+TEST(proof_includes_the_access_token_hash) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://resource.example.org", "GET",
+                            "https://resource.example.org/data", "the-token",
+                            FIXED_TIME, proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(token.value().payload().defines("ath"));
+
+  const auto thumbprint{proofer.thumbprint().value()};
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.access_token = "the-token";
+  options.bound_thumbprint = thumbprint;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "GET", "https://resource.example.org/data",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(proofer_thumbprint_matches_the_key) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+
+  const auto public_key{
+      sourcemeta::core::JWK::from(sourcemeta::core::parse_json(EC_PUBLIC_JWK))};
+  EXPECT_TRUE(public_key.has_value());
+  EXPECT_EQ(proofer.thumbprint().value(),
+            public_key.value().thumbprint().value());
+}
+
+TEST(proof_thumbprint_extracts_the_key) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_proof_thumbprint(proof).value(),
+            proofer.thumbprint().value());
+}
+
+TEST(proof_thumbprint_rejects_a_malformed_proof) {
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_dpop_proof_thumbprint("not-a-jwt").has_value());
+}
+
+TEST(confirmation_binds_the_thumbprint) {
+  const auto confirmation{sourcemeta::core::oauth_dpop_confirmation(
+      "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I")};
+  EXPECT_TRUE(confirmation.is_object());
+  EXPECT_EQ(confirmation.at("jkt").to_string(),
+            "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I");
+}
+
+TEST(verify_accepts_a_bound_thumbprint) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://resource.example.org", "GET",
+                            "https://resource.example.org/data", "the-token",
+                            FIXED_TIME, proof));
+
+  const auto thumbprint{proofer.thumbprint().value()};
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.access_token = "the-token";
+  options.bound_thumbprint = thumbprint;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "GET", "https://resource.example.org/data",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_accepts_an_allowed_algorithm) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const std::array allowed{sourcemeta::core::JWSAlgorithm::ES256};
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.allowed_algorithms = allowed;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "https://server.example.com/token",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(proofer_includes_an_observed_nonce) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  proofer.observe("https://server.example.com", "the-nonce");
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().payload().at("nonce").to_string(), "the-nonce");
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.expected_nonce = "the-nonce";
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "https://server.example.com/token",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_rejects_a_proof_count_other_than_one) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.proof_count = 2;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::ProofCount);
+}
+
+TEST(verify_rejects_a_malformed_proof) {
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                "not-a-jwt", "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Malformed);
+}
+
+TEST(verify_rejects_a_wrong_method) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(
+      sourcemeta::core::oauth_dpop_verify(
+          proof, "GET", "https://server.example.com/token", FIXED_TIME, options)
+          .value(),
+      sourcemeta::core::OAuthDPoPError::MethodMismatch);
+}
+
+TEST(verify_rejects_a_wrong_target) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/introspect",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::TargetMismatch);
+}
+
+TEST(verify_normalizes_the_target_before_comparing) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "HTTPS://Server.Example.COM:443/token",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_rejects_a_stale_proof) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token",
+                FIXED_TIME + std::chrono::seconds{600}, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Expired);
+}
+
+TEST(verify_rejects_a_proof_from_the_future) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token",
+                FIXED_TIME - std::chrono::seconds{60}, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Expired);
+}
+
+TEST(verify_rejects_an_unexpected_type) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{sourcemeta::core::parse_json(R"({"typ":"jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::UnexpectedType);
+}
+
+TEST(verify_rejects_a_symmetric_algorithm) {
+  const auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(OCT_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"HS256"})")};
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::UnsupportedAlgorithm);
+}
+
+TEST(verify_rejects_an_algorithm_outside_policy) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const std::array allowed{sourcemeta::core::JWSAlgorithm::ES384};
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.allowed_algorithms = allowed;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::UnsupportedAlgorithm);
+}
+
+TEST(verify_rejects_a_private_key_in_the_header) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PRIVATE_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::PrivateKey);
+}
+
+TEST(verify_rejects_a_missing_claim) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PUBLIC_JWK));
+  const auto payload{
+      sourcemeta::core::parse_json(R"({"jti":"x","htm":"POST","iat":1})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::MissingClaim);
+}
+
+TEST(verify_rejects_a_missing_jwk_header) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::MissingClaim);
+}
+
+TEST(verify_rejects_a_broken_signature) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(OTHER_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Signature);
+}
+
+TEST(verify_rejects_a_missing_required_nonce) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.expected_nonce = "the-nonce";
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::MissingNonce);
+}
+
+TEST(verify_rejects_a_nonce_mismatch) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  proofer.observe("https://server.example.com", "stale-nonce");
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.expected_nonce = "fresh-nonce";
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::NonceMismatch);
+}
+
+TEST(verify_rejects_a_missing_access_token_hash) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://resource.example.org", "GET",
+                            "https://resource.example.org/data", "", FIXED_TIME,
+                            proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.access_token = "the-token";
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "GET", "https://resource.example.org/data", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::AccessTokenMismatch);
+}
+
+TEST(verify_rejects_an_access_token_hash_mismatch) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://resource.example.org", "GET",
+                            "https://resource.example.org/data", "one-token",
+                            FIXED_TIME, proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.access_token = "another-token";
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "GET", "https://resource.example.org/data", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::AccessTokenMismatch);
+}
+
+TEST(verify_rejects_a_key_binding_mismatch) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://resource.example.org", "GET",
+                            "https://resource.example.org/data", "the-token",
+                            FIXED_TIME, proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.access_token = "the-token";
+  options.bound_thumbprint = "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I";
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "GET", "https://resource.example.org/data", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::KeyMismatch);
+}
+
+TEST(replay_store_accepts_then_rejects) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{300}));
+  EXPECT_FALSE(store.check_and_insert("id", "https://server.example.com/token",
+                                      FIXED_TIME, std::chrono::seconds{300}));
+}
+
+TEST(replay_store_separates_targets) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{300}));
+  EXPECT_TRUE(store.check_and_insert("id",
+                                     "https://server.example.com/introspect",
+                                     FIXED_TIME, std::chrono::seconds{300}));
+}
+
+TEST(replay_store_prunes_an_expired_entry) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{10}));
+  EXPECT_EQ(store.size(FIXED_TIME), 1);
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME + std::chrono::seconds{20},
+                                     std::chrono::seconds{10}));
+  EXPECT_EQ(store.size(FIXED_TIME + std::chrono::seconds{20}), 1);
+}
+
+TEST(replay_store_size_counts_live_entries) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_EQ(store.size(FIXED_TIME), 0);
+  EXPECT_TRUE(store.check_and_insert("one", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{10}));
+  EXPECT_TRUE(store.check_and_insert("two", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{10}));
+  EXPECT_EQ(store.size(FIXED_TIME), 2);
+  EXPECT_EQ(store.size(FIXED_TIME + std::chrono::seconds{11}), 0);
+}
+
+TEST(valid_dpop_nonce_accepts_the_nonce_character_set) {
+  EXPECT_TRUE(
+      sourcemeta::core::oauth_is_valid_dpop_nonce("eyJ7S_zG.eyJH0-Z.HX4w-7v"));
+  EXPECT_TRUE(sourcemeta::core::oauth_is_valid_dpop_nonce("!"));
+}
+
+TEST(valid_dpop_nonce_rejects_empty_and_disallowed_characters) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_valid_dpop_nonce(""));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_valid_dpop_nonce("has space"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_valid_dpop_nonce("has\"quote"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_valid_dpop_nonce("has\\backslash"));
+}
+
+TEST(valid_dpop_nonce_boundary_characters) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_valid_dpop_nonce("#"));
+  EXPECT_TRUE(sourcemeta::core::oauth_is_valid_dpop_nonce("~"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_valid_dpop_nonce("\x7F"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_valid_dpop_nonce("\x80"));
+}
+
+TEST(proof_thumbprint_matches_the_rfc9449_vector) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(OTHER_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+  EXPECT_EQ(
+      sourcemeta::core::oauth_dpop_proof_thumbprint(proof.value()).value(),
+      OTHER_THUMBPRINT);
+}
+
+TEST(proof_embeds_only_the_public_key) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  const auto &embedded{token.value().header().at("jwk")};
+  EXPECT_FALSE(embedded.defines("d"));
+  EXPECT_FALSE(embedded.defines("p"));
+  EXPECT_FALSE(embedded.defines("q"));
+  EXPECT_TRUE(embedded.defines("kty"));
+  EXPECT_TRUE(embedded.defines("crv"));
+  EXPECT_TRUE(embedded.defines("x"));
+  EXPECT_TRUE(embedded.defines("y"));
+}
+
+TEST(proofer_builds_a_verifiable_rsa_proof) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(RSA_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::RS256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().algorithm().value(),
+            sourcemeta::core::JWSAlgorithm::RS256);
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "https://server.example.com/token",
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_normalizes_an_empty_path) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().payload().at("htu").to_string(),
+            "https://server.example.com/");
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_dpop_verify(
+          proof, "POST", "https://server.example.com/", FIXED_TIME, options)
+          .has_value());
+}
+
+TEST(proof_strips_userinfo_from_the_target) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://user:pass@server.example.com/token", "",
+                            FIXED_TIME, proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().payload().at("htu").to_string(),
+            "https://server.example.com/token");
+}
+
+TEST(verify_accepts_iat_at_the_window_edges) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "https://server.example.com/token",
+                   FIXED_TIME + std::chrono::seconds{300}, options)
+                   .has_value());
+  EXPECT_FALSE(sourcemeta::core::oauth_dpop_verify(
+                   proof, "POST", "https://server.example.com/token",
+                   FIXED_TIME - std::chrono::seconds{5}, options)
+                   .has_value());
+}
+
+TEST(verify_rejects_iat_one_second_past_the_window_edges) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token",
+                FIXED_TIME + std::chrono::seconds{301}, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Expired);
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "POST", "https://server.example.com/token",
+                FIXED_TIME - std::chrono::seconds{6}, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Expired);
+}
+
+TEST(verify_rejects_a_missing_jti) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"htm":"POST","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::MissingClaim);
+}
+
+TEST(verify_rejects_a_missing_htm) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htu":"https://server.example.com/token",)"
+      R"("iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::MissingClaim);
+}
+
+TEST(verify_rejects_a_missing_iat) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST","htu":"https://server.example.com/token"})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::MissingClaim);
+}
+
+TEST(proof_thumbprint_rejects_a_proof_without_a_jwk) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  const auto payload{sourcemeta::core::parse_json(R"({"jti":"x"})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_dpop_proof_thumbprint(proof.value()).has_value());
+}
+
+TEST(verify_rejects_a_presented_token_without_a_binding) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://resource.example.org", "GET",
+                            "https://resource.example.org/data", "the-token",
+                            FIXED_TIME, proof));
+
+  sourcemeta::core::OAuthDPoPVerifyOptions options;
+  options.access_token = "the-token";
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof, "GET", "https://resource.example.org/data", FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::KeyMismatch);
+}
+
+TEST(replay_store_detects_an_equivalent_target) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{300}));
+  EXPECT_FALSE(store.check_and_insert("id",
+                                      "HTTPS://Server.Example.COM:443/token",
+                                      FIXED_TIME, std::chrono::seconds{300}));
+}
+
+TEST(replay_store_separator_prevents_ambiguity) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_TRUE(store.check_and_insert("ab", "https://server.example.com/c",
+                                     FIXED_TIME, std::chrono::seconds{300}));
+  EXPECT_TRUE(store.check_and_insert("a", "https://server.example.com/bc",
+                                     FIXED_TIME, std::chrono::seconds{300}));
+}
+
+TEST(confirmation_has_a_single_member) {
+  const auto confirmation{
+      sourcemeta::core::oauth_dpop_confirmation(OTHER_THUMBPRINT)};
+  EXPECT_EQ(confirmation.size(), 1);
+}
+
+TEST(proofer_uses_the_latest_observed_nonce) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  proofer.observe("https://server.example.com", "first-nonce");
+  proofer.observe("https://server.example.com", "second-nonce");
+  std::string proof;
+  EXPECT_TRUE(proofer.proof("https://server.example.com", "POST",
+                            "https://server.example.com/token", "", FIXED_TIME,
+                            proof));
+
+  const auto token{sourcemeta::core::JWT::from(proof)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().payload().at("nonce").to_string(), "second-nonce");
+}
+
+TEST(proofer_rejects_an_unparseable_target) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  sourcemeta::core::OAuthDPoPProofer proofer{
+      std::move(key.value()), sourcemeta::core::JWSAlgorithm::ES256};
+  std::string proof;
+  EXPECT_FALSE(proofer.proof("https://server.example.com", "POST", "not a url",
+                             "", FIXED_TIME, proof));
+}

--- a/test/oauth/oauth_dpop_test.cc
+++ b/test/oauth/oauth_dpop_test.cc
@@ -275,6 +275,28 @@ TEST(verify_rejects_a_malformed_proof) {
             sourcemeta::core::OAuthDPoPError::Malformed);
 }
 
+TEST(verify_rejects_a_proof_with_a_duplicate_claim) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  auto header{
+      sourcemeta::core::parse_json(R"({"typ":"dpop+jwt","alg":"ES256"})")};
+  header.assign("jwk", sourcemeta::core::parse_json(EC_PUBLIC_JWK));
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"jti":"x","htm":"POST",)"
+      R"("htu":"https://server.example.com/token",)"
+      R"("htu":"https://evil.example/token","iat":1562262616})")};
+  const auto proof{sourcemeta::core::jwt_sign(header, payload, key.value())};
+  EXPECT_TRUE(proof.has_value());
+
+  const sourcemeta::core::OAuthDPoPVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_dpop_verify(
+                proof.value(), "POST", "https://server.example.com/token",
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthDPoPError::Malformed);
+}
+
 TEST(verify_rejects_a_wrong_method) {
   auto key{sourcemeta::core::JWKPrivate::from(
       sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
@@ -933,6 +955,29 @@ TEST(replay_store_separator_prevents_ambiguity) {
                                      FIXED_TIME, std::chrono::seconds{300}));
   EXPECT_TRUE(store.check_and_insert("a", "https://server.example.com/bc",
                                      FIXED_TIME, std::chrono::seconds{300}));
+}
+
+TEST(replay_store_evicts_the_earliest_at_capacity) {
+  sourcemeta::core::OAuthDPoPReplayStore store{2};
+  EXPECT_TRUE(store.check_and_insert("first",
+                                     "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds{100}));
+  EXPECT_TRUE(store.check_and_insert(
+      "second", "https://server.example.com/token",
+      FIXED_TIME + std::chrono::seconds{1}, std::chrono::seconds{100}));
+  EXPECT_TRUE(store.check_and_insert(
+      "third", "https://server.example.com/token",
+      FIXED_TIME + std::chrono::seconds{2}, std::chrono::seconds{100}));
+  EXPECT_EQ(store.size(FIXED_TIME + std::chrono::seconds{2}), 2);
+  EXPECT_FALSE(store.check_and_insert(
+      "second", "https://server.example.com/token",
+      FIXED_TIME + std::chrono::seconds{2}, std::chrono::seconds{100}));
+  EXPECT_FALSE(store.check_and_insert(
+      "third", "https://server.example.com/token",
+      FIXED_TIME + std::chrono::seconds{2}, std::chrono::seconds{100}));
+  EXPECT_TRUE(store.check_and_insert(
+      "first", "https://server.example.com/token",
+      FIXED_TIME + std::chrono::seconds{2}, std::chrono::seconds{100}));
 }
 
 TEST(confirmation_has_a_single_member) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

