### PR TITLE
Single-source the per-backend crypto key internals

### DIFF
--- a/src/core/crypto/CMakeLists.txt
+++ b/src/core/crypto/CMakeLists.txt
@@ -166,7 +166,7 @@ else()
     crypto_rsa_oaep_other.cc crypto_ecdh_other.cc
     crypto_aes_block.h crypto_aes_kw_loop.h crypto_sha1_other.h
     crypto_bignum.h crypto_ecc.h crypto_eddsa.h crypto_shake256.h
-    crypto_pkcs8.h)
+    crypto_pkcs8.h crypto_other.h)
 endif()
 
 if(SOURCEMETA_CORE_INSTALL)

--- a/src/core/crypto/crypto_apple.h
+++ b/src/core/crypto/crypto_apple.h
@@ -1,9 +1,12 @@
 #ifndef SOURCEMETA_CORE_CRYPTO_APPLE_H_
 #define SOURCEMETA_CORE_CRYPTO_APPLE_H_
 
-// Security-framework key export helpers shared by the Apple signing and
-// verification backends, so the external representation handling stays
-// single-sourced
+// The Apple key internals and the Security-framework export helper shared
+// across the Apple backends, so the parsed key layout and the external
+// representation handling stay single-sourced
+
+#include <sourcemeta/core/crypto_sign.h>
+#include <sourcemeta/core/crypto_verify.h>
 
 #include <CoreFoundation/CoreFoundation.h> // CF*, kCF*
 #include <Security/Security.h>             // Sec*, kSec*
@@ -13,6 +16,27 @@
 #include <string>   // std::string
 
 namespace sourcemeta::core {
+
+// The parsed key keeps the platform key object alive for reuse. The Edwards
+// curves have no Security framework primitive, so they keep the raw seed or
+// point and operate through CryptoKit or the reference implementation
+struct PublicKey::Internal {
+  PublicKey::Type kind;
+  SecKeyRef key;
+  std::string modulus;
+  std::size_t field_bytes;
+  std::string edwards_point;
+  EdwardsCurve edwards_curve;
+};
+
+struct PrivateKey::Internal {
+  PrivateKey::Type kind;
+  SecKeyRef key;
+  std::size_t field_bytes;
+  std::string edwards_seed;
+  EdwardsCurve edwards_curve;
+  bool rsa_pss_restricted{false};
+};
 
 // Copy the platform's external representation of a key, the PKCS#1 structure
 // for RSA and the X9.63 uncompressed point for elliptic curve keys

--- a/src/core/crypto/crypto_ecdh_apple.cc
+++ b/src/core/crypto/crypto_ecdh_apple.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/core/crypto_ecdh.h>
 
+#include "crypto_apple.h"
+
 #include <CoreFoundation/CoreFoundation.h> // CF*, kCF*
 #include <Security/Security.h>             // Sec*, kSec*
 
@@ -8,26 +10,6 @@
 #include <string>   // std::string
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling Apple key backends, since
-// each translation unit that reads a key redeclares its file-private members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  SecKeyRef key;
-  std::string modulus;
-  std::size_t field_bytes;
-  std::string edwards_point;
-  EdwardsCurve edwards_curve;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  SecKeyRef key;
-  std::size_t field_bytes;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-};
 
 auto ecdh_derive(const PrivateKey &private_key, const PublicKey &public_key)
     -> std::optional<std::string> {

--- a/src/core/crypto/crypto_ecdh_openssl.cc
+++ b/src/core/crypto/crypto_ecdh_openssl.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/core/crypto_ecdh.h>
 
+#include "crypto_openssl.h"
+
 #include <openssl/evp.h> // EVP_*
 
 #include <cstddef>  // std::size_t
@@ -8,23 +10,6 @@
 #include <utility>  // std::move
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling OpenSSL key backends, since
-// each translation unit that reads a key redeclares its file-private members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  EVP_PKEY *key;
-  std::string modulus;
-  std::size_t field_bytes;
-  std::size_t signature_bytes;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  EVP_PKEY *key;
-  std::size_t field_bytes;
-  bool rsa_pss_restricted{false};
-};
 
 auto ecdh_derive(const PrivateKey &private_key, const PublicKey &public_key)
     -> std::optional<std::string> {

--- a/src/core/crypto/crypto_ecdh_other.cc
+++ b/src/core/crypto/crypto_ecdh_other.cc
@@ -2,6 +2,7 @@
 
 #include "crypto_bignum.h"
 #include "crypto_ecc.h"
+#include "crypto_other.h"
 
 #include <optional> // std::optional, std::nullopt
 #include <string>   // std::string
@@ -13,33 +14,6 @@
 // RFC 7518 Section 4.6 consumes)
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling reference key backends,
-// since each translation unit that reads a key redeclares its file-private
-// members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  std::string modulus;
-  std::string exponent;
-  std::string coordinate_x;
-  std::string coordinate_y;
-  EllipticCurve elliptic_curve;
-  EdwardsCurve edwards_curve;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  std::string modulus;
-  std::string public_exponent;
-  std::string private_exponent;
-  std::string scalar;
-  EllipticCurve elliptic_curve;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-  std::string coordinate_x;
-  std::string coordinate_y;
-};
 
 namespace {
 auto to_curve_parameters(const EllipticCurve curve) -> EllipticCurveParameters {

--- a/src/core/crypto/crypto_ecdh_windows.cc
+++ b/src/core/crypto/crypto_ecdh_windows.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/core/crypto_ecdh.h>
 
+#include "crypto_windows.h"
+
 #include <windows.h> // ULONG, PUCHAR, LPCWSTR
 // clang-format off
 #include <bcrypt.h> // BCrypt*, BCRYPT_*
@@ -13,28 +15,6 @@
 #include <utility>   // std::move
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling Windows key backends, since
-// each translation unit that reads a key redeclares its file-private members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  BCRYPT_ALG_HANDLE algorithm;
-  BCRYPT_KEY_HANDLE key;
-  std::size_t field_bytes;
-  std::string modulus;
-  std::string edwards_point;
-  EdwardsCurve edwards_curve;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  BCRYPT_ALG_HANDLE algorithm;
-  BCRYPT_KEY_HANDLE key;
-  std::size_t field_bytes;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-};
 
 namespace {
 // The elliptic curve is recovered from the field width, since the sign backend

--- a/src/core/crypto/crypto_openssl.h
+++ b/src/core/crypto/crypto_openssl.h
@@ -1,9 +1,11 @@
 #ifndef SOURCEMETA_CORE_CRYPTO_OPENSSL_H_
 #define SOURCEMETA_CORE_CRYPTO_OPENSSL_H_
 
-// OpenSSL key export helpers shared by the signing and verification backends,
-// so the provider parameter handling and the curve mapping stay single-sourced
+// The OpenSSL key internals and the export helpers shared across the OpenSSL
+// backends, so the parsed key layout, the provider parameter handling, and the
+// curve mapping stay single-sourced
 
+#include <sourcemeta/core/crypto_sign.h>
 #include <sourcemeta/core/crypto_verify.h>
 
 #include <openssl/bn.h>         // BIGNUM, BN_*
@@ -17,6 +19,27 @@
 #include <string_view> // std::string_view
 
 namespace sourcemeta::core {
+
+// The parsed key keeps the native handle alive so that many operations reuse it
+struct PublicKey::Internal {
+  PublicKey::Type kind;
+  EVP_PKEY *key;
+  // The stripped modulus, kept for the RSA signature range check
+  std::string modulus;
+  // The field width for the elliptic curve signature size check
+  std::size_t field_bytes;
+  // The expected signature length for the Edwards curve
+  std::size_t signature_bytes;
+};
+
+struct PrivateKey::Internal {
+  PrivateKey::Type kind;
+  EVP_PKEY *key;
+  // The field width for the elliptic curve raw signature encoding
+  std::size_t field_bytes;
+  // Set for an id-RSASSA-PSS key, which is refused for PKCS1v15 signing
+  bool rsa_pss_restricted{false};
+};
 
 // The platform reports the curve under its canonical name rather than the JWK
 // alias the key was built with, so both are accepted

--- a/src/core/crypto/crypto_other.h
+++ b/src/core/crypto/crypto_other.h
@@ -1,0 +1,44 @@
+#ifndef SOURCEMETA_CORE_CRYPTO_OTHER_H_
+#define SOURCEMETA_CORE_CRYPTO_OTHER_H_
+
+// The reference backend key internals, so the parsed key layout stays
+// single-sourced across the reference backends
+
+#include <sourcemeta/core/crypto_sign.h>
+#include <sourcemeta/core/crypto_verify.h>
+
+#include <string> // std::string
+
+namespace sourcemeta::core {
+
+struct PublicKey::Internal {
+  PublicKey::Type kind;
+  std::string modulus;
+  std::string exponent;
+  std::string coordinate_x;
+  std::string coordinate_y;
+  EllipticCurve elliptic_curve;
+  EdwardsCurve edwards_curve;
+};
+
+struct PrivateKey::Internal {
+  PrivateKey::Type kind;
+  std::string modulus;
+  std::string public_exponent;
+  std::string private_exponent;
+  std::string scalar;
+  EllipticCurve elliptic_curve;
+  std::string edwards_seed;
+  EdwardsCurve edwards_curve;
+  bool rsa_pss_restricted{false};
+  // The public coordinates, kept so the public key can be recovered without
+  // recomputing the point from the scalar. A key parsed from a PEM document,
+  // which carries only the scalar on this backend, recomputes them at parse
+  // time, so they are populated for every elliptic curve private key
+  std::string coordinate_x;
+  std::string coordinate_y;
+};
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/crypto/crypto_rsa_oaep_apple.cc
+++ b/src/core/crypto/crypto_rsa_oaep_apple.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/core/crypto_rsa_oaep.h>
 
+#include "crypto_apple.h"
+
 #include <CoreFoundation/CoreFoundation.h> // CF*, kCF*
 #include <Security/Security.h>             // Sec*, kSec*
 
@@ -11,26 +13,6 @@
 #include <utility>     // std::unreachable
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling Apple key backends, since
-// each translation unit that reads a key redeclares its file-private members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  SecKeyRef key;
-  std::string modulus;
-  std::size_t field_bytes;
-  std::string edwards_point;
-  EdwardsCurve edwards_curve;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  SecKeyRef key;
-  std::size_t field_bytes;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-};
 
 namespace {
 auto make_data(const std::string_view value) -> CFDataRef {

--- a/src/core/crypto/crypto_rsa_oaep_openssl.cc
+++ b/src/core/crypto/crypto_rsa_oaep_openssl.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/core/crypto_rsa_oaep.h>
 
+#include "crypto_openssl.h"
+
 #include <openssl/evp.h> // EVP_*
 #include <openssl/rsa.h> // RSA_PKCS1_OAEP_PADDING
 
@@ -10,23 +12,6 @@
 #include <utility>     // std::move, std::unreachable
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling OpenSSL key backends, since
-// each translation unit that reads a key redeclares its file-private members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  EVP_PKEY *key;
-  std::string modulus;
-  std::size_t field_bytes;
-  std::size_t signature_bytes;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  EVP_PKEY *key;
-  std::size_t field_bytes;
-  bool rsa_pss_restricted{false};
-};
 
 namespace {
 auto to_message_digest(const RSAOAEPHash hash) -> const EVP_MD * {

--- a/src/core/crypto/crypto_rsa_oaep_other.cc
+++ b/src/core/crypto/crypto_rsa_oaep_other.cc
@@ -3,6 +3,7 @@
 
 #include "crypto_bignum.h"
 #include "crypto_helpers.h"
+#include "crypto_other.h"
 #include "crypto_random.h"
 #include "crypto_sha1_other.h"
 
@@ -23,33 +24,6 @@
 // distinguishing one
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling reference key backends,
-// since each translation unit that reads a key redeclares its file-private
-// members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  std::string modulus;
-  std::string exponent;
-  std::string coordinate_x;
-  std::string coordinate_y;
-  EllipticCurve elliptic_curve;
-  EdwardsCurve edwards_curve;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  std::string modulus;
-  std::string public_exponent;
-  std::string private_exponent;
-  std::string scalar;
-  EllipticCurve elliptic_curve;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-  std::string coordinate_x;
-  std::string coordinate_y;
-};
 
 namespace {
 auto hash_length(const RSAOAEPHash hash) -> std::size_t {

--- a/src/core/crypto/crypto_rsa_oaep_windows.cc
+++ b/src/core/crypto/crypto_rsa_oaep_windows.cc
@@ -1,5 +1,7 @@
 #include <sourcemeta/core/crypto_rsa_oaep.h>
 
+#include "crypto_windows.h"
+
 #include <windows.h> // ULONG, PUCHAR, LPCWSTR, DWORD
 // clang-format off
 #include <bcrypt.h> // BCrypt*, BCRYPT_*
@@ -12,28 +14,6 @@
 #include <utility>     // std::move, std::unreachable
 
 namespace sourcemeta::core {
-
-// The layout matches the definitions in the sibling Windows key backends, since
-// each translation unit that reads a key redeclares its file-private members
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  BCRYPT_ALG_HANDLE algorithm;
-  BCRYPT_KEY_HANDLE key;
-  std::size_t field_bytes;
-  std::string modulus;
-  std::string edwards_point;
-  EdwardsCurve edwards_curve;
-};
-
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  BCRYPT_ALG_HANDLE algorithm;
-  BCRYPT_KEY_HANDLE key;
-  std::size_t field_bytes;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-};
 
 namespace {
 auto to_cng_algorithm(const RSAOAEPHash hash) -> LPCWSTR {

--- a/src/core/crypto/crypto_sign_apple.cc
+++ b/src/core/crypto/crypto_sign_apple.cc
@@ -19,22 +19,6 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::unreachable
 
-namespace sourcemeta::core {
-
-// The parsed key keeps the platform key object alive for reuse. The Edwards
-// curves have no Security framework primitive, so they keep the raw seed and
-// sign through CryptoKit or the reference implementation
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  SecKeyRef key;
-  std::size_t field_bytes;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-};
-
-} // namespace sourcemeta::core
-
 namespace {
 
 auto to_sec_key_pkcs1_v15_algorithm(

--- a/src/core/crypto/crypto_sign_openssl.cc
+++ b/src/core/crypto/crypto_sign_openssl.cc
@@ -21,21 +21,6 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::unreachable
 
-namespace sourcemeta::core {
-
-// The parsed key keeps the native handle alive so that many signatures are
-// produced without rebuilding it
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  EVP_PKEY *key;
-  // The field width for the elliptic curve raw signature encoding
-  std::size_t field_bytes;
-  // Set for an id-RSASSA-PSS key, which is refused for PKCS1v15 signing
-  bool rsa_pss_restricted{false};
-};
-
-} // namespace sourcemeta::core
-
 namespace {
 
 auto to_message_digest(

--- a/src/core/crypto/crypto_sign_other.cc
+++ b/src/core/crypto/crypto_sign_other.cc
@@ -6,6 +6,7 @@
 #include "crypto_ecc.h"
 #include "crypto_eddsa.h"
 #include "crypto_helpers.h"
+#include "crypto_other.h"
 #include "crypto_pkcs8.h"
 
 #include <array>       // std::array
@@ -377,26 +378,6 @@ auto ec_public_from_scalar(const EllipticCurve curve,
 }
 
 } // namespace
-
-// The reference backend parses the key material into big integers inside each
-// signature, so the parsed key simply holds the raw material
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  std::string modulus;
-  std::string public_exponent;
-  std::string private_exponent;
-  std::string scalar;
-  EllipticCurve elliptic_curve;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-  // The public coordinates, kept so the public key can be recovered without
-  // recomputing the point from the scalar. A key parsed from a PEM document,
-  // which carries only the scalar on this backend, recomputes them at parse
-  // time, so they are populated for every elliptic curve private key
-  std::string coordinate_x;
-  std::string coordinate_y;
-};
 
 PrivateKey::PrivateKey(Internal *internal) noexcept : internal_{internal} {}
 

--- a/src/core/crypto/crypto_sign_windows.cc
+++ b/src/core/crypto/crypto_sign_windows.cc
@@ -24,23 +24,6 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::unreachable
 
-namespace sourcemeta::core {
-
-// The parsed key keeps both the algorithm provider and the imported key handle
-// alive for reuse. The Edwards curves have no CNG primitive, so they keep the
-// raw seed and sign through the reference implementation
-struct PrivateKey::Internal {
-  PrivateKey::Type kind;
-  BCRYPT_ALG_HANDLE algorithm;
-  BCRYPT_KEY_HANDLE key;
-  std::size_t field_bytes;
-  std::string edwards_seed;
-  EdwardsCurve edwards_curve;
-  bool rsa_pss_restricted{false};
-};
-
-} // namespace sourcemeta::core
-
 namespace {
 
 auto to_cng_algorithm(

--- a/src/core/crypto/crypto_verify_apple.cc
+++ b/src/core/crypto/crypto_verify_apple.cc
@@ -18,22 +18,6 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::unreachable
 
-namespace sourcemeta::core {
-
-// The parsed key keeps the platform key object alive for reuse. The Edwards
-// curves have no Security framework primitive, so they keep the raw encoded
-// point and verify through CryptoKit or the reference implementation
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  SecKeyRef key;
-  std::string modulus;
-  std::size_t field_bytes;
-  std::string edwards_point;
-  EdwardsCurve edwards_curve;
-};
-
-} // namespace sourcemeta::core
-
 namespace {
 
 auto to_sec_key_pkcs1_v15_algorithm(

--- a/src/core/crypto/crypto_verify_openssl.cc
+++ b/src/core/crypto/crypto_verify_openssl.cc
@@ -18,23 +18,6 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::unreachable
 
-namespace sourcemeta::core {
-
-// The parsed key keeps the native handle alive so that many signatures verify
-// without rebuilding it
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  EVP_PKEY *key;
-  // The stripped modulus, kept for the RSA signature range check
-  std::string modulus;
-  // The field width for the elliptic curve signature size check
-  std::size_t field_bytes;
-  // The expected signature length for the Edwards curve
-  std::size_t signature_bytes;
-};
-
-} // namespace sourcemeta::core
-
 namespace {
 
 auto to_message_digest(

--- a/src/core/crypto/crypto_verify_other.cc
+++ b/src/core/crypto/crypto_verify_other.cc
@@ -5,6 +5,7 @@
 #include "crypto_ecc.h"
 #include "crypto_eddsa.h"
 #include "crypto_helpers.h"
+#include "crypto_other.h"
 
 #include <array>       // std::array
 #include <cassert>     // assert
@@ -340,19 +341,6 @@ auto verify_ecdsa(const EllipticCurve curve, const SignatureHashFunction hash,
 }
 
 } // namespace
-
-// The reference backend parses the key material into big integers inside each
-// verification, which is cheap next to the modular arithmetic, so the parsed
-// key simply holds the raw material
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  std::string modulus;
-  std::string exponent;
-  std::string coordinate_x;
-  std::string coordinate_y;
-  EllipticCurve elliptic_curve;
-  EdwardsCurve edwards_curve;
-};
 
 PublicKey::PublicKey(Internal *internal) noexcept : internal_{internal} {}
 

--- a/src/core/crypto/crypto_verify_windows.cc
+++ b/src/core/crypto/crypto_verify_windows.cc
@@ -22,23 +22,6 @@
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::unreachable
 
-namespace sourcemeta::core {
-
-// The parsed key keeps both the algorithm provider and the imported key handle
-// alive for reuse. The Edwards curves have no CNG primitive, so they keep the
-// raw encoded point and verify through the reference implementation
-struct PublicKey::Internal {
-  PublicKey::Type kind;
-  BCRYPT_ALG_HANDLE algorithm;
-  BCRYPT_KEY_HANDLE key;
-  std::size_t field_bytes;
-  std::string modulus;
-  std::string edwards_point;
-  EdwardsCurve edwards_curve;
-};
-
-} // namespace sourcemeta::core
-
 namespace {
 
 auto to_cng_algorithm(

--- a/src/core/crypto/crypto_windows.h
+++ b/src/core/crypto/crypto_windows.h
@@ -1,8 +1,9 @@
 #ifndef SOURCEMETA_CORE_CRYPTO_WINDOWS_H_
 #define SOURCEMETA_CORE_CRYPTO_WINDOWS_H_
 
-// CNG helpers shared across backends, so the native blob export and the
-// chunked hash ingestion stay single-sourced
+// The CNG key internals and the helpers shared across the CNG backends, so the
+// parsed key layout, the native blob export, and the chunked hash ingestion
+// stay single-sourced
 
 #ifndef NOMINMAX
 #define NOMINMAX
@@ -13,6 +14,9 @@
 // BCRYPT_SUCCESS
 #include <bcrypt.h>
 
+#include <sourcemeta/core/crypto_sign.h>
+#include <sourcemeta/core/crypto_verify.h>
+
 #include <cstddef>     // std::size_t
 #include <limits>      // std::numeric_limits
 #include <optional>    // std::optional, std::nullopt
@@ -20,6 +24,29 @@
 #include <string_view> // std::string_view
 
 namespace sourcemeta::core {
+
+// The parsed key keeps both the algorithm provider and the imported key handle
+// alive for reuse. The Edwards curves have no CNG primitive, so they keep the
+// raw seed or point and operate through the reference implementation
+struct PublicKey::Internal {
+  PublicKey::Type kind;
+  BCRYPT_ALG_HANDLE algorithm;
+  BCRYPT_KEY_HANDLE key;
+  std::size_t field_bytes;
+  std::string modulus;
+  std::string edwards_point;
+  EdwardsCurve edwards_curve;
+};
+
+struct PrivateKey::Internal {
+  PrivateKey::Type kind;
+  BCRYPT_ALG_HANDLE algorithm;
+  BCRYPT_KEY_HANDLE key;
+  std::size_t field_bytes;
+  std::string edwards_seed;
+  EdwardsCurve edwards_curve;
+  bool rsa_pss_restricted{false};
+};
 
 // Feed a buffer into a hash object. The data interface is not const-qualified
 // but never writes through the pointer, and it takes a 32-bit length, so


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

