### PR TITLE
Add multi-part overloads for `sha256_digest` and `hmac_sha256_digest`

### DIFF
--- a/src/core/crypto/CMakeLists.txt
+++ b/src/core/crypto/CMakeLists.txt
@@ -9,7 +9,8 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME crypto
     crypto_sha512.cc crypto_sha1.cc
     crypto_uuid.cc crypto_fnv128.cc crypto_crc32.cc crypto_base64.cc
     crypto_random.cc crypto_sign_rsa.cc crypto_aes_gcm.cc
-    crypto_sha2_64.h crypto_random.h crypto_helpers.h crypto_der.h crypto_aes.h)
+    crypto_sha2_64.h crypto_sha256_other.h crypto_random.h crypto_helpers.h
+    crypto_der.h crypto_aes.h)
 
 target_link_libraries(sourcemeta_core_crypto
   PRIVATE sourcemeta::core::text sourcemeta::core::numeric)

--- a/src/core/crypto/crypto_hmac_sha256_apple.cc
+++ b/src/core/crypto/crypto_hmac_sha256_apple.cc
@@ -1,9 +1,13 @@
 #include <sourcemeta/core/crypto_hmac_sha256.h>
 
-#include <CommonCrypto/CommonHMAC.h> // CCHmac, kCCHmacAlgSHA256
+// CCHmac, CCHmacContext, CCHmacInit, CCHmacUpdate, CCHmacFinal,
+// kCCHmacAlgSHA256
+#include <CommonCrypto/CommonHMAC.h>
 
-#include <array>   // std::array
-#include <cstdint> // std::uint8_t
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
@@ -13,6 +17,21 @@ auto hmac_sha256_digest(const std::string_view key,
   std::array<std::uint8_t, 32> digest{};
   CCHmac(kCCHmacAlgSHA256, key.data(), key.size(), message.data(),
          message.size(), digest.data());
+  return digest;
+}
+
+auto hmac_sha256_digest(const std::string_view key,
+                        const std::span<const std::string_view> message)
+    -> std::array<std::uint8_t, 32> {
+  CCHmacContext context;
+  CCHmacInit(&context, kCCHmacAlgSHA256, key.data(), key.size());
+
+  for (const auto part : message) {
+    CCHmacUpdate(&context, part.data(), part.size());
+  }
+
+  std::array<std::uint8_t, 32> digest{};
+  CCHmacFinal(&context, digest.data());
   return digest;
 }
 

--- a/src/core/crypto/crypto_hmac_sha256_openssl.cc
+++ b/src/core/crypto/crypto_hmac_sha256_openssl.cc
@@ -11,19 +11,35 @@
 #include <stdexcept>   // std::runtime_error
 #include <string_view> // std::string_view
 
+namespace {
+
+// Fetching the algorithm on every digest would repeat a provider lookup, so
+// the handle is fetched once and reused, as OpenSSL recommends for frequently
+// used algorithms
+struct HmacAlgorithm {
+  HmacAlgorithm() : handle{EVP_MAC_fetch(nullptr, "HMAC", nullptr)} {}
+  ~HmacAlgorithm() { EVP_MAC_free(this->handle); }
+  HmacAlgorithm(const HmacAlgorithm &) = delete;
+  HmacAlgorithm(HmacAlgorithm &&) = delete;
+  auto operator=(const HmacAlgorithm &) -> HmacAlgorithm & = delete;
+  auto operator=(HmacAlgorithm &&) -> HmacAlgorithm & = delete;
+  EVP_MAC *handle;
+};
+
+} // namespace
+
 namespace sourcemeta::core {
 
 auto hmac_sha256_digest(const std::string_view key,
                         const std::span<const std::string_view> message)
     -> std::array<std::uint8_t, 32> {
-  auto *mac = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
-  if (mac == nullptr) {
+  static const HmacAlgorithm algorithm;
+  if (algorithm.handle == nullptr) {
     throw std::runtime_error("Could not fetch the OpenSSL HMAC algorithm");
   }
 
-  auto *context = EVP_MAC_CTX_new(mac);
+  auto *context = EVP_MAC_CTX_new(algorithm.handle);
   if (context == nullptr) {
-    EVP_MAC_free(mac);
     throw std::runtime_error("Could not allocate OpenSSL MAC context");
   }
 
@@ -55,7 +71,6 @@ auto hmac_sha256_digest(const std::string_view key,
   success = success &&
             EVP_MAC_final(context, digest.data(), &length, digest.size()) == 1;
   EVP_MAC_CTX_free(context);
-  EVP_MAC_free(mac);
   if (!success) {
     throw std::runtime_error("Could not compute HMAC-SHA256 digest");
   }

--- a/src/core/crypto/crypto_hmac_sha256_openssl.cc
+++ b/src/core/crypto/crypto_hmac_sha256_openssl.cc
@@ -1,41 +1,73 @@
 #include <sourcemeta/core/crypto_hmac_sha256.h>
-#include <sourcemeta/core/crypto_sha256.h>
 
-#include <openssl/evp.h>  // EVP_sha256
-#include <openssl/hmac.h> // HMAC
+#include <openssl/core_names.h> // OSSL_MAC_PARAM_DIGEST
+#include <openssl/evp.h>        // EVP_MAC_*
+#include <openssl/params.h>     // OSSL_PARAM, OSSL_PARAM_construct_*
 
-#include <array>     // std::array
-#include <cstddef>   // std::size_t
-#include <cstdint>   // std::uint8_t
-#include <stdexcept> // std::runtime_error
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
 auto hmac_sha256_digest(const std::string_view key,
-                        const std::string_view message)
+                        const std::span<const std::string_view> message)
     -> std::array<std::uint8_t, 32> {
-  // A key longer than the block size is hashed first (RFC 2104 Section 2),
-  // which also keeps the key length within the OpenSSL length parameter
-  constexpr std::size_t block_size{64};
-  std::array<std::uint8_t, 32> key_digest{};
-  const unsigned char *key_data{
-      reinterpret_cast<const unsigned char *>(key.data())};
-  auto key_size{key.size()};
-  if (key_size > block_size) {
-    key_digest = sha256_digest(key);
-    key_data = key_digest.data();
-    key_size = key_digest.size();
+  auto *mac = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
+  if (mac == nullptr) {
+    throw std::runtime_error("Could not fetch the OpenSSL HMAC algorithm");
+  }
+
+  auto *context = EVP_MAC_CTX_new(mac);
+  if (context == nullptr) {
+    EVP_MAC_free(mac);
+    throw std::runtime_error("Could not allocate OpenSSL MAC context");
+  }
+
+  // The parameter interface is not const-qualified but never writes through
+  // the pointer
+  std::array<OSSL_PARAM, 2> parameters{
+      {OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
+                                        const_cast<char *>("SHA256"), 0),
+       OSSL_PARAM_construct_end()}};
+
+  // An empty view may carry a null pointer, which the MAC interface would
+  // interpret as a request to reuse a previously set key
+  static constexpr unsigned char empty_key{0x00};
+  const auto *key_data{
+      key.empty() ? &empty_key
+                  : reinterpret_cast<const unsigned char *>(key.data())};
+
+  auto success{EVP_MAC_init(context, key_data, key.size(), parameters.data()) ==
+               1};
+  for (const auto part : message) {
+    success = success &&
+              EVP_MAC_update(
+                  context, reinterpret_cast<const unsigned char *>(part.data()),
+                  part.size()) == 1;
   }
 
   std::array<std::uint8_t, 32> digest{};
-  unsigned int length{0};
-  if (HMAC(EVP_sha256(), key_data, static_cast<int>(key_size),
-           reinterpret_cast<const unsigned char *>(message.data()),
-           message.size(), digest.data(), &length) == nullptr) {
+  std::size_t length{0};
+  success = success &&
+            EVP_MAC_final(context, digest.data(), &length, digest.size()) == 1;
+  EVP_MAC_CTX_free(context);
+  EVP_MAC_free(mac);
+  if (!success) {
     throw std::runtime_error("Could not compute HMAC-SHA256 digest");
   }
 
   return digest;
+}
+
+auto hmac_sha256_digest(const std::string_view key,
+                        const std::string_view message)
+    -> std::array<std::uint8_t, 32> {
+  return hmac_sha256_digest(key,
+                            std::span<const std::string_view>{&message, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_hmac_sha256_openssl.cc
+++ b/src/core/crypto/crypto_hmac_sha256_openssl.cc
@@ -15,9 +15,14 @@ namespace {
 
 // Fetching the algorithm on every digest would repeat a provider lookup, so
 // the handle is fetched once and reused, as OpenSSL recommends for frequently
-// used algorithms
+// used algorithms. A failed fetch throws so that initialization is retried on
+// a later call, as a provider may be loaded after the first attempt
 struct HmacAlgorithm {
-  HmacAlgorithm() : handle{EVP_MAC_fetch(nullptr, "HMAC", nullptr)} {}
+  HmacAlgorithm() : handle{EVP_MAC_fetch(nullptr, "HMAC", nullptr)} {
+    if (this->handle == nullptr) {
+      throw std::runtime_error("Could not fetch the OpenSSL HMAC algorithm");
+    }
+  }
   ~HmacAlgorithm() { EVP_MAC_free(this->handle); }
   HmacAlgorithm(const HmacAlgorithm &) = delete;
   HmacAlgorithm(HmacAlgorithm &&) = delete;
@@ -34,10 +39,6 @@ auto hmac_sha256_digest(const std::string_view key,
                         const std::span<const std::string_view> message)
     -> std::array<std::uint8_t, 32> {
   static const HmacAlgorithm algorithm;
-  if (algorithm.handle == nullptr) {
-    throw std::runtime_error("Could not fetch the OpenSSL HMAC algorithm");
-  }
-
   auto *context = EVP_MAC_CTX_new(algorithm.handle);
   if (context == nullptr) {
     throw std::runtime_error("Could not allocate OpenSSL MAC context");

--- a/src/core/crypto/crypto_hmac_sha256_other.cc
+++ b/src/core/crypto/crypto_hmac_sha256_other.cc
@@ -1,16 +1,19 @@
 #include <sourcemeta/core/crypto_hmac_sha256.h>
 #include <sourcemeta/core/crypto_sha256.h>
 
-#include <array>   // std::array
-#include <cstddef> // std::size_t
-#include <cstdint> // std::uint8_t
-#include <cstring> // std::memcpy
-#include <string>  // std::string
+#include "crypto_sha256_other.h"
+
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <cstring>     // std::memcpy
+#include <span>        // std::span
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
 auto hmac_sha256_digest(const std::string_view key,
-                        const std::string_view message)
+                        const std::span<const std::string_view> message)
     -> std::array<std::uint8_t, 32> {
   // SHA-256 operates on 64-byte blocks (FIPS 180-4 Section 5.1.1), which is the
   // block size the HMAC construction pads the key to (RFC 2104 Section 2)
@@ -28,18 +31,38 @@ auto hmac_sha256_digest(const std::string_view key,
 
   // H((K XOR opad) || H((K XOR ipad) || message)) with ipad = 0x36 and
   // opad = 0x5c repeated to the block size (RFC 2104 Section 2)
-  std::string inner_input(block_size, '\x00');
-  std::string outer_input(block_size, '\x00');
+  std::array<std::uint8_t, block_size> inner_key{};
+  std::array<std::uint8_t, block_size> outer_key{};
   for (std::size_t index = 0; index < block_size; ++index) {
-    inner_input[index] = static_cast<char>(padded_key[index] ^ 0x36);
-    outer_input[index] = static_cast<char>(padded_key[index] ^ 0x5c);
+    inner_key[index] = static_cast<std::uint8_t>(padded_key[index] ^ 0x36);
+    outer_key[index] = static_cast<std::uint8_t>(padded_key[index] ^ 0x5c);
   }
 
-  inner_input.append(message);
-  const auto inner_digest{sha256_digest(inner_input)};
-  outer_input.append(reinterpret_cast<const char *>(inner_digest.data()),
-                     inner_digest.size());
-  return sha256_digest(outer_input);
+  Sha256Context inner_context;
+  sha256_update(
+      inner_context,
+      {reinterpret_cast<const char *>(inner_key.data()), inner_key.size()});
+  for (const auto part : message) {
+    sha256_update(inner_context, part);
+  }
+
+  const auto inner_digest{sha256_finalize(inner_context)};
+
+  Sha256Context outer_context;
+  sha256_update(
+      outer_context,
+      {reinterpret_cast<const char *>(outer_key.data()), outer_key.size()});
+  sha256_update(outer_context,
+                {reinterpret_cast<const char *>(inner_digest.data()),
+                 inner_digest.size()});
+  return sha256_finalize(outer_context);
+}
+
+auto hmac_sha256_digest(const std::string_view key,
+                        const std::string_view message)
+    -> std::array<std::uint8_t, 32> {
+  return hmac_sha256_digest(key,
+                            std::span<const std::string_view>{&message, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_hmac_sha256_windows.cc
+++ b/src/core/crypto/crypto_hmac_sha256_windows.cc
@@ -7,41 +7,14 @@
 
 #include <bcrypt.h> // BCrypt*, BCRYPT_*
 
+#include "crypto_windows.h"
+
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint8_t
-#include <limits>      // std::numeric_limits
 #include <span>        // std::span
 #include <stdexcept>   // std::runtime_error
 #include <string_view> // std::string_view
-
-namespace {
-
-auto hmac_sha256_hash_data(BCRYPT_HASH_HANDLE hash,
-                           const std::string_view input) -> bool {
-  // The data interface is not const-qualified but never writes through
-  // the pointer, and it takes a 32-bit length, so larger inputs must be
-  // fed in chunks
-  auto *remaining_data{
-      reinterpret_cast<unsigned char *>(const_cast<char *>(input.data()))};
-  auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
-  while (remaining_size > 0) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
-                                                         : remaining_size};
-    if (!BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
-                                       static_cast<ULONG>(chunk_size), 0))) {
-      return false;
-    }
-
-    remaining_data += chunk_size;
-    remaining_size -= chunk_size;
-  }
-
-  return true;
-}
-
-} // namespace
 
 namespace sourcemeta::core {
 
@@ -80,7 +53,7 @@ auto hmac_sha256_digest(const std::string_view key,
 
   auto success{true};
   for (const auto part : message) {
-    success = success && hmac_sha256_hash_data(hash, part);
+    success = success && hash_data_chunked(hash, part);
   }
 
   std::array<std::uint8_t, 32> digest{};

--- a/src/core/crypto/crypto_hmac_sha256_windows.cc
+++ b/src/core/crypto/crypto_hmac_sha256_windows.cc
@@ -7,16 +7,46 @@
 
 #include <bcrypt.h> // BCrypt*, BCRYPT_*
 
-#include <array>     // std::array
-#include <cstddef>   // std::size_t
-#include <cstdint>   // std::uint8_t
-#include <limits>    // std::numeric_limits
-#include <stdexcept> // std::runtime_error
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <limits>      // std::numeric_limits
+#include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
+#include <string_view> // std::string_view
+
+namespace {
+
+auto hmac_sha256_hash_data(BCRYPT_HASH_HANDLE hash,
+                           const std::string_view input) -> bool {
+  // The data interface is not const-qualified but never writes through
+  // the pointer, and it takes a 32-bit length, so larger inputs must be
+  // fed in chunks
+  auto *remaining_data{
+      reinterpret_cast<unsigned char *>(const_cast<char *>(input.data()))};
+  auto remaining_size{input.size()};
+  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
+  while (remaining_size > 0) {
+    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+                                                         : remaining_size};
+    if (!BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
+                                       static_cast<ULONG>(chunk_size), 0))) {
+      return false;
+    }
+
+    remaining_data += chunk_size;
+    remaining_size -= chunk_size;
+  }
+
+  return true;
+}
+
+} // namespace
 
 namespace sourcemeta::core {
 
 auto hmac_sha256_digest(const std::string_view key,
-                        const std::string_view message)
+                        const std::span<const std::string_view> message)
     -> std::array<std::uint8_t, 32> {
   // A key longer than the block size is hashed first (RFC 2104 Section 2),
   // which also keeps the key length within the CNG length parameter. The
@@ -48,21 +78,9 @@ auto hmac_sha256_digest(const std::string_view key,
     throw std::runtime_error("Could not create the CNG HMAC-SHA256 hash");
   }
 
-  // The data interface is not const-qualified but never writes through
-  // the pointer, and it takes a 32-bit length, so larger inputs must be
-  // fed in chunks
-  auto *remaining_data{
-      reinterpret_cast<unsigned char *>(const_cast<char *>(message.data()))};
-  auto remaining_size{message.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
   auto success{true};
-  while (remaining_size > 0 && success) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
-                                                         : remaining_size};
-    success = BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
-                                            static_cast<ULONG>(chunk_size), 0));
-    remaining_data += chunk_size;
-    remaining_size -= chunk_size;
+  for (const auto part : message) {
+    success = success && hmac_sha256_hash_data(hash, part);
   }
 
   std::array<std::uint8_t, 32> digest{};
@@ -78,6 +96,13 @@ auto hmac_sha256_digest(const std::string_view key,
   }
 
   return digest;
+}
+
+auto hmac_sha256_digest(const std::string_view key,
+                        const std::string_view message)
+    -> std::array<std::uint8_t, 32> {
+  return hmac_sha256_digest(key,
+                            std::span<const std::string_view>{&message, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_sha256_apple.cc
+++ b/src/core/crypto/crypto_sha256_apple.cc
@@ -2,18 +2,17 @@
 
 #include <CommonCrypto/CommonDigest.h> // CC_SHA256*, CC_LONG
 
-#include <array>   // std::array
-#include <cstddef> // std::size_t
-#include <cstdint> // std::uint8_t
-#include <limits>  // std::numeric_limits
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <limits>      // std::numeric_limits
+#include <span>        // std::span
+#include <string_view> // std::string_view
 
-namespace sourcemeta::core {
+namespace {
 
-auto sha256_digest(const std::string_view input)
-    -> std::array<std::uint8_t, 32> {
-  CC_SHA256_CTX context;
-  CC_SHA256_Init(&context);
-
+auto sha256_update(CC_SHA256_CTX &context, const std::string_view input)
+    -> void {
   // The platform update interface takes a 32-bit length, so larger
   // inputs must be fed in chunks
   const auto *remaining_data{input.data()};
@@ -27,10 +26,29 @@ auto sha256_digest(const std::string_view input)
     remaining_data += chunk_size;
     remaining_size -= chunk_size;
   }
+}
+
+} // namespace
+
+namespace sourcemeta::core {
+
+auto sha256_digest(const std::span<const std::string_view> input)
+    -> std::array<std::uint8_t, 32> {
+  CC_SHA256_CTX context;
+  CC_SHA256_Init(&context);
+
+  for (const auto part : input) {
+    sha256_update(context, part);
+  }
 
   std::array<std::uint8_t, CC_SHA256_DIGEST_LENGTH> digest{};
   CC_SHA256_Final(digest.data(), &context);
   return digest;
+}
+
+auto sha256_digest(const std::string_view input)
+    -> std::array<std::uint8_t, 32> {
+  return sha256_digest(std::span<const std::string_view>{&input, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_sha256_openssl.cc
+++ b/src/core/crypto/crypto_sha256_openssl.cc
@@ -2,23 +2,31 @@
 
 #include <openssl/evp.h> // EVP_*
 
-#include <array>     // std::array
-#include <cstdint>   // std::uint8_t
-#include <stdexcept> // std::runtime_error
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
-auto sha256_digest(const std::string_view input)
+auto sha256_digest(const std::span<const std::string_view> input)
     -> std::array<std::uint8_t, 32> {
   auto *context = EVP_MD_CTX_new();
   if (context == nullptr) {
     throw std::runtime_error("Could not allocate OpenSSL digest context");
   }
 
-  if (EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1 ||
-      EVP_DigestUpdate(context, input.data(), input.size()) != 1) {
+  if (EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1) {
     EVP_MD_CTX_free(context);
     throw std::runtime_error("Could not compute SHA-256 digest");
+  }
+
+  for (const auto part : input) {
+    if (EVP_DigestUpdate(context, part.data(), part.size()) != 1) {
+      EVP_MD_CTX_free(context);
+      throw std::runtime_error("Could not compute SHA-256 digest");
+    }
   }
 
   std::array<std::uint8_t, 32> digest{};
@@ -30,6 +38,11 @@ auto sha256_digest(const std::string_view input)
 
   EVP_MD_CTX_free(context);
   return digest;
+}
+
+auto sha256_digest(const std::string_view input)
+    -> std::array<std::uint8_t, 32> {
+  return sha256_digest(std::span<const std::string_view>{&input, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_sha256_other.cc
+++ b/src/core/crypto/crypto_sha256_other.cc
@@ -1,185 +1,27 @@
 #include <sourcemeta/core/crypto_sha256.h>
 
-#include <array>   // std::array
-#include <cstddef> // std::size_t
-#include <cstdint> // std::uint8_t, std::uint32_t, std::uint64_t
-#include <cstring> // std::memcpy
+#include "crypto_sha256_other.h"
 
-namespace {
-
-inline constexpr auto rotate_right(std::uint32_t value,
-                                   std::uint64_t count) noexcept
-    -> std::uint32_t {
-  return (value >> count) | (value << (32u - count));
-}
-
-// FIPS 180-4 Section 4.1.2 logical functions
-inline constexpr auto big_sigma_0(std::uint32_t value) noexcept
-    -> std::uint32_t {
-  return rotate_right(value, 2u) ^ rotate_right(value, 13u) ^
-         rotate_right(value, 22u);
-}
-
-inline constexpr auto big_sigma_1(std::uint32_t value) noexcept
-    -> std::uint32_t {
-  return rotate_right(value, 6u) ^ rotate_right(value, 11u) ^
-         rotate_right(value, 25u);
-}
-
-inline constexpr auto small_sigma_0(std::uint32_t value) noexcept
-    -> std::uint32_t {
-  return rotate_right(value, 7u) ^ rotate_right(value, 18u) ^ (value >> 3u);
-}
-
-inline constexpr auto small_sigma_1(std::uint32_t value) noexcept
-    -> std::uint32_t {
-  return rotate_right(value, 17u) ^ rotate_right(value, 19u) ^ (value >> 10u);
-}
-
-// Equivalent to (x & y) ^ (~x & z) but avoids a bitwise NOT
-inline constexpr auto choice(std::uint32_t x, std::uint32_t y,
-                             std::uint32_t z) noexcept -> std::uint32_t {
-  return z ^ (x & (y ^ z));
-}
-
-inline constexpr auto majority(std::uint32_t x, std::uint32_t y,
-                               std::uint32_t z) noexcept -> std::uint32_t {
-  return (x & y) ^ (x & z) ^ (y & z);
-}
-
-inline auto sha256_process_block(const unsigned char *block,
-                                 std::array<std::uint32_t, 8> &state) noexcept
-    -> void {
-  // First 32 bits of the fractional parts of the cube roots
-  // of the first 64 prime numbers (FIPS 180-4 Section 4.2.2)
-  static constexpr std::array<std::uint32_t, 64> round_constants = {
-      {0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU,
-       0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U, 0xd807aa98U, 0x12835b01U,
-       0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U,
-       0xc19bf174U, 0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
-       0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU, 0x983e5152U,
-       0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U,
-       0x06ca6351U, 0x14292967U, 0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU,
-       0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
-       0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U, 0xd192e819U,
-       0xd6990624U, 0xf40e3585U, 0x106aa070U, 0x19a4c116U, 0x1e376c08U,
-       0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU,
-       0x682e6ff3U, 0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
-       0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U}};
-
-  // Decode 16 big-endian 32-bit words from the block
-  std::array<std::uint32_t, 64> schedule;
-  for (std::uint64_t word_index = 0; word_index < 16u; ++word_index) {
-    const std::uint64_t byte_index = word_index * 4u;
-    schedule[word_index] =
-        (static_cast<std::uint32_t>(block[byte_index]) << 24u) |
-        (static_cast<std::uint32_t>(block[byte_index + 1u]) << 16u) |
-        (static_cast<std::uint32_t>(block[byte_index + 2u]) << 8u) |
-        static_cast<std::uint32_t>(block[byte_index + 3u]);
-  }
-
-  // Extend the message schedule (FIPS 180-4 Section 6.2.2 step 1)
-  for (std::uint64_t index = 16u; index < 64u; ++index) {
-    schedule[index] =
-        small_sigma_1(schedule[index - 2u]) + schedule[index - 7u] +
-        small_sigma_0(schedule[index - 15u]) + schedule[index - 16u];
-  }
-
-  auto working = state;
-
-  // Compression function (FIPS 180-4 Section 6.2.2 step 3)
-  for (std::uint64_t round_index = 0u; round_index < 64u; ++round_index) {
-    const auto temporary_1 = working[7] + big_sigma_1(working[4]) +
-                             choice(working[4], working[5], working[6]) +
-                             round_constants[round_index] +
-                             schedule[round_index];
-    const auto temporary_2 =
-        big_sigma_0(working[0]) + majority(working[0], working[1], working[2]);
-
-    working[7] = working[6];
-    working[6] = working[5];
-    working[5] = working[4];
-    working[4] = working[3] + temporary_1;
-    working[3] = working[2];
-    working[2] = working[1];
-    working[1] = working[0];
-    working[0] = temporary_1 + temporary_2;
-  }
-
-  for (std::uint64_t index = 0u; index < 8u; ++index) {
-    state[index] += working[index];
-  }
-}
-
-} // namespace
+#include <array>       // std::array
+#include <cstdint>     // std::uint8_t
+#include <span>        // std::span
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
+auto sha256_digest(const std::span<const std::string_view> input)
+    -> std::array<std::uint8_t, 32> {
+  Sha256Context context;
+  for (const auto part : input) {
+    sha256_update(context, part);
+  }
+
+  return sha256_finalize(context);
+}
+
 auto sha256_digest(const std::string_view input)
     -> std::array<std::uint8_t, 32> {
-  // Initial hash values: first 32 bits of the fractional parts of the
-  // square roots of the first 8 primes (FIPS 180-4 Section 5.3.3)
-  std::array<std::uint32_t, 8> state{};
-  state[0] = 0x6a09e667U;
-  state[1] = 0xbb67ae85U;
-  state[2] = 0x3c6ef372U;
-  state[3] = 0xa54ff53aU;
-  state[4] = 0x510e527fU;
-  state[5] = 0x9b05688cU;
-  state[6] = 0x1f83d9abU;
-  state[7] = 0x5be0cd19U;
-
-  const auto *const input_bytes =
-      reinterpret_cast<const unsigned char *>(input.data());
-  const std::size_t input_length = input.size();
-
-  // Process all full 64-byte blocks directly from the input (streaming)
-  std::size_t processed_bytes = 0u;
-  while (input_length - processed_bytes >= 64u) {
-    sha256_process_block(input_bytes + processed_bytes, state);
-    processed_bytes += 64u;
-  }
-
-  // Prepare the final block(s) (one or two 64-byte blocks)
-  std::array<unsigned char, 128> final_block{};
-  const std::size_t remaining_bytes = input_length - processed_bytes;
-  if (remaining_bytes > 0u) {
-    std::memcpy(final_block.data(), input_bytes + processed_bytes,
-                remaining_bytes);
-  }
-
-  // Append the 0x80 byte after the message data
-  final_block[remaining_bytes] = 0x80u;
-
-  // Append length in bits as big-endian 64-bit at the end of the padding
-  const std::uint64_t message_length_bits =
-      static_cast<std::uint64_t>(input_length) * 8ull;
-
-  if (remaining_bytes < 56u) {
-    for (std::uint64_t index = 0u; index < 8u; ++index) {
-      final_block[56u + index] = static_cast<unsigned char>(
-          (message_length_bits >> (8u * (7u - index))) & 0xffu);
-    }
-    sha256_process_block(final_block.data(), state);
-  } else {
-    for (std::uint64_t index = 0u; index < 8u; ++index) {
-      final_block[64u + 56u + index] = static_cast<unsigned char>(
-          (message_length_bits >> (8u * (7u - index))) & 0xffu);
-    }
-
-    sha256_process_block(final_block.data(), state);
-    sha256_process_block(final_block.data() + 64u, state);
-  }
-
-  std::array<std::uint8_t, 32> digest{};
-  for (std::size_t word_index = 0u; word_index < 8u; ++word_index) {
-    for (std::size_t byte_index = 0u; byte_index < 4u; ++byte_index) {
-      digest[(word_index * 4u) + byte_index] = static_cast<std::uint8_t>(
-          (state[word_index] >> (8u * (3u - byte_index))) & 0xffu);
-    }
-  }
-
-  return digest;
+  return sha256_digest(std::span<const std::string_view>{&input, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_sha256_other.h
+++ b/src/core/crypto/crypto_sha256_other.h
@@ -1,0 +1,221 @@
+#ifndef SOURCEMETA_CORE_CRYPTO_SHA256_OTHER_H_
+#define SOURCEMETA_CORE_CRYPTO_SHA256_OTHER_H_
+
+// Shared FIPS 180-4 streaming core for SHA-256, used only by the fallback
+// implementations
+
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t, std::uint32_t, std::uint64_t
+#include <cstring>     // std::memcpy
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+// The count must be between 1 and 31, as the complementary shift is
+// undefined otherwise
+inline constexpr auto sha256_rotate_right(std::uint32_t value,
+                                          std::uint64_t count) noexcept
+    -> std::uint32_t {
+  return (value >> count) | (value << (32u - count));
+}
+
+// FIPS 180-4 Section 4.1.2 logical functions
+inline constexpr auto sha256_big_sigma_0(std::uint32_t value) noexcept
+    -> std::uint32_t {
+  return sha256_rotate_right(value, 2u) ^ sha256_rotate_right(value, 13u) ^
+         sha256_rotate_right(value, 22u);
+}
+
+inline constexpr auto sha256_big_sigma_1(std::uint32_t value) noexcept
+    -> std::uint32_t {
+  return sha256_rotate_right(value, 6u) ^ sha256_rotate_right(value, 11u) ^
+         sha256_rotate_right(value, 25u);
+}
+
+inline constexpr auto sha256_small_sigma_0(std::uint32_t value) noexcept
+    -> std::uint32_t {
+  return sha256_rotate_right(value, 7u) ^ sha256_rotate_right(value, 18u) ^
+         (value >> 3u);
+}
+
+inline constexpr auto sha256_small_sigma_1(std::uint32_t value) noexcept
+    -> std::uint32_t {
+  return sha256_rotate_right(value, 17u) ^ sha256_rotate_right(value, 19u) ^
+         (value >> 10u);
+}
+
+// Equivalent to (x & y) ^ (~x & z) but avoids a bitwise NOT
+inline constexpr auto sha256_choice(std::uint32_t x, std::uint32_t y,
+                                    std::uint32_t z) noexcept -> std::uint32_t {
+  return z ^ (x & (y ^ z));
+}
+
+inline constexpr auto sha256_majority(std::uint32_t x, std::uint32_t y,
+                                      std::uint32_t z) noexcept
+    -> std::uint32_t {
+  return (x & y) ^ (x & z) ^ (y & z);
+}
+
+inline auto sha256_process_block(const std::uint8_t *block,
+                                 std::array<std::uint32_t, 8> &state) noexcept
+    -> void {
+  // First 32 bits of the fractional parts of the cube roots
+  // of the first 64 prime numbers (FIPS 180-4 Section 4.2.2)
+  static constexpr std::array<std::uint32_t, 64> round_constants = {
+      {0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U, 0x3956c25bU,
+       0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U, 0xd807aa98U, 0x12835b01U,
+       0x243185beU, 0x550c7dc3U, 0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U,
+       0xc19bf174U, 0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
+       0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU, 0x983e5152U,
+       0xa831c66dU, 0xb00327c8U, 0xbf597fc7U, 0xc6e00bf3U, 0xd5a79147U,
+       0x06ca6351U, 0x14292967U, 0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU,
+       0x53380d13U, 0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+       0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U, 0xd192e819U,
+       0xd6990624U, 0xf40e3585U, 0x106aa070U, 0x19a4c116U, 0x1e376c08U,
+       0x2748774cU, 0x34b0bcb5U, 0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU,
+       0x682e6ff3U, 0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+       0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U}};
+
+  // Decode 16 big-endian 32-bit words from the block
+  std::array<std::uint32_t, 64> schedule;
+  for (std::uint64_t word_index = 0; word_index < 16u; ++word_index) {
+    const std::uint64_t byte_index = word_index * 4u;
+    schedule[word_index] =
+        (static_cast<std::uint32_t>(block[byte_index]) << 24u) |
+        (static_cast<std::uint32_t>(block[byte_index + 1u]) << 16u) |
+        (static_cast<std::uint32_t>(block[byte_index + 2u]) << 8u) |
+        static_cast<std::uint32_t>(block[byte_index + 3u]);
+  }
+
+  // Extend the message schedule (FIPS 180-4 Section 6.2.2 step 1)
+  for (std::uint64_t index = 16u; index < 64u; ++index) {
+    schedule[index] =
+        sha256_small_sigma_1(schedule[index - 2u]) + schedule[index - 7u] +
+        sha256_small_sigma_0(schedule[index - 15u]) + schedule[index - 16u];
+  }
+
+  auto working = state;
+
+  // Compression function (FIPS 180-4 Section 6.2.2 step 3)
+  for (std::uint64_t round_index = 0u; round_index < 64u; ++round_index) {
+    const auto temporary_1 = working[7] + sha256_big_sigma_1(working[4]) +
+                             sha256_choice(working[4], working[5], working[6]) +
+                             round_constants[round_index] +
+                             schedule[round_index];
+    const auto temporary_2 =
+        sha256_big_sigma_0(working[0]) +
+        sha256_majority(working[0], working[1], working[2]);
+
+    working[7] = working[6];
+    working[6] = working[5];
+    working[5] = working[4];
+    working[4] = working[3] + temporary_1;
+    working[3] = working[2];
+    working[2] = working[1];
+    working[1] = working[0];
+    working[0] = temporary_1 + temporary_2;
+  }
+
+  for (std::uint64_t index = 0u; index < 8u; ++index) {
+    state[index] += working[index];
+  }
+}
+
+struct Sha256Context {
+  // Initial hash values: first 32 bits of the fractional parts of the
+  // square roots of the first 8 primes (FIPS 180-4 Section 5.3.3)
+  std::array<std::uint32_t, 8> state{{0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U,
+                                      0xa54ff53aU, 0x510e527fU, 0x9b05688cU,
+                                      0x1f83d9abU, 0x5be0cd19U}};
+  std::array<std::uint8_t, 64> block{};
+  std::size_t block_size{0u};
+  std::uint64_t message_size{0u};
+};
+
+inline auto sha256_update(Sha256Context &context,
+                          const std::string_view input) noexcept -> void {
+  if (input.empty()) {
+    return;
+  }
+
+  const auto *input_bytes =
+      reinterpret_cast<const std::uint8_t *>(input.data());
+  std::size_t remaining_bytes = input.size();
+  context.message_size += input.size();
+
+  // Top up a partially filled block first, processing it once full
+  if (context.block_size > 0u) {
+    const std::size_t capacity = context.block.size() - context.block_size;
+    const std::size_t taken_bytes =
+        remaining_bytes < capacity ? remaining_bytes : capacity;
+    std::memcpy(context.block.data() + context.block_size, input_bytes,
+                taken_bytes);
+    context.block_size += taken_bytes;
+    input_bytes += taken_bytes;
+    remaining_bytes -= taken_bytes;
+    if (context.block_size == context.block.size()) {
+      sha256_process_block(context.block.data(), context.state);
+      context.block_size = 0u;
+    }
+  }
+
+  // Process all full 64-byte blocks directly from the input (streaming)
+  while (remaining_bytes >= 64u) {
+    sha256_process_block(input_bytes, context.state);
+    input_bytes += 64u;
+    remaining_bytes -= 64u;
+  }
+
+  // Buffer whatever is left for a later update or the final padding
+  if (remaining_bytes > 0u) {
+    std::memcpy(context.block.data(), input_bytes, remaining_bytes);
+    context.block_size = remaining_bytes;
+  }
+}
+
+inline auto sha256_finalize(Sha256Context &context) noexcept
+    -> std::array<std::uint8_t, 32> {
+  // Prepare the final block(s) (one or two 64-byte blocks)
+  std::array<std::uint8_t, 128> final_block{};
+  const std::size_t remaining_bytes = context.block_size;
+  if (remaining_bytes > 0u) {
+    std::memcpy(final_block.data(), context.block.data(), remaining_bytes);
+  }
+
+  // Append the 0x80 byte after the message data
+  final_block[remaining_bytes] = 0x80u;
+
+  // Append length in bits as big-endian 64-bit at the end of the padding
+  const std::uint64_t message_length_bits = context.message_size * 8ull;
+
+  if (remaining_bytes < 56u) {
+    for (std::uint64_t index = 0u; index < 8u; ++index) {
+      final_block[56u + index] = static_cast<std::uint8_t>(
+          (message_length_bits >> (8u * (7u - index))) & 0xffu);
+    }
+    sha256_process_block(final_block.data(), context.state);
+  } else {
+    for (std::uint64_t index = 0u; index < 8u; ++index) {
+      final_block[64u + 56u + index] = static_cast<std::uint8_t>(
+          (message_length_bits >> (8u * (7u - index))) & 0xffu);
+    }
+
+    sha256_process_block(final_block.data(), context.state);
+    sha256_process_block(final_block.data() + 64u, context.state);
+  }
+
+  std::array<std::uint8_t, 32> digest{};
+  for (std::size_t word_index = 0u; word_index < 8u; ++word_index) {
+    for (std::size_t byte_index = 0u; byte_index < 4u; ++byte_index) {
+      digest[(word_index * 4u) + byte_index] = static_cast<std::uint8_t>(
+          (context.state[word_index] >> (8u * (3u - byte_index))) & 0xffu);
+    }
+  }
+
+  return digest;
+}
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/crypto/crypto_sha256_windows.cc
+++ b/src/core/crypto/crypto_sha256_windows.cc
@@ -6,15 +6,45 @@
 
 #include <bcrypt.h> // BCrypt*, BCRYPT_*
 
-#include <array>     // std::array
-#include <cstddef>   // std::size_t
-#include <cstdint>   // std::uint8_t
-#include <limits>    // std::numeric_limits
-#include <stdexcept> // std::runtime_error
+#include <array>       // std::array
+#include <cstddef>     // std::size_t
+#include <cstdint>     // std::uint8_t
+#include <limits>      // std::numeric_limits
+#include <span>        // std::span
+#include <stdexcept>   // std::runtime_error
+#include <string_view> // std::string_view
+
+namespace {
+
+auto sha256_hash_data(BCRYPT_HASH_HANDLE hash, const std::string_view input)
+    -> bool {
+  // The data interface is not const-qualified but never writes through
+  // the pointer, and it takes a 32-bit length, so larger inputs must be
+  // fed in chunks
+  auto *remaining_data{
+      reinterpret_cast<unsigned char *>(const_cast<char *>(input.data()))};
+  auto remaining_size{input.size()};
+  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
+  while (remaining_size > 0) {
+    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+                                                         : remaining_size};
+    if (!BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
+                                       static_cast<ULONG>(chunk_size), 0))) {
+      return false;
+    }
+
+    remaining_data += chunk_size;
+    remaining_size -= chunk_size;
+  }
+
+  return true;
+}
+
+} // namespace
 
 namespace sourcemeta::core {
 
-auto sha256_digest(const std::string_view input)
+auto sha256_digest(const std::span<const std::string_view> input)
     -> std::array<std::uint8_t, 32> {
   BCRYPT_ALG_HANDLE algorithm{nullptr};
   if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(
@@ -29,21 +59,9 @@ auto sha256_digest(const std::string_view input)
     throw std::runtime_error("Could not create the CNG SHA-256 hash");
   }
 
-  // The data interface is not const-qualified but never writes through
-  // the pointer, and it takes a 32-bit length, so larger inputs must be
-  // fed in chunks
-  auto *remaining_data{
-      reinterpret_cast<unsigned char *>(const_cast<char *>(input.data()))};
-  auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
   auto success{true};
-  while (remaining_size > 0 && success) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
-                                                         : remaining_size};
-    success = BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
-                                            static_cast<ULONG>(chunk_size), 0));
-    remaining_data += chunk_size;
-    remaining_size -= chunk_size;
+  for (const auto part : input) {
+    success = success && sha256_hash_data(hash, part);
   }
 
   std::array<std::uint8_t, 32> digest{};
@@ -59,6 +77,11 @@ auto sha256_digest(const std::string_view input)
   }
 
   return digest;
+}
+
+auto sha256_digest(const std::string_view input)
+    -> std::array<std::uint8_t, 32> {
+  return sha256_digest(std::span<const std::string_view>{&input, 1});
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_sha256_windows.cc
+++ b/src/core/crypto/crypto_sha256_windows.cc
@@ -6,41 +6,13 @@
 
 #include <bcrypt.h> // BCrypt*, BCRYPT_*
 
+#include "crypto_windows.h"
+
 #include <array>       // std::array
-#include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint8_t
-#include <limits>      // std::numeric_limits
 #include <span>        // std::span
 #include <stdexcept>   // std::runtime_error
 #include <string_view> // std::string_view
-
-namespace {
-
-auto sha256_hash_data(BCRYPT_HASH_HANDLE hash, const std::string_view input)
-    -> bool {
-  // The data interface is not const-qualified but never writes through
-  // the pointer, and it takes a 32-bit length, so larger inputs must be
-  // fed in chunks
-  auto *remaining_data{
-      reinterpret_cast<unsigned char *>(const_cast<char *>(input.data()))};
-  auto remaining_size{input.size()};
-  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
-  while (remaining_size > 0) {
-    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
-                                                         : remaining_size};
-    if (!BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
-                                       static_cast<ULONG>(chunk_size), 0))) {
-      return false;
-    }
-
-    remaining_data += chunk_size;
-    remaining_size -= chunk_size;
-  }
-
-  return true;
-}
-
-} // namespace
 
 namespace sourcemeta::core {
 
@@ -61,7 +33,7 @@ auto sha256_digest(const std::span<const std::string_view> input)
 
   auto success{true};
   for (const auto part : input) {
-    success = success && sha256_hash_data(hash, part);
+    success = success && hash_data_chunked(hash, part);
   }
 
   std::array<std::uint8_t, 32> digest{};

--- a/src/core/crypto/crypto_windows.h
+++ b/src/core/crypto/crypto_windows.h
@@ -1,20 +1,49 @@
 #ifndef SOURCEMETA_CORE_CRYPTO_WINDOWS_H_
 #define SOURCEMETA_CORE_CRYPTO_WINDOWS_H_
 
-// CNG key export helper shared by the signing and verification backends, so the
-// native blob export stays single-sourced
+// CNG helpers shared across backends, so the native blob export and the
+// chunked hash ingestion stay single-sourced
 
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
 #include <windows.h> // ULONG, LPCWSTR
 
-#include <bcrypt.h> // BCryptExportKey, BCRYPT_KEY_HANDLE, BCRYPT_SUCCESS
+// BCryptExportKey, BCryptHashData, BCRYPT_KEY_HANDLE, BCRYPT_HASH_HANDLE,
+// BCRYPT_SUCCESS
+#include <bcrypt.h>
 
-#include <optional> // std::optional, std::nullopt
-#include <string>   // std::string
+#include <cstddef>     // std::size_t
+#include <limits>      // std::numeric_limits
+#include <optional>    // std::optional, std::nullopt
+#include <string>      // std::string
+#include <string_view> // std::string_view
 
 namespace sourcemeta::core {
+
+// Feed a buffer into a hash object. The data interface is not const-qualified
+// but never writes through the pointer, and it takes a 32-bit length, so
+// larger inputs must be fed in chunks
+inline auto hash_data_chunked(BCRYPT_HASH_HANDLE hash,
+                              const std::string_view input) -> bool {
+  auto *remaining_data{
+      reinterpret_cast<unsigned char *>(const_cast<char *>(input.data()))};
+  auto remaining_size{input.size()};
+  constexpr std::size_t maximum_chunk{std::numeric_limits<ULONG>::max()};
+  while (remaining_size > 0) {
+    const auto chunk_size{remaining_size > maximum_chunk ? maximum_chunk
+                                                         : remaining_size};
+    if (!BCRYPT_SUCCESS(BCryptHashData(hash, remaining_data,
+                                       static_cast<ULONG>(chunk_size), 0))) {
+      return false;
+    }
+
+    remaining_data += chunk_size;
+    remaining_size -= chunk_size;
+  }
+
+  return true;
+}
 
 // Export a native key blob, sizing the buffer in a first call and filling it in
 // a second

--- a/src/core/crypto/include/sourcemeta/core/crypto_hmac_sha256.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_hmac_sha256.h
@@ -8,6 +8,7 @@
 #include <array>       // std::array
 #include <cstdint>     // std::uint8_t
 #include <ostream>     // std::ostream
+#include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -57,6 +58,25 @@ auto SOURCEMETA_CORE_CRYPTO_EXPORT hmac_sha256(const std::string_view key,
 /// ```
 auto SOURCEMETA_CORE_CRYPTO_EXPORT
 hmac_sha256_digest(const std::string_view key, const std::string_view message)
+    -> std::array<std::uint8_t, 32>;
+
+/// @ingroup crypto
+/// Authenticate a message given as a sequence of string parts under a key
+/// using HMAC-SHA256, as if the parts were a single concatenated message,
+/// returning the raw digest bytes. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/crypto.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string_view>
+///
+/// const std::array<std::string_view, 2> parts{{"foo ", "bar"}};
+/// const auto digest{sourcemeta::core::hmac_sha256_digest("key", parts)};
+/// assert(digest.size() == 32);
+/// ```
+auto SOURCEMETA_CORE_CRYPTO_EXPORT hmac_sha256_digest(
+    const std::string_view key, std::span<const std::string_view> message)
     -> std::array<std::uint8_t, 32>;
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/include/sourcemeta/core/crypto_sha256.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_sha256.h
@@ -8,6 +8,7 @@
 #include <array>       // std::array
 #include <cstdint>     // std::uint8_t
 #include <ostream>     // std::ostream
+#include <span>        // std::span
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -53,6 +54,23 @@ auto SOURCEMETA_CORE_CRYPTO_EXPORT sha256(const std::string_view input)
 /// ```
 auto SOURCEMETA_CORE_CRYPTO_EXPORT sha256_digest(const std::string_view input)
     -> std::array<std::uint8_t, 32>;
+
+/// @ingroup crypto
+/// Hash a sequence of string parts using SHA-256 as if they were a single
+/// concatenated input, returning the raw digest bytes. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/crypto.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string_view>
+///
+/// const std::array<std::string_view, 2> parts{{"foo ", "bar"}};
+/// const auto digest{sourcemeta::core::sha256_digest(parts)};
+/// assert(digest.size() == 32);
+/// ```
+auto SOURCEMETA_CORE_CRYPTO_EXPORT sha256_digest(
+    std::span<const std::string_view> input) -> std::array<std::uint8_t, 32>;
 
 } // namespace sourcemeta::core
 

--- a/test/crypto/crypto_hmac_sha256_test.cc
+++ b/test/crypto/crypto_hmac_sha256_test.cc
@@ -4,9 +4,18 @@
 
 #include <array>       // std::array
 #include <cstdint>     // std::uint8_t
+#include <span>        // std::span
 #include <sstream>     // std::ostringstream
 #include <string>      // std::string
 #include <string_view> // std::string_view
+#include <vector>      // std::vector
+
+namespace {
+auto digest_to_hex(const std::array<std::uint8_t, 32> &digest) -> std::string {
+  return sourcemeta::core::bytes_to_hex(
+      {reinterpret_cast<const char *>(digest.data()), digest.size()});
+}
+} // namespace
 
 // RFC 4231 Section 4.2 (Test Case 1)
 TEST(rfc4231_case_1) {
@@ -84,4 +93,117 @@ TEST(digest_case_2) {
   EXPECT_EQ(sourcemeta::core::hmac_sha256_digest(
                 "Jefe", "what do ya want for nothing?"),
             expected);
+}
+
+// RFC 4231 Section 4.2 (Test Case 1)
+TEST(digest_parts_rfc4231_case_1_single) {
+  const std::string key(20, '\x0b');
+  const std::array<std::string_view, 1> parts{{"Hi There"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+}
+
+// RFC 4231 Section 4.2 (Test Case 1)
+TEST(digest_parts_rfc4231_case_1_split) {
+  const std::string key(20, '\x0b');
+  const std::array<std::string_view, 2> parts{{"Hi ", "There"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+}
+
+// RFC 4231 Section 4.2 (Test Case 1)
+TEST(digest_parts_rfc4231_case_1_with_empty_parts) {
+  const std::string key(20, '\x0b');
+  const std::array<std::string_view, 3> parts{{"", "Hi There", ""}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7");
+}
+
+// RFC 4231 Section 4.3 (Test Case 2)
+TEST(digest_parts_rfc4231_case_2_split) {
+  const std::array<std::string_view, 2> parts{
+      {"what do ya want ", "for nothing?"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest("Jefe", parts)),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+}
+
+// RFC 4231 Section 4.4 (Test Case 3)
+TEST(digest_parts_rfc4231_case_3_split_halves) {
+  const std::string key(20, '\xaa');
+  const std::string first(25, '\xdd');
+  const std::string second(25, '\xdd');
+  const std::array<std::string_view, 2> parts{{first, second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe");
+}
+
+// RFC 4231 Section 4.4 (Test Case 3)
+TEST(digest_parts_rfc4231_case_3_single_byte_parts) {
+  const std::string key(20, '\xaa');
+  const std::vector<std::string_view> parts(50, "\xdd");
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe");
+}
+
+// RFC 4231 Section 4.5 (Test Case 4)
+TEST(digest_parts_rfc4231_case_4_split) {
+  const auto key{sourcemeta::core::hex_to_bytes(
+                     "0102030405060708090a0b0c0d0e0f10111213141516171819")
+                     .value()};
+  const std::string message(50, '\xcd');
+  const std::string_view view{message};
+  const std::array<std::string_view, 2> parts{
+      {view.substr(0, 10), view.substr(10)}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b");
+}
+
+// RFC 4231 Section 4.7 (Test Case 6), a key longer than the block size
+TEST(digest_parts_rfc4231_case_6_split) {
+  const std::string key(131, '\xaa');
+  const std::array<std::string_view, 2> parts{
+      {"Test Using Larger Than Block-Size Key", " - Hash Key First"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54");
+}
+
+// RFC 4231 Section 4.8 (Test Case 7), a key longer than the block size and a
+// message split so that a part crosses the block boundary
+TEST(digest_parts_rfc4231_case_7_three_parts) {
+  const std::string key(131, '\xaa');
+  const std::string message{
+      "This is a test using a larger than block-size key and a "
+      "larger than block-size data. The key needs to be hashed "
+      "before being used by the HMAC algorithm."};
+  const std::string_view view{message};
+  const std::array<std::string_view, 3> parts{
+      {view.substr(0, 40), view.substr(40, 40), view.substr(80)}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(key, parts)),
+            "9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2");
+}
+
+TEST(digest_parts_empty_key_empty_span) {
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(
+                "", std::span<const std::string_view>{})),
+            "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
+}
+
+TEST(digest_parts_empty_key_empty_part) {
+  const std::array<std::string_view, 1> parts{{""}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest("", parts)),
+            "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
+}
+
+TEST(digest_parts_null_key_view_empty_span) {
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest(
+                std::string_view{}, std::span<const std::string_view>{})),
+            "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad");
+}
+
+TEST(digest_parts_message_part_crossing_block_boundary) {
+  const std::array<std::string_view, 2> parts{
+      {"0123456789012345678901234567890123456789",
+       "0123456789012345678901234567890123456789"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::hmac_sha256_digest("key", parts)),
+            "fb39f382d4c6474312831ee858de2c270451a90f6e6dcc48594aa24eec785584");
 }

--- a/test/crypto/crypto_sha256_test.cc
+++ b/test/crypto/crypto_sha256_test.cc
@@ -1,10 +1,21 @@
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/test.h>
+#include <sourcemeta/core/text.h>
 
 #include <array>   // std::array
 #include <cstdint> // std::uint8_t
+#include <span>    // std::span
 #include <sstream>
 #include <string>
+#include <string_view> // std::string_view
+#include <vector>      // std::vector
+
+namespace {
+auto digest_to_hex(const std::array<std::uint8_t, 32> &digest) -> std::string {
+  return sourcemeta::core::bytes_to_hex(
+      {reinterpret_cast<const char *>(digest.data()), digest.size()});
+}
+} // namespace
 
 // Try $ echo -n "" | sha256sum
 TEST(empty_string) {
@@ -102,4 +113,238 @@ TEST(digest_abc) {
        0xde, 0x5d, 0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17,
        0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad}};
   EXPECT_EQ(sourcemeta::core::sha256_digest("abc"), expected);
+}
+
+// Try $ echo -n "" | sha256sum
+TEST(digest_parts_empty_span) {
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(
+                std::span<const std::string_view>{})),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+// Try $ echo -n "" | sha256sum
+TEST(digest_parts_one_empty_part) {
+  const std::array<std::string_view, 1> parts{{""}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+// Try $ echo -n "" | sha256sum
+TEST(digest_parts_three_empty_parts) {
+  const std::array<std::string_view, 3> parts{{"", "", ""}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+}
+
+// Try $ echo -n "abc" | sha256sum
+TEST(digest_parts_single_abc) {
+  const std::array<std::string_view, 1> parts{{"abc"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+// Try $ echo -n "abc" | sha256sum
+TEST(digest_parts_abc_first_letter_split) {
+  const std::array<std::string_view, 2> parts{{"a", "bc"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+// Try $ echo -n "abc" | sha256sum
+TEST(digest_parts_abc_last_letter_split) {
+  const std::array<std::string_view, 2> parts{{"ab", "c"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+// Try $ echo -n "abc" | sha256sum
+TEST(digest_parts_abc_letter_by_letter) {
+  const std::array<std::string_view, 3> parts{{"a", "b", "c"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+// Try $ echo -n "abc" | sha256sum
+TEST(digest_parts_abc_with_empty_parts_between) {
+  const std::array<std::string_view, 5> parts{{"", "a", "", "bc", ""}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+}
+
+// Try $ echo -n "foo bar" | sha256sum
+TEST(digest_parts_example_string) {
+  const std::array<std::string_view, 2> parts{{"foo ", "bar"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "fbc1a9f858ea9e177916964bd88c3d37b91a1e84412765e29950777f265c4b75");
+}
+
+// Try $ echo -n "The quick brown fox jumps over the lazy dog" | sha256sum
+TEST(digest_parts_quick_brown_fox) {
+  const std::array<std::string_view, 3> parts{
+      {"The quick brown ", "fox jumps ", "over the lazy dog"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
+}
+
+// FIPS 180-4 example message of 56 bytes, filling the final block up to the
+// point where the length no longer fits and a second padding block is needed
+TEST(digest_parts_two_padding_blocks_single) {
+  const std::array<std::string_view, 1> parts{
+      {"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+}
+
+// FIPS 180-4 example message of 56 bytes, filling the final block up to the
+// point where the length no longer fits and a second padding block is needed
+TEST(digest_parts_two_padding_blocks_split) {
+  const std::array<std::string_view, 2> parts{
+      {"abcdbcdecdefdefgefghfghighij", "hijkijkljklmklmnlmnomnopnopq"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+}
+
+TEST(digest_parts_55_bytes_single) {
+  const std::string input(55, 'a');
+  const std::array<std::string_view, 1> parts{{input}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318");
+}
+
+TEST(digest_parts_55_bytes_split) {
+  const std::string first(27, 'a');
+  const std::string second(28, 'a');
+  const std::array<std::string_view, 2> parts{{first, second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318");
+}
+
+TEST(digest_parts_56_bytes_split) {
+  const std::string first(55, 'a');
+  const std::array<std::string_view, 2> parts{{first, "a"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a");
+}
+
+TEST(digest_parts_57_bytes_split) {
+  const std::string second(56, 'a');
+  const std::array<std::string_view, 2> parts{{"a", second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "f13b2d724659eb3bf47f2dd6af1accc87b81f09f59f2b75e5c0bed6589dfe8c6");
+}
+
+TEST(digest_parts_63_bytes_split) {
+  const std::string first(62, 'a');
+  const std::array<std::string_view, 2> parts{{first, "a"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "7d3e74a05d7db15bce4ad9ec0658ea98e3f06eeecf16b4c6fff2da457ddc2f34");
+}
+
+TEST(digest_parts_64_bytes_single) {
+  const std::string input(64, 'a');
+  const std::array<std::string_view, 1> parts{{input}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb");
+}
+
+TEST(digest_parts_64_bytes_split_last_byte) {
+  const std::string first(63, 'a');
+  const std::array<std::string_view, 2> parts{{first, "a"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb");
+}
+
+TEST(digest_parts_64_bytes_split_first_byte) {
+  const std::string second(63, 'a');
+  const std::array<std::string_view, 2> parts{{"a", second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb");
+}
+
+TEST(digest_parts_64_bytes_split_halves) {
+  const std::string first(32, 'a');
+  const std::string second(32, 'a');
+  const std::array<std::string_view, 2> parts{{first, second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb");
+}
+
+TEST(digest_parts_65_bytes_split_after_block) {
+  const std::string first(64, 'a');
+  const std::array<std::string_view, 2> parts{{first, "a"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "635361c48bb9eab14198e76ea8ab7f1a41685d6ad62aa9146d301d4f17eb0ae0");
+}
+
+TEST(digest_parts_65_bytes_split_before_block) {
+  const std::string second(64, 'a');
+  const std::array<std::string_view, 2> parts{{"a", second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "635361c48bb9eab14198e76ea8ab7f1a41685d6ad62aa9146d301d4f17eb0ae0");
+}
+
+// FIPS 180-4 example message of 112 bytes spanning two full blocks
+TEST(digest_parts_two_block_message_split_at_block) {
+  const std::array<std::string_view, 2> parts{
+      {"abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn",
+       "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1");
+}
+
+// FIPS 180-4 example message of 112 bytes spanning two full blocks
+TEST(digest_parts_two_block_message_split_unevenly) {
+  const std::array<std::string_view, 2> parts{
+      {"a", "bcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmn"
+            "hijklmnoijklmnopjklmnopqklmnopqrlmnopqrsmnopqrstnopqrstu"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1");
+}
+
+TEST(digest_parts_part_crossing_block_boundary) {
+  const std::array<std::string_view, 2> parts{
+      {"0123456789012345678901234567890123456789",
+       "0123456789012345678901234567890123456789"}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "af1909413b96cbb29927b3a67f3a8879c801a37be383e5f9b31df5fa8d10fa2b");
+}
+
+TEST(digest_parts_small_part_then_multi_block_part) {
+  const std::string second(200, 'b');
+  const std::array<std::string_view, 2> parts{{"0123456789", second}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "c65c2079436f4c3794c35a33d3b74abe2af91e7dd0e73b214ae3fb519af79b7e");
+}
+
+TEST(digest_parts_one_hundred_fifty_single_byte_parts) {
+  const std::vector<std::string_view> parts(150, "a");
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "7595af82ae2fa59cd9bf3b4405d31c69b98de71fed5945fd777d8ab3b393a85f");
+}
+
+TEST(digest_parts_one_million_a_chars_three_parts) {
+  const std::string input(1000000, 'a');
+  const std::string_view view{input};
+  const std::array<std::string_view, 3> parts{
+      {view.substr(0, 1), view.substr(1, 999998), view.substr(999999)}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+}
+
+TEST(digest_parts_embedded_nuls_and_binary_bytes) {
+  const std::array<std::string_view, 2> parts{
+      {std::string_view{"\x00\x01", 2}, std::string_view{"\x02", 1}}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "ae4b3280e56e2faf83f414a6e3dabe9d5fbe18976544c05fed121accb85b53fc");
+}
+
+// Try $ echo -n "The quick brown fox jumps over the lazy dog" | sha256sum
+TEST(digest_parts_views_into_same_buffer) {
+  const std::string input{"The quick brown fox jumps over the lazy dog"};
+  const std::string_view view{input};
+  const std::array<std::string_view, 4> parts{
+      {view.substr(0, 10), view.substr(10, 1), view.substr(11, 21),
+       view.substr(32)}};
+  EXPECT_EQ(digest_to_hex(sourcemeta::core::sha256_digest(parts)),
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592");
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

