### PR TITLE
Add various JSON convenience helpers for `src/core/oauth`

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -24,6 +24,7 @@
 #include <limits>           // std::numeric_limits
 #include <memory>           // std::allocator
 #include <set>              // std::set
+#include <span>             // std::span
 #include <sstream>          // std::basic_istringstream
 #include <stdexcept>        // std::out_of_range
 #include <string>           // std::basic_string, std::char_traits
@@ -1668,6 +1669,70 @@ public:
   /// ```
   [[nodiscard]] auto contains(const StringView element) const -> bool;
 
+  /// This method checks, given a pre-calculated hash, whether an array-valued
+  /// object member contains a string, returning false when the member is absent
+  /// or is not such an array. The instance must be an object. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::JSON document =
+  ///   sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON");
+  /// assert(document.array_member_contains("tags",
+  ///   document.as_object().hash("tags"), "b"));
+  /// ```
+  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
+  array_member_contains(const StringView key,
+                        const typename Object::hash_type hash,
+                        const StringView value) const -> bool {
+    assert(this->is_object());
+    const auto *member{this->try_at(key, hash)};
+    return member != nullptr && member->is_array() && member->contains(value);
+  }
+
+  /// This method checks whether an array-valued object member contains a
+  /// string. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::JSON document =
+  ///   sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON");
+  /// assert(document.array_member_contains("tags", "b"));
+  /// ```
+  [[nodiscard]] SOURCEMETA_FORCEINLINE inline auto
+  array_member_contains(const StringView key, const StringView value) const
+      -> bool {
+    return this->array_member_contains(key, Object::hash(key), value);
+  }
+
+  /// This method checks whether this value is an array whose every element is a
+  /// string. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// const sourcemeta::core::JSON document =
+  ///   sourcemeta::core::parse_json(R"JSON([ "a", "b" ])JSON");
+  /// assert(document.is_array_of_strings());
+  /// ```
+  [[nodiscard]] auto is_array_of_strings() const -> bool {
+    if (!this->is_array()) {
+      return false;
+    }
+
+    for (const auto &element : this->as_array()) {
+      if (!element.is_string()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   /// This method checks if a JSON string includes a given substring. For
   /// example:
   ///
@@ -1946,6 +2011,95 @@ public:
   /// inserted value
   auto assign_assume_new(String &&key, JSON &&value, Object::hash_type hash)
       -> JSON &;
+
+  /// This method assigns a string object member with a pre-computed hash unless
+  /// the value is empty, in which case the member is left absent, assuming the
+  /// key is new. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
+  /// document.assign_if_nonempty("foo", document.as_object().hash("foo"),
+  ///                             "bar");
+  /// assert(document.at("foo").to_string() == "bar");
+  /// ```
+  SOURCEMETA_FORCEINLINE inline auto
+  assign_if_nonempty(const StringView key,
+                     const typename Object::hash_type hash,
+                     const StringView value) -> void {
+    if (!value.empty()) {
+      this->assign_assume_new(String{key}, JSON{value}, hash);
+    }
+  }
+
+  /// This method assigns a string object member unless the value is empty, in
+  /// which case the member is left absent, assuming the key is new. For
+  /// example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
+  /// document.assign_if_nonempty("foo", "bar");
+  /// assert(document.at("foo").to_string() == "bar");
+  /// ```
+  SOURCEMETA_FORCEINLINE inline auto assign_if_nonempty(const StringView key,
+                                                        const StringView value)
+      -> void {
+    this->assign_if_nonempty(key, Object::hash(key), value);
+  }
+
+  /// This method assigns an array-of-strings object member with a pre-computed
+  /// hash unless the array is empty, in which case the member is left absent,
+  /// assuming the key is new. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <array>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
+  /// const std::array<std::string_view, 2> values{{"a", "b"}};
+  /// document.assign_if_nonempty("foo", document.as_object().hash("foo"),
+  ///                             values);
+  /// assert(document.at("foo").size() == 2);
+  /// ```
+  auto assign_if_nonempty(const StringView key,
+                          const typename Object::hash_type hash,
+                          const std::span<const StringView> values) -> void {
+    if (values.empty()) {
+      return;
+    }
+
+    auto array{JSON::make_array()};
+    for (const auto value : values) {
+      array.push_back(JSON{value});
+    }
+
+    this->assign_assume_new(String{key}, std::move(array), hash);
+  }
+
+  /// This method assigns an array-of-strings object member unless the array is
+  /// empty, in which case the member is left absent, assuming the key is new.
+  /// For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <array>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::JSON document = sourcemeta::core::JSON::make_object();
+  /// const std::array<std::string_view, 2> values{{"a", "b"}};
+  /// document.assign_if_nonempty("foo", values);
+  /// assert(document.at("foo").size() == 2);
+  /// ```
+  auto assign_if_nonempty(const StringView key,
+                          const std::span<const StringView> values) -> void {
+    this->assign_if_nonempty(key, Object::hash(key), values);
+  }
 
   /// This method deletes an object key. For example:
   ///

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -71,17 +71,6 @@ auto string_member(const JSON &data, const JSON::StringView name,
   return std::string_view{member->to_string()};
 }
 
-auto array_member_contains(const JSON &data, const JSON::StringView name,
-                           const JSON::Object::hash_type hash,
-                           const JSON::StringView value) -> bool {
-  if (!data.is_object()) {
-    return false;
-  }
-
-  const auto *member{data.try_at(name, hash)};
-  return member != nullptr && member->is_array() && member->contains(value);
-}
-
 auto validated_server_metadata(JSON &&data, const std::string_view issuer)
     -> JSON {
   if (!data.is_object()) {
@@ -113,10 +102,11 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
   // RFC 8414 Section 2: a signing algorithm list is REQUIRED alongside the JWT
   // authentication methods, "none" MUST NOT appear in it, and Section 3.2
   // forbids a zero-element array, so an empty list is also invalid
-  if (array_member_contains(data, "token_endpoint_auth_methods_supported"sv,
-                            HASH_TOKEN_AUTH_METHODS, "private_key_jwt") ||
-      array_member_contains(data, "token_endpoint_auth_methods_supported"sv,
-                            HASH_TOKEN_AUTH_METHODS, "client_secret_jwt")) {
+  if (data.array_member_contains("token_endpoint_auth_methods_supported"sv,
+                                 HASH_TOKEN_AUTH_METHODS, "private_key_jwt") ||
+      data.array_member_contains("token_endpoint_auth_methods_supported"sv,
+                                 HASH_TOKEN_AUTH_METHODS,
+                                 "client_secret_jwt")) {
     const auto *algorithms{
         data.try_at("token_endpoint_auth_signing_alg_values_supported"sv,
                     HASH_TOKEN_AUTH_ALGS)};
@@ -330,8 +320,8 @@ auto OAuthServerMetadata::authorization_response_iss_parameter_supported() const
 
 auto OAuthServerMetadata::supports_response_type(
     const std::string_view value) const -> bool {
-  return array_member_contains(this->data_, "response_types_supported"sv,
-                               HASH_RESPONSE_TYPES, value);
+  return this->data_.array_member_contains("response_types_supported"sv,
+                                           HASH_RESPONSE_TYPES, value);
 }
 
 auto OAuthServerMetadata::supports_grant_type(
@@ -353,9 +343,8 @@ auto OAuthServerMetadata::supports_code_challenge_method(
     const std::string_view value) const -> bool {
   // RFC 8414 Section 2: an omitted list means PKCE is not supported, so there
   // is no default to fall back to
-  return array_member_contains(this->data_,
-                               "code_challenge_methods_supported"sv,
-                               HASH_CODE_CHALLENGE_METHODS, value);
+  return this->data_.array_member_contains("code_challenge_methods_supported"sv,
+                                           HASH_CODE_CHALLENGE_METHODS, value);
 }
 
 auto OAuthServerMetadata::supports_token_endpoint_auth_method(
@@ -415,8 +404,8 @@ auto OAuthResourceMetadata::first_authorization_server() const
 
 auto OAuthResourceMetadata::supports_authorization_server(
     const std::string_view value) const -> bool {
-  return array_member_contains(this->data_, "authorization_servers"sv,
-                               HASH_AUTHORIZATION_SERVERS, value);
+  return this->data_.array_member_contains("authorization_servers"sv,
+                                           HASH_AUTHORIZATION_SERVERS, value);
 }
 
 auto OAuthResourceMetadata::jwks_uri() const
@@ -426,14 +415,14 @@ auto OAuthResourceMetadata::jwks_uri() const
 
 auto OAuthResourceMetadata::supports_bearer_method(
     const std::string_view value) const -> bool {
-  return array_member_contains(this->data_, "bearer_methods_supported"sv,
-                               HASH_BEARER_METHODS, value);
+  return this->data_.array_member_contains("bearer_methods_supported"sv,
+                                           HASH_BEARER_METHODS, value);
 }
 
 auto OAuthResourceMetadata::supports_scope(const std::string_view value) const
     -> bool {
-  return array_member_contains(this->data_, "scopes_supported"sv,
-                               HASH_SCOPES_SUPPORTED, value);
+  return this->data_.array_member_contains("scopes_supported"sv,
+                                           HASH_SCOPES_SUPPORTED, value);
 }
 
 auto OAuthResourceMetadata::dpop_bound_access_tokens_required() const -> bool {
@@ -449,32 +438,6 @@ auto OAuthResourceMetadata::dpop_bound_access_tokens_required() const -> bool {
 auto OAuthResourceMetadata::data() const -> const JSON & { return this->data_; }
 
 namespace {
-
-auto assign_scalar_member(JSON &object, const JSON::StringView name,
-                          const JSON::Object::hash_type hash,
-                          const std::string_view value) -> void {
-  if (!value.empty()) {
-    object.assign_assume_new(std::string{name}, JSON{value}, hash);
-  }
-}
-
-auto assign_array_member(JSON &object, const JSON::StringView name,
-                         const JSON::Object::hash_type hash,
-                         const std::span<const std::string_view> values)
-    -> void {
-  // RFC 8414 Section 3.2: "Claims with zero elements MUST be omitted", so an
-  // empty list is not emitted
-  if (values.empty()) {
-    return;
-  }
-
-  auto array{JSON::make_array()};
-  for (const auto value : values) {
-    array.push_back(JSON{value});
-  }
-
-  object.assign_assume_new(std::string{name}, std::move(array), hash);
-}
 
 auto span_contains(const std::span<const std::string_view> values,
                    const std::string_view target) -> bool {
@@ -547,34 +510,33 @@ auto oauth_make_server_metadata(const OAuthServerMetadataConfig &config)
 
   auto document{JSON::make_object()};
   document.assign_assume_new("issuer", JSON{config.issuer}, HASH_ISSUER);
-  assign_scalar_member(document, "authorization_endpoint",
-                       HASH_AUTHORIZATION_ENDPOINT,
-                       config.authorization_endpoint);
-  assign_scalar_member(document, "token_endpoint", HASH_TOKEN_ENDPOINT,
-                       config.token_endpoint);
-  assign_scalar_member(document, "registration_endpoint",
-                       HASH_REGISTRATION_ENDPOINT,
-                       config.registration_endpoint);
-  assign_scalar_member(document, "pushed_authorization_request_endpoint",
-                       HASH_PAR_ENDPOINT,
-                       config.pushed_authorization_request_endpoint);
-  assign_scalar_member(document, "jwks_uri", HASH_JWKS_URI, config.jwks_uri);
-  assign_array_member(document, "response_types_supported", HASH_RESPONSE_TYPES,
-                      config.response_types_supported);
-  assign_array_member(document, "grant_types_supported", HASH_GRANT_TYPES,
-                      config.grant_types_supported);
-  assign_array_member(document, "code_challenge_methods_supported",
-                      HASH_CODE_CHALLENGE_METHODS,
-                      config.code_challenge_methods_supported);
-  assign_array_member(document, "token_endpoint_auth_methods_supported",
-                      HASH_TOKEN_AUTH_METHODS,
-                      config.token_endpoint_auth_methods_supported);
-  assign_array_member(document,
-                      "token_endpoint_auth_signing_alg_values_supported",
-                      HASH_TOKEN_AUTH_ALGS,
-                      config.token_endpoint_auth_signing_alg_values_supported);
-  assign_array_member(document, "scopes_supported", HASH_SCOPES_SUPPORTED,
-                      config.scopes_supported);
+  document.assign_if_nonempty("authorization_endpoint",
+                              HASH_AUTHORIZATION_ENDPOINT,
+                              config.authorization_endpoint);
+  document.assign_if_nonempty("token_endpoint", HASH_TOKEN_ENDPOINT,
+                              config.token_endpoint);
+  document.assign_if_nonempty("registration_endpoint",
+                              HASH_REGISTRATION_ENDPOINT,
+                              config.registration_endpoint);
+  document.assign_if_nonempty("pushed_authorization_request_endpoint",
+                              HASH_PAR_ENDPOINT,
+                              config.pushed_authorization_request_endpoint);
+  document.assign_if_nonempty("jwks_uri", HASH_JWKS_URI, config.jwks_uri);
+  document.assign_if_nonempty("response_types_supported", HASH_RESPONSE_TYPES,
+                              config.response_types_supported);
+  document.assign_if_nonempty("grant_types_supported", HASH_GRANT_TYPES,
+                              config.grant_types_supported);
+  document.assign_if_nonempty("code_challenge_methods_supported",
+                              HASH_CODE_CHALLENGE_METHODS,
+                              config.code_challenge_methods_supported);
+  document.assign_if_nonempty("token_endpoint_auth_methods_supported",
+                              HASH_TOKEN_AUTH_METHODS,
+                              config.token_endpoint_auth_methods_supported);
+  document.assign_if_nonempty(
+      "token_endpoint_auth_signing_alg_values_supported", HASH_TOKEN_AUTH_ALGS,
+      config.token_endpoint_auth_signing_alg_values_supported);
+  document.assign_if_nonempty("scopes_supported", HASH_SCOPES_SUPPORTED,
+                              config.scopes_supported);
   // RFC 9126 Section 5: the default is false, so the flag is emitted only when
   // the server requires pushed authorization requests
   if (config.require_pushed_authorization_requests) {

--- a/src/core/oauth/oauth_registration.cc
+++ b/src/core/oauth/oauth_registration.cc
@@ -50,35 +50,10 @@ const auto HASH_REGISTRATION_CLIENT_URI{
 const auto HASH_ERROR{JSON::Object::hash("error"sv)};
 const auto HASH_ERROR_DESCRIPTION{JSON::Object::hash("error_description"sv)};
 
-auto array_member_contains(const JSON &data, const JSON::StringView name,
-                           const JSON::Object::hash_type hash,
-                           const JSON::StringView value) -> bool {
-  if (!data.is_object()) {
-    return false;
-  }
-
-  const auto *member{data.try_at(name, hash)};
-  return member != nullptr && member->is_array() && member->contains(value);
-}
-
 auto array_member_is_present(const JSON &data, const JSON::StringView name,
                              const JSON::Object::hash_type hash) -> bool {
   const auto *member{data.try_at(name, hash)};
   return member != nullptr && member->is_array();
-}
-
-auto is_string_array(const JSON &value) -> bool {
-  if (!value.is_array()) {
-    return false;
-  }
-
-  for (const auto &element : value.as_array()) {
-    if (!element.is_string()) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 // A membership predicate that falls back to the specification default when the
@@ -123,37 +98,13 @@ auto validated_client_metadata(JSON &&data) -> JSON {
       data.try_at("response_types"sv, HASH_RESPONSE_TYPES)};
   const auto *auth_method{data.try_at("token_endpoint_auth_method"sv,
                                       HASH_TOKEN_ENDPOINT_AUTH_METHOD)};
-  if ((grant_types != nullptr && !is_string_array(*grant_types)) ||
-      (response_types != nullptr && !is_string_array(*response_types)) ||
+  if ((grant_types != nullptr && !grant_types->is_array_of_strings()) ||
+      (response_types != nullptr && !response_types->is_array_of_strings()) ||
       (auth_method != nullptr && !auth_method->is_string())) {
     throw OAuthRegistrationParseError{};
   }
 
   return std::move(data);
-}
-
-auto assign_scalar_member(JSON &object, const JSON::StringView name,
-                          const JSON::Object::hash_type hash,
-                          const std::string_view value) -> void {
-  if (!value.empty()) {
-    object.assign_assume_new(std::string{name}, JSON{value}, hash);
-  }
-}
-
-auto assign_array_member(JSON &object, const JSON::StringView name,
-                         const JSON::Object::hash_type hash,
-                         const std::span<const std::string_view> values)
-    -> void {
-  if (values.empty()) {
-    return;
-  }
-
-  auto array{JSON::make_array()};
-  for (const auto value : values) {
-    array.push_back(JSON{value});
-  }
-
-  object.assign_assume_new(std::string{name}, std::move(array), hash);
 }
 
 // RFC 7519 Section 4.1: the registered claims describe the JSON Web Token that
@@ -182,8 +133,8 @@ auto OAuthClientMetadata::from(JSON &&data)
 
 auto OAuthClientMetadata::has_redirect_uri(const std::string_view value) const
     -> bool {
-  return array_member_contains(this->data_, "redirect_uris"sv,
-                               HASH_REDIRECT_URIS, value);
+  return this->data_.array_member_contains("redirect_uris"sv,
+                                           HASH_REDIRECT_URIS, value);
 }
 
 auto OAuthClientMetadata::token_endpoint_auth_method() const
@@ -234,7 +185,7 @@ auto OAuthClientMetadata::scope() const -> std::optional<std::string_view> {
 
 auto OAuthClientMetadata::has_contact(const std::string_view value) const
     -> bool {
-  return array_member_contains(this->data_, "contacts"sv, HASH_CONTACTS, value);
+  return this->data_.array_member_contains("contacts"sv, HASH_CONTACTS, value);
 }
 
 auto OAuthClientMetadata::tos_uri() const -> std::optional<std::string_view> {
@@ -339,36 +290,34 @@ auto oauth_make_registration_request(
   }
 
   auto document{JSON::make_object()};
-  assign_array_member(document, "redirect_uris", HASH_REDIRECT_URIS,
-                      config.redirect_uris);
+  document.assign_if_nonempty("redirect_uris", HASH_REDIRECT_URIS,
+                              config.redirect_uris);
   if (config.jwks != nullptr) {
     document.assign_assume_new(std::string{"jwks"}, JSON{*config.jwks},
                                HASH_JWKS);
   }
-  assign_scalar_member(document, "token_endpoint_auth_method",
-                       HASH_TOKEN_ENDPOINT_AUTH_METHOD,
-                       config.token_endpoint_auth_method);
-  assign_array_member(document, "grant_types", HASH_GRANT_TYPES,
-                      config.grant_types);
-  assign_array_member(document, "response_types", HASH_RESPONSE_TYPES,
-                      config.response_types);
-  assign_scalar_member(document, "client_name", HASH_CLIENT_NAME,
-                       config.client_name);
-  assign_scalar_member(document, "client_uri", HASH_CLIENT_URI,
-                       config.client_uri);
-  assign_scalar_member(document, "logo_uri", HASH_LOGO_URI, config.logo_uri);
-  assign_scalar_member(document, "scope", HASH_SCOPE, config.scope);
-  assign_array_member(document, "contacts", HASH_CONTACTS, config.contacts);
-  assign_scalar_member(document, "tos_uri", HASH_TOS_URI, config.tos_uri);
-  assign_scalar_member(document, "policy_uri", HASH_POLICY_URI,
-                       config.policy_uri);
-  assign_scalar_member(document, "jwks_uri", HASH_JWKS_URI, config.jwks_uri);
-  assign_scalar_member(document, "software_id", HASH_SOFTWARE_ID,
-                       config.software_id);
-  assign_scalar_member(document, "software_version", HASH_SOFTWARE_VERSION,
-                       config.software_version);
-  assign_scalar_member(document, "software_statement", HASH_SOFTWARE_STATEMENT,
-                       config.software_statement);
+  document.assign_if_nonempty("token_endpoint_auth_method",
+                              HASH_TOKEN_ENDPOINT_AUTH_METHOD,
+                              config.token_endpoint_auth_method);
+  document.assign_if_nonempty("grant_types", HASH_GRANT_TYPES,
+                              config.grant_types);
+  document.assign_if_nonempty("response_types", HASH_RESPONSE_TYPES,
+                              config.response_types);
+  document.assign_if_nonempty("client_name", HASH_CLIENT_NAME,
+                              config.client_name);
+  document.assign_if_nonempty("client_uri", HASH_CLIENT_URI, config.client_uri);
+  document.assign_if_nonempty("logo_uri", HASH_LOGO_URI, config.logo_uri);
+  document.assign_if_nonempty("scope", HASH_SCOPE, config.scope);
+  document.assign_if_nonempty("contacts", HASH_CONTACTS, config.contacts);
+  document.assign_if_nonempty("tos_uri", HASH_TOS_URI, config.tos_uri);
+  document.assign_if_nonempty("policy_uri", HASH_POLICY_URI, config.policy_uri);
+  document.assign_if_nonempty("jwks_uri", HASH_JWKS_URI, config.jwks_uri);
+  document.assign_if_nonempty("software_id", HASH_SOFTWARE_ID,
+                              config.software_id);
+  document.assign_if_nonempty("software_version", HASH_SOFTWARE_VERSION,
+                              config.software_version);
+  document.assign_if_nonempty("software_statement", HASH_SOFTWARE_STATEMENT,
+                              config.software_statement);
 
   return document;
 }
@@ -396,14 +345,14 @@ auto oauth_registration_grant_response_consistent(
   const bool response_types_present{
       data.is_object() &&
       array_member_is_present(data, "response_types"sv, HASH_RESPONSE_TYPES)};
-  const bool grants_authorization_code{array_member_contains(
-      data, "grant_types"sv, HASH_GRANT_TYPES, "authorization_code"sv)};
-  const bool grants_implicit{array_member_contains(
-      data, "grant_types"sv, HASH_GRANT_TYPES, "implicit"sv)};
-  const bool responds_code{array_member_contains(
-      data, "response_types"sv, HASH_RESPONSE_TYPES, "code"sv)};
-  const bool responds_token{array_member_contains(
-      data, "response_types"sv, HASH_RESPONSE_TYPES, "token"sv)};
+  const bool grants_authorization_code{data.array_member_contains(
+      "grant_types"sv, HASH_GRANT_TYPES, "authorization_code"sv)};
+  const bool grants_implicit{data.array_member_contains(
+      "grant_types"sv, HASH_GRANT_TYPES, "implicit"sv)};
+  const bool responds_code{data.array_member_contains(
+      "response_types"sv, HASH_RESPONSE_TYPES, "code"sv)};
+  const bool responds_token{data.array_member_contains(
+      "response_types"sv, HASH_RESPONSE_TYPES, "token"sv)};
 
   // RFC 7591 Section 2.1: the authorization code grant pairs with the code
   // response type and the implicit grant with the token response type. Only

--- a/test/json/json_array_test.cc
+++ b/test/json/json_array_test.cc
@@ -684,3 +684,23 @@ TEST(erase_if_all) {
 
   EXPECT_EQ(document, expected);
 }
+
+TEST(is_array_of_strings_true) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([ "a", "b" ])JSON")};
+  EXPECT_TRUE(document.is_array_of_strings());
+}
+
+TEST(is_array_of_strings_empty_is_vacuously_true) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([])JSON")};
+  EXPECT_TRUE(document.is_array_of_strings());
+}
+
+TEST(is_array_of_strings_with_a_non_string_element) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([ "a", 1 ])JSON")};
+  EXPECT_FALSE(document.is_array_of_strings());
+}
+
+TEST(is_array_of_strings_non_array) {
+  const sourcemeta::core::JSON document{"a"};
+  EXPECT_FALSE(document.is_array_of_strings());
+}

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -2,9 +2,12 @@
 #include <sourcemeta/core/test.h>
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <set>
+#include <span>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
@@ -1532,4 +1535,102 @@ TEST(keys_differing_by_trailing_null_are_distinct) {
   EXPECT_EQ(document.size(), 2);
   EXPECT_EQ(document.at("a").to_integer(), 1);
   EXPECT_EQ(document.at(key_with_null).to_integer(), 2);
+}
+
+TEST(array_member_contains_present) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON")};
+  EXPECT_TRUE(document.array_member_contains(
+      "tags", document.as_object().hash("tags"), "b"));
+}
+
+TEST(array_member_contains_absent_value) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON")};
+  EXPECT_FALSE(document.array_member_contains(
+      "tags", document.as_object().hash("tags"), "c"));
+}
+
+TEST(array_member_contains_missing_member) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "other": 1 })JSON")};
+  EXPECT_FALSE(document.array_member_contains(
+      "tags", document.as_object().hash("tags"), "a"));
+}
+
+TEST(array_member_contains_wrong_member_type) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "tags": "a" })JSON")};
+  EXPECT_FALSE(document.array_member_contains(
+      "tags", document.as_object().hash("tags"), "a"));
+}
+
+TEST(array_member_contains_computes_hash) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "tags": [ "a", "b" ] })JSON")};
+  EXPECT_TRUE(document.array_member_contains("tags", "a"));
+  EXPECT_FALSE(document.array_member_contains("tags", "z"));
+}
+
+TEST(is_array_of_strings_true) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([ "a", "b" ])JSON")};
+  EXPECT_TRUE(document.is_array_of_strings());
+}
+
+TEST(is_array_of_strings_empty_is_vacuously_true) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([])JSON")};
+  EXPECT_TRUE(document.is_array_of_strings());
+}
+
+TEST(is_array_of_strings_with_a_non_string_element) {
+  const auto document{sourcemeta::core::parse_json(R"JSON([ "a", 1 ])JSON")};
+  EXPECT_FALSE(document.is_array_of_strings());
+}
+
+TEST(is_array_of_strings_non_array) {
+  const sourcemeta::core::JSON document{"a"};
+  EXPECT_FALSE(document.is_array_of_strings());
+}
+
+TEST(assign_if_nonempty_scalar_assigns) {
+  auto document{sourcemeta::core::JSON::make_object()};
+  document.assign_if_nonempty("foo", document.as_object().hash("foo"), "bar");
+  EXPECT_TRUE(document.defines("foo"));
+  EXPECT_EQ(document.at("foo").to_string(), "bar");
+}
+
+TEST(assign_if_nonempty_scalar_skips_empty) {
+  auto document{sourcemeta::core::JSON::make_object()};
+  document.assign_if_nonempty("foo", document.as_object().hash("foo"), "");
+  EXPECT_FALSE(document.defines("foo"));
+}
+
+TEST(assign_if_nonempty_scalar_computes_hash) {
+  auto document{sourcemeta::core::JSON::make_object()};
+  document.assign_if_nonempty("foo", "bar");
+  EXPECT_EQ(document.at("foo").to_string(), "bar");
+}
+
+TEST(assign_if_nonempty_array_assigns) {
+  auto document{sourcemeta::core::JSON::make_object()};
+  const std::array<std::string_view, 2> values{{"a", "b"}};
+  document.assign_if_nonempty("foo", document.as_object().hash("foo"), values);
+  EXPECT_TRUE(document.defines("foo"));
+  EXPECT_TRUE(document.at("foo").is_array());
+  EXPECT_EQ(document.at("foo").size(), 2);
+  EXPECT_EQ(document.at("foo").at(0).to_string(), "a");
+}
+
+TEST(assign_if_nonempty_array_skips_empty) {
+  auto document{sourcemeta::core::JSON::make_object()};
+  const std::span<const std::string_view> values{};
+  document.assign_if_nonempty("foo", document.as_object().hash("foo"), values);
+  EXPECT_FALSE(document.defines("foo"));
+}
+
+TEST(assign_if_nonempty_array_computes_hash) {
+  auto document{sourcemeta::core::JSON::make_object()};
+  const std::array<std::string_view, 1> values{{"a"}};
+  document.assign_if_nonempty("foo", values);
+  EXPECT_EQ(document.at("foo").size(), 1);
 }

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -1572,26 +1572,6 @@ TEST(array_member_contains_computes_hash) {
   EXPECT_FALSE(document.array_member_contains("tags", "z"));
 }
 
-TEST(is_array_of_strings_true) {
-  const auto document{sourcemeta::core::parse_json(R"JSON([ "a", "b" ])JSON")};
-  EXPECT_TRUE(document.is_array_of_strings());
-}
-
-TEST(is_array_of_strings_empty_is_vacuously_true) {
-  const auto document{sourcemeta::core::parse_json(R"JSON([])JSON")};
-  EXPECT_TRUE(document.is_array_of_strings());
-}
-
-TEST(is_array_of_strings_with_a_non_string_element) {
-  const auto document{sourcemeta::core::parse_json(R"JSON([ "a", 1 ])JSON")};
-  EXPECT_FALSE(document.is_array_of_strings());
-}
-
-TEST(is_array_of_strings_non_array) {
-  const sourcemeta::core::JSON document{"a"};
-  EXPECT_FALSE(document.is_array_of_strings());
-}
-
 TEST(assign_if_nonempty_scalar_assigns) {
   auto document{sourcemeta::core::JSON::make_object()};
   document.assign_if_nonempty("foo", document.as_object().hash("foo"), "bar");


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

