### PR TITLE
Add AES-GCM encryption with associated data over all key sizes

### DIFF
--- a/src/core/crypto/crypto_aes.h
+++ b/src/core/crypto/crypto_aes.h
@@ -1,29 +1,31 @@
 #ifndef SOURCEMETA_CORE_CRYPTO_AES_H_
 #define SOURCEMETA_CORE_CRYPTO_AES_H_
 
+#include <sourcemeta/core/crypto_aes_gcm.h>
+
 #include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
 namespace sourcemeta::core {
 
-// The raw AES-256 Galois/Counter Mode primitive (NIST SP 800-38D) with a 96-bit
-// nonce, no associated data, and a 128-bit tag, defined once per backend. The
-// framing that adds the nonce and length checks lives in the shared seal and
-// unseal functions, so these assume a 32-byte key and a 12-byte nonce
+// The raw AES Galois/Counter Mode primitive (NIST SP 800-38D), defined once per
+// backend, over a 128, 192, or 256-bit key, a 96-bit initialization vector, and
+// associated data that is authenticated but not encrypted. The length checks
+// live in the shared encrypt and decrypt functions, so these assume a 16, 24,
+// or 32-byte key, a 12-byte initialization vector, and a 16-byte tag
 
-// Encrypt the plaintext, returning the ciphertext followed by the 16-byte
-// authentication tag
-auto aes_256_gcm_encrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view plaintext)
-    -> std::optional<std::string>;
+// Encrypt the plaintext, returning the ciphertext and its 16-byte tag
+auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext>;
 
-// Decrypt the ciphertext, which is followed by its 16-byte tag, verifying the
-// tag before returning the plaintext and rejecting a mismatch
-auto aes_256_gcm_decrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view ciphertext)
+// Decrypt the ciphertext, verifying the tag before returning the plaintext and
+// rejecting a mismatch
+auto aes_gcm_open(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view ciphertext, const std::string_view tag)
     -> std::optional<std::string>;
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_aes_apple.h
+++ b/src/core/crypto/crypto_aes_apple.h
@@ -3,22 +3,24 @@
 
 #include <cstddef> // std::size_t
 
-// Seal a plaintext with AES-256 in Galois/Counter Mode through CryptoKit,
-// writing the ciphertext followed by the 16-byte tag into the output buffer,
-// which the caller sizes to the plaintext length plus 16. Returns false when
-// the key or nonce is not a valid length
-extern "C" auto sourcemeta_core_aes_256_gcm_seal_cryptokit(
+// Seal a plaintext with AES in Galois/Counter Mode through CryptoKit, writing
+// the ciphertext (the plaintext length) and its 16-byte tag into the two output
+// buffers. Returns false when the key, nonce, or a buffer is invalid
+extern "C" auto sourcemeta_core_aes_gcm_seal_cryptokit(
     const unsigned char *key, std::size_t key_size, const unsigned char *nonce,
     std::size_t nonce_size, const unsigned char *plaintext,
-    std::size_t plaintext_size, unsigned char *output) -> bool;
+    std::size_t plaintext_size, const unsigned char *associated_data,
+    std::size_t associated_data_size, unsigned char *ciphertext_output,
+    unsigned char *tag_output) -> bool;
 
 // Open a message sealed with the function above, writing the plaintext into the
 // output buffer, which the caller sizes to the ciphertext length. Returns false
 // when the tag does not verify or the input is malformed
-extern "C" auto sourcemeta_core_aes_256_gcm_open_cryptokit(
+extern "C" auto sourcemeta_core_aes_gcm_open_cryptokit(
     const unsigned char *key, std::size_t key_size, const unsigned char *nonce,
     std::size_t nonce_size, const unsigned char *ciphertext,
     std::size_t ciphertext_size, const unsigned char *tag, std::size_t tag_size,
+    const unsigned char *associated_data, std::size_t associated_data_size,
     unsigned char *output) -> bool;
 
 #endif

--- a/src/core/crypto/crypto_aes_block.h
+++ b/src/core/crypto/crypto_aes_block.h
@@ -3,9 +3,9 @@
 
 // The AES block cipher (FIPS 197) for the reference backend, shared by the
 // modes of operation built on top of it. This is not constant-time, which is
-// acceptable only because this backend is the non-production fallback. Only the
-// 256-bit key schedule and the forward cipher are provided here, the other key
-// sizes and the inverse cipher are added by the modes that need them
+// acceptable only because this backend is the non-production fallback. The
+// forward cipher over 128, 192, and 256-bit keys is provided here, the inverse
+// cipher is added by the modes that need it
 
 #include <array>       // std::array
 #include <cassert>     // assert
@@ -41,7 +41,16 @@ inline constexpr std::array<std::uint8_t, 256> aes_substitution{
      0xb0, 0x54, 0xbb, 0x16}};
 
 using AesBlock = std::array<std::uint8_t, 16>;
+// The expanded key material fits the largest schedule, the 256-bit key over 14
+// rounds (FIPS 197 Section 5.2)
 using AesRoundKeys = std::array<std::uint8_t, 240>;
+
+// A key schedule together with its round count, since AES-128, AES-192, and
+// AES-256 run 10, 12, and 14 rounds respectively (FIPS 197 Section 5.1)
+struct AesKeySchedule {
+  AesRoundKeys round_keys;
+  std::size_t rounds;
+};
 
 // Multiply by two in GF(2^8) with the AES reduction polynomial (FIPS 197
 // Section 4.2)
@@ -65,28 +74,35 @@ inline auto aes_field_multiply(const std::uint8_t left,
   return product;
 }
 
-// AES-256 key expansion (FIPS 197 Section 5.2, with the 256-bit key schedule)
-inline auto aes_expand_key(const std::string_view key) -> AesRoundKeys {
-  assert(key.size() == 32);
-  AesRoundKeys round_keys{};
-  for (std::size_t index = 0; index < 32; ++index) {
+// AES key expansion (FIPS 197 Section 5.2) over a 128, 192, or 256-bit key
+inline auto aes_expand_key(const std::string_view key) -> AesKeySchedule {
+  assert(key.size() == 16 || key.size() == 24 || key.size() == 32);
+  // The number of 32-bit words in the key, four, six, or eight (FIPS 197 Table
+  // 4), and the round count it yields
+  const auto key_words{key.size() / 4};
+  const auto rounds{key_words + 6};
+  AesKeySchedule schedule{.round_keys = {}, .rounds = rounds};
+  auto &round_keys{schedule.round_keys};
+  for (std::size_t index = 0; index < key.size(); ++index) {
     round_keys[index] = static_cast<std::uint8_t>(key[index]);
   }
 
+  const auto expanded_bytes{16 * (rounds + 1)};
   std::uint8_t round_constant{0x01};
-  for (std::size_t index = 32; index < round_keys.size(); index += 4) {
+  for (std::size_t index = key.size(); index < expanded_bytes; index += 4) {
     std::array<std::uint8_t, 4> word{
         {round_keys[index - 4], round_keys[index - 3], round_keys[index - 2],
          round_keys[index - 1]}};
     const auto position{index / 4};
-    if (position % 8 == 0) {
+    if (position % key_words == 0) {
       const auto first{word[0]};
       word[0] = aes_substitution[word[1]] ^ round_constant;
       word[1] = aes_substitution[word[2]];
       word[2] = aes_substitution[word[3]];
       word[3] = aes_substitution[first];
       round_constant = aes_xtime(round_constant);
-    } else if (position % 8 == 4) {
+    } else if (key_words > 6 && position % key_words == 4) {
+      // The extra substitution mid-schedule applies only to the 256-bit key
       for (auto &byte : word) {
         byte = aes_substitution[byte];
       }
@@ -94,15 +110,16 @@ inline auto aes_expand_key(const std::string_view key) -> AesRoundKeys {
 
     for (std::size_t offset = 0; offset < 4; ++offset) {
       round_keys[index + offset] =
-          round_keys[index - 32 + offset] ^ word[offset];
+          round_keys[index - key.size() + offset] ^ word[offset];
     }
   }
 
-  return round_keys;
+  return schedule;
 }
 
-inline auto aes_encrypt_block(const AesRoundKeys &round_keys, AesBlock state)
+inline auto aes_encrypt_block(const AesKeySchedule &schedule, AesBlock state)
     -> AesBlock {
+  const auto &round_keys{schedule.round_keys};
   const auto add_round_key{[&round_keys, &state](const std::size_t round) {
     for (std::size_t index = 0; index < 16; ++index) {
       state[index] ^= round_keys[(round * 16) + index];
@@ -110,7 +127,7 @@ inline auto aes_encrypt_block(const AesRoundKeys &round_keys, AesBlock state)
   }};
 
   add_round_key(0);
-  for (std::size_t round = 1; round <= 14; ++round) {
+  for (std::size_t round = 1; round <= schedule.rounds; ++round) {
     for (auto &byte : state) {
       byte = aes_substitution[byte];
     }
@@ -122,7 +139,7 @@ inline auto aes_encrypt_block(const AesRoundKeys &round_keys, AesBlock state)
                             state[11]}};
     state = shifted;
 
-    if (round != 14) {
+    if (round != schedule.rounds) {
       // MixColumns (FIPS 197 Section 5.1.3)
       for (std::size_t column = 0; column < 4; ++column) {
         const auto base{column * 4};

--- a/src/core/crypto/crypto_aes_gcm.cc
+++ b/src/core/crypto/crypto_aes_gcm.cc
@@ -15,52 +15,85 @@
 namespace sourcemeta::core {
 
 namespace {
-// A 256-bit key, a 96-bit nonce, and a 128-bit tag (NIST SP 800-38D)
-constexpr std::size_t KEY_BYTES{32};
-constexpr std::size_t NONCE_BYTES{12};
+// A 96-bit initialization vector and a 128-bit tag (NIST SP 800-38D)
+constexpr std::size_t IV_BYTES{12};
 constexpr std::size_t TAG_BYTES{16};
+// A 256-bit key, the only size the self-contained seal accepts
+constexpr std::size_t SEAL_KEY_BYTES{32};
 // An upper bound the backends can all process without narrowing their lengths
 constexpr std::size_t MAX_INPUT_BYTES{
     static_cast<std::size_t>(std::numeric_limits<int>::max())};
+
+auto is_valid_key_size(const std::size_t size) -> bool {
+  return size == 16 || size == 24 || size == 32;
+}
 } // namespace
+
+auto aes_gcm_encrypt(const std::string_view key, const std::string_view iv,
+                     const std::string_view associated_data,
+                     const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext> {
+  if (!is_valid_key_size(key.size()) || iv.size() != IV_BYTES ||
+      plaintext.size() > MAX_INPUT_BYTES ||
+      associated_data.size() > MAX_INPUT_BYTES) {
+    return std::nullopt;
+  }
+
+  return aes_gcm_seal(key, iv, associated_data, plaintext);
+}
+
+auto aes_gcm_decrypt(const std::string_view key, const std::string_view iv,
+                     const std::string_view associated_data,
+                     const std::string_view ciphertext,
+                     const std::string_view tag) -> std::optional<std::string> {
+  if (!is_valid_key_size(key.size()) || iv.size() != IV_BYTES ||
+      tag.size() != TAG_BYTES || ciphertext.size() > MAX_INPUT_BYTES ||
+      associated_data.size() > MAX_INPUT_BYTES) {
+    return std::nullopt;
+  }
+
+  return aes_gcm_open(key, iv, associated_data, ciphertext, tag);
+}
 
 auto aes_256_gcm_seal(const std::string_view key,
                       const std::string_view plaintext)
     -> std::optional<std::string> {
-  if (key.size() != KEY_BYTES || plaintext.size() > MAX_INPUT_BYTES) {
+  if (key.size() != SEAL_KEY_BYTES) {
     return std::nullopt;
   }
 
-  std::string nonce(NONCE_BYTES, '\x00');
+  std::string nonce(IV_BYTES, '\x00');
   try {
     fill_random_bytes(std::span<std::uint8_t>{
-        reinterpret_cast<std::uint8_t *>(nonce.data()), NONCE_BYTES});
+        reinterpret_cast<std::uint8_t *>(nonce.data()), IV_BYTES});
   } catch (const std::exception &) {
     return std::nullopt;
   }
 
-  const auto ciphertext{aes_256_gcm_encrypt(key, nonce, plaintext)};
-  if (!ciphertext.has_value()) {
+  const auto result{aes_gcm_encrypt(key, nonce, "", plaintext)};
+  if (!result.has_value()) {
     return std::nullopt;
   }
 
   // The sealed message is the nonce followed by the ciphertext and its tag
   std::string sealed{std::move(nonce)};
-  sealed.append(ciphertext.value());
+  sealed.append(result.value().ciphertext);
+  sealed.append(result.value().tag);
   return sealed;
 }
 
 auto aes_256_gcm_unseal(const std::string_view key,
                         const std::string_view sealed)
     -> std::optional<std::string> {
-  if (key.size() != KEY_BYTES || sealed.size() < NONCE_BYTES + TAG_BYTES ||
-      sealed.size() - NONCE_BYTES - TAG_BYTES > MAX_INPUT_BYTES) {
+  if (key.size() != SEAL_KEY_BYTES || sealed.size() < IV_BYTES + TAG_BYTES) {
     return std::nullopt;
   }
 
-  const auto nonce{sealed.substr(0, NONCE_BYTES)};
-  const auto ciphertext{sealed.substr(NONCE_BYTES)};
-  return aes_256_gcm_decrypt(key, nonce, ciphertext);
+  const auto nonce{sealed.substr(0, IV_BYTES)};
+  const auto ciphertext{
+      sealed.substr(IV_BYTES, sealed.size() - IV_BYTES - TAG_BYTES)};
+  const auto tag{sealed.substr(sealed.size() - TAG_BYTES)};
+  return aes_gcm_decrypt(key, nonce, "", ciphertext, tag);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_aes_gcm.cc
+++ b/src/core/crypto/crypto_aes_gcm.cc
@@ -77,8 +77,7 @@ auto aes_256_gcm_seal(const std::string_view key,
 
   // The sealed message is the nonce followed by the ciphertext and its tag
   std::string sealed{std::move(nonce)};
-  sealed.append(result.value().ciphertext);
-  sealed.append(result.value().tag);
+  sealed.append(result.value().data);
   return sealed;
 }
 

--- a/src/core/crypto/crypto_aes_gcm_apple.cc
+++ b/src/core/crypto/crypto_aes_gcm_apple.cc
@@ -13,39 +13,41 @@ constexpr std::size_t TAG_BYTES{16};
 
 namespace sourcemeta::core {
 
-auto aes_256_gcm_encrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view plaintext)
-    -> std::optional<std::string> {
-  std::string output(plaintext.size() + TAG_BYTES, '\x00');
-  if (!sourcemeta_core_aes_256_gcm_seal_cryptokit(
+auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext> {
+  AESGCMCiphertext result{.ciphertext = std::string(plaintext.size(), '\x00'),
+                          .tag = std::string(TAG_BYTES, '\x00')};
+  if (!sourcemeta_core_aes_gcm_seal_cryptokit(
           reinterpret_cast<const unsigned char *>(key.data()), key.size(),
-          reinterpret_cast<const unsigned char *>(nonce.data()), nonce.size(),
+          reinterpret_cast<const unsigned char *>(iv.data()), iv.size(),
           reinterpret_cast<const unsigned char *>(plaintext.data()),
-          plaintext.size(), reinterpret_cast<unsigned char *>(output.data()))) {
+          plaintext.size(),
+          reinterpret_cast<const unsigned char *>(associated_data.data()),
+          associated_data.size(),
+          reinterpret_cast<unsigned char *>(result.ciphertext.data()),
+          reinterpret_cast<unsigned char *>(result.tag.data()))) {
     return std::nullopt;
   }
 
-  return output;
+  return result;
 }
 
-auto aes_256_gcm_decrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view ciphertext)
+auto aes_gcm_open(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view ciphertext, const std::string_view tag)
     -> std::optional<std::string> {
-  if (ciphertext.size() < TAG_BYTES) {
-    return std::nullopt;
-  }
-
-  const auto message{ciphertext.substr(0, ciphertext.size() - TAG_BYTES)};
-  const auto tag{ciphertext.substr(ciphertext.size() - TAG_BYTES)};
-  std::string output(message.size(), '\x00');
-  if (!sourcemeta_core_aes_256_gcm_open_cryptokit(
+  std::string output(ciphertext.size(), '\x00');
+  if (!sourcemeta_core_aes_gcm_open_cryptokit(
           reinterpret_cast<const unsigned char *>(key.data()), key.size(),
-          reinterpret_cast<const unsigned char *>(nonce.data()), nonce.size(),
-          reinterpret_cast<const unsigned char *>(message.data()),
-          message.size(), reinterpret_cast<const unsigned char *>(tag.data()),
-          tag.size(), reinterpret_cast<unsigned char *>(output.data()))) {
+          reinterpret_cast<const unsigned char *>(iv.data()), iv.size(),
+          reinterpret_cast<const unsigned char *>(ciphertext.data()),
+          ciphertext.size(),
+          reinterpret_cast<const unsigned char *>(tag.data()), tag.size(),
+          reinterpret_cast<const unsigned char *>(associated_data.data()),
+          associated_data.size(),
+          reinterpret_cast<unsigned char *>(output.data()))) {
     return std::nullopt;
   }
 

--- a/src/core/crypto/crypto_aes_gcm_apple.cc
+++ b/src/core/crypto/crypto_aes_gcm_apple.cc
@@ -17,17 +17,18 @@ auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
                   const std::string_view associated_data,
                   const std::string_view plaintext)
     -> std::optional<AESGCMCiphertext> {
-  AESGCMCiphertext result{.ciphertext = std::string(plaintext.size(), '\x00'),
-                          .tag = std::string(TAG_BYTES, '\x00')};
+  // A single buffer holds the ciphertext followed by its 16-byte tag, which the
+  // shim writes into through the two output pointers
+  AESGCMCiphertext result{
+      .data = std::string(plaintext.size() + TAG_BYTES, '\x00')};
+  auto *const output{reinterpret_cast<unsigned char *>(result.data.data())};
   if (!sourcemeta_core_aes_gcm_seal_cryptokit(
           reinterpret_cast<const unsigned char *>(key.data()), key.size(),
           reinterpret_cast<const unsigned char *>(iv.data()), iv.size(),
           reinterpret_cast<const unsigned char *>(plaintext.data()),
           plaintext.size(),
           reinterpret_cast<const unsigned char *>(associated_data.data()),
-          associated_data.size(),
-          reinterpret_cast<unsigned char *>(result.ciphertext.data()),
-          reinterpret_cast<unsigned char *>(result.tag.data()))) {
+          associated_data.size(), output, output + plaintext.size())) {
     return std::nullopt;
   }
 

--- a/src/core/crypto/crypto_aes_gcm_openssl.cc
+++ b/src/core/crypto/crypto_aes_gcm_openssl.cc
@@ -39,8 +39,9 @@ auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
   }
 
   std::optional<AESGCMCiphertext> result;
-  std::string ciphertext(plaintext.size(), '\x00');
-  std::string tag(TAG_BYTES, '\x00');
+  // A single buffer holds the ciphertext followed by its 16-byte tag
+  std::string data(plaintext.size() + TAG_BYTES, '\x00');
+  auto *const output{reinterpret_cast<unsigned char *>(data.data())};
   int length{0};
   int final_length{0};
   int associated_length{0};
@@ -58,18 +59,14 @@ auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
            static_cast<int>(associated_data.size())) == 1) &&
       (plaintext.empty() ||
        EVP_EncryptUpdate(
-           context, reinterpret_cast<unsigned char *>(ciphertext.data()),
-           &length, reinterpret_cast<const unsigned char *>(plaintext.data()),
+           context, output, &length,
+           reinterpret_cast<const unsigned char *>(plaintext.data()),
            static_cast<int>(plaintext.size())) == 1) &&
-      EVP_EncryptFinal_ex(context,
-                          reinterpret_cast<unsigned char *>(ciphertext.data()) +
-                              length,
-                          &final_length) == 1 &&
+      EVP_EncryptFinal_ex(context, output + length, &final_length) == 1 &&
       EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_GET_TAG,
                           static_cast<int>(TAG_BYTES),
-                          reinterpret_cast<unsigned char *>(tag.data())) == 1) {
-    result = AESGCMCiphertext{.ciphertext = std::move(ciphertext),
-                              .tag = std::move(tag)};
+                          output + plaintext.size()) == 1) {
+    result = AESGCMCiphertext{.data = std::move(data)};
   }
 
   EVP_CIPHER_CTX_free(context);

--- a/src/core/crypto/crypto_aes_gcm_openssl.cc
+++ b/src/core/crypto/crypto_aes_gcm_openssl.cc
@@ -10,32 +10,52 @@
 
 namespace {
 constexpr std::size_t TAG_BYTES{16};
+
+auto cipher_for_key(const std::size_t key_size) -> const EVP_CIPHER * {
+  switch (key_size) {
+    case 16:
+      return EVP_aes_128_gcm();
+    case 24:
+      return EVP_aes_192_gcm();
+    case 32:
+      return EVP_aes_256_gcm();
+    default:
+      return nullptr;
+  }
+}
 } // namespace
 
 namespace sourcemeta::core {
 
-auto aes_256_gcm_encrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view plaintext)
-    -> std::optional<std::string> {
+auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext> {
+  const auto *const cipher{cipher_for_key(key.size())};
   auto *context{EVP_CIPHER_CTX_new()};
-  if (context == nullptr) {
+  if (cipher == nullptr || context == nullptr) {
+    EVP_CIPHER_CTX_free(context);
     return std::nullopt;
   }
 
-  std::optional<std::string> result;
+  std::optional<AESGCMCiphertext> result;
   std::string ciphertext(plaintext.size(), '\x00');
   std::string tag(TAG_BYTES, '\x00');
   int length{0};
   int final_length{0};
-  if (EVP_EncryptInit_ex(context, EVP_aes_256_gcm(), nullptr, nullptr,
-                         nullptr) == 1 &&
+  int associated_length{0};
+  if (EVP_EncryptInit_ex(context, cipher, nullptr, nullptr, nullptr) == 1 &&
       EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN,
-                          static_cast<int>(nonce.size()), nullptr) == 1 &&
-      EVP_EncryptInit_ex(
-          context, nullptr, nullptr,
-          reinterpret_cast<const unsigned char *>(key.data()),
-          reinterpret_cast<const unsigned char *>(nonce.data())) == 1 &&
+                          static_cast<int>(iv.size()), nullptr) == 1 &&
+      EVP_EncryptInit_ex(context, nullptr, nullptr,
+                         reinterpret_cast<const unsigned char *>(key.data()),
+                         reinterpret_cast<const unsigned char *>(iv.data())) ==
+          1 &&
+      (associated_data.empty() ||
+       EVP_EncryptUpdate(
+           context, nullptr, &associated_length,
+           reinterpret_cast<const unsigned char *>(associated_data.data()),
+           static_cast<int>(associated_data.size())) == 1) &&
       (plaintext.empty() ||
        EVP_EncryptUpdate(
            context, reinterpret_cast<unsigned char *>(ciphertext.data()),
@@ -48,46 +68,47 @@ auto aes_256_gcm_encrypt(const std::string_view key,
       EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_GET_TAG,
                           static_cast<int>(TAG_BYTES),
                           reinterpret_cast<unsigned char *>(tag.data())) == 1) {
-    ciphertext.append(tag);
-    result = std::move(ciphertext);
+    result = AESGCMCiphertext{.ciphertext = std::move(ciphertext),
+                              .tag = std::move(tag)};
   }
 
   EVP_CIPHER_CTX_free(context);
   return result;
 }
 
-auto aes_256_gcm_decrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view ciphertext)
+auto aes_gcm_open(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view ciphertext, const std::string_view tag)
     -> std::optional<std::string> {
-  if (ciphertext.size() < TAG_BYTES) {
-    return std::nullopt;
-  }
-
-  const auto message{ciphertext.substr(0, ciphertext.size() - TAG_BYTES)};
-  const auto tag{ciphertext.substr(ciphertext.size() - TAG_BYTES)};
+  const auto *const cipher{cipher_for_key(key.size())};
   auto *context{EVP_CIPHER_CTX_new()};
-  if (context == nullptr) {
+  if (cipher == nullptr || context == nullptr) {
+    EVP_CIPHER_CTX_free(context);
     return std::nullopt;
   }
 
   std::optional<std::string> result;
-  std::string plaintext(message.size(), '\x00');
+  std::string plaintext(ciphertext.size(), '\x00');
   int length{0};
   int final_length{0};
-  if (EVP_DecryptInit_ex(context, EVP_aes_256_gcm(), nullptr, nullptr,
-                         nullptr) == 1 &&
+  int associated_length{0};
+  if (EVP_DecryptInit_ex(context, cipher, nullptr, nullptr, nullptr) == 1 &&
       EVP_CIPHER_CTX_ctrl(context, EVP_CTRL_GCM_SET_IVLEN,
-                          static_cast<int>(nonce.size()), nullptr) == 1 &&
-      EVP_DecryptInit_ex(
-          context, nullptr, nullptr,
-          reinterpret_cast<const unsigned char *>(key.data()),
-          reinterpret_cast<const unsigned char *>(nonce.data())) == 1 &&
-      (message.empty() ||
+                          static_cast<int>(iv.size()), nullptr) == 1 &&
+      EVP_DecryptInit_ex(context, nullptr, nullptr,
+                         reinterpret_cast<const unsigned char *>(key.data()),
+                         reinterpret_cast<const unsigned char *>(iv.data())) ==
+          1 &&
+      (associated_data.empty() ||
+       EVP_DecryptUpdate(
+           context, nullptr, &associated_length,
+           reinterpret_cast<const unsigned char *>(associated_data.data()),
+           static_cast<int>(associated_data.size())) == 1) &&
+      (ciphertext.empty() ||
        EVP_DecryptUpdate(
            context, reinterpret_cast<unsigned char *>(plaintext.data()),
-           &length, reinterpret_cast<const unsigned char *>(message.data()),
-           static_cast<int>(message.size())) == 1) &&
+           &length, reinterpret_cast<const unsigned char *>(ciphertext.data()),
+           static_cast<int>(ciphertext.size())) == 1) &&
       EVP_CIPHER_CTX_ctrl(
           context, EVP_CTRL_GCM_SET_TAG, static_cast<int>(TAG_BYTES),
           const_cast<unsigned char *>(

--- a/src/core/crypto/crypto_aes_gcm_other.cc
+++ b/src/core/crypto/crypto_aes_gcm_other.cc
@@ -150,10 +150,10 @@ auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
                   const std::string_view plaintext)
     -> std::optional<AESGCMCiphertext> {
   const auto context{make_context(key, iv)};
-  AESGCMCiphertext result{.ciphertext = counter_mode(context, plaintext),
-                          .tag = {}};
-  const auto tag{compute_tag(context, associated_data, result.ciphertext)};
-  result.tag.assign(reinterpret_cast<const char *>(tag.data()), tag.size());
+  // The tag is computed over the ciphertext, then appended to it
+  AESGCMCiphertext result{.data = counter_mode(context, plaintext)};
+  const auto tag{compute_tag(context, associated_data, result.data)};
+  result.data.append(reinterpret_cast<const char *>(tag.data()), tag.size());
   return result;
 }
 

--- a/src/core/crypto/crypto_aes_gcm_other.cc
+++ b/src/core/crypto/crypto_aes_gcm_other.cc
@@ -1,16 +1,16 @@
 #include "crypto_aes.h"
 #include "crypto_aes_block.h"
 
+#include <cassert>     // assert
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint8_t, std::uint64_t
 #include <optional>    // std::optional, std::nullopt
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
-// A from-scratch AES-256 in Galois/Counter Mode (NIST SP 800-38D) for the
-// reference backend, over the shared AES block cipher. This is not
-// constant-time, which is acceptable only because this backend is the
-// non-production fallback
+// A from-scratch AES in Galois/Counter Mode (NIST SP 800-38D) for the reference
+// backend, over the shared AES block cipher. This is not constant-time, which
+// is acceptable only because this backend is the non-production fallback
 
 namespace sourcemeta::core {
 namespace {
@@ -59,27 +59,28 @@ auto ghash(const AesBlock &key, const std::string_view data,
 }
 
 struct Context {
-  AesRoundKeys round_keys;
+  AesKeySchedule schedule;
   AesBlock hash_key;
   AesBlock counter_zero;
   AesBlock tag_mask;
 };
 
-auto make_context(const std::string_view key, const std::string_view nonce)
+auto make_context(const std::string_view key, const std::string_view iv)
     -> Context {
-  Context context{.round_keys = aes_expand_key(key),
+  assert(iv.size() == 12);
+  Context context{.schedule = aes_expand_key(key),
                   .hash_key = {},
                   .counter_zero = {},
                   .tag_mask = {}};
-  context.hash_key = aes_encrypt_block(context.round_keys, AesBlock{});
+  context.hash_key = aes_encrypt_block(context.schedule, AesBlock{});
   for (std::size_t index = 0; index < 12; ++index) {
-    context.counter_zero[index] = static_cast<std::uint8_t>(nonce[index]);
+    context.counter_zero[index] = static_cast<std::uint8_t>(iv[index]);
   }
 
-  // The 96-bit nonce yields the pre-counter block nonce || 0x00000001
+  // The 96-bit initialization vector yields the pre-counter block iv ||
+  // 0x00000001
   context.counter_zero[15] = 1;
-  context.tag_mask =
-      aes_encrypt_block(context.round_keys, context.counter_zero);
+  context.tag_mask = aes_encrypt_block(context.schedule, context.counter_zero);
   return context;
 }
 
@@ -98,7 +99,7 @@ auto counter_mode(const Context &context, const std::string_view input)
   AesBlock counter{context.counter_zero};
   for (std::size_t offset = 0; offset < input.size(); offset += 16) {
     increment_counter(counter);
-    const auto keystream{aes_encrypt_block(context.round_keys, counter)};
+    const auto keystream{aes_encrypt_block(context.schedule, counter)};
     for (std::size_t index = 0; index < 16 && offset + index < input.size();
          ++index) {
       output[offset + index] = static_cast<char>(
@@ -109,13 +110,22 @@ auto counter_mode(const Context &context, const std::string_view input)
   return output;
 }
 
-// The authentication tag over an empty associated data and the ciphertext
-auto compute_tag(const Context &context, const std::string_view ciphertext)
-    -> AesBlock {
-  auto accumulator{ghash(context.hash_key, ciphertext, AesBlock{})};
+// The authentication tag over the associated data and the ciphertext (NIST SP
+// 800-38D Section 7.1)
+auto compute_tag(const Context &context, const std::string_view associated_data,
+                 const std::string_view ciphertext) -> AesBlock {
+  auto accumulator{ghash(context.hash_key, associated_data, AesBlock{})};
+  accumulator = ghash(context.hash_key, ciphertext, accumulator);
+
+  // The final GHASH block is the bit lengths of the associated data and the
+  // ciphertext, each as a 64-bit big-endian integer
   AesBlock lengths{};
+  const auto associated_bits{
+      static_cast<std::uint64_t>(associated_data.size()) * 8};
   const auto ciphertext_bits{static_cast<std::uint64_t>(ciphertext.size()) * 8};
   for (std::size_t index = 0; index < 8; ++index) {
+    lengths[7 - index] =
+        static_cast<std::uint8_t>((associated_bits >> (8 * index)) & 0xffu);
     lengths[15 - index] =
         static_cast<std::uint8_t>((ciphertext_bits >> (8 * index)) & 0xffu);
   }
@@ -135,42 +145,36 @@ auto compute_tag(const Context &context, const std::string_view ciphertext)
 
 } // namespace
 
-auto aes_256_gcm_encrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view plaintext)
-    -> std::optional<std::string> {
-  const auto context{make_context(key, nonce)};
-  std::string ciphertext{counter_mode(context, plaintext)};
-  const auto tag{compute_tag(context, ciphertext)};
-  ciphertext.append(reinterpret_cast<const char *>(tag.data()), tag.size());
-  return ciphertext;
+auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext> {
+  const auto context{make_context(key, iv)};
+  AESGCMCiphertext result{.ciphertext = counter_mode(context, plaintext),
+                          .tag = {}};
+  const auto tag{compute_tag(context, associated_data, result.ciphertext)};
+  result.tag.assign(reinterpret_cast<const char *>(tag.data()), tag.size());
+  return result;
 }
 
-auto aes_256_gcm_decrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view ciphertext)
+auto aes_gcm_open(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view ciphertext, const std::string_view tag)
     -> std::optional<std::string> {
-  if (ciphertext.size() < 16) {
-    return std::nullopt;
-  }
-
-  const auto message{ciphertext.substr(0, ciphertext.size() - 16)};
-  const auto received_tag{ciphertext.substr(ciphertext.size() - 16)};
-  const auto context{make_context(key, nonce)};
-  const auto tag{compute_tag(context, message)};
+  const auto context{make_context(key, iv)};
+  const auto expected{compute_tag(context, associated_data, ciphertext)};
 
   std::uint8_t difference{0};
   for (std::size_t index = 0; index < 16; ++index) {
     difference = static_cast<std::uint8_t>(
-        difference |
-        (tag[index] ^ static_cast<std::uint8_t>(received_tag[index])));
+        difference | (expected[index] ^ static_cast<std::uint8_t>(tag[index])));
   }
 
   if (difference != 0) {
     return std::nullopt;
   }
 
-  return counter_mode(context, message);
+  return counter_mode(context, ciphertext);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/crypto/crypto_aes_gcm_windows.cc
+++ b/src/core/crypto/crypto_aes_gcm_windows.cc
@@ -32,17 +32,17 @@ auto as_buffer(const wchar_t *const value) -> PUCHAR {
 
 namespace sourcemeta::core {
 
-auto aes_256_gcm_encrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view plaintext)
-    -> std::optional<std::string> {
+auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext> {
   BCRYPT_ALG_HANDLE algorithm{nullptr};
   if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(
           &algorithm, BCRYPT_AES_ALGORITHM, nullptr, 0))) {
     return std::nullopt;
   }
 
-  std::optional<std::string> result;
+  std::optional<AESGCMCiphertext> result;
   BCRYPT_KEY_HANDLE key_handle{nullptr};
   if (BCRYPT_SUCCESS(BCryptSetProperty(algorithm, BCRYPT_CHAINING_MODE,
                                        as_buffer(BCRYPT_CHAIN_MODE_GCM),
@@ -50,23 +50,25 @@ auto aes_256_gcm_encrypt(const std::string_view key,
       BCRYPT_SUCCESS(BCryptGenerateSymmetricKey(
           algorithm, &key_handle, nullptr, 0, as_buffer(key),
           static_cast<ULONG>(key.size()), 0))) {
+    std::string ciphertext(plaintext.size(), '\x00');
+    std::string tag(TAG_BYTES, '\x00');
     BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO info;
     BCRYPT_INIT_AUTH_MODE_INFO(info);
-    info.pbNonce = as_buffer(nonce);
-    info.cbNonce = static_cast<ULONG>(nonce.size());
-    std::string tag(TAG_BYTES, '\x00');
+    info.pbNonce = as_buffer(iv);
+    info.cbNonce = static_cast<ULONG>(iv.size());
+    info.pbAuthData = as_buffer(associated_data);
+    info.cbAuthData = static_cast<ULONG>(associated_data.size());
     info.pbTag = as_buffer(tag);
     info.cbTag = static_cast<ULONG>(TAG_BYTES);
 
-    std::string ciphertext(plaintext.size(), '\x00');
     ULONG written{0};
     if (BCRYPT_SUCCESS(BCryptEncrypt(key_handle, as_buffer(plaintext),
                                      static_cast<ULONG>(plaintext.size()),
                                      &info, nullptr, 0, as_buffer(ciphertext),
                                      static_cast<ULONG>(ciphertext.size()),
                                      &written, 0))) {
-      ciphertext.append(tag);
-      result = std::move(ciphertext);
+      result = AESGCMCiphertext{.ciphertext = std::move(ciphertext),
+                                .tag = std::move(tag)};
     }
 
     BCryptDestroyKey(key_handle);
@@ -76,16 +78,10 @@ auto aes_256_gcm_encrypt(const std::string_view key,
   return result;
 }
 
-auto aes_256_gcm_decrypt(const std::string_view key,
-                         const std::string_view nonce,
-                         const std::string_view ciphertext)
+auto aes_gcm_open(const std::string_view key, const std::string_view iv,
+                  const std::string_view associated_data,
+                  const std::string_view ciphertext, const std::string_view tag)
     -> std::optional<std::string> {
-  if (ciphertext.size() < TAG_BYTES) {
-    return std::nullopt;
-  }
-
-  const auto message{ciphertext.substr(0, ciphertext.size() - TAG_BYTES)};
-  auto tag{std::string{ciphertext.substr(ciphertext.size() - TAG_BYTES)}};
   BCRYPT_ALG_HANDLE algorithm{nullptr};
   if (!BCRYPT_SUCCESS(BCryptOpenAlgorithmProvider(
           &algorithm, BCRYPT_AES_ALGORITHM, nullptr, 0))) {
@@ -102,18 +98,21 @@ auto aes_256_gcm_decrypt(const std::string_view key,
           static_cast<ULONG>(key.size()), 0))) {
     BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO info;
     BCRYPT_INIT_AUTH_MODE_INFO(info);
-    info.pbNonce = as_buffer(nonce);
-    info.cbNonce = static_cast<ULONG>(nonce.size());
+    info.pbNonce = as_buffer(iv);
+    info.cbNonce = static_cast<ULONG>(iv.size());
+    info.pbAuthData = as_buffer(associated_data);
+    info.cbAuthData = static_cast<ULONG>(associated_data.size());
     info.pbTag = as_buffer(tag);
-    info.cbTag = static_cast<ULONG>(TAG_BYTES);
+    info.cbTag = static_cast<ULONG>(tag.size());
 
-    std::string plaintext(message.size(), '\x00');
+    std::string plaintext(ciphertext.size(), '\x00');
     ULONG written{0};
     // Reports a tag mismatch through the status, so a tampered message fails
-    if (BCRYPT_SUCCESS(BCryptDecrypt(
-            key_handle, as_buffer(message), static_cast<ULONG>(message.size()),
-            &info, nullptr, 0, as_buffer(plaintext),
-            static_cast<ULONG>(plaintext.size()), &written, 0))) {
+    if (BCRYPT_SUCCESS(BCryptDecrypt(key_handle, as_buffer(ciphertext),
+                                     static_cast<ULONG>(ciphertext.size()),
+                                     &info, nullptr, 0, as_buffer(plaintext),
+                                     static_cast<ULONG>(plaintext.size()),
+                                     &written, 0))) {
       result = std::move(plaintext);
     }
 

--- a/src/core/crypto/crypto_aes_gcm_windows.cc
+++ b/src/core/crypto/crypto_aes_gcm_windows.cc
@@ -50,25 +50,25 @@ auto aes_gcm_seal(const std::string_view key, const std::string_view iv,
       BCRYPT_SUCCESS(BCryptGenerateSymmetricKey(
           algorithm, &key_handle, nullptr, 0, as_buffer(key),
           static_cast<ULONG>(key.size()), 0))) {
-    std::string ciphertext(plaintext.size(), '\x00');
-    std::string tag(TAG_BYTES, '\x00');
+    // A single buffer holds the ciphertext followed by its 16-byte tag, which
+    // the mode info writes into at the offset past the ciphertext
+    std::string data(plaintext.size() + TAG_BYTES, '\x00');
     BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO info;
     BCRYPT_INIT_AUTH_MODE_INFO(info);
     info.pbNonce = as_buffer(iv);
     info.cbNonce = static_cast<ULONG>(iv.size());
     info.pbAuthData = as_buffer(associated_data);
     info.cbAuthData = static_cast<ULONG>(associated_data.size());
-    info.pbTag = as_buffer(tag);
+    info.pbTag = as_buffer(data) + plaintext.size();
     info.cbTag = static_cast<ULONG>(TAG_BYTES);
 
     ULONG written{0};
     if (BCRYPT_SUCCESS(BCryptEncrypt(key_handle, as_buffer(plaintext),
                                      static_cast<ULONG>(plaintext.size()),
-                                     &info, nullptr, 0, as_buffer(ciphertext),
-                                     static_cast<ULONG>(ciphertext.size()),
+                                     &info, nullptr, 0, as_buffer(data),
+                                     static_cast<ULONG>(plaintext.size()),
                                      &written, 0))) {
-      result = AESGCMCiphertext{.ciphertext = std::move(ciphertext),
-                                .tag = std::move(tag)};
+      result = AESGCMCiphertext{.data = std::move(data)};
     }
 
     BCryptDestroyKey(key_handle);

--- a/src/core/crypto/crypto_eddsa_cryptokit.mm
+++ b/src/core/crypto/crypto_eddsa_cryptokit.mm
@@ -40,43 +40,62 @@ extern "C" auto sourcemeta_core_eddsa_ed25519_sign_cryptokit(
   }
 }
 
-extern "C" auto sourcemeta_core_aes_256_gcm_seal_cryptokit(
+extern "C" auto sourcemeta_core_aes_gcm_seal_cryptokit(
     const unsigned char *key, std::size_t key_size, const unsigned char *nonce,
     std::size_t nonce_size, const unsigned char *plaintext,
-    std::size_t plaintext_size, unsigned char *output) -> bool {
+    std::size_t plaintext_size, const unsigned char *associated_data,
+    std::size_t associated_data_size, unsigned char *ciphertext_output,
+    unsigned char *tag_output) -> bool {
   @autoreleasepool {
     NSData *const key_data{[NSData dataWithBytes:key length:key_size]};
     NSData *const nonce_data{[NSData dataWithBytes:nonce length:nonce_size]};
     NSData *const plaintext_data{[NSData dataWithBytes:plaintext
                                                 length:plaintext_size]};
+    NSData *const associated{[NSData dataWithBytes:associated_data
+                                            length:associated_data_size]};
     NSData *const result{[SourcemetaCoreAESGCM sealWithKey:key_data
                                                      nonce:nonce_data
-                                                 plaintext:plaintext_data]};
-    if (output == nullptr || result == nil ||
-        result.length != plaintext_size + 16) {
+                                                 plaintext:plaintext_data
+                                            associatedData:associated]};
+    // CryptoKit returns the ciphertext followed by its 16-byte tag
+    if (result == nil || result.length != plaintext_size + 16 ||
+        tag_output == nullptr) {
       return false;
     }
 
-    std::memcpy(output, result.bytes, result.length);
+    const auto *const bytes{static_cast<const unsigned char *>(result.bytes)};
+    if (plaintext_size > 0) {
+      if (ciphertext_output == nullptr) {
+        return false;
+      }
+
+      std::memcpy(ciphertext_output, bytes, plaintext_size);
+    }
+
+    std::memcpy(tag_output, bytes + plaintext_size, 16);
     return true;
   }
 }
 
-extern "C" auto sourcemeta_core_aes_256_gcm_open_cryptokit(
+extern "C" auto sourcemeta_core_aes_gcm_open_cryptokit(
     const unsigned char *key, std::size_t key_size, const unsigned char *nonce,
     std::size_t nonce_size, const unsigned char *ciphertext,
     std::size_t ciphertext_size, const unsigned char *tag,
-    std::size_t tag_size, unsigned char *output) -> bool {
+    std::size_t tag_size, const unsigned char *associated_data,
+    std::size_t associated_data_size, unsigned char *output) -> bool {
   @autoreleasepool {
     NSData *const key_data{[NSData dataWithBytes:key length:key_size]};
     NSData *const nonce_data{[NSData dataWithBytes:nonce length:nonce_size]};
     NSData *const ciphertext_data{[NSData dataWithBytes:ciphertext
                                                  length:ciphertext_size]};
     NSData *const tag_data{[NSData dataWithBytes:tag length:tag_size]};
+    NSData *const associated{[NSData dataWithBytes:associated_data
+                                            length:associated_data_size]};
     NSData *const result{[SourcemetaCoreAESGCM openWithKey:key_data
                                                      nonce:nonce_data
                                                 ciphertext:ciphertext_data
-                                                       tag:tag_data]};
+                                                       tag:tag_data
+                                            associatedData:associated]};
     if (result == nil) {
       return false;
     }

--- a/src/core/crypto/crypto_eddsa_cryptokit.swift
+++ b/src/core/crypto/crypto_eddsa_cryptokit.swift
@@ -27,13 +27,13 @@ public final class SourcemetaCoreEd25519: NSObject {
   }
 }
 
-// AES-256 in Galois/Counter Mode, which the Apple Security framework does not
+// AES in Galois/Counter Mode, which the Apple Security framework does not
 // expose through its C API either. CryptoKit provides it since macOS 10.15
 @objc(SourcemetaCoreAESGCM)
 public final class SourcemetaCoreAESGCM: NSObject {
-  @objc public static func seal(key: Data, nonce: Data,
-                                plaintext: Data) -> Data? {
-    guard key.count == 32 else {
+  @objc public static func seal(key: Data, nonce: Data, plaintext: Data,
+                                associatedData: Data) -> Data? {
+    guard key.count == 16 || key.count == 24 || key.count == 32 else {
       return nil
     }
 
@@ -43,7 +43,7 @@ public final class SourcemetaCoreAESGCM: NSObject {
 
     guard let box = try? AES.GCM.seal(
         plaintext, using: SymmetricKey(data: key),
-        nonce: sealingNonce) else {
+        nonce: sealingNonce, authenticating: associatedData) else {
       return nil
     }
 
@@ -51,8 +51,8 @@ public final class SourcemetaCoreAESGCM: NSObject {
   }
 
   @objc public static func open(key: Data, nonce: Data, ciphertext: Data,
-                                tag: Data) -> Data? {
-    guard key.count == 32 else {
+                                tag: Data, associatedData: Data) -> Data? {
+    guard key.count == 16 || key.count == 24 || key.count == 32 else {
       return nil
     }
 
@@ -62,6 +62,7 @@ public final class SourcemetaCoreAESGCM: NSObject {
       return nil
     }
 
-    return try? AES.GCM.open(box, using: SymmetricKey(data: key))
+    return try? AES.GCM.open(
+        box, using: SymmetricKey(data: key), authenticating: associatedData)
   }
 }

--- a/src/core/crypto/include/sourcemeta/core/crypto_aes_gcm.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_aes_gcm.h
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/crypto_export.h>
 #endif
 
+#include <cassert>     // assert
 #include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -12,13 +13,23 @@
 namespace sourcemeta::core {
 
 /// @ingroup crypto
-/// The output of an AES-GCM encryption, the ciphertext alongside its 16-byte
-/// authentication tag.
+/// The output of an AES-GCM encryption, a single owned buffer holding the
+/// ciphertext followed by its 16-byte authentication tag, exposed as views.
 struct AESGCMCiphertext {
-  /// The encrypted bytes, the same length as the plaintext.
-  std::string ciphertext;
+  /// The ciphertext followed by its 16-byte authentication tag.
+  std::string data;
+
+  /// The ciphertext, the same length as the plaintext.
+  [[nodiscard]] auto ciphertext() const -> std::string_view {
+    assert(this->data.size() >= 16);
+    return std::string_view{this->data}.substr(0, this->data.size() - 16);
+  }
+
   /// The 16-byte authentication tag.
-  std::string tag;
+  [[nodiscard]] auto tag() const -> std::string_view {
+    assert(this->data.size() >= 16);
+    return std::string_view{this->data}.substr(this->data.size() - 16);
+  }
 };
 
 /// @ingroup crypto
@@ -53,7 +64,7 @@ auto SOURCEMETA_CORE_CRYPTO_EXPORT aes_gcm_encrypt(
 /// #include <cassert>
 ///
 /// const auto plaintext{sourcemeta::core::aes_gcm_decrypt(
-///     key, iv, "", result.value().ciphertext, result.value().tag)};
+///     key, iv, "", result.value().ciphertext(), result.value().tag())};
 /// assert(plaintext.has_value());
 /// ```
 auto SOURCEMETA_CORE_CRYPTO_EXPORT aes_gcm_decrypt(

--- a/src/core/crypto/include/sourcemeta/core/crypto_aes_gcm.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_aes_gcm.h
@@ -12,6 +12,56 @@
 namespace sourcemeta::core {
 
 /// @ingroup crypto
+/// The output of an AES-GCM encryption, the ciphertext alongside its 16-byte
+/// authentication tag.
+struct AESGCMCiphertext {
+  /// The encrypted bytes, the same length as the plaintext.
+  std::string ciphertext;
+  /// The 16-byte authentication tag.
+  std::string tag;
+};
+
+/// @ingroup crypto
+/// Encrypt a plaintext with AES in Galois/Counter Mode (NIST SP 800-38D) under
+/// a 128, 192, or 256-bit key, a 96-bit initialization vector, and associated
+/// data that is authenticated but not encrypted. Returns no value when the key
+/// is not one of the three valid sizes, the initialization vector is not 96
+/// bits, or an input is too large to process. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/crypto.h>
+/// #include <cassert>
+///
+/// const auto result{sourcemeta::core::aes_gcm_encrypt(key, iv, "", "hello")};
+/// assert(result.has_value());
+/// ```
+auto SOURCEMETA_CORE_CRYPTO_EXPORT aes_gcm_encrypt(
+    const std::string_view key, const std::string_view iv,
+    const std::string_view associated_data, const std::string_view plaintext)
+    -> std::optional<AESGCMCiphertext>;
+
+/// @ingroup crypto
+/// Decrypt a message produced by aes_gcm_encrypt under the same key,
+/// initialization vector, and associated data, returning the original
+/// plaintext. Returns no value when the key or initialization vector is not a
+/// valid length, the tag is not 16 bytes, an input is too large to process, or
+/// the authentication tag does not verify, so a tampered message is rejected
+/// rather than decrypted. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/crypto.h>
+/// #include <cassert>
+///
+/// const auto plaintext{sourcemeta::core::aes_gcm_decrypt(
+///     key, iv, "", result.value().ciphertext, result.value().tag)};
+/// assert(plaintext.has_value());
+/// ```
+auto SOURCEMETA_CORE_CRYPTO_EXPORT aes_gcm_decrypt(
+    const std::string_view key, const std::string_view iv,
+    const std::string_view associated_data, const std::string_view ciphertext,
+    const std::string_view tag) -> std::optional<std::string>;
+
+/// @ingroup crypto
 /// Seal a plaintext under a 256-bit key using AES-256 in Galois/Counter Mode
 /// (NIST SP 800-38D) with a fresh random nonce and no associated data. The
 /// result is the self-contained sealed message, the nonce followed by the

--- a/test/crypto/crypto_aes_gcm_test.cc
+++ b/test/crypto/crypto_aes_gcm_test.cc
@@ -97,11 +97,11 @@ TEST(aes_gcm_round_trips_with_a_128_bit_key) {
   const auto result{sourcemeta::core::aes_gcm_encrypt(
       KEY_128, IV, ASSOCIATED_DATA, plaintext)};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().ciphertext.size(), plaintext.size());
-  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  EXPECT_EQ(result.value().ciphertext().size(), plaintext.size());
+  EXPECT_EQ(result.value().tag().size(), TAG_SIZE);
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY_128, IV, ASSOCIATED_DATA, result.value().ciphertext,
-      result.value().tag)};
+      KEY_128, IV, ASSOCIATED_DATA, result.value().ciphertext(),
+      result.value().tag())};
   EXPECT_TRUE(opened.has_value());
   EXPECT_EQ(opened.value(), plaintext);
 }
@@ -111,11 +111,11 @@ TEST(aes_gcm_round_trips_with_a_192_bit_key) {
   const auto result{sourcemeta::core::aes_gcm_encrypt(
       KEY_192, IV, ASSOCIATED_DATA, plaintext)};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().ciphertext.size(), plaintext.size());
-  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  EXPECT_EQ(result.value().ciphertext().size(), plaintext.size());
+  EXPECT_EQ(result.value().tag().size(), TAG_SIZE);
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY_192, IV, ASSOCIATED_DATA, result.value().ciphertext,
-      result.value().tag)};
+      KEY_192, IV, ASSOCIATED_DATA, result.value().ciphertext(),
+      result.value().tag())};
   EXPECT_TRUE(opened.has_value());
   EXPECT_EQ(opened.value(), plaintext);
 }
@@ -125,10 +125,11 @@ TEST(aes_gcm_round_trips_with_a_256_bit_key) {
   const auto result{
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, plaintext)};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().ciphertext.size(), plaintext.size());
-  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  EXPECT_EQ(result.value().ciphertext().size(), plaintext.size());
+  EXPECT_EQ(result.value().tag().size(), TAG_SIZE);
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext, result.value().tag)};
+      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext(),
+      result.value().tag())};
   EXPECT_TRUE(opened.has_value());
   EXPECT_EQ(opened.value(), plaintext);
 }
@@ -139,7 +140,8 @@ TEST(aes_gcm_round_trips_across_block_boundaries) {
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, plaintext)};
   EXPECT_TRUE(result.has_value());
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext, result.value().tag)};
+      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext(),
+      result.value().tag())};
   EXPECT_TRUE(opened.has_value());
   EXPECT_EQ(opened.value(), plaintext);
 }
@@ -148,10 +150,11 @@ TEST(aes_gcm_round_trips_an_empty_plaintext) {
   const auto result{
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().ciphertext.size(), std::string::size_type{0});
-  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  EXPECT_EQ(result.value().ciphertext().size(), std::string::size_type{0});
+  EXPECT_EQ(result.value().tag().size(), TAG_SIZE);
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext, result.value().tag)};
+      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext(),
+      result.value().tag())};
   EXPECT_TRUE(opened.has_value());
   EXPECT_EQ(opened.value(), "");
 }
@@ -161,7 +164,7 @@ TEST(aes_gcm_round_trips_empty_associated_data) {
   const auto result{sourcemeta::core::aes_gcm_encrypt(KEY, IV, "", plaintext)};
   EXPECT_TRUE(result.has_value());
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY, IV, "", result.value().ciphertext, result.value().tag)};
+      KEY, IV, "", result.value().ciphertext(), result.value().tag())};
   EXPECT_TRUE(opened.has_value());
   EXPECT_EQ(opened.value(), plaintext);
 }
@@ -175,16 +178,16 @@ TEST(aes_gcm_encrypt_is_deterministic_for_the_same_inputs) {
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "identical")};
   EXPECT_TRUE(first.has_value());
   EXPECT_TRUE(second.has_value());
-  EXPECT_EQ(first.value().ciphertext, second.value().ciphertext);
-  EXPECT_EQ(first.value().tag, second.value().tag);
+  EXPECT_EQ(first.value().ciphertext(), second.value().ciphertext());
+  EXPECT_EQ(first.value().tag(), second.value().tag());
 }
 
 TEST(aes_gcm_decrypt_rejects_different_associated_data) {
   const auto result{
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "hello")};
   const auto opened{sourcemeta::core::aes_gcm_decrypt(
-      KEY, IV, "different-header", result.value().ciphertext,
-      result.value().tag)};
+      KEY, IV, "different-header", result.value().ciphertext(),
+      result.value().tag())};
   EXPECT_FALSE(opened.has_value());
 }
 
@@ -192,9 +195,10 @@ TEST(aes_gcm_decrypt_rejects_a_tampered_tag) {
   auto result{
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "hello")
           .value()};
-  result.tag.back() = static_cast<char>(result.tag.back() ^ 0x01);
-  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY, IV, ASSOCIATED_DATA,
-                                                 result.ciphertext, result.tag)
+  // The tag is the final sixteen bytes of the buffer
+  result.data.back() = static_cast<char>(result.data.back() ^ 0x01);
+  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(
+                   KEY, IV, ASSOCIATED_DATA, result.ciphertext(), result.tag())
                    .has_value());
 }
 
@@ -202,9 +206,10 @@ TEST(aes_gcm_decrypt_rejects_a_tampered_ciphertext) {
   auto result{sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA,
                                                 "a longer payload here")
                   .value()};
-  result.ciphertext[0] = static_cast<char>(result.ciphertext[0] ^ 0x01);
-  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY, IV, ASSOCIATED_DATA,
-                                                 result.ciphertext, result.tag)
+  // The first byte of the buffer is the first ciphertext byte
+  result.data[0] = static_cast<char>(result.data[0] ^ 0x01);
+  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(
+                   KEY, IV, ASSOCIATED_DATA, result.ciphertext(), result.tag())
                    .has_value());
 }
 
@@ -212,8 +217,8 @@ TEST(aes_gcm_decrypt_rejects_a_different_key) {
   const auto result{
       sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "hello")};
   EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY_128, IV, ASSOCIATED_DATA,
-                                                 result.value().ciphertext,
-                                                 result.value().tag)
+                                                 result.value().ciphertext(),
+                                                 result.value().tag())
                    .has_value());
 }
 
@@ -232,7 +237,7 @@ TEST(aes_gcm_encrypt_rejects_a_wrong_size_iv) {
 TEST(aes_gcm_decrypt_rejects_a_wrong_size_tag) {
   const auto result{sourcemeta::core::aes_gcm_encrypt(KEY, IV, "", "hello")};
   EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY, IV, "",
-                                                 result.value().ciphertext,
+                                                 result.value().ciphertext(),
                                                  std::string(15, '\x00'))
                    .has_value());
 }

--- a/test/crypto/crypto_aes_gcm_test.cc
+++ b/test/crypto/crypto_aes_gcm_test.cc
@@ -10,6 +10,21 @@ static const std::string KEY{
         "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
         .value()};
 
+static const std::string KEY_128{
+    sourcemeta::core::hex_to_bytes("000102030405060708090a0b0c0d0e0f").value()};
+
+static const std::string KEY_192{
+    sourcemeta::core::hex_to_bytes(
+        "000102030405060708090a0b0c0d0e0f1011121314151617")
+        .value()};
+
+static const std::string IV{
+    sourcemeta::core::hex_to_bytes("101112131415161718191a1b").value()};
+
+static constexpr std::string_view ASSOCIATED_DATA{"protected-header"};
+
+static constexpr std::string::size_type TAG_SIZE{16};
+
 TEST(aes_256_gcm_round_trips) {
   const std::string_view plaintext{"a secret session cookie payload"};
   const auto sealed{sourcemeta::core::aes_256_gcm_seal(KEY, plaintext)};
@@ -75,4 +90,149 @@ TEST(aes_256_gcm_seal_rejects_a_wrong_size_key) {
 TEST(aes_256_gcm_unseal_rejects_a_short_input) {
   EXPECT_FALSE(
       sourcemeta::core::aes_256_gcm_unseal(KEY, "too short").has_value());
+}
+
+TEST(aes_gcm_round_trips_with_a_128_bit_key) {
+  const std::string_view plaintext{"a secret session cookie payload"};
+  const auto result{sourcemeta::core::aes_gcm_encrypt(
+      KEY_128, IV, ASSOCIATED_DATA, plaintext)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().ciphertext.size(), plaintext.size());
+  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY_128, IV, ASSOCIATED_DATA, result.value().ciphertext,
+      result.value().tag)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), plaintext);
+}
+
+TEST(aes_gcm_round_trips_with_a_192_bit_key) {
+  const std::string_view plaintext{"a secret session cookie payload"};
+  const auto result{sourcemeta::core::aes_gcm_encrypt(
+      KEY_192, IV, ASSOCIATED_DATA, plaintext)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().ciphertext.size(), plaintext.size());
+  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY_192, IV, ASSOCIATED_DATA, result.value().ciphertext,
+      result.value().tag)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), plaintext);
+}
+
+TEST(aes_gcm_round_trips_with_a_256_bit_key) {
+  const std::string_view plaintext{"a secret session cookie payload"};
+  const auto result{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, plaintext)};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().ciphertext.size(), plaintext.size());
+  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext, result.value().tag)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), plaintext);
+}
+
+TEST(aes_gcm_round_trips_across_block_boundaries) {
+  const std::string plaintext(100, 'z');
+  const auto result{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, plaintext)};
+  EXPECT_TRUE(result.has_value());
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext, result.value().tag)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), plaintext);
+}
+
+TEST(aes_gcm_round_trips_an_empty_plaintext) {
+  const auto result{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value().ciphertext.size(), std::string::size_type{0});
+  EXPECT_EQ(result.value().tag.size(), TAG_SIZE);
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY, IV, ASSOCIATED_DATA, result.value().ciphertext, result.value().tag)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), "");
+}
+
+TEST(aes_gcm_round_trips_empty_associated_data) {
+  const std::string_view plaintext{"payload without associated data"};
+  const auto result{sourcemeta::core::aes_gcm_encrypt(KEY, IV, "", plaintext)};
+  EXPECT_TRUE(result.has_value());
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY, IV, "", result.value().ciphertext, result.value().tag)};
+  EXPECT_TRUE(opened.has_value());
+  EXPECT_EQ(opened.value(), plaintext);
+}
+
+TEST(aes_gcm_encrypt_is_deterministic_for_the_same_inputs) {
+  // Unlike the self-sealing helper, this primitive takes the initialization
+  // vector from the caller, so the same inputs produce the same output
+  const auto first{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "identical")};
+  const auto second{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "identical")};
+  EXPECT_TRUE(first.has_value());
+  EXPECT_TRUE(second.has_value());
+  EXPECT_EQ(first.value().ciphertext, second.value().ciphertext);
+  EXPECT_EQ(first.value().tag, second.value().tag);
+}
+
+TEST(aes_gcm_decrypt_rejects_different_associated_data) {
+  const auto result{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "hello")};
+  const auto opened{sourcemeta::core::aes_gcm_decrypt(
+      KEY, IV, "different-header", result.value().ciphertext,
+      result.value().tag)};
+  EXPECT_FALSE(opened.has_value());
+}
+
+TEST(aes_gcm_decrypt_rejects_a_tampered_tag) {
+  auto result{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "hello")
+          .value()};
+  result.tag.back() = static_cast<char>(result.tag.back() ^ 0x01);
+  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY, IV, ASSOCIATED_DATA,
+                                                 result.ciphertext, result.tag)
+                   .has_value());
+}
+
+TEST(aes_gcm_decrypt_rejects_a_tampered_ciphertext) {
+  auto result{sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA,
+                                                "a longer payload here")
+                  .value()};
+  result.ciphertext[0] = static_cast<char>(result.ciphertext[0] ^ 0x01);
+  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY, IV, ASSOCIATED_DATA,
+                                                 result.ciphertext, result.tag)
+                   .has_value());
+}
+
+TEST(aes_gcm_decrypt_rejects_a_different_key) {
+  const auto result{
+      sourcemeta::core::aes_gcm_encrypt(KEY, IV, ASSOCIATED_DATA, "hello")};
+  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY_128, IV, ASSOCIATED_DATA,
+                                                 result.value().ciphertext,
+                                                 result.value().tag)
+                   .has_value());
+}
+
+TEST(aes_gcm_encrypt_rejects_a_wrong_size_key) {
+  EXPECT_FALSE(
+      sourcemeta::core::aes_gcm_encrypt(std::string(20, '\x00'), IV, "", "x")
+          .has_value());
+}
+
+TEST(aes_gcm_encrypt_rejects_a_wrong_size_iv) {
+  EXPECT_FALSE(
+      sourcemeta::core::aes_gcm_encrypt(KEY, std::string(16, '\x00'), "", "x")
+          .has_value());
+}
+
+TEST(aes_gcm_decrypt_rejects_a_wrong_size_tag) {
+  const auto result{sourcemeta::core::aes_gcm_encrypt(KEY, IV, "", "hello")};
+  EXPECT_FALSE(sourcemeta::core::aes_gcm_decrypt(KEY, IV, "",
+                                                 result.value().ciphertext,
+                                                 std::string(15, '\x00'))
+                   .has_value());
 }

--- a/test/crypto/wycheproof_test.cc
+++ b/test/crypto/wycheproof_test.cc
@@ -378,9 +378,10 @@ auto register_aes_gcm_tests(const std::filesystem::path &path,
   const auto document{load(path)};
   const auto stem{path.stem().string()};
   for (const auto &group : document.at("testGroups").as_array()) {
-    // The sealing format fixes a 256-bit key, a 96-bit nonce, a 128-bit tag,
-    // and no associated data, so only that subset is driven through unseal
-    if (group.at("keySize").to_integer() != 256 ||
+    // The primitive fixes a 96-bit initialization vector and a 128-bit tag over
+    // 128, 192, and 256-bit keys, and authenticates associated data
+    const auto key_size{group.at("keySize").to_integer()};
+    if ((key_size != 128 && key_size != 192 && key_size != 256) ||
         group.at("ivSize").to_integer() != 96 ||
         group.at("tagSize").to_integer() != 128) {
       continue;
@@ -388,38 +389,45 @@ auto register_aes_gcm_tests(const std::filesystem::path &path,
 
     for (const auto &test : group.at("tests").as_array()) {
       const std::string result{test.at("result").to_string()};
-      if (result == "acceptable" || !test.at("aad").to_string().empty()) {
+      if (result == "acceptable") {
         continue;
       }
 
       const auto key{
           sourcemeta::core::hex_to_bytes(test.at("key").to_string())};
       const auto iv{sourcemeta::core::hex_to_bytes(test.at("iv").to_string())};
+      const auto associated_data{
+          sourcemeta::core::hex_to_bytes(test.at("aad").to_string())};
       const auto message{
           sourcemeta::core::hex_to_bytes(test.at("msg").to_string())};
       const auto ciphertext{
           sourcemeta::core::hex_to_bytes(test.at("ct").to_string())};
       const auto tag{
           sourcemeta::core::hex_to_bytes(test.at("tag").to_string())};
-      if (!key.has_value() || !iv.has_value() || !message.has_value() ||
-          !ciphertext.has_value() || !tag.has_value()) {
+      if (!key.has_value() || !iv.has_value() || !associated_data.has_value() ||
+          !message.has_value() || !ciphertext.has_value() || !tag.has_value()) {
         continue;
       }
 
-      // The sealed message is the nonce, ciphertext, and tag joined, assembled
-      // once here rather than on every run of the registered case
-      std::string sealed{iv.value()};
-      sealed.append(ciphertext.value());
-      sealed.append(tag.value());
       register_case(
           suite_name,
           stem + "_tc" + std::to_string(test.at("tcId").to_integer()),
-          [key = key.value(), sealed = std::move(sealed),
+          [key = key.value(), iv = iv.value(),
+           associated_data = associated_data.value(),
+           ciphertext = ciphertext.value(), tag = tag.value(),
            plaintext = message.value(), expected = (result == "valid")]() {
-            const auto opened{
-                sourcemeta::core::aes_256_gcm_unseal(key, sealed)};
+            const auto opened{sourcemeta::core::aes_gcm_decrypt(
+                key, iv, associated_data, ciphertext, tag)};
             EXPECT_EQ(opened.has_value() && opened.value() == plaintext,
                       expected);
+            // A valid vector must also reproduce exactly under encryption
+            if (expected) {
+              const auto sealed{sourcemeta::core::aes_gcm_encrypt(
+                  key, iv, associated_data, plaintext)};
+              EXPECT_TRUE(sealed.has_value());
+              EXPECT_EQ(sealed.value().ciphertext, ciphertext);
+              EXPECT_EQ(sealed.value().tag, tag);
+            }
           });
     }
   }

--- a/test/crypto/wycheproof_test.cc
+++ b/test/crypto/wycheproof_test.cc
@@ -425,8 +425,8 @@ auto register_aes_gcm_tests(const std::filesystem::path &path,
               const auto sealed{sourcemeta::core::aes_gcm_encrypt(
                   key, iv, associated_data, plaintext)};
               EXPECT_TRUE(sealed.has_value());
-              EXPECT_EQ(sealed.value().ciphertext, ciphertext);
-              EXPECT_EQ(sealed.value().tag, tag);
+              EXPECT_EQ(sealed.value().ciphertext(), ciphertext);
+              EXPECT_EQ(sealed.value().tag(), tag);
             }
           });
     }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

