### PR TITLE
Add a wiping request body path to the HTTP client

### DIFF
--- a/src/core/crypto/include/sourcemeta/core/crypto_secure.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_secure.h
@@ -252,6 +252,11 @@ public:
     return {this->buffer_.data(), this->buffer_.size()};
   }
 
+  /// A pointer to the held bytes, valid until the next mutation.
+  [[nodiscard]] auto data() const noexcept -> const char * {
+    return this->buffer_.data();
+  }
+
   /// Whether the held bytes equal the given view.
   [[nodiscard]] auto operator==(const std::string_view other) const noexcept
       -> bool {

--- a/src/core/crypto/include/sourcemeta/core/crypto_secure.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_secure.h
@@ -249,6 +249,12 @@ public:
 
   /// A view over the held bytes.
   [[nodiscard]] operator std::string_view() const noexcept {
+    // An empty buffer may expose a null data pointer, so a default view is
+    // returned rather than constructing one from a possibly-null pointer
+    if (this->buffer_.empty()) {
+      return {};
+    }
+
     return {this->buffer_.data(), this->buffer_.size()};
   }
 

--- a/src/core/http/CMakeLists.txt
+++ b/src/core/http/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(sourcemeta_core_http PUBLIC sourcemeta::core::json)
 target_link_libraries(sourcemeta_core_http PUBLIC sourcemeta::core::text)
 target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::time)
 target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::dns)
-target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::crypto)
+target_link_libraries(sourcemeta_core_http PUBLIC sourcemeta::core::crypto)
 target_link_libraries(sourcemeta_core_http PRIVATE sourcemeta::core::uri)
 
 if(SOURCEMETA_CORE_HTTP_USE_SYSTEM_CURL)

--- a/src/core/http/aws_sigv4.cc
+++ b/src/core/http/aws_sigv4.cc
@@ -287,9 +287,9 @@ auto HTTPSystemRequest::sign_aws_sigv4(
 
   const auto amz_date{to_iso8601_basic(moment)};
   const std::string_view date{std::string_view{amz_date}.substr(0, 8)};
-  const auto payload_hash{sha256(
-      this->body_.has_value() ? std::string_view{this->body_.value().data}
-                              : std::string_view{})};
+  const auto payload_hash{sha256(this->body_.has_value()
+                                     ? this->body_.value().bytes()
+                                     : std::string_view{})};
 
   // Drop any signing headers left over from a previous signature so that
   // re-signing replaces them rather than appending duplicates

--- a/src/core/http/client_curl.cc
+++ b/src/core/http/client_curl.cc
@@ -366,10 +366,11 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
     std::string content_type_line{"Content-Type: "};
     content_type_line += this->body_.value().content_type;
     header_list.append(content_type_line);
-    api.easy_setopt(handle.get(), CURLOPT_POSTFIELDSIZE_LARGE,
-                    static_cast<curl_off_t>(this->body_.value().data.size()));
+    api.easy_setopt(
+        handle.get(), CURLOPT_POSTFIELDSIZE_LARGE,
+        static_cast<curl_off_t>(this->body_.value().bytes().size()));
     api.easy_setopt(handle.get(), CURLOPT_POSTFIELDS,
-                    this->body_.value().data.data());
+                    this->body_.value().bytes().data());
   }
 
   if (header_list.get()) {

--- a/src/core/http/client_darwin.mm
+++ b/src/core/http/client_darwin.mm
@@ -144,8 +144,8 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
         [url_request setValue:to_nsstring(this->body_.value().content_type)
             forHTTPHeaderField:@"Content-Type"];
         url_request.HTTPBody =
-            [NSData dataWithBytes:this->body_.value().data.data()
-                           length:this->body_.value().data.size()];
+            [NSData dataWithBytes:this->body_.value().bytes().data()
+                           length:this->body_.value().bytes().size()];
       }
 
       NSURLSessionConfiguration *configuration{

--- a/src/core/http/client_windows.cc
+++ b/src/core/http/client_windows.cc
@@ -193,7 +193,8 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
   LPVOID body_data{WINHTTP_NO_REQUEST_DATA};
   DWORD body_size{0};
   if (this->body_.has_value()) {
-    if (this->body_.value().data.size() > std::numeric_limits<DWORD>::max()) {
+    if (this->body_.value().bytes().size() >
+        std::numeric_limits<DWORD>::max()) {
       throw HTTPError{this->method_, this->url_,
                       "The request body is too large"};
     }
@@ -201,8 +202,8 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
     serialized_headers += "Content-Type: ";
     serialized_headers += this->body_.value().content_type;
     serialized_headers += "\r\n";
-    body_data = const_cast<char *>(this->body_.value().data.data());
-    body_size = static_cast<DWORD>(this->body_.value().data.size());
+    body_data = const_cast<char *>(this->body_.value().bytes().data());
+    body_size = static_cast<DWORD>(this->body_.value().bytes().size());
   }
 
   const auto request_headers{

--- a/src/core/http/include/sourcemeta/core/http_system.h
+++ b/src/core/http/include/sourcemeta/core/http_system.h
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/http_export.h>
 #endif
 
+#include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/http_aws_sigv4.h>
 #include <sourcemeta/core/http_method.h>
 #include <sourcemeta/core/http_status.h>
@@ -17,6 +18,7 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <utility>     // std::move, std::pair
+#include <variant>     // std::variant, std::visit
 #include <vector>      // std::vector
 
 namespace sourcemeta::core {
@@ -163,6 +165,17 @@ public:
     return *this;
   }
 
+  /// Set the request body from wiping storage, sent along with the given
+  /// `Content-Type` header. The body is held in the wiping storage so a secret
+  /// it carries, such as a client secret or PKCE code verifier, is never copied
+  /// into an ordinary string
+  auto body(SecureString data, std::string content_type)
+      -> HTTPSystemRequest & {
+    this->body_ =
+        Body{.data = std::move(data), .content_type = std::move(content_type)};
+    return *this;
+  }
+
   /// Set whether to follow redirects, on by default
   auto follow_redirects(const bool value) -> HTTPSystemRequest & {
     this->follow_redirects_ = value;
@@ -224,8 +237,17 @@ public:
 
 private:
   struct Body {
-    std::string data;
+    // A plain body carries no secret and keeps the ordinary string storage,
+    // while a body set from wiping storage stays in it, so the common request
+    // pays nothing and a secret one is never copied into an ordinary string
+    std::variant<std::string, SecureString> data;
     std::string content_type;
+
+    [[nodiscard]] auto bytes() const -> std::string_view {
+      return std::visit(
+          [](const auto &value) -> std::string_view { return value; },
+          this->data);
+    }
   };
 
   std::string url_;

--- a/test/crypto/crypto_secure_test.cc
+++ b/test/crypto/crypto_secure_test.cc
@@ -36,6 +36,11 @@ TEST(secure_string_holds_its_content) {
   EXPECT_EQ(secret.size(), 7);
 }
 
+TEST(secure_string_exposes_its_bytes_through_data) {
+  const sourcemeta::core::SecureString secret{"hunter2"};
+  EXPECT_EQ(std::string_view(secret.data(), secret.size()), "hunter2");
+}
+
 TEST(secure_string_appends_content) {
   sourcemeta::core::SecureString secret{"hunter"};
   secret.append("2");

--- a/test/crypto/crypto_secure_test.cc
+++ b/test/crypto/crypto_secure_test.cc
@@ -41,6 +41,13 @@ TEST(secure_string_exposes_its_bytes_through_data) {
   EXPECT_EQ(std::string_view(secret.data(), secret.size()), "hunter2");
 }
 
+TEST(secure_string_of_empty_content_views_as_empty) {
+  const sourcemeta::core::SecureString secret{};
+  const std::string_view view{secret};
+  EXPECT_TRUE(view.empty());
+  EXPECT_EQ(view, std::string_view{});
+}
+
 TEST(secure_string_appends_content) {
   sourcemeta::core::SecureString secret{"hunter"};
   secret.append("2");

--- a/test/http/http_system_request_test.cc
+++ b/test/http/http_system_request_test.cc
@@ -168,6 +168,25 @@ TEST(sign_aws_sigv4_hashes_the_body) {
   EXPECT_TRUE(request.header("Authorization").has_value());
 }
 
+TEST(sign_aws_sigv4_hashes_a_secure_string_body) {
+  const auto moment{
+      sourcemeta::core::from_iso8601_basic("20150830T123600Z").value()};
+  sourcemeta::core::HTTPSystemRequest request{
+      "https://example.amazonaws.com/", sourcemeta::core::HTTPMethod::POST};
+  request.body(sourcemeta::core::SecureString{"Param1=value1"},
+               "application/x-www-form-urlencoded");
+  request.sign_aws_sigv4(
+      {.access_key_id = "AKIDEXAMPLE",
+       .secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+       .session_token = ""},
+      "us-east-1", "service", moment);
+
+  // A wiping-storage body is read and signed identically to a plain-string one
+  EXPECT_EQ(request.header("x-amz-content-sha256").value(),
+            sourcemeta::core::sha256("Param1=value1"));
+  EXPECT_TRUE(request.header("Authorization").has_value());
+}
+
 TEST(sign_aws_sigv4_adds_session_token_when_present) {
   const auto moment{
       sourcemeta::core::from_iso8601_basic("20150830T123600Z").value()};

--- a/test/http/http_system_request_test.cc
+++ b/test/http/http_system_request_test.cc
@@ -187,6 +187,25 @@ TEST(sign_aws_sigv4_hashes_a_secure_string_body) {
   EXPECT_TRUE(request.header("Authorization").has_value());
 }
 
+TEST(sign_aws_sigv4_hashes_an_empty_secure_string_body) {
+  const auto moment{
+      sourcemeta::core::from_iso8601_basic("20150830T123600Z").value()};
+  sourcemeta::core::HTTPSystemRequest request{
+      "https://example.amazonaws.com/", sourcemeta::core::HTTPMethod::POST};
+  request.body(sourcemeta::core::SecureString{},
+               "application/x-www-form-urlencoded");
+  request.sign_aws_sigv4(
+      {.access_key_id = "AKIDEXAMPLE",
+       .secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+       .session_token = ""},
+      "us-east-1", "service", moment);
+
+  // An empty wiping-storage body views a possibly-null buffer and must hash as
+  // the empty string
+  EXPECT_EQ(request.header("x-amz-content-sha256").value(),
+            sourcemeta::core::sha256(""));
+}
+
 TEST(sign_aws_sigv4_adds_session_token_when_present) {
   const auto moment{
       sourcemeta::core::from_iso8601_basic("20150830T123600Z").value()};


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

