### PR TITLE
test(crypto): expand is_uuid_like coverage for nibbles, Max, and non-hex characters

### DIFF
--- a/test/crypto/crypto_uuid_test.cc
+++ b/test/crypto/crypto_uuid_test.cc
@@ -133,3 +133,199 @@ TEST(invalid_urn_prefix) {
   EXPECT_FALSE(sourcemeta::core::is_uuid_like(
       "urn:uuid:2eb8aa08-aa98-11ea-b4aa-73b441d16380"));
 }
+
+TEST(valid_max) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("ffffffff-ffff-ffff-ffff-ffffffffffff"));
+}
+
+// RFC 9562 Section 4.2: the version nibble (index 14) is a semantic field, not
+// a syntactic constraint - every nibble 0-f is a valid string representation.
+// RFC 9562 Section 4.1: the variant nibble (index 19) is likewise
+// unconstrained.
+TEST(valid_version_nibble_0) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-01ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_1) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_2) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-21ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_3) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-31ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_4) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-41ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_5) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-51ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_6) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-61ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_7) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-71ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_8) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-81ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_9) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-91ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_a) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-a1ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_b) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-b1ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_c) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-c1ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_d) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-d1ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_e) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-e1ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_version_nibble_f) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-f1ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_0) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-04aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_1) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-14aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_2) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-24aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_3) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-34aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_4) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-44aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_5) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-54aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_6) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-64aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_7) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-74aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_8) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-84aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_9) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-94aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_a) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-a4aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_b) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_c) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-c4aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_d) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-d4aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_e) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-e4aa-73b441d16380"));
+}
+
+TEST(valid_variant_nibble_f) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-f4aa-73b441d16380"));
+}
+
+TEST(invalid_underscore_separator) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d1_380"));
+}
+
+TEST(invalid_leading_plus) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_uuid_like("+eb8aa08-aa98-11ea-b4aa-73b441d16380"));
+}
+
+TEST(invalid_hex_radix_prefix) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_uuid_like("0x000000-0000-0000-0000-000000000000"));
+}
+
+// U+0968 DEVANAGARI DIGIT TWO is not a HEXDIG.
+TEST(invalid_non_ascii_digit) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_uuid_like("\xe0\xa5\xa8"
+                                     "eb8aa08-aa98-11ea-b4aa-73b441d16380"));
+}
+
+TEST(invalid_trailing_newline) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_uuid_like("2eb8aa08-aa98-11ea-b4aa-73b441d16380\n"));
+}


### PR DESCRIPTION
I added 8 test blocks to `is_uuid_like`. Core already passes all of them, so this is coverage, not a fix.

What is new:

- `valid_max` - the Max UUID (all `f`), RFC 9562 section 5.10, alongside the existing Nil case.
- `valid_all_version_nibbles` and `valid_all_variant_nibbles` - loops over `0`-`f` at index 14 and index 19, pinning that `is_uuid_like` treats the version and variant as semantic fields, not syntactic constraints (RFC 9562 sections 4.1 and 4.2).
- `invalid_underscore_separator`, `invalid_leading_plus`, `invalid_hex_radix_prefix`, `invalid_non_ascii_digit` - characters that a lenient integer parser tolerates (`_`, `+`, `0x`, a Unicode decimal digit) but `HEXDIG` does not. `is_uuid_like` rejects them through its byte-level hex check, unlike a checker that validates the hex content with an integer parser.
- `invalid_trailing_newline` - a complete UUID followed by `\n`.

How I checked the expected values: I compiled and ran every block against the real `is_uuid_like` before staging - all 8 pass.

RFC references: RFC 9562 sections 4, 4.1, 4.2, 5.9, 5.10.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

