### PR TITLE
Implement a `is_canonical_langtag` helper

### DIFF
--- a/src/core/langtag/include/sourcemeta/core/langtag.h
+++ b/src/core/langtag/include/sourcemeta/core/langtag.h
@@ -42,6 +42,27 @@ namespace sourcemeta::core {
 SOURCEMETA_CORE_LANGTAG_EXPORT
 auto is_langtag(const std::string_view value) -> bool;
 
+/// @ingroup langtag
+/// Check whether the given string is a well-formed language tag per RFC 5646
+/// (BCP 47) that also follows the recommended casing conventions of RFC 5646
+/// Section 2.1.1: script subtags in titlecase, region subtags in uppercase,
+/// and every other subtag, including every subtag after a singleton, in
+/// lowercase. The deprecated irregular grandfathered tags are rejected, as
+/// the registry maps each of them to a canonical replacement. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/langtag.h>
+///
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::is_canonical_langtag("en-GB"));
+/// assert(sourcemeta::core::is_canonical_langtag("zh-Hant-HK"));
+/// assert(!sourcemeta::core::is_canonical_langtag("en-gb"));
+/// assert(!sourcemeta::core::is_canonical_langtag("EN"));
+/// ```
+SOURCEMETA_CORE_LANGTAG_EXPORT
+auto is_canonical_langtag(const std::string_view value) -> bool;
+
 } // namespace sourcemeta::core
 
 #endif

--- a/src/core/langtag/langtag.cc
+++ b/src/core/langtag/langtag.cc
@@ -249,4 +249,41 @@ auto is_langtag(const std::string_view value) -> bool {
   return is_irregular_grandfathered(value);
 }
 
+auto is_canonical_langtag(const std::string_view value) -> bool {
+  // The registry maps every irregular grandfathered tag to a canonical
+  // replacement, so none of them is canonical.
+  if (!is_langtag(value) || is_irregular_grandfathered(value)) {
+    return false;
+  }
+
+  bool initial{true};
+  bool after_singleton{false};
+  std::size_t position{0};
+  while (position < value.size()) {
+    const auto subtag{subtag_at(value, position)};
+
+    // Per RFC 5646 Section 2.1.1, region subtags are uppercase and script
+    // subtags are titlecase, while every other subtag, including everything
+    // that follows a singleton, is lowercase.
+    const auto letters{is_alpha(subtag)};
+    const bool region{!initial && !after_singleton && letters &&
+                      subtag.size() == 2};
+    const bool script{!initial && !after_singleton && letters &&
+                      subtag.size() == 4};
+    for (std::size_t index{0}; index < subtag.size(); index += 1) {
+      const bool expect_uppercase{region || (script && index == 0)};
+      const bool uppercase{!is_lowercase(subtag[index])};
+      if (uppercase != expect_uppercase) {
+        return false;
+      }
+    }
+
+    initial = false;
+    after_singleton = after_singleton || subtag.size() == 1;
+    advance(value, position, subtag.size());
+  }
+
+  return true;
+}
+
 } // namespace sourcemeta::core

--- a/test/langtag/langtag_test.cc
+++ b/test/langtag/langtag_test.cc
@@ -451,3 +451,127 @@ TEST(whitespace) {
   EXPECT_FALSE(sourcemeta::core::is_langtag("en "));
   EXPECT_FALSE(sourcemeta::core::is_langtag("en US"));
 }
+
+// RFC 5646 Section 2.1.1: a lowercase primary language subtag is canonical
+TEST(canonical_simple_language) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("en"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("mas"));
+}
+
+// RFC 5646 Section 2.1.1: the primary language subtag is lowercase
+TEST(canonical_uppercase_language_rejected) {
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("EN"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("En"));
+}
+
+// RFC 5646 Section 2.1.1: a four-letter subtag at the start of the tag is a
+// primary language, not a script, so it stays lowercase
+TEST(canonical_four_letter_language_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("aaaa"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("Aaaa"));
+}
+
+// RFC 5646 Section 2.1.1: region subtags are uppercase
+TEST(canonical_region_uppercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("en-GB"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("de-DE"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-gb"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-Gb"));
+}
+
+// RFC 5646 Section 2.1.1: numeric region subtags carry no casing
+TEST(canonical_numeric_region) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("es-419"));
+}
+
+// RFC 5646 Section 2.1.1: script subtags are titlecase
+TEST(canonical_script_titlecase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("zh-Hant"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("zh-hant"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("zh-HANT"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("zh-hANT"));
+}
+
+// RFC 5646 Section 2.1.1: titlecase script and uppercase region together
+TEST(canonical_script_and_region) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("zh-Hant-HK"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("sr-Latn-RS"));
+}
+
+// RFC 5646 Section 2.1.1: extended language subtags are lowercase
+TEST(canonical_extlang_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("zh-yue-Hant-CN"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("zh-YUE"));
+}
+
+// RFC 5646 Section 2.1.1: variant subtags are lowercase
+TEST(canonical_variant_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("sl-rozaj-biske"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("sl-ROZAJ"));
+}
+
+// RFC 5646 Section 2.1.1: a digit-led variant keeps its letters lowercase
+TEST(canonical_digit_led_variant) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("de-CH-1901"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("de-1abc"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("de-1ABC"));
+}
+
+// RFC 5646 Section 2.1.1: extension singletons are lowercase
+TEST(canonical_singleton_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("en-a-bbb"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-A-bbb"));
+}
+
+// RFC 5646 Section 2.1.1: extension subtags are lowercase
+TEST(canonical_extension_subtags_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("en-US-u-islamcal"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-a-BBB"));
+}
+
+// RFC 5646 Section 2.1.1: two-letter and four-letter subtags that occur after
+// a singleton stay lowercase, as in the examples of that section
+TEST(canonical_after_singleton_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("en-CA-x-ca"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("az-Latn-x-latn"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-CA-x-CA"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("az-Latn-x-Latn"));
+}
+
+// RFC 5646 Section 2.1.1: private use tags are lowercase throughout
+TEST(canonical_private_use_lowercase) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("x-foo"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("x-ab"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("X-foo"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("x-FOO"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("x-AB"));
+}
+
+// RFC 5646 Appendix A: a well-formed private use sequence with uppercase
+// subtags is not canonical
+TEST(canonical_rfc_private_use_examples) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("de-CH-x-phonebk"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("az-Arab-x-AYB"));
+}
+
+// RFC 5646 Section 2.2.8: the registry deprecates every irregular
+// grandfathered tag in favour of a canonical replacement
+TEST(canonical_irregular_grandfathered_rejected) {
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-GB-oed"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("i-klingon"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("sgn-BE-FR"));
+}
+
+// RFC 5646 Section 2.2.8: the regular grandfathered tags match the grammar
+// and are already lowercase
+TEST(canonical_regular_grandfathered) {
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("zh-min-nan"));
+  EXPECT_TRUE(sourcemeta::core::is_canonical_langtag("art-lojban"));
+}
+
+// RFC 5646 Section 2.1: a canonical tag is first of all a language tag
+TEST(canonical_malformed_rejected) {
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag(""));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-"));
+  EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("de-419-DE"));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

