### PR TITLE
Implement a `rsplit_once` text helper

### DIFF
--- a/src/lang/text/include/sourcemeta/core/text.h
+++ b/src/lang/text/include/sourcemeta/core/text.h
@@ -479,6 +479,26 @@ auto split_once(const std::string_view input,
 
 /// @ingroup text
 ///
+/// Split `input` at the last occurrence of `delimiter`, returning the
+/// parts before and after it. Return `std::nullopt` when the delimiter is
+/// absent. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/text.h>
+/// #include <cassert>
+///
+/// const auto parts{sourcemeta::core::rsplit_once("a.b.c", '.')};
+/// assert(parts.has_value());
+/// assert(parts->first == "a.b");
+/// assert(parts->second == "c");
+/// assert(!sourcemeta::core::rsplit_once("no separator", '.').has_value());
+/// ```
+SOURCEMETA_CORE_TEXT_EXPORT
+auto rsplit_once(const std::string_view input, const char delimiter) noexcept
+    -> std::optional<std::pair<std::string_view, std::string_view>>;
+
+/// @ingroup text
+///
 /// Iterate the parts of `input` separated by `delimiter`, invoking
 /// `callback` with each part. For example:
 ///

--- a/src/lang/text/text.cc
+++ b/src/lang/text/text.cc
@@ -144,6 +144,19 @@ auto split_once(const std::string_view input, const char delimiter) noexcept
   return std::pair{before, after};
 }
 
+auto rsplit_once(const std::string_view input, const char delimiter) noexcept
+    -> std::optional<std::pair<std::string_view, std::string_view>> {
+  const auto position{input.rfind(delimiter)};
+  if (position == std::string_view::npos) {
+    return std::nullopt;
+  }
+  std::string_view before{input};
+  before.remove_suffix(input.size() - position);
+  std::string_view after{input};
+  after.remove_prefix(position + 1);
+  return std::pair{before, after};
+}
+
 auto split_once(const std::string_view input,
                 const std::string_view delimiter) noexcept
     -> std::optional<std::pair<std::string_view, std::string_view>> {

--- a/test/text/CMakeLists.txt
+++ b/test/text/CMakeLists.txt
@@ -8,6 +8,7 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME text
           text_unquote_test.cc
           text_less_ignore_case_test.cc
           text_trim_test.cc text_take_until_test.cc text_split_once_test.cc
+          text_rsplit_once_test.cc
           text_split_test.cc text_join_to_test.cc
           text_hex_to_bytes_test.cc text_bytes_to_hex_test.cc
           text_is_hex_digit_test.cc text_hex_digit_value_test.cc

--- a/test/text/text_rsplit_once_test.cc
+++ b/test/text/text_rsplit_once_test.cc
@@ -1,0 +1,60 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/text.h>
+
+TEST(delimiter_in_middle) {
+  const auto parts{sourcemeta::core::rsplit_once("key=value", '=')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "key");
+  EXPECT_EQ(parts->second, "value");
+}
+
+TEST(delimiter_at_start) {
+  const auto parts{sourcemeta::core::rsplit_once("=value", '=')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "");
+  EXPECT_EQ(parts->second, "value");
+}
+
+TEST(delimiter_at_end) {
+  const auto parts{sourcemeta::core::rsplit_once("key=", '=')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "key");
+  EXPECT_EQ(parts->second, "");
+}
+
+TEST(delimiter_absent) {
+  EXPECT_FALSE(sourcemeta::core::rsplit_once("no separator", '=').has_value());
+}
+
+TEST(delimiter_only_last_occurrence) {
+  const auto parts{sourcemeta::core::rsplit_once("a=b=c", '=')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "a=b");
+  EXPECT_EQ(parts->second, "c");
+}
+
+TEST(empty_input) {
+  EXPECT_FALSE(sourcemeta::core::rsplit_once("", '=').has_value());
+}
+
+TEST(only_delimiter) {
+  const auto parts{sourcemeta::core::rsplit_once("=", '=')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "");
+  EXPECT_EQ(parts->second, "");
+}
+
+TEST(splits_an_acct_identifier_at_the_last_at_sign) {
+  const auto parts{
+      sourcemeta::core::rsplit_once("alice@corp@example.com", '@')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "alice@corp");
+  EXPECT_EQ(parts->second, "example.com");
+}
+
+TEST(a_trailing_delimiter_leaves_an_empty_suffix) {
+  const auto parts{sourcemeta::core::rsplit_once("a=b=", '=')};
+  EXPECT_TRUE(parts.has_value());
+  EXPECT_EQ(parts->first, "a=b");
+  EXPECT_EQ(parts->second, "");
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

