### PR TITLE
Honor a custom `response_type` in the OAuth authorization URL builder

### DIFF
--- a/src/core/oauth/include/sourcemeta/core/oauth_authorization.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_authorization.h
@@ -73,11 +73,12 @@ struct OAuthAuthorizationRequest {
   std::string_view request_uri;
   /// The JWK thumbprint of the DPoP proof public key (RFC 9449 Section 10).
   std::string_view dpop_jkt;
-  /// The response type, a space-delimited set the authorization URL builder
-  /// forces to `code` while the pushed request builder honors an override,
-  /// surfaced on parse so a server can tell a missing value from one it does
-  /// not understand (RFC 6749 Section 3.1.1). It is placed after the older
-  /// members so an existing positional initializer keeps populating them.
+  /// The response type, a space-delimited set that defaults to `code` when
+  /// unset and is otherwise honored by the authorization URL and pushed request
+  /// builders alike, surfaced on parse so a server can tell a missing value
+  /// from one it does not understand (RFC 6749 Section 3.1.1). It is placed
+  /// after the older members so an existing positional initializer keeps
+  /// populating them.
   std::string_view response_type;
   /// The repeatable resource indicators, each an absolute URI without a
   /// fragment (RFC 8707 Section 2).
@@ -89,11 +90,11 @@ struct OAuthAuthorizationRequest {
 
 /// @ingroup oauth
 /// Build an authorization request URL by appending the query to the endpoint
-/// (RFC 6749 Section 4.1.1). The `response_type` is always `code`, since the
-/// implicit grant is not represented, every value is percent-escaped, an
-/// existing query on the endpoint is honored, and the code challenge method is
-/// emitted only when a challenge is present. The sink is appended to and never
-/// cleared. For example:
+/// (RFC 6749 Section 4.1.1). The `response_type` defaults to `code` and is
+/// honored when set, every value is percent-escaped, an existing query on the
+/// endpoint is honored, and the code challenge method is emitted only when a
+/// challenge is present. The sink is appended to and never cleared. For
+/// example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>

--- a/src/core/oauth/oauth_authorization.cc
+++ b/src/core/oauth/oauth_authorization.cc
@@ -83,9 +83,11 @@ auto oauth_build_authorization_url(const std::string_view endpoint,
     sink.push_back('?');
   }
 
-  // RFC 6749 Section 4.1.1: the authorization code flow is the only response
-  // type this builder emits, since the implicit grant is not represented
-  URI::append_query_parameter(sink, "response_type", "code");
+  // RFC 6749 Section 3.1.1: the request selects the response type, defaulting
+  // to the authorization code flow when the caller leaves it unset
+  URI::append_query_parameter(
+      sink, "response_type",
+      request.response_type.empty() ? "code" : request.response_type);
 
   if (!request.client_id.empty()) {
     URI::append_query_parameter(sink, "client_id", request.client_id);

--- a/test/oauth/oauth_authorization_test.cc
+++ b/test/oauth/oauth_authorization_test.cc
@@ -14,6 +14,94 @@ TEST(build_url_minimal_emits_response_type_and_client_id) {
                  "&client_id=s6BhdRkqt3");
 }
 
+TEST(build_url_defaults_response_type_to_code_when_unset) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=code&client_id=abc");
+}
+
+TEST(build_url_honors_an_explicit_code_response_type) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.response_type = "code";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=code&client_id=abc");
+}
+
+TEST(build_url_honors_an_id_token_response_type) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.response_type = "id_token";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=id_token&client_id=abc");
+}
+
+TEST(build_url_honors_a_token_response_type) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.response_type = "token";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url,
+            "https://server.example/auth?response_type=token&client_id=abc");
+}
+
+TEST(build_url_honors_a_hybrid_code_id_token_response_type) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.response_type = "code id_token";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth"
+                 "?response_type=code%20id_token&client_id=abc");
+}
+
+TEST(build_url_honors_an_implicit_id_token_token_response_type) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.response_type = "id_token token";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth"
+                 "?response_type=id_token%20token&client_id=abc");
+}
+
+TEST(build_url_honors_a_hybrid_code_id_token_token_response_type) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.client_id = "abc";
+  request.response_type = "code id_token token";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth"
+                 "?response_type=code%20id_token%20token&client_id=abc");
+}
+
+TEST(build_url_emits_the_response_type_before_other_parameters) {
+  sourcemeta::core::OAuthAuthorizationRequest request;
+  request.response_type = "code id_token";
+  request.client_id = "abc";
+  request.state = "xyz";
+  std::string url;
+  sourcemeta::core::oauth_build_authorization_url("https://server.example/auth",
+                                                  request, url);
+  EXPECT_EQ(url, "https://server.example/auth"
+                 "?response_type=code%20id_token&client_id=abc&state=xyz");
+}
+
 TEST(build_url_full_code_flow_with_pkce) {
   sourcemeta::core::OAuthAuthorizationRequest request;
   request.client_id = "s6BhdRkqt3";


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

