### PR TITLE
Support `constexpr` on `PropertyHashJSON`

### DIFF
--- a/src/core/http/problem.cc
+++ b/src/core/http/problem.cc
@@ -7,11 +7,13 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto HTTP_HASH_TYPE{sourcemeta::core::JSON::Object::hash("type"sv)};
-const auto HTTP_HASH_TITLE{sourcemeta::core::JSON::Object::hash("title"sv)};
-const auto HTTP_HASH_STATUS{sourcemeta::core::JSON::Object::hash("status"sv)};
-const auto HTTP_HASH_DETAIL{sourcemeta::core::JSON::Object::hash("detail"sv)};
-const auto HTTP_HASH_INSTANCE{
+constexpr auto HTTP_HASH_TYPE{sourcemeta::core::JSON::Object::hash("type"sv)};
+constexpr auto HTTP_HASH_TITLE{sourcemeta::core::JSON::Object::hash("title"sv)};
+constexpr auto HTTP_HASH_STATUS{
+    sourcemeta::core::JSON::Object::hash("status"sv)};
+constexpr auto HTTP_HASH_DETAIL{
+    sourcemeta::core::JSON::Object::hash("detail"sv)};
+constexpr auto HTTP_HASH_INSTANCE{
     sourcemeta::core::JSON::Object::hash("instance"sv)};
 
 } // namespace

--- a/src/core/jose/jose_jwk.cc
+++ b/src/core/jose/jose_jwk.cc
@@ -11,22 +11,22 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto HASH_KTY{sourcemeta::core::JSON::Object::hash("kty"sv)};
-const auto HASH_N{sourcemeta::core::JSON::Object::hash("n"sv)};
-const auto HASH_E{sourcemeta::core::JSON::Object::hash("e"sv)};
-const auto HASH_CRV{sourcemeta::core::JSON::Object::hash("crv"sv)};
-const auto HASH_X{sourcemeta::core::JSON::Object::hash("x"sv)};
-const auto HASH_Y{sourcemeta::core::JSON::Object::hash("y"sv)};
-const auto HASH_KID{sourcemeta::core::JSON::Object::hash("kid"sv)};
-const auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
-const auto HASH_D{sourcemeta::core::JSON::Object::hash("d"sv)};
-const auto HASH_P{sourcemeta::core::JSON::Object::hash("p"sv)};
-const auto HASH_Q{sourcemeta::core::JSON::Object::hash("q"sv)};
-const auto HASH_DP{sourcemeta::core::JSON::Object::hash("dp"sv)};
-const auto HASH_DQ{sourcemeta::core::JSON::Object::hash("dq"sv)};
-const auto HASH_QI{sourcemeta::core::JSON::Object::hash("qi"sv)};
-const auto HASH_OTH{sourcemeta::core::JSON::Object::hash("oth"sv)};
-const auto HASH_K{sourcemeta::core::JSON::Object::hash("k"sv)};
+constexpr auto HASH_KTY{sourcemeta::core::JSON::Object::hash("kty"sv)};
+constexpr auto HASH_N{sourcemeta::core::JSON::Object::hash("n"sv)};
+constexpr auto HASH_E{sourcemeta::core::JSON::Object::hash("e"sv)};
+constexpr auto HASH_CRV{sourcemeta::core::JSON::Object::hash("crv"sv)};
+constexpr auto HASH_X{sourcemeta::core::JSON::Object::hash("x"sv)};
+constexpr auto HASH_Y{sourcemeta::core::JSON::Object::hash("y"sv)};
+constexpr auto HASH_KID{sourcemeta::core::JSON::Object::hash("kid"sv)};
+constexpr auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
+constexpr auto HASH_D{sourcemeta::core::JSON::Object::hash("d"sv)};
+constexpr auto HASH_P{sourcemeta::core::JSON::Object::hash("p"sv)};
+constexpr auto HASH_Q{sourcemeta::core::JSON::Object::hash("q"sv)};
+constexpr auto HASH_DP{sourcemeta::core::JSON::Object::hash("dp"sv)};
+constexpr auto HASH_DQ{sourcemeta::core::JSON::Object::hash("dq"sv)};
+constexpr auto HASH_QI{sourcemeta::core::JSON::Object::hash("qi"sv)};
+constexpr auto HASH_OTH{sourcemeta::core::JSON::Object::hash("oth"sv)};
+constexpr auto HASH_K{sourcemeta::core::JSON::Object::hash("k"sv)};
 
 auto to_jwk_kind(const sourcemeta::core::JWK::Type type) noexcept
     -> sourcemeta::core::JWKKind {

--- a/src/core/jose/jose_jwk_private.cc
+++ b/src/core/jose/jose_jwk_private.cc
@@ -12,22 +12,22 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto HASH_KTY{sourcemeta::core::JSON::Object::hash("kty"sv)};
-const auto HASH_N{sourcemeta::core::JSON::Object::hash("n"sv)};
-const auto HASH_E{sourcemeta::core::JSON::Object::hash("e"sv)};
-const auto HASH_D{sourcemeta::core::JSON::Object::hash("d"sv)};
-const auto HASH_P{sourcemeta::core::JSON::Object::hash("p"sv)};
-const auto HASH_Q{sourcemeta::core::JSON::Object::hash("q"sv)};
-const auto HASH_DP{sourcemeta::core::JSON::Object::hash("dp"sv)};
-const auto HASH_DQ{sourcemeta::core::JSON::Object::hash("dq"sv)};
-const auto HASH_QI{sourcemeta::core::JSON::Object::hash("qi"sv)};
-const auto HASH_OTH{sourcemeta::core::JSON::Object::hash("oth"sv)};
-const auto HASH_K{sourcemeta::core::JSON::Object::hash("k"sv)};
-const auto HASH_CRV{sourcemeta::core::JSON::Object::hash("crv"sv)};
-const auto HASH_X{sourcemeta::core::JSON::Object::hash("x"sv)};
-const auto HASH_Y{sourcemeta::core::JSON::Object::hash("y"sv)};
-const auto HASH_KID{sourcemeta::core::JSON::Object::hash("kid"sv)};
-const auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
+constexpr auto HASH_KTY{sourcemeta::core::JSON::Object::hash("kty"sv)};
+constexpr auto HASH_N{sourcemeta::core::JSON::Object::hash("n"sv)};
+constexpr auto HASH_E{sourcemeta::core::JSON::Object::hash("e"sv)};
+constexpr auto HASH_D{sourcemeta::core::JSON::Object::hash("d"sv)};
+constexpr auto HASH_P{sourcemeta::core::JSON::Object::hash("p"sv)};
+constexpr auto HASH_Q{sourcemeta::core::JSON::Object::hash("q"sv)};
+constexpr auto HASH_DP{sourcemeta::core::JSON::Object::hash("dp"sv)};
+constexpr auto HASH_DQ{sourcemeta::core::JSON::Object::hash("dq"sv)};
+constexpr auto HASH_QI{sourcemeta::core::JSON::Object::hash("qi"sv)};
+constexpr auto HASH_OTH{sourcemeta::core::JSON::Object::hash("oth"sv)};
+constexpr auto HASH_K{sourcemeta::core::JSON::Object::hash("k"sv)};
+constexpr auto HASH_CRV{sourcemeta::core::JSON::Object::hash("crv"sv)};
+constexpr auto HASH_X{sourcemeta::core::JSON::Object::hash("x"sv)};
+constexpr auto HASH_Y{sourcemeta::core::JSON::Object::hash("y"sv)};
+constexpr auto HASH_KID{sourcemeta::core::JSON::Object::hash("kid"sv)};
+constexpr auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
 
 // A required string member decoded from base64url, empty when the member is
 // missing, of the wrong type, malformed, or decodes to nothing

--- a/src/core/jose/jose_jwks.cc
+++ b/src/core/jose/jose_jwks.cc
@@ -7,7 +7,7 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto HASH_KEYS{sourcemeta::core::JSON::Object::hash("keys"sv)};
+constexpr auto HASH_KEYS{sourcemeta::core::JSON::Object::hash("keys"sv)};
 
 } // namespace
 

--- a/src/core/jose/jose_jwt.cc
+++ b/src/core/jose/jose_jwt.cc
@@ -14,17 +14,17 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
-const auto HASH_CRIT{sourcemeta::core::JSON::Object::hash("crit"sv)};
-const auto HASH_KID{sourcemeta::core::JSON::Object::hash("kid"sv)};
-const auto HASH_TYP{sourcemeta::core::JSON::Object::hash("typ"sv)};
-const auto HASH_ISS{sourcemeta::core::JSON::Object::hash("iss"sv)};
-const auto HASH_SUB{sourcemeta::core::JSON::Object::hash("sub"sv)};
-const auto HASH_AUD{sourcemeta::core::JSON::Object::hash("aud"sv)};
-const auto HASH_EXP{sourcemeta::core::JSON::Object::hash("exp"sv)};
-const auto HASH_NBF{sourcemeta::core::JSON::Object::hash("nbf"sv)};
-const auto HASH_IAT{sourcemeta::core::JSON::Object::hash("iat"sv)};
-const auto HASH_JTI{sourcemeta::core::JSON::Object::hash("jti"sv)};
+constexpr auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
+constexpr auto HASH_CRIT{sourcemeta::core::JSON::Object::hash("crit"sv)};
+constexpr auto HASH_KID{sourcemeta::core::JSON::Object::hash("kid"sv)};
+constexpr auto HASH_TYP{sourcemeta::core::JSON::Object::hash("typ"sv)};
+constexpr auto HASH_ISS{sourcemeta::core::JSON::Object::hash("iss"sv)};
+constexpr auto HASH_SUB{sourcemeta::core::JSON::Object::hash("sub"sv)};
+constexpr auto HASH_AUD{sourcemeta::core::JSON::Object::hash("aud"sv)};
+constexpr auto HASH_EXP{sourcemeta::core::JSON::Object::hash("exp"sv)};
+constexpr auto HASH_NBF{sourcemeta::core::JSON::Object::hash("nbf"sv)};
+constexpr auto HASH_IAT{sourcemeta::core::JSON::Object::hash("iat"sv)};
+constexpr auto HASH_JTI{sourcemeta::core::JSON::Object::hash("jti"sv)};
 
 auto string_claim(const sourcemeta::core::JSON &object,
                   const sourcemeta::core::JSON::StringView name,

--- a/src/core/jose/jose_jwt_sign.cc
+++ b/src/core/jose/jose_jwt_sign.cc
@@ -11,8 +11,8 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
-const auto HASH_CRIT{sourcemeta::core::JSON::Object::hash("crit"sv)};
+constexpr auto HASH_ALG{sourcemeta::core::JSON::Object::hash("alg"sv)};
+constexpr auto HASH_CRIT{sourcemeta::core::JSON::Object::hash("crit"sv)};
 
 auto compact(const sourcemeta::core::JSON &document) -> std::string {
   std::ostringstream stream;

--- a/src/core/json/include/sourcemeta/core/json_hash.h
+++ b/src/core/json/include/sourcemeta/core/json_hash.h
@@ -3,7 +3,9 @@
 
 #include <sourcemeta/core/numeric.h>
 
+#include <bit>        // std::endian
 #include <cassert>    // assert
+#include <cstddef>    // std::size_t
 #include <cstring>    // std::memcpy
 #include <functional> // std::reference_wrapper
 
@@ -42,11 +44,31 @@ template <typename T> struct PropertyHashJSON {
 
   /// Compute a perfect hash from raw data
   [[nodiscard]]
-  inline auto perfect(const char *data, const std::size_t size) const noexcept
-      -> hash_type {
+  constexpr auto perfect(const char *data,
+                         const std::size_t size) const noexcept -> hash_type {
     hash_type result;
     assert(size > 0);
-    std::memcpy(reinterpret_cast<char *>(&result) + 1, data, size);
+    if consteval {
+      // A constant evaluation cannot memcpy through a reinterpret_cast, so pack
+      // the bytes arithmetically instead. This reproduces the runtime memcpy on
+      // a little-endian target, where the packed bytes read back as the same
+      // integer, which the static assertion enforces so the two can never
+      // silently diverge
+      static_assert(std::endian::native == std::endian::little);
+      for (std::size_t index = 0; index < size; index += 1) {
+        const auto byte{static_cast<typename hash_type::type>(
+            static_cast<unsigned char>(data[index]))};
+        const auto position{index + 1};
+        if (position < 16) {
+          result.a |= byte << (8 * position);
+        } else {
+          result.b |= byte << (8 * (position - 16));
+        }
+      }
+    } else {
+      std::memcpy(reinterpret_cast<char *>(&result) + 1, data, size);
+    }
+
     return result;
   }
 
@@ -54,7 +76,7 @@ template <typename T> struct PropertyHashJSON {
   // std::string to std::string_view, so we provide separate overloads with
   // duplicated logic instead of unifying on a single parameter type
 
-  inline auto operator()(const T &value) const noexcept -> hash_type {
+  constexpr auto operator()(const T &value) const noexcept -> hash_type {
     const auto size{value.size()};
     switch (size) {
       case 0:
@@ -135,8 +157,9 @@ template <typename T> struct PropertyHashJSON {
     }
   }
 
-  inline auto operator()(const char *data,
-                         const std::size_t size) const noexcept -> hash_type {
+  constexpr auto operator()(const char *data,
+                            const std::size_t size) const noexcept
+      -> hash_type {
     switch (size) {
       case 0:
         return {};
@@ -217,7 +240,7 @@ template <typename T> struct PropertyHashJSON {
 
   /// Check whether the given hash is a perfect hash
   [[nodiscard]]
-  inline auto is_perfect(const hash_type &hash) const noexcept -> bool {
+  constexpr auto is_perfect(const hash_type &hash) const noexcept -> bool {
     // If there is anything written past the first byte,
     // then it is a perfect hash
     return (hash.a & 255) == 0;

--- a/src/core/json/include/sourcemeta/core/json_hash.h
+++ b/src/core/json/include/sourcemeta/core/json_hash.h
@@ -60,9 +60,9 @@ template <typename T> struct PropertyHashJSON {
             static_cast<unsigned char>(data[index]))};
         const auto position{index + 1};
         if (position < 16) {
-          result.a |= byte << (8 * position);
+          result.a |= byte << static_cast<int>(8 * position);
         } else {
-          result.b |= byte << (8 * (position - 16));
+          result.b |= byte << static_cast<int>(8 * (position - 16));
         }
       }
     } else {
@@ -148,11 +148,11 @@ template <typename T> struct PropertyHashJSON {
         // string length, and to exploit the fact that most JSON objects don't
         // have a lot of entries, so hash collision is not as common
         auto hash = this->perfect(value.data(), 31);
-        hash.a |=
-            1 + (size + static_cast<typename hash_type::type>(value.front()) +
-                 static_cast<typename hash_type::type>(value.back())) %
-                    // Make sure the property hash can never exceed 8 bits
-                    255;
+        hash.a |= 1 + (static_cast<std::uint64_t>(size) +
+                       static_cast<typename hash_type::type>(value.front()) +
+                       static_cast<typename hash_type::type>(value.back())) %
+                          // Make sure the property hash can never exceed 8 bits
+                          255;
         return hash;
     }
   }
@@ -230,7 +230,8 @@ template <typename T> struct PropertyHashJSON {
         // string length, and to exploit the fact that most JSON objects don't
         // have a lot of entries, so hash collision is not as common
         auto hash = this->perfect(data, 31);
-        hash.a |= 1 + (size + static_cast<typename hash_type::type>(data[0]) +
+        hash.a |= 1 + (static_cast<std::uint64_t>(size) +
+                       static_cast<typename hash_type::type>(data[0]) +
                        static_cast<typename hash_type::type>(data[size - 1])) %
                           // Make sure the property hash can never exceed 8 bits
                           255;

--- a/src/core/json/include/sourcemeta/core/json_object.h
+++ b/src/core/json/include/sourcemeta/core/json_object.h
@@ -178,20 +178,21 @@ public:
   // the `Key`-accepting overload as before.
 
   /// Compute a hash for a key
-  [[nodiscard]] static inline auto hash(const Key &key) noexcept -> hash_type {
+  [[nodiscard]] static constexpr auto hash(const Key &key) noexcept
+      -> hash_type {
     return hasher(key);
   }
 
   /// Compute a hash for a key
   template <typename T>
     requires std::same_as<std::remove_cvref_t<T>, KeyView>
-  [[nodiscard]] static inline auto hash(T key) noexcept -> hash_type {
+  [[nodiscard]] static constexpr auto hash(T key) noexcept -> hash_type {
     return hasher(key.data(), key.size());
   }
 
   /// Compute a hash from raw data
-  [[nodiscard]] static inline auto hash(const char *raw_data,
-                                        const std::size_t raw_size) noexcept
+  [[nodiscard]] static constexpr auto hash(const char *raw_data,
+                                           const std::size_t raw_size) noexcept
       -> hash_type {
     return hasher(raw_data, raw_size);
   }

--- a/src/core/jsonld/jsonld_keywords.h
+++ b/src/core/jsonld/jsonld_keywords.h
@@ -35,29 +35,35 @@ inline constexpr JSON::StringView KEYWORD_VOCAB{"@vocab"};
 
 // Precomputed object-key hashes for each keyword, so that object access never
 // has to recompute them.
-inline const auto KEYWORD_BASE_HASH{JSON::Object::hash(KEYWORD_BASE)};
-inline const auto KEYWORD_CONTAINER_HASH{JSON::Object::hash(KEYWORD_CONTAINER)};
-inline const auto KEYWORD_CONTEXT_HASH{JSON::Object::hash(KEYWORD_CONTEXT)};
-inline const auto KEYWORD_DIRECTION_HASH{JSON::Object::hash(KEYWORD_DIRECTION)};
-inline const auto KEYWORD_GRAPH_HASH{JSON::Object::hash(KEYWORD_GRAPH)};
-inline const auto KEYWORD_ID_HASH{JSON::Object::hash(KEYWORD_ID)};
-inline const auto KEYWORD_IMPORT_HASH{JSON::Object::hash(KEYWORD_IMPORT)};
-inline const auto KEYWORD_INCLUDED_HASH{JSON::Object::hash(KEYWORD_INCLUDED)};
-inline const auto KEYWORD_INDEX_HASH{JSON::Object::hash(KEYWORD_INDEX)};
-inline const auto KEYWORD_JSON_HASH{JSON::Object::hash(KEYWORD_JSON)};
-inline const auto KEYWORD_LANGUAGE_HASH{JSON::Object::hash(KEYWORD_LANGUAGE)};
-inline const auto KEYWORD_LIST_HASH{JSON::Object::hash(KEYWORD_LIST)};
-inline const auto KEYWORD_NEST_HASH{JSON::Object::hash(KEYWORD_NEST)};
-inline const auto KEYWORD_NONE_HASH{JSON::Object::hash(KEYWORD_NONE)};
-inline const auto KEYWORD_PREFIX_HASH{JSON::Object::hash(KEYWORD_PREFIX)};
-inline const auto KEYWORD_PROPAGATE_HASH{JSON::Object::hash(KEYWORD_PROPAGATE)};
-inline const auto KEYWORD_PROTECTED_HASH{JSON::Object::hash(KEYWORD_PROTECTED)};
-inline const auto KEYWORD_REVERSE_HASH{JSON::Object::hash(KEYWORD_REVERSE)};
-inline const auto KEYWORD_SET_HASH{JSON::Object::hash(KEYWORD_SET)};
-inline const auto KEYWORD_TYPE_HASH{JSON::Object::hash(KEYWORD_TYPE)};
-inline const auto KEYWORD_VALUE_HASH{JSON::Object::hash(KEYWORD_VALUE)};
-inline const auto KEYWORD_VERSION_HASH{JSON::Object::hash(KEYWORD_VERSION)};
-inline const auto KEYWORD_VOCAB_HASH{JSON::Object::hash(KEYWORD_VOCAB)};
+inline constexpr auto KEYWORD_BASE_HASH{JSON::Object::hash(KEYWORD_BASE)};
+inline constexpr auto KEYWORD_CONTAINER_HASH{
+    JSON::Object::hash(KEYWORD_CONTAINER)};
+inline constexpr auto KEYWORD_CONTEXT_HASH{JSON::Object::hash(KEYWORD_CONTEXT)};
+inline constexpr auto KEYWORD_DIRECTION_HASH{
+    JSON::Object::hash(KEYWORD_DIRECTION)};
+inline constexpr auto KEYWORD_GRAPH_HASH{JSON::Object::hash(KEYWORD_GRAPH)};
+inline constexpr auto KEYWORD_ID_HASH{JSON::Object::hash(KEYWORD_ID)};
+inline constexpr auto KEYWORD_IMPORT_HASH{JSON::Object::hash(KEYWORD_IMPORT)};
+inline constexpr auto KEYWORD_INCLUDED_HASH{
+    JSON::Object::hash(KEYWORD_INCLUDED)};
+inline constexpr auto KEYWORD_INDEX_HASH{JSON::Object::hash(KEYWORD_INDEX)};
+inline constexpr auto KEYWORD_JSON_HASH{JSON::Object::hash(KEYWORD_JSON)};
+inline constexpr auto KEYWORD_LANGUAGE_HASH{
+    JSON::Object::hash(KEYWORD_LANGUAGE)};
+inline constexpr auto KEYWORD_LIST_HASH{JSON::Object::hash(KEYWORD_LIST)};
+inline constexpr auto KEYWORD_NEST_HASH{JSON::Object::hash(KEYWORD_NEST)};
+inline constexpr auto KEYWORD_NONE_HASH{JSON::Object::hash(KEYWORD_NONE)};
+inline constexpr auto KEYWORD_PREFIX_HASH{JSON::Object::hash(KEYWORD_PREFIX)};
+inline constexpr auto KEYWORD_PROPAGATE_HASH{
+    JSON::Object::hash(KEYWORD_PROPAGATE)};
+inline constexpr auto KEYWORD_PROTECTED_HASH{
+    JSON::Object::hash(KEYWORD_PROTECTED)};
+inline constexpr auto KEYWORD_REVERSE_HASH{JSON::Object::hash(KEYWORD_REVERSE)};
+inline constexpr auto KEYWORD_SET_HASH{JSON::Object::hash(KEYWORD_SET)};
+inline constexpr auto KEYWORD_TYPE_HASH{JSON::Object::hash(KEYWORD_TYPE)};
+inline constexpr auto KEYWORD_VALUE_HASH{JSON::Object::hash(KEYWORD_VALUE)};
+inline constexpr auto KEYWORD_VERSION_HASH{JSON::Object::hash(KEYWORD_VERSION)};
+inline constexpr auto KEYWORD_VOCAB_HASH{JSON::Object::hash(KEYWORD_VOCAB)};
 
 // Markers used internally by inverse context creation, term selection, and node
 // map generation. These are not JSON-LD document keywords: @default is the name
@@ -66,8 +72,8 @@ inline const auto KEYWORD_VOCAB_HASH{JSON::Object::hash(KEYWORD_VOCAB)};
 inline constexpr JSON::StringView KEYWORD_ANY{"@any"};
 inline constexpr JSON::StringView KEYWORD_DEFAULT{"@default"};
 inline constexpr JSON::StringView KEYWORD_NULL{"@null"};
-inline const auto KEYWORD_ANY_HASH{JSON::Object::hash(KEYWORD_ANY)};
-inline const auto KEYWORD_DEFAULT_HASH{JSON::Object::hash(KEYWORD_DEFAULT)};
+inline constexpr auto KEYWORD_ANY_HASH{JSON::Object::hash(KEYWORD_ANY)};
+inline constexpr auto KEYWORD_DEFAULT_HASH{JSON::Object::hash(KEYWORD_DEFAULT)};
 
 // A stable owned copy of the @context keyword, suitable as a JSON Pointer
 // token. (A namespace-scope JSON::String constant would trip clang-tidy's

--- a/src/core/jsonrpc/jsonrpc.cc
+++ b/src/core/jsonrpc/jsonrpc.cc
@@ -10,19 +10,22 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto JSONRPC_HASH_ID{sourcemeta::core::JSON::Object::hash("id"sv)};
-const auto JSONRPC_HASH_JSONRPC{
+constexpr auto JSONRPC_HASH_ID{sourcemeta::core::JSON::Object::hash("id"sv)};
+constexpr auto JSONRPC_HASH_JSONRPC{
     sourcemeta::core::JSON::Object::hash("jsonrpc"sv)};
-const auto JSONRPC_HASH_METHOD{
+constexpr auto JSONRPC_HASH_METHOD{
     sourcemeta::core::JSON::Object::hash("method"sv)};
-const auto JSONRPC_HASH_RESULT{
+constexpr auto JSONRPC_HASH_RESULT{
     sourcemeta::core::JSON::Object::hash("result"sv)};
-const auto JSONRPC_HASH_ERROR{sourcemeta::core::JSON::Object::hash("error"sv)};
-const auto JSONRPC_HASH_CODE{sourcemeta::core::JSON::Object::hash("code"sv)};
-const auto JSONRPC_HASH_MESSAGE{
+constexpr auto JSONRPC_HASH_ERROR{
+    sourcemeta::core::JSON::Object::hash("error"sv)};
+constexpr auto JSONRPC_HASH_CODE{
+    sourcemeta::core::JSON::Object::hash("code"sv)};
+constexpr auto JSONRPC_HASH_MESSAGE{
     sourcemeta::core::JSON::Object::hash("message"sv)};
-const auto JSONRPC_HASH_DATA{sourcemeta::core::JSON::Object::hash("data"sv)};
-const auto JSONRPC_HASH_PARAMS{
+constexpr auto JSONRPC_HASH_DATA{
+    sourcemeta::core::JSON::Object::hash("data"sv)};
+constexpr auto JSONRPC_HASH_PARAMS{
     sourcemeta::core::JSON::Object::hash("params"sv)};
 
 } // namespace

--- a/src/core/mcp/mcp.cc
+++ b/src/core/mcp/mcp.cc
@@ -16,59 +16,64 @@
 namespace {
 using namespace std::string_view_literals;
 
-const auto MCP_HASH_ANNOTATIONS{
+constexpr auto MCP_HASH_ANNOTATIONS{
     sourcemeta::core::JSON::Object::hash("annotations"sv)};
-const auto MCP_HASH_ARGUMENTS{
+constexpr auto MCP_HASH_ARGUMENTS{
     sourcemeta::core::JSON::Object::hash("arguments"sv)};
-const auto MCP_HASH_CAPABILITIES{
+constexpr auto MCP_HASH_CAPABILITIES{
     sourcemeta::core::JSON::Object::hash("capabilities"sv)};
-const auto MCP_HASH_COMPLETIONS{
+constexpr auto MCP_HASH_COMPLETIONS{
     sourcemeta::core::JSON::Object::hash("completions"sv)};
-const auto MCP_HASH_CONTENT{sourcemeta::core::JSON::Object::hash("content"sv)};
-const auto MCP_HASH_CONTENTS{
+constexpr auto MCP_HASH_CONTENT{
+    sourcemeta::core::JSON::Object::hash("content"sv)};
+constexpr auto MCP_HASH_CONTENTS{
     sourcemeta::core::JSON::Object::hash("contents"sv)};
-const auto MCP_HASH_DESCRIPTION{
+constexpr auto MCP_HASH_DESCRIPTION{
     sourcemeta::core::JSON::Object::hash("description"sv)};
-const auto MCP_HASH_DESTRUCTIVE_HINT{
+constexpr auto MCP_HASH_DESTRUCTIVE_HINT{
     sourcemeta::core::JSON::Object::hash("destructiveHint"sv)};
-const auto MCP_HASH_IDEMPOTENT_HINT{
+constexpr auto MCP_HASH_IDEMPOTENT_HINT{
     sourcemeta::core::JSON::Object::hash("idempotentHint"sv)};
-const auto MCP_HASH_INPUT_SCHEMA{
+constexpr auto MCP_HASH_INPUT_SCHEMA{
     sourcemeta::core::JSON::Object::hash("inputSchema"sv)};
-const auto MCP_HASH_INSTRUCTIONS{
+constexpr auto MCP_HASH_INSTRUCTIONS{
     sourcemeta::core::JSON::Object::hash("instructions"sv)};
-const auto MCP_HASH_IS_ERROR{sourcemeta::core::JSON::Object::hash("isError"sv)};
-const auto MCP_HASH_LOGGING{sourcemeta::core::JSON::Object::hash("logging"sv)};
-const auto MCP_HASH_MIME_TYPE{
+constexpr auto MCP_HASH_IS_ERROR{
+    sourcemeta::core::JSON::Object::hash("isError"sv)};
+constexpr auto MCP_HASH_LOGGING{
+    sourcemeta::core::JSON::Object::hash("logging"sv)};
+constexpr auto MCP_HASH_MIME_TYPE{
     sourcemeta::core::JSON::Object::hash("mimeType"sv)};
-const auto MCP_HASH_NAME{sourcemeta::core::JSON::Object::hash("name"sv)};
-const auto MCP_HASH_OPEN_WORLD_HINT{
+constexpr auto MCP_HASH_NAME{sourcemeta::core::JSON::Object::hash("name"sv)};
+constexpr auto MCP_HASH_OPEN_WORLD_HINT{
     sourcemeta::core::JSON::Object::hash("openWorldHint"sv)};
-const auto MCP_HASH_OUTPUT_SCHEMA{
+constexpr auto MCP_HASH_OUTPUT_SCHEMA{
     sourcemeta::core::JSON::Object::hash("outputSchema"sv)};
-const auto MCP_HASH_PRIORITY{
+constexpr auto MCP_HASH_PRIORITY{
     sourcemeta::core::JSON::Object::hash("priority"sv)};
-const auto MCP_HASH_PROMPTS{sourcemeta::core::JSON::Object::hash("prompts"sv)};
-const auto MCP_HASH_PROTOCOL_VERSION{
+constexpr auto MCP_HASH_PROMPTS{
+    sourcemeta::core::JSON::Object::hash("prompts"sv)};
+constexpr auto MCP_HASH_PROTOCOL_VERSION{
     sourcemeta::core::JSON::Object::hash("protocolVersion"sv)};
-const auto MCP_HASH_READ_ONLY_HINT{
+constexpr auto MCP_HASH_READ_ONLY_HINT{
     sourcemeta::core::JSON::Object::hash("readOnlyHint"sv)};
-const auto MCP_HASH_RESOURCES{
+constexpr auto MCP_HASH_RESOURCES{
     sourcemeta::core::JSON::Object::hash("resources"sv)};
-const auto MCP_HASH_SERVER_INFO{
+constexpr auto MCP_HASH_SERVER_INFO{
     sourcemeta::core::JSON::Object::hash("serverInfo"sv)};
-const auto MCP_HASH_SIZE{sourcemeta::core::JSON::Object::hash("size"sv)};
-const auto MCP_HASH_STRUCTURED_CONTENT{
+constexpr auto MCP_HASH_SIZE{sourcemeta::core::JSON::Object::hash("size"sv)};
+constexpr auto MCP_HASH_STRUCTURED_CONTENT{
     sourcemeta::core::JSON::Object::hash("structuredContent"sv)};
-const auto MCP_HASH_TEXT{sourcemeta::core::JSON::Object::hash("text"sv)};
-const auto MCP_HASH_TITLE{sourcemeta::core::JSON::Object::hash("title"sv)};
-const auto MCP_HASH_TOOLS{sourcemeta::core::JSON::Object::hash("tools"sv)};
-const auto MCP_HASH_TYPE{sourcemeta::core::JSON::Object::hash("type"sv)};
-const auto MCP_HASH_URI{sourcemeta::core::JSON::Object::hash("uri"sv)};
-const auto MCP_HASH_URI_TEMPLATE{
+constexpr auto MCP_HASH_TEXT{sourcemeta::core::JSON::Object::hash("text"sv)};
+constexpr auto MCP_HASH_TITLE{sourcemeta::core::JSON::Object::hash("title"sv)};
+constexpr auto MCP_HASH_TOOLS{sourcemeta::core::JSON::Object::hash("tools"sv)};
+constexpr auto MCP_HASH_TYPE{sourcemeta::core::JSON::Object::hash("type"sv)};
+constexpr auto MCP_HASH_URI{sourcemeta::core::JSON::Object::hash("uri"sv)};
+constexpr auto MCP_HASH_URI_TEMPLATE{
     sourcemeta::core::JSON::Object::hash("uriTemplate"sv)};
-const auto MCP_HASH_VERSION{sourcemeta::core::JSON::Object::hash("version"sv)};
-const auto MCP_HASH_WEBSITE_URL{
+constexpr auto MCP_HASH_VERSION{
+    sourcemeta::core::JSON::Object::hash("version"sv)};
+constexpr auto MCP_HASH_WEBSITE_URL{
     sourcemeta::core::JSON::Object::hash("websiteUrl"sv)};
 
 } // namespace

--- a/src/core/oauth/oauth_assertion.cc
+++ b/src/core/oauth/oauth_assertion.cc
@@ -23,14 +23,14 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_ALG{JSON::Object::hash("alg"sv)};
-const auto HASH_KID{JSON::Object::hash("kid"sv)};
-const auto HASH_ISS{JSON::Object::hash("iss"sv)};
-const auto HASH_SUB{JSON::Object::hash("sub"sv)};
-const auto HASH_AUD{JSON::Object::hash("aud"sv)};
-const auto HASH_EXP{JSON::Object::hash("exp"sv)};
-const auto HASH_IAT{JSON::Object::hash("iat"sv)};
-const auto HASH_JTI{JSON::Object::hash("jti"sv)};
+constexpr auto HASH_ALG{JSON::Object::hash("alg"sv)};
+constexpr auto HASH_KID{JSON::Object::hash("kid"sv)};
+constexpr auto HASH_ISS{JSON::Object::hash("iss"sv)};
+constexpr auto HASH_SUB{JSON::Object::hash("sub"sv)};
+constexpr auto HASH_AUD{JSON::Object::hash("aud"sv)};
+constexpr auto HASH_EXP{JSON::Object::hash("exp"sv)};
+constexpr auto HASH_IAT{JSON::Object::hash("iat"sv)};
+constexpr auto HASH_JTI{JSON::Object::hash("jti"sv)};
 
 auto to_epoch_seconds(const std::chrono::system_clock::time_point point)
     -> std::int64_t {

--- a/src/core/oauth/oauth_bearer.cc
+++ b/src/core/oauth/oauth_bearer.cc
@@ -17,9 +17,9 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_AUD{JSON::Object::hash("aud"sv)};
-const auto HASH_CNF{JSON::Object::hash("cnf"sv)};
-const auto HASH_JKT{JSON::Object::hash("jkt"sv)};
+constexpr auto HASH_AUD{JSON::Object::hash("aud"sv)};
+constexpr auto HASH_CNF{JSON::Object::hash("cnf"sv)};
+constexpr auto HASH_JKT{JSON::Object::hash("jkt"sv)};
 
 auto oauth_skip_ows(const std::string_view value, std::size_t position) noexcept
     -> std::size_t {

--- a/src/core/oauth/oauth_device.cc
+++ b/src/core/oauth/oauth_device.cc
@@ -29,13 +29,13 @@ using namespace std::literals::string_view_literals;
 constexpr std::string_view USER_CODE_ALPHABET{"BCDFGHJKLMNPQRSTVWXZ"};
 constexpr std::chrono::seconds DEFAULT_INTERVAL{5};
 
-const auto HASH_DEVICE_CODE{JSON::Object::hash("device_code"sv)};
-const auto HASH_USER_CODE{JSON::Object::hash("user_code"sv)};
-const auto HASH_VERIFICATION_URI{JSON::Object::hash("verification_uri"sv)};
-const auto HASH_VERIFICATION_URI_COMPLETE{
+constexpr auto HASH_DEVICE_CODE{JSON::Object::hash("device_code"sv)};
+constexpr auto HASH_USER_CODE{JSON::Object::hash("user_code"sv)};
+constexpr auto HASH_VERIFICATION_URI{JSON::Object::hash("verification_uri"sv)};
+constexpr auto HASH_VERIFICATION_URI_COMPLETE{
     JSON::Object::hash("verification_uri_complete"sv)};
-const auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
-const auto HASH_INTERVAL{JSON::Object::hash("interval"sv)};
+constexpr auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
+constexpr auto HASH_INTERVAL{JSON::Object::hash("interval"sv)};
 
 auto normalize_user_code(const std::string_view value) -> SecureString {
   SecureString result;

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -29,27 +29,27 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_TYP{JSON::Object::hash("typ"sv)};
-const auto HASH_ALG{JSON::Object::hash("alg"sv)};
-const auto HASH_JWK{JSON::Object::hash("jwk"sv)};
-const auto HASH_JTI{JSON::Object::hash("jti"sv)};
-const auto HASH_HTM{JSON::Object::hash("htm"sv)};
-const auto HASH_HTU{JSON::Object::hash("htu"sv)};
-const auto HASH_IAT{JSON::Object::hash("iat"sv)};
-const auto HASH_ATH{JSON::Object::hash("ath"sv)};
-const auto HASH_NONCE{JSON::Object::hash("nonce"sv)};
-const auto HASH_JKT{JSON::Object::hash("jkt"sv)};
+constexpr auto HASH_TYP{JSON::Object::hash("typ"sv)};
+constexpr auto HASH_ALG{JSON::Object::hash("alg"sv)};
+constexpr auto HASH_JWK{JSON::Object::hash("jwk"sv)};
+constexpr auto HASH_JTI{JSON::Object::hash("jti"sv)};
+constexpr auto HASH_HTM{JSON::Object::hash("htm"sv)};
+constexpr auto HASH_HTU{JSON::Object::hash("htu"sv)};
+constexpr auto HASH_IAT{JSON::Object::hash("iat"sv)};
+constexpr auto HASH_ATH{JSON::Object::hash("ath"sv)};
+constexpr auto HASH_NONCE{JSON::Object::hash("nonce"sv)};
+constexpr auto HASH_JKT{JSON::Object::hash("jkt"sv)};
 
 // The private JSON Web Key members whose presence marks a private key (RFC 7518
 // Sections 6.2.2 and 6.3.2, RFC 8037 Section 2, RFC 7518 Section 6.4)
-const auto HASH_D{JSON::Object::hash("d"sv)};
-const auto HASH_P{JSON::Object::hash("p"sv)};
-const auto HASH_Q{JSON::Object::hash("q"sv)};
-const auto HASH_DP{JSON::Object::hash("dp"sv)};
-const auto HASH_DQ{JSON::Object::hash("dq"sv)};
-const auto HASH_QI{JSON::Object::hash("qi"sv)};
-const auto HASH_OTH{JSON::Object::hash("oth"sv)};
-const auto HASH_K{JSON::Object::hash("k"sv)};
+constexpr auto HASH_D{JSON::Object::hash("d"sv)};
+constexpr auto HASH_P{JSON::Object::hash("p"sv)};
+constexpr auto HASH_Q{JSON::Object::hash("q"sv)};
+constexpr auto HASH_DP{JSON::Object::hash("dp"sv)};
+constexpr auto HASH_DQ{JSON::Object::hash("dq"sv)};
+constexpr auto HASH_QI{JSON::Object::hash("qi"sv)};
+constexpr auto HASH_OTH{JSON::Object::hash("oth"sv)};
+constexpr auto HASH_K{JSON::Object::hash("k"sv)};
 
 // RFC 9449 Section 4.2: the HTTP target URI without query and fragment, with
 // the syntax and scheme normalization Section 4.3 recommends applied so the

--- a/src/core/oauth/oauth_introspection.cc
+++ b/src/core/oauth/oauth_introspection.cc
@@ -16,17 +16,17 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_ACTIVE{JSON::Object::hash("active"sv)};
-const auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
-const auto HASH_CLIENT_ID{JSON::Object::hash("client_id"sv)};
-const auto HASH_USERNAME{JSON::Object::hash("username"sv)};
-const auto HASH_TOKEN_TYPE{JSON::Object::hash("token_type"sv)};
-const auto HASH_SUB{JSON::Object::hash("sub"sv)};
-const auto HASH_ISS{JSON::Object::hash("iss"sv)};
-const auto HASH_JTI{JSON::Object::hash("jti"sv)};
-const auto HASH_EXP{JSON::Object::hash("exp"sv)};
-const auto HASH_IAT{JSON::Object::hash("iat"sv)};
-const auto HASH_NBF{JSON::Object::hash("nbf"sv)};
+constexpr auto HASH_ACTIVE{JSON::Object::hash("active"sv)};
+constexpr auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
+constexpr auto HASH_CLIENT_ID{JSON::Object::hash("client_id"sv)};
+constexpr auto HASH_USERNAME{JSON::Object::hash("username"sv)};
+constexpr auto HASH_TOKEN_TYPE{JSON::Object::hash("token_type"sv)};
+constexpr auto HASH_SUB{JSON::Object::hash("sub"sv)};
+constexpr auto HASH_ISS{JSON::Object::hash("iss"sv)};
+constexpr auto HASH_JTI{JSON::Object::hash("jti"sv)};
+constexpr auto HASH_EXP{JSON::Object::hash("exp"sv)};
+constexpr auto HASH_IAT{JSON::Object::hash("iat"sv)};
+constexpr auto HASH_NBF{JSON::Object::hash("nbf"sv)};
 
 } // namespace
 

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -19,41 +19,41 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_ISSUER{JSON::Object::hash("issuer"sv)};
-const auto HASH_AUTHORIZATION_ENDPOINT{
+constexpr auto HASH_ISSUER{JSON::Object::hash("issuer"sv)};
+constexpr auto HASH_AUTHORIZATION_ENDPOINT{
     JSON::Object::hash("authorization_endpoint"sv)};
-const auto HASH_TOKEN_ENDPOINT{JSON::Object::hash("token_endpoint"sv)};
-const auto HASH_REGISTRATION_ENDPOINT{
+constexpr auto HASH_TOKEN_ENDPOINT{JSON::Object::hash("token_endpoint"sv)};
+constexpr auto HASH_REGISTRATION_ENDPOINT{
     JSON::Object::hash("registration_endpoint"sv)};
-const auto HASH_PAR_ENDPOINT{
+constexpr auto HASH_PAR_ENDPOINT{
     JSON::Object::hash("pushed_authorization_request_endpoint"sv)};
-const auto HASH_REQUIRE_PAR{
+constexpr auto HASH_REQUIRE_PAR{
     JSON::Object::hash("require_pushed_authorization_requests"sv)};
-const auto HASH_REVOCATION_ENDPOINT{
+constexpr auto HASH_REVOCATION_ENDPOINT{
     JSON::Object::hash("revocation_endpoint"sv)};
-const auto HASH_INTROSPECTION_ENDPOINT{
+constexpr auto HASH_INTROSPECTION_ENDPOINT{
     JSON::Object::hash("introspection_endpoint"sv)};
-const auto HASH_JWKS_URI{JSON::Object::hash("jwks_uri"sv)};
-const auto HASH_RESPONSE_TYPES{
+constexpr auto HASH_JWKS_URI{JSON::Object::hash("jwks_uri"sv)};
+constexpr auto HASH_RESPONSE_TYPES{
     JSON::Object::hash("response_types_supported"sv)};
-const auto HASH_GRANT_TYPES{JSON::Object::hash("grant_types_supported"sv)};
-const auto HASH_CODE_CHALLENGE_METHODS{
+constexpr auto HASH_GRANT_TYPES{JSON::Object::hash("grant_types_supported"sv)};
+constexpr auto HASH_CODE_CHALLENGE_METHODS{
     JSON::Object::hash("code_challenge_methods_supported"sv)};
-const auto HASH_TOKEN_AUTH_METHODS{
+constexpr auto HASH_TOKEN_AUTH_METHODS{
     JSON::Object::hash("token_endpoint_auth_methods_supported"sv)};
-const auto HASH_TOKEN_AUTH_ALGS{
+constexpr auto HASH_TOKEN_AUTH_ALGS{
     JSON::Object::hash("token_endpoint_auth_signing_alg_values_supported"sv)};
-const auto HASH_ISS_SUPPORTED{
+constexpr auto HASH_ISS_SUPPORTED{
     JSON::Object::hash("authorization_response_iss_parameter_supported"sv)};
-const auto HASH_RESOURCE{JSON::Object::hash("resource"sv)};
-const auto HASH_AUTHORIZATION_SERVERS{
+constexpr auto HASH_RESOURCE{JSON::Object::hash("resource"sv)};
+constexpr auto HASH_AUTHORIZATION_SERVERS{
     JSON::Object::hash("authorization_servers"sv)};
-const auto HASH_BEARER_METHODS{
+constexpr auto HASH_BEARER_METHODS{
     JSON::Object::hash("bearer_methods_supported"sv)};
-const auto HASH_SCOPES_SUPPORTED{JSON::Object::hash("scopes_supported"sv)};
-const auto HASH_DPOP_BOUND_REQUIRED{
+constexpr auto HASH_SCOPES_SUPPORTED{JSON::Object::hash("scopes_supported"sv)};
+constexpr auto HASH_DPOP_BOUND_REQUIRED{
     JSON::Object::hash("dpop_bound_access_tokens_required"sv)};
-const auto HASH_RESOURCE_SIGNING_ALGS{
+constexpr auto HASH_RESOURCE_SIGNING_ALGS{
     JSON::Object::hash("resource_signing_alg_values_supported"sv)};
 
 auto string_member(const JSON &data, const JSON::StringView name,

--- a/src/core/oauth/oauth_par.cc
+++ b/src/core/oauth/oauth_par.cc
@@ -22,8 +22,8 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_REQUEST_URI{JSON::Object::hash("request_uri"sv)};
-const auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
+constexpr auto HASH_REQUEST_URI{JSON::Object::hash("request_uri"sv)};
+constexpr auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
 
 // RFC 9126 Section 2.2: the recommended request URI form, a URN whose final
 // segment is the random reference

--- a/src/core/oauth/oauth_registration.cc
+++ b/src/core/oauth/oauth_registration.cc
@@ -20,35 +20,37 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_REDIRECT_URIS{JSON::Object::hash("redirect_uris"sv)};
-const auto HASH_TOKEN_ENDPOINT_AUTH_METHOD{
+constexpr auto HASH_REDIRECT_URIS{JSON::Object::hash("redirect_uris"sv)};
+constexpr auto HASH_TOKEN_ENDPOINT_AUTH_METHOD{
     JSON::Object::hash("token_endpoint_auth_method"sv)};
-const auto HASH_GRANT_TYPES{JSON::Object::hash("grant_types"sv)};
-const auto HASH_RESPONSE_TYPES{JSON::Object::hash("response_types"sv)};
-const auto HASH_CLIENT_NAME{JSON::Object::hash("client_name"sv)};
-const auto HASH_CLIENT_URI{JSON::Object::hash("client_uri"sv)};
-const auto HASH_LOGO_URI{JSON::Object::hash("logo_uri"sv)};
-const auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
-const auto HASH_CONTACTS{JSON::Object::hash("contacts"sv)};
-const auto HASH_TOS_URI{JSON::Object::hash("tos_uri"sv)};
-const auto HASH_POLICY_URI{JSON::Object::hash("policy_uri"sv)};
-const auto HASH_JWKS_URI{JSON::Object::hash("jwks_uri"sv)};
-const auto HASH_JWKS{JSON::Object::hash("jwks"sv)};
-const auto HASH_SOFTWARE_ID{JSON::Object::hash("software_id"sv)};
-const auto HASH_SOFTWARE_VERSION{JSON::Object::hash("software_version"sv)};
-const auto HASH_SOFTWARE_STATEMENT{JSON::Object::hash("software_statement"sv)};
-const auto HASH_CLIENT_ID{JSON::Object::hash("client_id"sv)};
-const auto HASH_CLIENT_SECRET{JSON::Object::hash("client_secret"sv)};
-const auto HASH_CLIENT_ID_ISSUED_AT{
+constexpr auto HASH_GRANT_TYPES{JSON::Object::hash("grant_types"sv)};
+constexpr auto HASH_RESPONSE_TYPES{JSON::Object::hash("response_types"sv)};
+constexpr auto HASH_CLIENT_NAME{JSON::Object::hash("client_name"sv)};
+constexpr auto HASH_CLIENT_URI{JSON::Object::hash("client_uri"sv)};
+constexpr auto HASH_LOGO_URI{JSON::Object::hash("logo_uri"sv)};
+constexpr auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
+constexpr auto HASH_CONTACTS{JSON::Object::hash("contacts"sv)};
+constexpr auto HASH_TOS_URI{JSON::Object::hash("tos_uri"sv)};
+constexpr auto HASH_POLICY_URI{JSON::Object::hash("policy_uri"sv)};
+constexpr auto HASH_JWKS_URI{JSON::Object::hash("jwks_uri"sv)};
+constexpr auto HASH_JWKS{JSON::Object::hash("jwks"sv)};
+constexpr auto HASH_SOFTWARE_ID{JSON::Object::hash("software_id"sv)};
+constexpr auto HASH_SOFTWARE_VERSION{JSON::Object::hash("software_version"sv)};
+constexpr auto HASH_SOFTWARE_STATEMENT{
+    JSON::Object::hash("software_statement"sv)};
+constexpr auto HASH_CLIENT_ID{JSON::Object::hash("client_id"sv)};
+constexpr auto HASH_CLIENT_SECRET{JSON::Object::hash("client_secret"sv)};
+constexpr auto HASH_CLIENT_ID_ISSUED_AT{
     JSON::Object::hash("client_id_issued_at"sv)};
-const auto HASH_CLIENT_SECRET_EXPIRES_AT{
+constexpr auto HASH_CLIENT_SECRET_EXPIRES_AT{
     JSON::Object::hash("client_secret_expires_at"sv)};
-const auto HASH_REGISTRATION_ACCESS_TOKEN{
+constexpr auto HASH_REGISTRATION_ACCESS_TOKEN{
     JSON::Object::hash("registration_access_token"sv)};
-const auto HASH_REGISTRATION_CLIENT_URI{
+constexpr auto HASH_REGISTRATION_CLIENT_URI{
     JSON::Object::hash("registration_client_uri"sv)};
-const auto HASH_ERROR{JSON::Object::hash("error"sv)};
-const auto HASH_ERROR_DESCRIPTION{JSON::Object::hash("error_description"sv)};
+constexpr auto HASH_ERROR{JSON::Object::hash("error"sv)};
+constexpr auto HASH_ERROR_DESCRIPTION{
+    JSON::Object::hash("error_description"sv)};
 
 auto array_member_is_present(const JSON &data, const JSON::StringView name,
                              const JSON::Object::hash_type hash) -> bool {

--- a/src/core/oauth/oauth_token.cc
+++ b/src/core/oauth/oauth_token.cc
@@ -20,14 +20,15 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_ACCESS_TOKEN{JSON::Object::hash("access_token"sv)};
-const auto HASH_TOKEN_TYPE{JSON::Object::hash("token_type"sv)};
-const auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
-const auto HASH_REFRESH_TOKEN{JSON::Object::hash("refresh_token"sv)};
-const auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
-const auto HASH_ERROR{JSON::Object::hash("error"sv)};
-const auto HASH_ERROR_DESCRIPTION{JSON::Object::hash("error_description"sv)};
-const auto HASH_ERROR_URI{JSON::Object::hash("error_uri"sv)};
+constexpr auto HASH_ACCESS_TOKEN{JSON::Object::hash("access_token"sv)};
+constexpr auto HASH_TOKEN_TYPE{JSON::Object::hash("token_type"sv)};
+constexpr auto HASH_EXPIRES_IN{JSON::Object::hash("expires_in"sv)};
+constexpr auto HASH_REFRESH_TOKEN{JSON::Object::hash("refresh_token"sv)};
+constexpr auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
+constexpr auto HASH_ERROR{JSON::Object::hash("error"sv)};
+constexpr auto HASH_ERROR_DESCRIPTION{
+    JSON::Object::hash("error_description"sv)};
+constexpr auto HASH_ERROR_URI{JSON::Object::hash("error_uri"sv)};
 
 auto string_member(const JSON &data, const JSON::StringView name,
                    const JSON::Object::hash_type hash)

--- a/src/core/oauth/oauth_token_exchange.cc
+++ b/src/core/oauth/oauth_token_exchange.cc
@@ -16,7 +16,8 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
-const auto HASH_ISSUED_TOKEN_TYPE{JSON::Object::hash("issued_token_type"sv)};
+constexpr auto HASH_ISSUED_TOKEN_TYPE{
+    JSON::Object::hash("issued_token_type"sv)};
 
 auto oauth_append_repeated(SecureString &sink, const std::string_view name,
                            const std::span<const std::string_view> values)

--- a/src/lang/numeric/include/sourcemeta/core/numeric_uint128.h
+++ b/src/lang/numeric/include/sourcemeta/core/numeric_uint128.h
@@ -28,92 +28,103 @@ struct uint128_t {
   /// The upper 64 bits of the value.
   std::uint64_t high;
 
-  uint128_t() noexcept : low{0}, high{0} {}
+  constexpr uint128_t() noexcept : low{0}, high{0} {}
   /// Construct from a signed integer, sign-extending negative values.
-  uint128_t(int value) noexcept
+  constexpr uint128_t(int value) noexcept
       : low{static_cast<std::uint64_t>(value)},
         high{value < 0 ? UINT64_MAX : 0} {}
   /// Construct from an unsigned integer.
-  uint128_t(unsigned int value) noexcept
+  constexpr uint128_t(unsigned int value) noexcept
       : low{static_cast<std::uint64_t>(value)}, high{0} {}
   /// Construct from a 64-bit unsigned integer.
-  uint128_t(std::uint64_t value) noexcept : low{value}, high{0} {}
+  constexpr uint128_t(std::uint64_t value) noexcept : low{value}, high{0} {}
   /// Construct from a 64-bit signed integer, sign-extending negative values.
-  uint128_t(std::int64_t value) noexcept
+  constexpr uint128_t(std::int64_t value) noexcept
       : low{static_cast<std::uint64_t>(value)},
         high{value < 0 ? UINT64_MAX : 0} {}
   /// Construct from separate upper and lower 64-bit halves.
-  uint128_t(std::uint64_t high_part, std::uint64_t low_part) noexcept
+  constexpr uint128_t(std::uint64_t high_part, std::uint64_t low_part) noexcept
       : low{low_part}, high{high_part} {}
 
-  explicit operator std::uint64_t() const noexcept { return this->low; }
-  explicit operator std::int64_t() const noexcept {
+  constexpr explicit operator std::uint64_t() const noexcept {
+    return this->low;
+  }
+  constexpr explicit operator std::int64_t() const noexcept {
     return static_cast<std::int64_t>(this->low);
   }
 
-  explicit operator bool() const noexcept {
+  constexpr explicit operator bool() const noexcept {
     return this->low != 0 || this->high != 0;
   }
 
-  auto operator+=(const uint128_t &other) noexcept -> uint128_t & {
+  constexpr auto operator+=(const uint128_t &other) noexcept -> uint128_t & {
     auto old_low = this->low;
     this->low += other.low;
     this->high += other.high + (this->low < old_low ? 1 : 0);
     return *this;
   }
 
-  auto operator-=(const uint128_t &other) noexcept -> uint128_t & {
+  constexpr auto operator-=(const uint128_t &other) noexcept -> uint128_t & {
     const auto old_low = this->low;
     this->low -= other.low;
     this->high -= other.high + (old_low < other.low ? 1 : 0);
     return *this;
   }
 
-  auto operator*=(const uint128_t &other) noexcept -> uint128_t & {
+  constexpr auto operator*=(const uint128_t &other) noexcept -> uint128_t & {
     *this = *this * other;
     return *this;
   }
 
-  auto operator%=(const uint128_t &other) noexcept -> uint128_t & {
+  constexpr auto operator%=(const uint128_t &other) noexcept -> uint128_t & {
     *this = *this % other;
     return *this;
   }
 
-  friend auto operator+(uint128_t left, const uint128_t &right) noexcept
+  friend constexpr auto operator+(uint128_t left,
+                                  const uint128_t &right) noexcept
       -> uint128_t {
     left += right;
     return left;
   }
 
-  friend auto operator-(uint128_t left, const uint128_t &right) noexcept
+  friend constexpr auto operator-(uint128_t left,
+                                  const uint128_t &right) noexcept
       -> uint128_t {
     left -= right;
     return left;
   }
 
-  friend auto operator*(const uint128_t &left, const uint128_t &right) noexcept
+  friend constexpr auto operator*(const uint128_t &left,
+                                  const uint128_t &right) noexcept
       -> uint128_t {
     std::uint64_t result_high;
+    std::uint64_t result_low;
+    // The intrinsic is not usable during constant evaluation, so fall through
+    // to the portable computation, which yields the same value
 #if defined(_MSC_VER)
-    auto result_low = _umul128(left.low, right.low, &result_high);
-#else
-    const std::uint64_t left_low{left.low & 0xFFFFFFFF};
-    const std::uint64_t left_high{left.low >> 32};
-    const std::uint64_t right_low{right.low & 0xFFFFFFFF};
-    const std::uint64_t right_high{right.low >> 32};
-    const std::uint64_t cross_1{left_high * right_low};
-    const std::uint64_t cross_2{left_low * right_high};
-    const std::uint64_t mid{cross_1 + (left_low * right_low >> 32)};
-    const std::uint64_t mid_2{(mid & 0xFFFFFFFF) + cross_2};
-    result_high = left_high * right_high + (mid >> 32) + (mid_2 >> 32);
-    auto result_low = (mid_2 << 32) | ((left_low * right_low) & 0xFFFFFFFF);
+    if !consteval {
+      result_low = _umul128(left.low, right.low, &result_high);
+    } else
 #endif
+    {
+      const std::uint64_t left_low{left.low & 0xFFFFFFFF};
+      const std::uint64_t left_high{left.low >> 32};
+      const std::uint64_t right_low{right.low & 0xFFFFFFFF};
+      const std::uint64_t right_high{right.low >> 32};
+      const std::uint64_t cross_1{left_high * right_low};
+      const std::uint64_t cross_2{left_low * right_high};
+      const std::uint64_t mid{cross_1 + (left_low * right_low >> 32)};
+      const std::uint64_t mid_2{(mid & 0xFFFFFFFF) + cross_2};
+      result_high = left_high * right_high + (mid >> 32) + (mid_2 >> 32);
+      result_low = (mid_2 << 32) | ((left_low * right_low) & 0xFFFFFFFF);
+    }
     result_high += left.low * right.high + left.high * right.low;
     return {result_high, result_low};
   }
 
-  friend auto operator/(const uint128_t &dividend,
-                        std::uint64_t divisor) noexcept -> uint128_t {
+  friend constexpr auto operator/(const uint128_t &dividend,
+                                  std::uint64_t divisor) noexcept -> uint128_t {
     if (dividend.high == 0) {
       return {0, dividend.low / divisor};
     }
@@ -121,37 +132,44 @@ struct uint128_t {
     auto quotient_high = dividend.high / divisor;
     auto remainder_high = dividend.high % divisor;
     std::uint64_t quotient_low;
-    std::uint64_t remainder;
     // The high half of the partial dividend must stay below the divisor, or the
     // hardware 128-by-64 division would overflow its 64-bit quotient. The
     // remainder of the earlier division guarantees this
     assert(remainder_high < divisor);
+    // The intrinsic is not usable during constant evaluation, so fall through
+    // to the portable computation, which yields the same value
 #if defined(_MSC_VER)
-    quotient_low = _udiv128(remainder_high, dividend.low, divisor, &remainder);
-#else
-    quotient_low = 0;
-    auto current_remainder = remainder_high;
-    for (int bit = 63; bit >= 0; --bit) {
-      const auto carry = current_remainder >> 63;
-      current_remainder =
-          (current_remainder << 1) | ((dividend.low >> bit) & 1);
-      if (carry || current_remainder >= divisor) {
-        current_remainder -= divisor;
-        quotient_low |= static_cast<std::uint64_t>(1) << bit;
+    if !consteval {
+      std::uint64_t remainder;
+      quotient_low =
+          _udiv128(remainder_high, dividend.low, divisor, &remainder);
+    } else
+#endif
+    {
+      quotient_low = 0;
+      auto current_remainder = remainder_high;
+      for (int bit = 63; bit >= 0; --bit) {
+        const auto carry = current_remainder >> 63;
+        current_remainder =
+            (current_remainder << 1) | ((dividend.low >> bit) & 1);
+        if (carry || current_remainder >= divisor) {
+          current_remainder -= divisor;
+          quotient_low |= static_cast<std::uint64_t>(1) << bit;
+        }
       }
     }
-#endif
     return {quotient_high, quotient_low};
   }
 
-  friend auto operator/(const uint128_t &dividend,
-                        const uint128_t &divisor) noexcept -> uint128_t {
+  friend constexpr auto operator/(const uint128_t &dividend,
+                                  const uint128_t &divisor) noexcept
+      -> uint128_t {
     assert(divisor.high == 0);
     return dividend / divisor.low;
   }
 
-  friend auto operator%(const uint128_t &dividend,
-                        std::uint64_t divisor) noexcept -> uint128_t {
+  friend constexpr auto operator%(const uint128_t &dividend,
+                                  std::uint64_t divisor) noexcept -> uint128_t {
     if (dividend.high == 0) {
       return {0, dividend.low % divisor};
     }
@@ -162,59 +180,65 @@ struct uint128_t {
     // hardware 128-by-64 division would overflow its 64-bit quotient. The
     // remainder of the earlier division guarantees this
     assert(remainder_high < divisor);
+    // The intrinsic is not usable during constant evaluation, so fall through
+    // to the portable computation, which yields the same value
 #if defined(_MSC_VER)
-    _udiv128(remainder_high, dividend.low, divisor, &remainder);
-#else
-    remainder = remainder_high;
-    for (int bit = 63; bit >= 0; --bit) {
-      const auto carry = remainder >> 63;
-      remainder = (remainder << 1) | ((dividend.low >> bit) & 1);
-      if (carry || remainder >= divisor) {
-        remainder -= divisor;
+    if !consteval {
+      _udiv128(remainder_high, dividend.low, divisor, &remainder);
+    } else
+#endif
+    {
+      remainder = remainder_high;
+      for (int bit = 63; bit >= 0; --bit) {
+        const auto carry = remainder >> 63;
+        remainder = (remainder << 1) | ((dividend.low >> bit) & 1);
+        if (carry || remainder >= divisor) {
+          remainder -= divisor;
+        }
       }
     }
-#endif
     return {0, remainder};
   }
 
-  friend auto operator%(const uint128_t &dividend,
-                        const uint128_t &divisor) noexcept -> uint128_t {
+  friend constexpr auto operator%(const uint128_t &dividend,
+                                  const uint128_t &divisor) noexcept
+      -> uint128_t {
     assert(divisor.high == 0);
     return dividend % divisor.low;
   }
 
-  friend auto operator<(const uint128_t &left, const uint128_t &right) noexcept
-      -> bool {
+  friend constexpr auto operator<(const uint128_t &left,
+                                  const uint128_t &right) noexcept -> bool {
     return left.high < right.high ||
            (left.high == right.high && left.low < right.low);
   }
 
-  friend auto operator>(const uint128_t &left, const uint128_t &right) noexcept
-      -> bool {
+  friend constexpr auto operator>(const uint128_t &left,
+                                  const uint128_t &right) noexcept -> bool {
     return right < left;
   }
 
-  friend auto operator<=(const uint128_t &left, const uint128_t &right) noexcept
-      -> bool {
+  friend constexpr auto operator<=(const uint128_t &left,
+                                   const uint128_t &right) noexcept -> bool {
     return !(right < left);
   }
 
-  friend auto operator>=(const uint128_t &left, const uint128_t &right) noexcept
-      -> bool {
+  friend constexpr auto operator>=(const uint128_t &left,
+                                   const uint128_t &right) noexcept -> bool {
     return !(left < right);
   }
 
-  friend auto operator==(const uint128_t &left, const uint128_t &right) noexcept
-      -> bool {
+  friend constexpr auto operator==(const uint128_t &left,
+                                   const uint128_t &right) noexcept -> bool {
     return left.high == right.high && left.low == right.low;
   }
 
-  friend auto operator!=(const uint128_t &left, const uint128_t &right) noexcept
-      -> bool {
+  friend constexpr auto operator!=(const uint128_t &left,
+                                   const uint128_t &right) noexcept -> bool {
     return !(left == right);
   }
 
-  friend auto operator<<(const uint128_t &value, int shift) noexcept
+  friend constexpr auto operator<<(const uint128_t &value, int shift) noexcept
       -> uint128_t {
     if (shift == 0) {
       return value;
@@ -228,7 +252,7 @@ struct uint128_t {
     }
   }
 
-  friend auto operator>>(const uint128_t &value, int shift) noexcept
+  friend constexpr auto operator>>(const uint128_t &value, int shift) noexcept
       -> uint128_t {
     if (shift == 0) {
       return value;
@@ -242,18 +266,20 @@ struct uint128_t {
     }
   }
 
-  friend auto operator|(const uint128_t &left, const uint128_t &right) noexcept
+  friend constexpr auto operator|(const uint128_t &left,
+                                  const uint128_t &right) noexcept
       -> uint128_t {
     return {left.high | right.high, left.low | right.low};
   }
 
-  auto operator|=(const uint128_t &other) noexcept -> uint128_t & {
+  constexpr auto operator|=(const uint128_t &other) noexcept -> uint128_t & {
     this->high |= other.high;
     this->low |= other.low;
     return *this;
   }
 
-  friend auto operator&(const uint128_t &left, const uint128_t &right) noexcept
+  friend constexpr auto operator&(const uint128_t &left,
+                                  const uint128_t &right) noexcept
       -> uint128_t {
     return {left.high & right.high, left.low & right.low};
   }

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -1614,3 +1614,28 @@ TEST(assign_if_nonempty_array_computes_hash) {
   document.assign_if_nonempty("foo", values);
   EXPECT_EQ(document.at("foo").size(), 1);
 }
+
+TEST(hash_is_a_constant_expression_matching_runtime) {
+  static constexpr auto compile_time{
+      sourcemeta::core::JSON::Object::hash(std::string_view{"foobar"})};
+  const auto run_time{
+      sourcemeta::core::JSON::Object::hash(std::string_view{"foobar"})};
+  EXPECT_TRUE(compile_time == run_time);
+}
+
+TEST(constexpr_hash_finds_an_object_member) {
+  static constexpr auto key_hash{
+      sourcemeta::core::JSON::Object::hash(std::string_view{"foo"})};
+  const auto document{sourcemeta::core::parse_json(R"JSON({ "foo": 1 })JSON")};
+  const auto *value{document.try_at(std::string_view{"foo"}, key_hash)};
+  EXPECT_TRUE(value != nullptr);
+  EXPECT_EQ(value->to_integer(), 1);
+}
+
+TEST(constexpr_hash_matches_runtime_for_a_long_key) {
+  static constexpr std::string_view key{
+      "a_property_name_that_is_definitely_longer_than_thirty_one_bytes"};
+  static constexpr auto compile_time{sourcemeta::core::JSON::Object::hash(key)};
+  const auto run_time{sourcemeta::core::JSON::Object::hash(key)};
+  EXPECT_TRUE(compile_time == run_time);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

