### PR TITLE
Implement a `JSON::unique_keys` method

### DIFF
--- a/src/core/json/include/sourcemeta/core/json_value.h
+++ b/src/core/json/include/sourcemeta/core/json_value.h
@@ -1772,6 +1772,19 @@ public:
   /// ```
   [[nodiscard]] auto unique() const -> bool;
 
+  /// This method checks if a JSON object does not name any key more than once.
+  /// The parser preserves repeated members rather than collapsing them, so this
+  /// detects a document whose object named a key twice. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/json.h>
+  /// #include <cassert>
+  ///
+  /// const auto document{sourcemeta::core::parse_json(R"({ "foo": 1 })")};
+  /// assert(document.unique_keys());
+  /// ```
+  [[nodiscard]] auto unique_keys() const -> bool;
+
   /*
    * Write operations
    */

--- a/src/core/json/json_value.cc
+++ b/src/core/json/json_value.cc
@@ -919,6 +919,28 @@ JSON::defines_any(std::initializer_list<JSON::String> keys) const -> bool {
   return true;
 }
 
+[[nodiscard]] auto JSON::unique_keys() const -> bool {
+  assert(this->is_object());
+  const auto &entries{this->data_object.data};
+  const auto size{entries.size()};
+
+  // Objects of 0 or 1 member have unique keys by definition
+  if (size <= 1) {
+    return true;
+  }
+
+  for (std::size_t index = 0; index < size; index++) {
+    for (std::size_t subindex = index + 1; subindex < size; subindex++) {
+      if (entries[subindex].key_equals(entries[index].first,
+                                       entries[index].hash)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 auto JSON::push_back(const JSON &value) -> void {
   assert(this->is_array());
   return this->data_array.data.push_back(value);

--- a/test/json/json_object_test.cc
+++ b/test/json/json_object_test.cc
@@ -1639,3 +1639,41 @@ TEST(constexpr_hash_matches_runtime_for_a_long_key) {
   const auto run_time{sourcemeta::core::JSON::Object::hash(key)};
   EXPECT_TRUE(compile_time == run_time);
 }
+
+TEST(unique_keys_empty_object) {
+  const auto document{sourcemeta::core::parse_json("{}")};
+  EXPECT_TRUE(document.unique_keys());
+}
+
+TEST(unique_keys_true) {
+  const auto document{
+      sourcemeta::core::parse_json(R"({ "foo": 1, "bar": 2, "baz": 3 })")};
+  EXPECT_TRUE(document.unique_keys());
+}
+
+TEST(unique_keys_false) {
+  const auto document{
+      sourcemeta::core::parse_json(R"({ "foo": 1, "bar": 2, "foo": 3 })")};
+  EXPECT_FALSE(document.unique_keys());
+}
+
+TEST(unique_keys_false_adjacent) {
+  const auto document{
+      sourcemeta::core::parse_json(R"({ "foo": 1, "foo": 2 })")};
+  EXPECT_FALSE(document.unique_keys());
+}
+
+TEST(unique_keys_false_long_keys) {
+  // Keys beyond the perfect-hash width exercise the string-comparison fallback
+  const std::string key(40, 'a');
+  const auto document{sourcemeta::core::parse_json("{ \"" + key + "\": 1, \"" +
+                                                   key + "\": 2 }")};
+  EXPECT_FALSE(document.unique_keys());
+}
+
+TEST(unique_keys_true_long_keys) {
+  const auto document{sourcemeta::core::parse_json(
+      R"({ "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1": 1,
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2": 2 })")};
+  EXPECT_TRUE(document.unique_keys());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

