### PR TITLE
Implement OAuth JWT bearer assertions (RFC 7521, RFC 7523)

### DIFF
--- a/src/core/oauth/CMakeLists.txt
+++ b/src/core/oauth/CMakeLists.txt
@@ -2,13 +2,15 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME oauth
   PRIVATE_HEADERS error.h profile.h pkce.h bearer.h random.h authorization.h
     token.h client_authentication.h transaction.h metadata.h metadata_provider.h
     token_exchange.h revocation.h introspection.h device.h dpop.h par.h
+    assertion.h
   SOURCES oauth_error.cc oauth_pkce.cc oauth_bearer.cc oauth_syntax.h
     oauth_random.cc oauth_authorization.cc oauth_authorization_parse.h
     oauth_encode.h oauth_decode.h
     oauth_json.h oauth_token.cc oauth_client_authentication.cc
     oauth_transaction.cc oauth_metadata.cc oauth_metadata_provider.cc
     oauth_ttl.h oauth_token_exchange.cc oauth_revocation.cc
-    oauth_introspection.cc oauth_device.cc oauth_dpop.cc oauth_par.cc)
+    oauth_introspection.cc oauth_device.cc oauth_dpop.cc oauth_par.cc
+    oauth_assertion.cc)
 
 target_link_libraries(sourcemeta_core_oauth
   PUBLIC sourcemeta::core::json)

--- a/src/core/oauth/include/sourcemeta/core/oauth.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth.h
@@ -6,6 +6,7 @@
 #endif
 
 // NOLINTBEGIN(misc-include-cleaner)
+#include <sourcemeta/core/oauth_assertion.h>
 #include <sourcemeta/core/oauth_authorization.h>
 #include <sourcemeta/core/oauth_bearer.h>
 #include <sourcemeta/core/oauth_client_authentication.h>

--- a/src/core/oauth/include/sourcemeta/core/oauth_assertion.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_assertion.h
@@ -51,14 +51,11 @@ inline constexpr std::string_view OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER{
 ///     key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
 /// assert(assertion.has_value());
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_build_assertion(const std::string_view issuer,
-                           const std::string_view subject,
-                           const std::string_view audience,
-                           const std::chrono::seconds lifetime,
-                           const std::chrono::system_clock::time_point now,
-                           const JWKPrivate &key, const JWSAlgorithm algorithm)
-    -> std::optional<std::string>;
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto oauth_build_assertion(
+    const std::string_view issuer, const std::string_view subject,
+    const std::string_view audience, const std::chrono::seconds lifetime,
+    const std::chrono::system_clock::time_point now, const JWKPrivate &key,
+    const JWSAlgorithm algorithm) -> std::optional<std::string>;
 
 /// @ingroup oauth
 /// Build a JWT bearer client authentication assertion (RFC 7523 Section 3), a
@@ -80,8 +77,7 @@ auto oauth_build_assertion(const std::string_view issuer,
 ///     sourcemeta::core::JWSAlgorithm::ES256)};
 /// assert(assertion.has_value());
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_build_client_assertion(
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto oauth_build_client_assertion(
     const std::string_view client_id, const std::string_view audience,
     const std::chrono::seconds lifetime,
     const std::chrono::system_clock::time_point now, const JWKPrivate &key,
@@ -133,7 +129,7 @@ auto oauth_build_token_request_jwt_bearer(const std::string_view assertion,
 enum class OAuthAssertionError : std::uint8_t {
   /// The assertion was not a well-formed JSON Web Token.
   Malformed,
-  /// The algorithm was absent or outside the accepted set (RFC 7523 Section 8).
+  /// The algorithm was absent or outside the accepted set (RFC 7523 Section 5).
   UnsupportedAlgorithm,
   /// No key verified the signature.
   UnknownKey,
@@ -163,7 +159,8 @@ enum class OAuthAssertionError : std::uint8_t {
 /// accepted algorithms are matched exactly, so an empty set accepts none, and a
 /// replay store, when set, rejects a reused identifier.
 struct OAuthAssertionVerifyOptions {
-  /// The algorithms accepted per local policy (RFC 7523 Section 8).
+  /// The algorithms accepted per local policy, a non-owning view whose backing
+  /// storage must outlive the verification (RFC 7523 Section 5).
   std::span<const JWSAlgorithm> allowed_algorithms{};
   /// The tolerance applied to the expiration, not-before, and issue times.
   std::chrono::seconds clock_skew{std::chrono::seconds{0}};
@@ -201,8 +198,7 @@ struct OAuthAssertionVerifyOptions {
 /// assert(!error.has_value() ||
 ///        error.value() == sourcemeta::core::OAuthAssertionError::Expired);
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-[[nodiscard]] auto oauth_verify_client_assertion(
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto oauth_verify_client_assertion(
     const std::string_view assertion,
     const std::span<const std::string_view> expected_audiences,
     const std::string_view request_client_id, const JWKS &keys,
@@ -232,11 +228,10 @@ SOURCEMETA_CORE_OAUTH_EXPORT
 /// const auto error{sourcemeta::core::oauth_verify_assertion_grant(
 ///     assertion, "https://issuer.example", audiences, keys,
 ///     std::chrono::system_clock::now(), options)};
-/// assert(error.has_value() ||
-///        !error.has_value());
+/// assert(!error.has_value() ||
+///        error.value() == sourcemeta::core::OAuthAssertionError::Issuer);
 /// ```
-SOURCEMETA_CORE_OAUTH_EXPORT
-[[nodiscard]] auto oauth_verify_assertion_grant(
+[[nodiscard]] SOURCEMETA_CORE_OAUTH_EXPORT auto oauth_verify_assertion_grant(
     const std::string_view assertion, const std::string_view expected_issuer,
     const std::span<const std::string_view> expected_audiences,
     const JWKS &keys, const std::chrono::system_clock::time_point now,

--- a/src/core/oauth/include/sourcemeta/core/oauth_assertion.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_assertion.h
@@ -1,0 +1,248 @@
+#ifndef SOURCEMETA_CORE_OAUTH_ASSERTION_H_
+#define SOURCEMETA_CORE_OAUTH_ASSERTION_H_
+
+#ifndef SOURCEMETA_CORE_OAUTH_EXPORT
+#include <sourcemeta/core/oauth_export.h>
+#endif
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/jose_algorithm.h>
+#include <sourcemeta/core/jose_jwk_private.h>
+#include <sourcemeta/core/jose_jwks.h>
+#include <sourcemeta/core/oauth_dpop.h>
+
+#include <chrono>      // std::chrono::seconds, std::chrono::system_clock
+#include <cstdint>     // std::uint8_t
+#include <optional>    // std::optional
+#include <span>        // std::span
+#include <string>      // std::string
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+/// @ingroup oauth
+/// The grant type identifier of a JWT bearer authorization grant (RFC 7523
+/// Section 2.1).
+inline constexpr std::string_view OAUTH_GRANT_TYPE_JWT_BEARER{
+    "urn:ietf:params:oauth:grant-type:jwt-bearer"};
+/// @ingroup oauth
+/// The client assertion type identifier of a JWT bearer client authentication
+/// assertion (RFC 7523 Section 2.2).
+inline constexpr std::string_view OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER{
+    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"};
+
+/// @ingroup oauth
+/// Build a JWT bearer assertion (RFC 7523 Section 3) signed with the given key
+/// and algorithm, carrying the issuer, subject, and a single audience, an
+/// expiration a lifetime past the given time, an issue time, and a random
+/// identifier, or no value when the key cannot sign. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/jose.h>
+/// #include <chrono>
+/// #include <cassert>
+///
+/// const auto key{sourcemeta::core::JWKPrivate::from_pem(pem)};
+/// assert(key.has_value());
+/// const auto assertion{sourcemeta::core::oauth_build_assertion(
+///     "issuer", "subject", "https://server.example/token",
+///     std::chrono::seconds{300}, std::chrono::system_clock::now(),
+///     key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+/// assert(assertion.has_value());
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_assertion(const std::string_view issuer,
+                           const std::string_view subject,
+                           const std::string_view audience,
+                           const std::chrono::seconds lifetime,
+                           const std::chrono::system_clock::time_point now,
+                           const JWKPrivate &key, const JWSAlgorithm algorithm)
+    -> std::optional<std::string>;
+
+/// @ingroup oauth
+/// Build a JWT bearer client authentication assertion (RFC 7523 Section 3), a
+/// self-issued assertion whose issuer and subject are both the client
+/// identifier (RFC 7521 Section 5.2), or no value when the key cannot sign. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/jose.h>
+/// #include <chrono>
+/// #include <cassert>
+///
+/// const auto key{sourcemeta::core::JWKPrivate::from_pem(pem)};
+/// assert(key.has_value());
+/// const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+///     "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+///     std::chrono::system_clock::now(), key.value(),
+///     sourcemeta::core::JWSAlgorithm::ES256)};
+/// assert(assertion.has_value());
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_client_assertion(
+    const std::string_view client_id, const std::string_view audience,
+    const std::chrono::seconds lifetime,
+    const std::chrono::system_clock::time_point now, const JWKPrivate &key,
+    const JWSAlgorithm algorithm) -> std::optional<std::string>;
+
+/// @ingroup oauth
+/// Append the client authentication assertion parameters (RFC 7521 Section 4.2)
+/// to the sink, the assertion and its JWT bearer type. No `client_id` is
+/// emitted, since the client is identified by the assertion subject. The
+/// assertion is a credential, so the sink is a wiping string, appended to and
+/// never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_client_assertion("eyJ...", body);
+/// assert(std::string_view{body}.starts_with("client_assertion_type="));
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_client_assertion(const std::string_view assertion,
+                            SecureString &sink) -> void;
+
+/// @ingroup oauth
+/// Append a JWT bearer authorization grant token request body (RFC 7523
+/// Section 2.1) to the sink, the grant type, the assertion, and the scope when
+/// present. No `client_id` is emitted, so the caller composes a client
+/// authentication builder into the same sink when the client authenticates. The
+/// assertion is a credential, so the sink is a wiping string, appended to and
+/// never cleared. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// sourcemeta::core::SecureString body;
+/// sourcemeta::core::oauth_build_token_request_jwt_bearer("eyJ...", "read",
+///                                                        body);
+/// assert(std::string_view{body}.starts_with("grant_type="));
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_build_token_request_jwt_bearer(const std::string_view assertion,
+                                          const std::string_view scope,
+                                          SecureString &sink) -> void;
+
+/// @ingroup oauth
+/// The reason a JWT bearer assertion failed verification (RFC 7523 Section 3).
+enum class OAuthAssertionError : std::uint8_t {
+  /// The assertion was not a well-formed JSON Web Token.
+  Malformed,
+  /// The algorithm was absent or outside the accepted set (RFC 7523 Section 8).
+  UnsupportedAlgorithm,
+  /// No key verified the signature.
+  UnknownKey,
+  /// The signature did not verify.
+  Signature,
+  /// The issuer claim was absent or did not match (RFC 7523 Section 3 check 1).
+  Issuer,
+  /// The subject claim was absent or did not match (RFC 7523 Section 3 check 2,
+  /// RFC 7521 Section 4.2).
+  Subject,
+  /// The audience claim did not identify this server (RFC 7523 Section 3
+  /// check 3).
+  Audience,
+  /// The assertion has expired (RFC 7523 Section 3 check 4).
+  Expired,
+  /// The assertion is not yet valid (RFC 7523 Section 3 check 5).
+  NotYetValid,
+  /// The issue time lies in the future (RFC 7523 Section 3 check 6).
+  IssuedInFuture,
+  /// The identifier was already seen within its window, a replay (RFC 7523
+  /// Section 3 check 7).
+  Replay
+};
+
+/// @ingroup oauth
+/// The inputs to JWT bearer assertion verification beyond the request. The
+/// accepted algorithms are matched exactly, so an empty set accepts none, and a
+/// replay store, when set, rejects a reused identifier.
+struct OAuthAssertionVerifyOptions {
+  /// The algorithms accepted per local policy (RFC 7523 Section 8).
+  std::span<const JWSAlgorithm> allowed_algorithms{};
+  /// The tolerance applied to the expiration, not-before, and issue times.
+  std::chrono::seconds clock_skew{std::chrono::seconds{0}};
+  /// The store tracking assertion identifiers to reject a replay, ignored when
+  /// null or when the assertion carries no identifier (RFC 7523 Section 3
+  /// check 7).
+  OAuthDPoPReplayStore *replay_store{nullptr};
+};
+
+/// @ingroup oauth
+/// Verify a JWT bearer client authentication assertion (RFC 7523 Section 3,
+/// RFC 7521 Section 5.2), returning the first failing check or no value when it
+/// verifies. The issuer and subject must both be the client identifier, the
+/// subject must match a presented `client_id` when one is given (RFC 7521
+/// Section 4.2), and the audience must match one of the accepted values by
+/// Simple String Comparison without normalization (RFC 3986 Section 6.2.1). A
+/// failure is reported to the client as `invalid_client` (RFC 7521
+/// Section 4.2.1). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/jose.h>
+/// #include <array>
+/// #include <chrono>
+/// #include <cassert>
+///
+/// const std::array<std::string_view, 1>
+/// audiences{{"https://server.example/token"}}; const std::array
+/// allowed{sourcemeta::core::JWSAlgorithm::ES256};
+/// sourcemeta::core::OAuthAssertionVerifyOptions options;
+/// options.allowed_algorithms = allowed;
+/// const auto error{sourcemeta::core::oauth_verify_client_assertion(
+///     assertion, audiences, "s6BhdRkqt3", keys,
+///     std::chrono::system_clock::now(), options)};
+/// assert(!error.has_value() ||
+///        error.value() == sourcemeta::core::OAuthAssertionError::Expired);
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+[[nodiscard]] auto oauth_verify_client_assertion(
+    const std::string_view assertion,
+    const std::span<const std::string_view> expected_audiences,
+    const std::string_view request_client_id, const JWKS &keys,
+    const std::chrono::system_clock::time_point now,
+    const OAuthAssertionVerifyOptions &options)
+    -> std::optional<OAuthAssertionError>;
+
+/// @ingroup oauth
+/// Verify a JWT bearer authorization grant assertion (RFC 7523 Section 3),
+/// returning the first failing check or no value when it verifies. The issuer
+/// must match the expected one, the subject identifies the accessor and is only
+/// required to be present, and the audience must match one of the accepted
+/// values by Simple String Comparison without normalization (RFC 3986
+/// Section 6.2.1). A failure is reported to the client as `invalid_grant`
+/// (RFC 6749 Section 5.2). For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/jose.h>
+/// #include <array>
+/// #include <chrono>
+/// #include <cassert>
+///
+/// const std::array<std::string_view, 1>
+/// audiences{{"https://server.example/token"}};
+/// sourcemeta::core::OAuthAssertionVerifyOptions options;
+/// const auto error{sourcemeta::core::oauth_verify_assertion_grant(
+///     assertion, "https://issuer.example", audiences, keys,
+///     std::chrono::system_clock::now(), options)};
+/// assert(error.has_value() ||
+///        !error.has_value());
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+[[nodiscard]] auto oauth_verify_assertion_grant(
+    const std::string_view assertion, const std::string_view expected_issuer,
+    const std::span<const std::string_view> expected_audiences,
+    const JWKS &keys, const std::chrono::system_clock::time_point now,
+    const OAuthAssertionVerifyOptions &options)
+    -> std::optional<OAuthAssertionError>;
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_dpop.h
@@ -277,11 +277,16 @@ public:
   /// returning false for one already seen within its window, which is a replay
   /// (RFC 9449 Section 11.1). Entries whose window has elapsed by the given
   /// time are pruned, and at capacity the entry closest to expiry is evicted.
+  /// The target is canonicalized as an HTTP target URI when `normalize_target`
+  /// is set, so an equivalent but differently spelled DPoP target still
+  /// collides (RFC 9449 Section 4.3 check 9), and keyed verbatim otherwise, for
+  /// a target compared without normalization such as an assertion audience.
   [[nodiscard]] auto
   check_and_insert(const std::string_view identifier,
                    const std::string_view target,
                    const std::chrono::system_clock::time_point now,
-                   const std::chrono::seconds window) -> bool;
+                   const std::chrono::seconds window,
+                   const bool normalize_target = true) -> bool;
 
   /// The number of entries whose window has not elapsed by the given time,
   /// counted without modifying the store, since expired entries are pruned when

--- a/src/core/oauth/oauth_assertion.cc
+++ b/src/core/oauth/oauth_assertion.cc
@@ -1,0 +1,231 @@
+#include <sourcemeta/core/oauth_assertion.h>
+
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/jose_algorithm.h>
+#include <sourcemeta/core/jose_jwt.h>
+#include <sourcemeta/core/jose_sign.h>
+#include <sourcemeta/core/jose_verify.h>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth_random.h>
+
+#include "oauth_encode.h"
+
+#include <algorithm>   // std::ranges::find_if
+#include <chrono>      // std::chrono::seconds, std::chrono::duration_cast
+#include <cstdint>     // std::int64_t
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
+#include <utility>     // std::unreachable
+
+namespace sourcemeta::core {
+
+namespace {
+
+using namespace std::literals::string_view_literals;
+
+const auto HASH_ALG{JSON::Object::hash("alg"sv)};
+const auto HASH_KID{JSON::Object::hash("kid"sv)};
+const auto HASH_ISS{JSON::Object::hash("iss"sv)};
+const auto HASH_SUB{JSON::Object::hash("sub"sv)};
+const auto HASH_AUD{JSON::Object::hash("aud"sv)};
+const auto HASH_EXP{JSON::Object::hash("exp"sv)};
+const auto HASH_IAT{JSON::Object::hash("iat"sv)};
+const auto HASH_JTI{JSON::Object::hash("jti"sv)};
+
+auto to_epoch_seconds(const std::chrono::system_clock::time_point point)
+    -> std::int64_t {
+  return static_cast<std::int64_t>(
+      std::chrono::duration_cast<std::chrono::seconds>(point.time_since_epoch())
+          .count());
+}
+
+auto map_verification_error(const JWTVerificationError error)
+    -> OAuthAssertionError {
+  switch (error) {
+    case JWTVerificationError::AlgorithmNotAllowed:
+      return OAuthAssertionError::UnsupportedAlgorithm;
+    case JWTVerificationError::UnknownKey:
+      return OAuthAssertionError::UnknownKey;
+    case JWTVerificationError::Signature:
+      return OAuthAssertionError::Signature;
+    case JWTVerificationError::Type:
+      return OAuthAssertionError::Malformed;
+    case JWTVerificationError::Issuer:
+      return OAuthAssertionError::Issuer;
+    case JWTVerificationError::Subject:
+      return OAuthAssertionError::Subject;
+    case JWTVerificationError::Audience:
+      return OAuthAssertionError::Audience;
+    case JWTVerificationError::Expiration:
+      return OAuthAssertionError::Expired;
+    case JWTVerificationError::NotBefore:
+      return OAuthAssertionError::NotYetValid;
+    case JWTVerificationError::IssuedAt:
+      return OAuthAssertionError::IssuedInFuture;
+  }
+
+  std::unreachable();
+}
+
+// The shared verification of a parsed JWT bearer assertion (RFC 7523
+// Section 3): find the audience the assertion targets, delegate the signature
+// and time checks to the JSON Web Token verifier, and reject a replayed
+// identifier
+auto verify_assertion(
+    const JWT &token, const std::string_view expected_issuer,
+    const std::optional<std::string_view> expected_subject,
+    const std::span<const std::string_view> expected_audiences,
+    const JWKS &keys, const std::chrono::system_clock::time_point now,
+    const OAuthAssertionVerifyOptions &options)
+    -> std::optional<OAuthAssertionError> {
+  // RFC 7523 Section 3 check 3 and RFC 3986 Section 6.2.1: the audience is
+  // matched by Simple String Comparison, so an accepted value is compared to
+  // the string or array claim without any normalization
+  const auto match{std::ranges::find_if(
+      expected_audiences, [&token](const std::string_view audience) -> bool {
+        return token.has_audience(audience);
+      })};
+  if (match == expected_audiences.end()) {
+    return OAuthAssertionError::Audience;
+  }
+
+  const auto error{jwt_verify(token, keys, options.allowed_algorithms,
+                              expected_issuer, *match, now, options.clock_skew,
+                              expected_subject, std::nullopt)};
+  if (error.has_value()) {
+    return map_verification_error(error.value());
+  }
+
+  // RFC 7523 Section 3 check 7: an identifier is tracked for the remaining
+  // validity of the assertion so it cannot be replayed, scoped to the audience
+  // it was issued for
+  if (options.replay_store != nullptr) {
+    const auto identifier{token.token_id()};
+    const auto expiration{token.expires_at()};
+    if (identifier.has_value() && expiration.has_value()) {
+      const auto remaining{std::chrono::duration_cast<std::chrono::seconds>(
+          expiration.value() - now)};
+      const auto window{remaining > std::chrono::seconds{0}
+                            ? remaining
+                            : std::chrono::seconds{0}};
+      if (!options.replay_store->check_and_insert(identifier.value(), *match,
+                                                  now, window)) {
+        return OAuthAssertionError::Replay;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+} // namespace
+
+auto oauth_build_assertion(const std::string_view issuer,
+                           const std::string_view subject,
+                           const std::string_view audience,
+                           const std::chrono::seconds lifetime,
+                           const std::chrono::system_clock::time_point now,
+                           const JWKPrivate &key, const JWSAlgorithm algorithm)
+    -> std::optional<std::string> {
+  auto header{JSON::make_object()};
+  header.assign_assume_new("alg", JSON{jws_algorithm_name(algorithm)},
+                           HASH_ALG);
+  // The key identifier lets the server select the verifying key (RFC 7515
+  // Section 4.1.4)
+  const auto key_id{key.key_id()};
+  if (key_id.has_value()) {
+    header.assign_assume_new("kid", JSON{key_id.value()}, HASH_KID);
+  }
+
+  auto payload{JSON::make_object()};
+  payload.assign_assume_new("iss", JSON{issuer}, HASH_ISS);
+  payload.assign_assume_new("sub", JSON{subject}, HASH_SUB);
+  payload.assign_assume_new("aud", JSON{audience}, HASH_AUD);
+  payload.assign_assume_new("exp", JSON{to_epoch_seconds(now + lifetime)},
+                            HASH_EXP);
+  payload.assign_assume_new("iat", JSON{to_epoch_seconds(now)}, HASH_IAT);
+  const auto identifier{oauth_random_token()};
+  payload.assign_assume_new(
+      "jti", JSON{std::string_view{identifier.data(), identifier.size()}},
+      HASH_JTI);
+
+  return jwt_sign(header, payload, key);
+}
+
+auto oauth_build_client_assertion(
+    const std::string_view client_id, const std::string_view audience,
+    const std::chrono::seconds lifetime,
+    const std::chrono::system_clock::time_point now, const JWKPrivate &key,
+    const JWSAlgorithm algorithm) -> std::optional<std::string> {
+  // RFC 7521 Section 5.2: a self-issued client authentication assertion has the
+  // client identifier as both its issuer and its subject
+  return oauth_build_assertion(client_id, client_id, audience, lifetime, now,
+                               key, algorithm);
+}
+
+auto oauth_client_assertion(const std::string_view assertion,
+                            SecureString &sink) -> void {
+  oauth_append_form_parameter(sink, "client_assertion_type",
+                              OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER);
+  oauth_append_form_parameter(sink, "client_assertion", assertion);
+}
+
+auto oauth_build_token_request_jwt_bearer(const std::string_view assertion,
+                                          const std::string_view scope,
+                                          SecureString &sink) -> void {
+  oauth_append_form_parameter(sink, "grant_type", OAUTH_GRANT_TYPE_JWT_BEARER);
+  oauth_append_form_parameter(sink, "assertion", assertion);
+  if (!scope.empty()) {
+    oauth_append_form_parameter(sink, "scope", scope);
+  }
+}
+
+auto oauth_verify_client_assertion(
+    const std::string_view assertion,
+    const std::span<const std::string_view> expected_audiences,
+    const std::string_view request_client_id, const JWKS &keys,
+    const std::chrono::system_clock::time_point now,
+    const OAuthAssertionVerifyOptions &options)
+    -> std::optional<OAuthAssertionError> {
+  const auto token{JWT::from(assertion)};
+  if (!token.has_value()) {
+    return OAuthAssertionError::Malformed;
+  }
+
+  const auto subject{token.value().subject()};
+  if (!subject.has_value()) {
+    return OAuthAssertionError::Subject;
+  }
+
+  // RFC 7521 Section 5.2: the issuer and subject are both the client
+  // identifier, and RFC 7521 Section 4.2: a presented client_id must identify
+  // the same client as the assertion subject
+  const auto expected_subject{request_client_id.empty() ? subject.value()
+                                                        : request_client_id};
+  return verify_assertion(token.value(), subject.value(), expected_subject,
+                          expected_audiences, keys, now, options);
+}
+
+auto oauth_verify_assertion_grant(
+    const std::string_view assertion, const std::string_view expected_issuer,
+    const std::span<const std::string_view> expected_audiences,
+    const JWKS &keys, const std::chrono::system_clock::time_point now,
+    const OAuthAssertionVerifyOptions &options)
+    -> std::optional<OAuthAssertionError> {
+  const auto token{JWT::from(assertion)};
+  if (!token.has_value()) {
+    return OAuthAssertionError::Malformed;
+  }
+
+  // RFC 7523 Section 3 check 2: a subject is REQUIRED, though for a grant it
+  // identifies the accessor rather than being constrained to a known value
+  if (!token.value().subject().has_value()) {
+    return OAuthAssertionError::Subject;
+  }
+
+  return verify_assertion(token.value(), expected_issuer, std::nullopt,
+                          expected_audiences, keys, now, options);
+}
+
+} // namespace sourcemeta::core

--- a/src/core/oauth/oauth_assertion.cc
+++ b/src/core/oauth/oauth_assertion.cc
@@ -97,15 +97,17 @@ auto verify_assertion(
     return map_verification_error(error.value());
   }
 
-  // RFC 7523 Section 3 check 7: an identifier is tracked for the remaining
-  // validity of the assertion so it cannot be replayed, scoped to the audience
-  // it was issued for
+  // RFC 7523 Section 3 check 7: an identifier is tracked for as long as the
+  // assertion would be accepted, scoped to the audience it was issued for. The
+  // clock skew is added to the remaining lifetime so the entry outlives the
+  // grace window in which the assertion is still accepted past its expiration
   if (options.replay_store != nullptr) {
     const auto identifier{token.token_id()};
     const auto expiration{token.expires_at()};
     if (identifier.has_value() && expiration.has_value()) {
       const auto remaining{std::chrono::duration_cast<std::chrono::seconds>(
-          expiration.value() - now)};
+                               expiration.value() - now) +
+                           options.clock_skew};
       const auto window{remaining > std::chrono::seconds{0}
                             ? remaining
                             : std::chrono::seconds{0}};

--- a/src/core/oauth/oauth_assertion.cc
+++ b/src/core/oauth/oauth_assertion.cc
@@ -10,7 +10,7 @@
 
 #include "oauth_encode.h"
 
-#include <algorithm>   // std::ranges::find_if
+#include <algorithm>   // std::ranges::find_if, std::clamp
 #include <chrono>      // std::chrono::seconds, std::chrono::duration_cast
 #include <cstdint>     // std::int64_t
 #include <optional>    // std::optional, std::nullopt
@@ -68,6 +68,33 @@ auto map_verification_error(const JWTVerificationError error)
   std::unreachable();
 }
 
+// RFC 7519 Section 4.1.3: the audience is a string or an array of strings, so
+// an array carrying a non-string element is a malformed claim the assertion is
+// rejected for (RFC 7523 Section 3 check 10) rather than accepted because
+// another element happens to match
+auto audience_is_well_formed(const JWT &token) -> bool {
+  if (!token.payload().is_object()) {
+    return false;
+  }
+
+  const auto *audience{token.payload().try_at("aud"sv, HASH_AUD)};
+  if (audience == nullptr || audience->is_string()) {
+    return true;
+  }
+
+  if (!audience->is_array()) {
+    return false;
+  }
+
+  for (const auto &element : audience->as_array()) {
+    if (!element.is_string()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 // The shared verification of a parsed JWT bearer assertion (RFC 7523
 // Section 3): find the audience the assertion targets, delegate the signature
 // and time checks to the JSON Web Token verifier, and reject a replayed
@@ -79,6 +106,10 @@ auto verify_assertion(
     const JWKS &keys, const std::chrono::system_clock::time_point now,
     const OAuthAssertionVerifyOptions &options)
     -> std::optional<OAuthAssertionError> {
+  if (!audience_is_well_formed(token)) {
+    return OAuthAssertionError::Audience;
+  }
+
   // RFC 7523 Section 3 check 3 and RFC 3986 Section 6.2.1: the audience is
   // matched by Simple String Comparison, so an accepted value is compared to
   // the string or array claim without any normalization
@@ -105,14 +136,23 @@ auto verify_assertion(
     const auto identifier{token.token_id()};
     const auto expiration{token.expires_at()};
     if (identifier.has_value() && expiration.has_value()) {
+      // The skew is clamped to the same non-negative bounded range the claim
+      // check applies, so a negative value cannot shorten the window below the
+      // acceptance window and a large one cannot overflow the store's expiry
+      const auto skew{std::clamp(options.clock_skew,
+                                 std::chrono::seconds::zero(),
+                                 std::chrono::seconds{31556952})};
       const auto remaining{std::chrono::duration_cast<std::chrono::seconds>(
                                expiration.value() - now) +
-                           options.clock_skew};
+                           skew};
       const auto window{remaining > std::chrono::seconds{0}
                             ? remaining
                             : std::chrono::seconds{0}};
+      // The audience is keyed verbatim, since assertion audiences are compared
+      // by Simple String Comparison and must not be URL-normalized (RFC 7523
+      // Section 3, RFC 3986 Section 6.2.1)
       if (!options.replay_store->check_and_insert(identifier.value(), *match,
-                                                  now, window)) {
+                                                  now, window, false)) {
         return OAuthAssertionError::Replay;
       }
     }

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -365,13 +365,15 @@ auto oauth_dpop_verify(const std::string_view proof,
 auto OAuthDPoPReplayStore::check_and_insert(
     const std::string_view identifier, const std::string_view target,
     const std::chrono::system_clock::time_point now,
-    const std::chrono::seconds window) -> bool {
+    const std::chrono::seconds window, const bool normalize_target) -> bool {
   // RFC 9449 Section 11.1: the identifier is tracked in the context of the
-  // target URI, so the digest covers both and one store safely spans targets.
-  // The target is normalized the same way the verifier compares the htu claim
+  // target, so the digest covers both and one store safely spans targets. A
+  // DPoP target is normalized the same way the verifier compares the htu claim
   // (Section 4.3 check 9), so a replay to an equivalent but differently spelled
-  // target is still detected rather than admitted as a fresh identifier
-  const auto normalized{dpop_normalize_target(target)};
+  // target is still detected rather than admitted as a fresh identifier, while
+  // a target compared verbatim, such as an assertion audience, is keyed as is
+  const auto normalized{normalize_target ? dpop_normalize_target(target)
+                                         : std::nullopt};
   const std::string_view effective{
       normalized.has_value() ? std::string_view{normalized.value()} : target};
   std::string material;

--- a/test/oauth/CMakeLists.txt
+++ b/test/oauth/CMakeLists.txt
@@ -5,7 +5,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME oauth
     oauth_metadata_test.cc oauth_metadata_provider_test.cc
     oauth_conformance_test.cc oauth_token_exchange_test.cc
     oauth_revocation_test.cc oauth_introspection_test.cc oauth_device_test.cc
-    oauth_dpop_test.cc oauth_par_test.cc)
+    oauth_dpop_test.cc oauth_par_test.cc oauth_assertion_test.cc)
 
 target_link_libraries(sourcemeta_core_oauth_unit
   PRIVATE sourcemeta::core::oauth)

--- a/test/oauth/oauth_assertion_test.cc
+++ b/test/oauth/oauth_assertion_test.cc
@@ -1,0 +1,327 @@
+#include <sourcemeta/core/jose.h>
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <chrono>      // std::chrono::seconds, std::chrono::system_clock
+#include <optional>    // std::optional
+#include <string_view> // std::string_view
+
+static constexpr std::string_view EC_PRIVATE_JWK{
+    R"({"kty":"EC","crv":"P-256",)"
+    R"("x":"2TARGSWq8F97iq3Ng48wCEN26cxzy8OCzbFa-6ZfnaI",)"
+    R"("y":"5lkzZqhWOkc2m2zJOotl6K3_x6-TSs9OnzQKwb35DxQ",)"
+    R"("d":"ttepxcp-OwXCj4-v4sGcxRxQRXA8D5Svu02yhcHvbd0"})"};
+
+static constexpr std::string_view JWKS_JSON{
+    R"({"keys":[{"kty":"EC","crv":"P-256",)"
+    R"("x":"2TARGSWq8F97iq3Ng48wCEN26cxzy8OCzbFa-6ZfnaI",)"
+    R"("y":"5lkzZqhWOkc2m2zJOotl6K3_x6-TSs9OnzQKwb35DxQ"}]})"};
+
+// A different P-256 key, so an assertion signed with the key above does not
+// verify against it
+static constexpr std::string_view OTHER_JWKS_JSON{
+    R"({"keys":[{"kty":"EC","crv":"P-256",)"
+    R"("x":"l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",)"
+    R"("y":"9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA"}]})"};
+
+static const auto FIXED_TIME{
+    std::chrono::system_clock::from_time_t(1562262616)};
+
+static const std::array<std::string_view, 1> AUDIENCES{
+    {"https://server.example/token"}};
+static const std::array<sourcemeta::core::JWSAlgorithm, 1> ALLOWED{
+    {sourcemeta::core::JWSAlgorithm::ES256}};
+
+TEST(grant_type_and_assertion_type_constants) {
+  EXPECT_EQ(sourcemeta::core::OAUTH_GRANT_TYPE_JWT_BEARER,
+            "urn:ietf:params:oauth:grant-type:jwt-bearer");
+  EXPECT_EQ(sourcemeta::core::OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER,
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer");
+}
+
+TEST(client_assertion_body_emits_the_parameters) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_client_assertion("eyJhbGc", body);
+  EXPECT_EQ(body, "client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-"
+                  "assertion-type%3Ajwt-bearer&client_assertion=eyJhbGc");
+}
+
+TEST(jwt_bearer_body_emits_the_grant_and_scope) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_jwt_bearer("eyJhbGc", "read",
+                                                         body);
+  EXPECT_EQ(body, "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-"
+                  "bearer&assertion=eyJhbGc&scope=read");
+}
+
+TEST(jwt_bearer_body_omits_an_empty_scope) {
+  sourcemeta::core::SecureString body;
+  sourcemeta::core::oauth_build_token_request_jwt_bearer("eyJhbGc", "", body);
+  EXPECT_EQ(body, "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-"
+                  "bearer&assertion=eyJhbGc");
+}
+
+TEST(build_client_assertion_carries_the_expected_claims) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
+
+  const auto token{sourcemeta::core::JWT::from(assertion.value())};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().algorithm().value(),
+            sourcemeta::core::JWSAlgorithm::ES256);
+  EXPECT_EQ(token.value().issuer().value(), "s6BhdRkqt3");
+  EXPECT_EQ(token.value().subject().value(), "s6BhdRkqt3");
+  EXPECT_TRUE(token.value().has_audience("https://server.example/token"));
+  EXPECT_TRUE(token.value().token_id().has_value());
+  EXPECT_EQ(token.value().issued_at().value(), FIXED_TIME);
+  EXPECT_EQ(token.value().expires_at().value(),
+            FIXED_TIME + std::chrono::seconds{300});
+}
+
+TEST(verify_client_assertion_accepts_a_valid_assertion) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
+
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_client_assertion_accepts_without_a_presented_client_id) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_verify_client_assertion(
+          assertion.value(), AUDIENCES, "", keys.value(), FIXED_TIME, options)
+          .has_value());
+}
+
+TEST(verify_client_assertion_rejects_a_client_id_mismatch) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "other-client", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Subject);
+}
+
+TEST(verify_client_assertion_rejects_a_non_self_issued_assertion) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  // Issuer and subject differ, which is invalid for client authentication
+  const auto assertion{sourcemeta::core::oauth_build_assertion(
+      "issuer", "s6BhdRkqt3", "https://server.example/token",
+      std::chrono::seconds{300}, FIXED_TIME, key.value(),
+      sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Issuer);
+}
+
+TEST(verify_client_assertion_rejects_a_wrong_audience) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://other.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Audience);
+}
+
+TEST(verify_client_assertion_matches_one_of_several_audiences) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/par", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  const std::array<std::string_view, 2> audiences{
+      {"https://server.example/token", "https://server.example/par"}};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), audiences, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_client_assertion_rejects_an_expired_assertion) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME + std::chrono::seconds{400}, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Expired);
+}
+
+TEST(verify_client_assertion_rejects_an_unsupported_algorithm) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
+      {sourcemeta::core::JWSAlgorithm::ES384}};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = allowed;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::UnsupportedAlgorithm);
+}
+
+TEST(verify_client_assertion_rejects_a_malformed_assertion) {
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                "not-a-jwt", AUDIENCES, "s6BhdRkqt3", keys.value(), FIXED_TIME,
+                options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Malformed);
+}
+
+TEST(verify_client_assertion_rejects_an_unknown_key) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{sourcemeta::core::JWKS::from(
+      sourcemeta::core::parse_json(OTHER_JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::UnknownKey);
+}
+
+TEST(verify_assertion_grant_accepts_a_valid_grant) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_assertion(
+      "https://issuer.example", "user123", "https://server.example/token",
+      std::chrono::seconds{300}, FIXED_TIME, key.value(),
+      sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_assertion_grant(
+                   assertion.value(), "https://issuer.example", AUDIENCES,
+                   keys.value(), FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_assertion_grant_rejects_a_wrong_issuer) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_assertion(
+      "https://issuer.example", "user123", "https://server.example/token",
+      std::chrono::seconds{300}, FIXED_TIME, key.value(),
+      sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_assertion_grant(
+                assertion.value(), "https://other.example", AUDIENCES,
+                keys.value(), FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Issuer);
+}
+
+TEST(verify_assertion_rejects_a_replayed_identifier) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  options.replay_store = &store;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Replay);
+}

--- a/test/oauth/oauth_assertion_test.cc
+++ b/test/oauth/oauth_assertion_test.cc
@@ -26,6 +26,32 @@ static constexpr std::string_view OTHER_JWKS_JSON{
     R"("x":"l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",)"
     R"("y":"9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA"}]})"};
 
+// The signing key carries a key identifier, so the built assertion names it in
+// the header
+static constexpr std::string_view EC_PRIVATE_JWK_WITH_KID{
+    R"({"kty":"EC","crv":"P-256","kid":"key-1",)"
+    R"("x":"2TARGSWq8F97iq3Ng48wCEN26cxzy8OCzbFa-6ZfnaI",)"
+    R"("y":"5lkzZqhWOkc2m2zJOotl6K3_x6-TSs9OnzQKwb35DxQ",)"
+    R"("d":"ttepxcp-OwXCj4-v4sGcxRxQRXA8D5Svu02yhcHvbd0"})"};
+
+// A different key published under the same identifier, so a named-key lookup
+// finds it but its signature does not verify
+static constexpr std::string_view OTHER_JWKS_WITH_KID{
+    R"({"keys":[{"kty":"EC","crv":"P-256","kid":"key-1",)"
+    R"("x":"l8tFrhx-34tV3hRICRDY9zCkDlpBhF42UQUfWVAWBFs",)"
+    R"("y":"9VE4jf_Ok_o64zbTTlcuNJajHmt6v9TDVrU0CdvGRDA"}]})"};
+
+static constexpr std::string_view OCT_JWK{
+    R"({"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T)"
+    R"(-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"})"};
+
+static constexpr std::string_view OCT_JWKS_JSON{
+    R"({"keys":[{"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQ)"
+    R"(Lr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow"}]})"};
+
+static constexpr std::string_view OTHER_OCT_JWKS_JSON{
+    R"({"keys":[{"kty":"oct","k":"b3RoZXItc2VjcmV0LWtleS1mb3ItaG1hYy10ZXN0aW5n"}]})"};
+
 static const auto FIXED_TIME{
     std::chrono::system_clock::from_time_t(1562262616)};
 
@@ -324,4 +350,274 @@ TEST(verify_assertion_rejects_a_replayed_identifier) {
                 FIXED_TIME, options)
                 .value(),
             sourcemeta::core::OAuthAssertionError::Replay);
+}
+
+TEST(build_assertion_carries_distinct_issuer_and_subject) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_assertion(
+      "https://issuer.example", "user123", "https://server.example/token",
+      std::chrono::seconds{300}, FIXED_TIME, key.value(),
+      sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
+
+  const auto token{sourcemeta::core::JWT::from(assertion.value())};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().issuer().value(), "https://issuer.example");
+  EXPECT_EQ(token.value().subject().value(), "user123");
+  EXPECT_FALSE(token.value().key_id().has_value());
+  EXPECT_EQ(token.value().issued_at().value(), FIXED_TIME);
+  EXPECT_EQ(token.value().expires_at().value(),
+            FIXED_TIME + std::chrono::seconds{300});
+}
+
+TEST(build_assertion_emits_the_key_id_header_when_present) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK_WITH_KID))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
+  const auto token{sourcemeta::core::JWT::from(assertion.value())};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_EQ(token.value().key_id().value(), "key-1");
+}
+
+TEST(verify_client_assertion_rejects_a_bad_signature_for_a_named_key) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK_WITH_KID))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{sourcemeta::core::JWKS::from(
+      sourcemeta::core::parse_json(OTHER_JWKS_WITH_KID))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Signature);
+}
+
+TEST(verify_client_assertion_accepts_a_symmetric_assertion) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(OCT_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::HS256)};
+  EXPECT_TRUE(assertion.has_value());
+  const auto keys{sourcemeta::core::JWKS::from(
+      sourcemeta::core::parse_json(OCT_JWKS_JSON))};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
+      {sourcemeta::core::JWSAlgorithm::HS256}};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = allowed;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_client_assertion_rejects_a_wrong_symmetric_secret) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(OCT_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::HS256)};
+  const auto keys{sourcemeta::core::JWKS::from(
+      sourcemeta::core::parse_json(OTHER_OCT_JWKS_JSON))};
+  const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
+      {sourcemeta::core::JWSAlgorithm::HS256}};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = allowed;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::UnknownKey);
+}
+
+TEST(verify_client_assertion_rejects_when_no_algorithm_is_allowed) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  const sourcemeta::core::OAuthAssertionVerifyOptions options;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::UnsupportedAlgorithm);
+}
+
+TEST(verify_client_assertion_rejects_a_not_yet_valid_assertion) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"iss":"s6BhdRkqt3","sub":"s6BhdRkqt3",)"
+      R"("aud":"https://server.example/token",)"
+      R"("exp":1562262916,"iat":1562262616,"nbf":1562263216})")};
+  const auto assertion{sourcemeta::core::jwt_sign(
+      sourcemeta::core::parse_json(R"({"alg":"ES256"})"), payload,
+      key.value())};
+  EXPECT_TRUE(assertion.has_value());
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::NotYetValid);
+}
+
+TEST(verify_client_assertion_rejects_an_assertion_issued_in_the_future) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME - std::chrono::seconds{100}, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::IssuedInFuture);
+}
+
+TEST(verify_client_assertion_tolerates_expiry_within_clock_skew) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  options.clock_skew = std::chrono::seconds{60};
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME + std::chrono::seconds{330}, options)
+                   .has_value());
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME + std::chrono::seconds{400}, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Expired);
+}
+
+TEST(verify_client_assertion_rejects_a_replay_within_clock_skew) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_client_assertion(
+      "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
+      FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  options.clock_skew = std::chrono::seconds{60};
+  options.replay_store = &store;
+  // Accepted ten seconds past expiry, still within the sixty-second skew
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME + std::chrono::seconds{310}, options)
+                   .has_value());
+  // A replay twenty seconds past expiry, still within skew, is caught because
+  // the replay entry outlives the grace window
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME + std::chrono::seconds{320}, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Replay);
+}
+
+TEST(verify_client_assertion_allows_reuse_without_an_identifier) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto payload{
+      sourcemeta::core::parse_json(R"({"iss":"s6BhdRkqt3","sub":"s6BhdRkqt3",)"
+                                   R"("aud":"https://server.example/token",)"
+                                   R"("exp":1562262916,"iat":1562262616})")};
+  const auto assertion{sourcemeta::core::jwt_sign(
+      sourcemeta::core::parse_json(R"({"alg":"ES256"})"), payload,
+      key.value())};
+  EXPECT_TRUE(assertion.has_value());
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  options.replay_store = &store;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+}
+
+TEST(verify_assertion_grant_rejects_a_missing_subject) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto payload{
+      sourcemeta::core::parse_json(R"({"iss":"https://issuer.example",)"
+                                   R"("aud":"https://server.example/token",)"
+                                   R"("exp":1562262916,"iat":1562262616})")};
+  const auto assertion{sourcemeta::core::jwt_sign(
+      sourcemeta::core::parse_json(R"({"alg":"ES256"})"), payload,
+      key.value())};
+  EXPECT_TRUE(assertion.has_value());
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_assertion_grant(
+                assertion.value(), "https://issuer.example", AUDIENCES,
+                keys.value(), FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Subject);
+}
+
+TEST(verify_assertion_grant_rejects_a_wrong_audience) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  const auto assertion{sourcemeta::core::oauth_build_assertion(
+      "https://issuer.example", "user123", "https://other.example/token",
+      std::chrono::seconds{300}, FIXED_TIME, key.value(),
+      sourcemeta::core::JWSAlgorithm::ES256)};
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_assertion_grant(
+                assertion.value(), "https://issuer.example", AUDIENCES,
+                keys.value(), FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Audience);
 }

--- a/test/oauth/oauth_assertion_test.cc
+++ b/test/oauth/oauth_assertion_test.cc
@@ -138,8 +138,10 @@ TEST(verify_client_assertion_accepts_without_a_presented_client_id) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_FALSE(
@@ -155,8 +157,10 @@ TEST(verify_client_assertion_rejects_a_client_id_mismatch) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -175,8 +179,10 @@ TEST(verify_client_assertion_rejects_a_non_self_issued_assertion) {
       "issuer", "s6BhdRkqt3", "https://server.example/token",
       std::chrono::seconds{300}, FIXED_TIME, key.value(),
       sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -193,8 +199,10 @@ TEST(verify_client_assertion_rejects_a_wrong_audience) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://other.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -211,8 +219,10 @@ TEST(verify_client_assertion_matches_one_of_several_audiences) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/par", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   const std::array<std::string_view, 2> audiences{
       {"https://server.example/token", "https://server.example/par"}};
   sourcemeta::core::OAuthAssertionVerifyOptions options;
@@ -230,8 +240,10 @@ TEST(verify_client_assertion_rejects_an_expired_assertion) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -248,8 +260,10 @@ TEST(verify_client_assertion_rejects_an_unsupported_algorithm) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::ES384}};
   sourcemeta::core::OAuthAssertionVerifyOptions options;
@@ -264,6 +278,7 @@ TEST(verify_client_assertion_rejects_an_unsupported_algorithm) {
 TEST(verify_client_assertion_rejects_a_malformed_assertion) {
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -280,8 +295,10 @@ TEST(verify_client_assertion_rejects_an_unknown_key) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(OTHER_JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -299,8 +316,10 @@ TEST(verify_assertion_grant_accepts_a_valid_grant) {
       "https://issuer.example", "user123", "https://server.example/token",
       std::chrono::seconds{300}, FIXED_TIME, key.value(),
       sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_FALSE(sourcemeta::core::oauth_verify_assertion_grant(
@@ -317,8 +336,10 @@ TEST(verify_assertion_grant_rejects_a_wrong_issuer) {
       "https://issuer.example", "user123", "https://server.example/token",
       std::chrono::seconds{300}, FIXED_TIME, key.value(),
       sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_assertion_grant(
@@ -335,8 +356,10 @@ TEST(verify_assertion_rejects_a_replayed_identifier) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthDPoPReplayStore store;
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
@@ -392,8 +415,10 @@ TEST(verify_client_assertion_rejects_a_bad_signature_for_a_named_key) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(OTHER_JWKS_WITH_KID))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -413,6 +438,7 @@ TEST(verify_client_assertion_accepts_a_symmetric_assertion) {
   EXPECT_TRUE(assertion.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(OCT_JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::HS256}};
   sourcemeta::core::OAuthAssertionVerifyOptions options;
@@ -430,8 +456,10 @@ TEST(verify_client_assertion_rejects_a_wrong_symmetric_secret) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::HS256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{sourcemeta::core::JWKS::from(
       sourcemeta::core::parse_json(OTHER_OCT_JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   const std::array<sourcemeta::core::JWSAlgorithm, 1> allowed{
       {sourcemeta::core::JWSAlgorithm::HS256}};
   sourcemeta::core::OAuthAssertionVerifyOptions options;
@@ -450,8 +478,10 @@ TEST(verify_client_assertion_rejects_when_no_algorithm_is_allowed) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   const sourcemeta::core::OAuthAssertionVerifyOptions options;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
                 assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
@@ -474,6 +504,7 @@ TEST(verify_client_assertion_rejects_a_not_yet_valid_assertion) {
   EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -490,8 +521,10 @@ TEST(verify_client_assertion_rejects_an_assertion_issued_in_the_future) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
@@ -508,8 +541,10 @@ TEST(verify_client_assertion_tolerates_expiry_within_clock_skew) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   options.clock_skew = std::chrono::seconds{60};
@@ -531,8 +566,10 @@ TEST(verify_client_assertion_rejects_a_replay_within_clock_skew) {
   const auto assertion{sourcemeta::core::oauth_build_client_assertion(
       "s6BhdRkqt3", "https://server.example/token", std::chrono::seconds{300},
       FIXED_TIME, key.value(), sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthDPoPReplayStore store;
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
@@ -566,6 +603,7 @@ TEST(verify_client_assertion_allows_reuse_without_an_identifier) {
   EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthDPoPReplayStore store;
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
@@ -594,6 +632,7 @@ TEST(verify_assertion_grant_rejects_a_missing_subject) {
   EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_assertion_grant(
@@ -611,8 +650,10 @@ TEST(verify_assertion_grant_rejects_a_wrong_audience) {
       "https://issuer.example", "user123", "https://other.example/token",
       std::chrono::seconds{300}, FIXED_TIME, key.value(),
       sourcemeta::core::JWSAlgorithm::ES256)};
+  EXPECT_TRUE(assertion.has_value());
   const auto keys{
       sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
   sourcemeta::core::OAuthAssertionVerifyOptions options;
   options.allowed_algorithms = ALLOWED;
   EXPECT_EQ(sourcemeta::core::oauth_verify_assertion_grant(
@@ -620,4 +661,72 @@ TEST(verify_assertion_grant_rejects_a_wrong_audience) {
                 keys.value(), FIXED_TIME, options)
                 .value(),
             sourcemeta::core::OAuthAssertionError::Audience);
+}
+
+TEST(verify_client_assertion_rejects_a_malformed_audience_array) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  // One element matches, but another is not a string, so the audience claim is
+  // malformed and rejected rather than accepted on the match
+  const auto payload{sourcemeta::core::parse_json(
+      R"({"iss":"s6BhdRkqt3","sub":"s6BhdRkqt3",)"
+      R"("aud":["https://server.example/token",123],)"
+      R"("exp":1562262916,"iat":1562262616})")};
+  const auto assertion{sourcemeta::core::jwt_sign(
+      sourcemeta::core::parse_json(R"({"alg":"ES256"})"), payload,
+      key.value())};
+  EXPECT_TRUE(assertion.has_value());
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  EXPECT_EQ(sourcemeta::core::oauth_verify_client_assertion(
+                assertion.value(), AUDIENCES, "s6BhdRkqt3", keys.value(),
+                FIXED_TIME, options)
+                .value(),
+            sourcemeta::core::OAuthAssertionError::Audience);
+}
+
+TEST(verify_client_assertion_keys_replay_by_exact_audience) {
+  auto key{sourcemeta::core::JWKPrivate::from(
+      sourcemeta::core::parse_json(EC_PRIVATE_JWK))};
+  EXPECT_TRUE(key.has_value());
+  // Two assertions share an identifier but target audiences that differ only by
+  // a default port, which URL normalization would collapse. The audience is
+  // keyed verbatim, so both are accepted rather than the second being a replay
+  const auto first{sourcemeta::core::jwt_sign(
+      sourcemeta::core::parse_json(R"({"alg":"ES256"})"),
+      sourcemeta::core::parse_json(
+          R"({"iss":"s6BhdRkqt3","sub":"s6BhdRkqt3",)"
+          R"("aud":"https://server.example/token",)"
+          R"("exp":1562262916,"iat":1562262616,"jti":"shared"})"),
+      key.value())};
+  const auto second{sourcemeta::core::jwt_sign(
+      sourcemeta::core::parse_json(R"({"alg":"ES256"})"),
+      sourcemeta::core::parse_json(
+          R"({"iss":"s6BhdRkqt3","sub":"s6BhdRkqt3",)"
+          R"("aud":"https://server.example:443/token",)"
+          R"("exp":1562262916,"iat":1562262616,"jti":"shared"})"),
+      key.value())};
+  EXPECT_TRUE(first.has_value());
+  EXPECT_TRUE(second.has_value());
+  const auto keys{
+      sourcemeta::core::JWKS::from(sourcemeta::core::parse_json(JWKS_JSON))};
+  EXPECT_TRUE(keys.has_value());
+  const std::array<std::string_view, 2> audiences{
+      {"https://server.example/token", "https://server.example:443/token"}};
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  sourcemeta::core::OAuthAssertionVerifyOptions options;
+  options.allowed_algorithms = ALLOWED;
+  options.replay_store = &store;
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   first.value(), audiences, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
+  EXPECT_FALSE(sourcemeta::core::oauth_verify_client_assertion(
+                   second.value(), audiences, "s6BhdRkqt3", keys.value(),
+                   FIXED_TIME, options)
+                   .has_value());
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

