### PR TITLE
Support directly encoding a buffer using `Base64url`

### DIFF
--- a/src/core/crypto/crypto_base64.cc
+++ b/src/core/crypto/crypto_base64.cc
@@ -5,6 +5,7 @@
 #include <cstdint>     // std::uint8_t, std::uint32_t
 #include <optional>    // std::optional, std::nullopt
 #include <ostream>     // std::ostream
+#include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -213,6 +214,12 @@ auto base64url_encode(const std::string_view input) -> std::string {
   result.reserve(((input.size() + 2) / 3) * 4);
   encode(input, BASE64URL_ALPHABET, false, result);
   return result;
+}
+
+auto base64url_encode(const std::span<const std::uint8_t> input)
+    -> std::string {
+  return base64url_encode(std::string_view{
+      reinterpret_cast<const char *>(input.data()), input.size()});
 }
 
 auto base64url_encode(const std::string_view input, SecureString &output)

--- a/src/core/crypto/crypto_base64.cc
+++ b/src/core/crypto/crypto_base64.cc
@@ -218,6 +218,12 @@ auto base64url_encode(const std::string_view input) -> std::string {
 
 auto base64url_encode(const std::span<const std::uint8_t> input)
     -> std::string {
+  // An empty span may carry a null pointer, which some standard libraries
+  // reject when constructing a string view even for a zero length
+  if (input.empty()) {
+    return {};
+  }
+
   return base64url_encode(std::string_view{
       reinterpret_cast<const char *>(input.data()), input.size()});
 }

--- a/src/core/crypto/include/sourcemeta/core/crypto_base64.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_base64.h
@@ -7,8 +7,10 @@
 
 #include <sourcemeta/core/crypto_secure.h>
 
+#include <cstdint>     // std::uint8_t
 #include <optional>    // std::optional
 #include <ostream>     // std::ostream
+#include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -119,6 +121,20 @@ base64url_encode(const std::string_view input, std::ostream &output) -> void;
 /// ```
 auto SOURCEMETA_CORE_CRYPTO_EXPORT
 base64url_encode(const std::string_view input) -> std::string;
+
+/// @ingroup crypto
+/// Encode raw bytes using unpadded Base64url (RFC 4648 Section 5), for a byte
+/// buffer such as a hash digest rather than a character string. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/crypto.h>
+/// #include <cassert>
+///
+/// const auto digest{sourcemeta::core::sha256_digest("fo")};
+/// assert(!sourcemeta::core::base64url_encode(digest).empty());
+/// ```
+auto SOURCEMETA_CORE_CRYPTO_EXPORT
+base64url_encode(std::span<const std::uint8_t> input) -> std::string;
 
 /// @ingroup crypto
 /// Append the unpadded Base64url encoding (RFC 4648 Section 5) of a byte

--- a/test/crypto/crypto_base64url_test.cc
+++ b/test/crypto/crypto_base64url_test.cc
@@ -1,8 +1,11 @@
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/test.h>
 
-#include <sstream> // std::ostringstream
-#include <string>  // std::string
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <sstream>     // std::ostringstream
+#include <string>      // std::string
+#include <string_view> // std::string_view
 
 // RFC 4648 Section 10 test vectors
 // See https://www.rfc-editor.org/rfc/rfc4648#section-10
@@ -72,6 +75,28 @@ TEST(encode_secure_string_overload_empty) {
   sourcemeta::core::SecureString output;
   sourcemeta::core::base64url_encode("", output);
   EXPECT_TRUE(output.empty());
+}
+
+TEST(encode_bytes_overload_foobar) {
+  const std::array<std::uint8_t, 6> input{{'f', 'o', 'o', 'b', 'a', 'r'}};
+  EXPECT_EQ(sourcemeta::core::base64url_encode(input), "Zm9vYmFy");
+}
+
+TEST(encode_bytes_overload_empty) {
+  const std::array<std::uint8_t, 0> input{};
+  EXPECT_EQ(sourcemeta::core::base64url_encode(input), "");
+}
+
+TEST(encode_bytes_overload_high_bytes) {
+  const std::array<std::uint8_t, 3> input{{0xFF, 0xFF, 0xFF}};
+  EXPECT_EQ(sourcemeta::core::base64url_encode(input), "____");
+}
+
+TEST(encode_bytes_overload_matches_the_string_view_form) {
+  const auto digest{sourcemeta::core::sha256_digest("fo")};
+  EXPECT_EQ(sourcemeta::core::base64url_encode(digest),
+            sourcemeta::core::base64url_encode(std::string_view{
+                reinterpret_cast<const char *>(digest.data()), digest.size()}));
 }
 
 TEST(decode_rfc4648_empty) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

