### PR TITLE
test(dns): expand is_hostname coverage for length, hyphen, dot, and A-label branches

### DIFF
--- a/test/dns/hostname_test.cc
+++ b/test/dns/hostname_test.cc
@@ -450,3 +450,588 @@ TEST(invalid_at_sign) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("user@host"));
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("user@host"));
 }
+
+// Total length cap. RFC 1123 §2.1: "Host software MUST handle host
+// names of up to 63 characters and SHOULD handle host names of up to 255
+// characters." The existing tests only reach the cap through four 63-byte
+// labels, so these reach it through many short ones instead
+
+TEST(valid_total_255_many_short_labels) {
+  // 128 single-character labels and 127 dots is 255 bytes, right at the cap
+  std::string hostname{"a"};
+  for (int index = 0; index < 127; ++index) {
+    hostname.append(".a");
+  }
+  EXPECT_EQ(hostname.size(), 255u);
+  EXPECT_TRUE(sourcemeta::core::is_hostname(hostname));
+}
+
+TEST(invalid_total_256_many_short_labels) {
+  // the same shape one byte over the cap, with every label still well formed
+  std::string hostname{"aa"};
+  for (int index = 0; index < 127; ++index) {
+    hostname.append(".a");
+  }
+  EXPECT_EQ(hostname.size(), 256u);
+  EXPECT_FALSE(sourcemeta::core::is_hostname(hostname));
+}
+
+TEST(invalid_total_far_over_cap) {
+  // the total-length check runs before any label scan, so an input far past
+  // the cap is rejected without walking it
+  EXPECT_FALSE(sourcemeta::core::is_hostname(std::string(100000, 'a')));
+}
+
+// Per-label cap in non-leading positions. RFC 1035 §2.3.4 caps a label at 63
+// octets, and the existing tests only exercise the first label
+
+TEST(valid_middle_label_63) {
+  // 63-character label between two other labels
+  EXPECT_TRUE(
+      sourcemeta::core::is_hostname("a." + std::string(63, 'a') + ".b"));
+}
+
+TEST(valid_last_label_63) {
+  // 63-character label in last position
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a." + std::string(63, 'a')));
+}
+
+TEST(invalid_middle_label_64) {
+  // 64-character label between two other labels
+  EXPECT_FALSE(
+      sourcemeta::core::is_hostname("a." + std::string(64, 'a') + ".b"));
+}
+
+TEST(invalid_last_label_64) {
+  // 64-character label in last position
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a." + std::string(64, 'a')));
+}
+
+// Hyphen placement. RFC 1123 §2.1 relaxes the first character to a letter or
+// a digit, and RFC 952 ASSUMPTIONS says "The last character must not be a
+// minus sign or period"
+
+TEST(invalid_hyphen_only) {
+  // a lone hyphen has no leading let-dig
+  EXPECT_FALSE(sourcemeta::core::is_hostname("-"));
+}
+
+TEST(invalid_double_hyphen_only) {
+  // two hyphens still have no leading let-dig
+  EXPECT_FALSE(sourcemeta::core::is_hostname("--"));
+}
+
+TEST(invalid_minimal_trailing_hyphen) {
+  // shortest label ending in a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a-"));
+}
+
+TEST(invalid_minimal_leading_hyphen) {
+  // shortest label starting with a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("-a"));
+}
+
+TEST(invalid_first_of_two_leading_hyphen) {
+  // first label of two starts with a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("-a.b"));
+}
+
+TEST(invalid_first_of_two_trailing_hyphen) {
+  // first label of two ends with a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a-.b"));
+}
+
+TEST(invalid_last_label_leading_hyphen) {
+  // last label starts with a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a.-b"));
+}
+
+TEST(invalid_last_label_trailing_hyphen) {
+  // last label ends with a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a.b-"));
+}
+
+TEST(invalid_hyphen_label_first) {
+  // a whole label that is just a hyphen, first
+  EXPECT_FALSE(sourcemeta::core::is_hostname("-.a"));
+}
+
+TEST(invalid_hyphen_label_last) {
+  // a whole label that is just a hyphen, last
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a.-"));
+}
+
+TEST(valid_three_interior_hyphens) {
+  // three consecutive interior hyphens
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a---b"));
+}
+
+TEST(valid_hyphen_heavy_label_63) {
+  // 63 characters that are hyphens except the two required let-dig ends
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a" + std::string(61, '-') + "b"));
+}
+
+TEST(valid_hyphen_in_every_label) {
+  // an interior hyphen in each of three labels
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a-b.c-d.e-f"));
+}
+
+// Dot structure. RFC 952 §B: <hname> ::= <name>*["."<name>], so every dot
+// must sit between two non-empty labels
+
+TEST(invalid_two_dots_only) {
+  // two dots with no label anywhere
+  EXPECT_FALSE(sourcemeta::core::is_hostname(".."));
+}
+
+TEST(invalid_three_dots_only) {
+  // three dots with no label anywhere
+  EXPECT_FALSE(sourcemeta::core::is_hostname("..."));
+}
+
+TEST(invalid_minimal_trailing_dot) {
+  // shortest trailing-dot form
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a."));
+}
+
+TEST(invalid_minimal_leading_dot) {
+  // shortest leading-dot form
+  EXPECT_FALSE(sourcemeta::core::is_hostname(".a"));
+}
+
+TEST(invalid_minimal_double_dot) {
+  // shortest empty interior label
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a..b"));
+}
+
+TEST(invalid_fqdn_trailing_dot) {
+  // root-anchored FQDN form with three labels
+  EXPECT_FALSE(sourcemeta::core::is_hostname("www.example.com."));
+}
+
+TEST(invalid_leading_dot_multi_label) {
+  // leading dot before a two-label name
+  EXPECT_FALSE(sourcemeta::core::is_hostname(".example.com"));
+}
+
+TEST(invalid_double_dot_before_tld) {
+  // two trailing dots after a two-label name
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.com.."));
+}
+
+TEST(valid_twenty_labels) {
+  // twenty single-character labels
+  EXPECT_TRUE(
+      sourcemeta::core::is_hostname("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t"));
+}
+
+// The "xn--" A-label branch. RFC 5890 §2.3.2.1 makes the ACE prefix
+// case-insensitive and calls a label that carries the prefix without being a
+// real Punycode encoding a "Fake A-label"
+
+TEST(xn_prefix_only) {
+  // the bare ACE prefix: the trailing-hyphen rule rejects it before the
+  // A-label check runs
+  EXPECT_FALSE(sourcemeta::core::is_hostname("xn--"));
+}
+
+TEST(xn_prefix_only_uppercase) {
+  // the same, in uppercase
+  EXPECT_FALSE(sourcemeta::core::is_hostname("XN--"));
+}
+
+TEST(xn_two_characters) {
+  // two characters, too short to carry the ACE prefix
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xn"));
+}
+
+TEST(xn_three_characters) {
+  // three characters, ends in a hyphen
+  EXPECT_FALSE(sourcemeta::core::is_hostname("xn-"));
+}
+
+TEST(xn_single_hyphen_at_three) {
+  // hyphen at position 3 only, so not an A-label
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xn-a"));
+}
+
+TEST(xn_body_single_letter) {
+  // a one-character Punycode body that does not decode to a U-label
+  EXPECT_FALSE(sourcemeta::core::is_hostname("xn--a"));
+}
+
+TEST(xn_prefix_not_at_label_start) {
+  // the ACE prefix only counts at the start of a label
+  EXPECT_TRUE(sourcemeta::core::is_hostname("axn--1234"));
+}
+
+TEST(xn_prefix_mixed_case_lower_body) {
+  // mixed-case prefix, lowercase body
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Xn--4gbwdl"));
+}
+
+TEST(xn_prefix_mixed_case_second_char) {
+  // mixed-case prefix on the second character
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xN--4gbwdl"));
+}
+
+TEST(xn_prefix_uppercase_lower_body) {
+  // uppercase prefix, lowercase body
+  EXPECT_TRUE(sourcemeta::core::is_hostname("XN--4gbwdl"));
+}
+
+TEST(xn_single_label_valid) {
+  // a valid A-label on its own
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xn--4gbwdl"));
+}
+
+TEST(xn_valid_second_label) {
+  // a valid A-label after an ASCII label
+  EXPECT_TRUE(sourcemeta::core::is_hostname("example.xn--wgbh1c"));
+}
+
+TEST(xn_invalid_second_label) {
+  // the A-label check also runs on non-leading labels
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.xn--X"));
+}
+
+TEST(xn_valid_russian_tld) {
+  // the A-label for the Cyrillic .rf top-level domain
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xn--p1ai"));
+}
+
+TEST(xn_valid_two_a_labels_and_ascii) {
+  // A-labels around an ASCII label
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xn--p1ai.example.xn--p1ai"));
+}
+
+TEST(xn_body_trailing_hyphen) {
+  // an ACE-prefixed label ending in a hyphen, rejected by the LDH rule first
+  EXPECT_FALSE(sourcemeta::core::is_hostname("xn--a-"));
+}
+
+TEST(xn_prefix_only_middle_label) {
+  // the bare ACE prefix as a middle label
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a.xn--.b"));
+}
+
+TEST(xn_real_a_label_at_63) {
+  // the A-label for 55 letter a followed by U+00E4, exactly at the 63-octet
+  // cap
+  EXPECT_TRUE(
+      sourcemeta::core::is_hostname("xn--" + std::string(55, 'a') + "-uve"));
+}
+
+TEST(xn_real_a_label_at_64) {
+  // the same shape with one more letter a, one octet past the cap
+  EXPECT_FALSE(
+      sourcemeta::core::is_hostname("xn--" + std::string(56, 'a') + "-qye"));
+}
+
+TEST(xn_fake_body_leading_delimiter) {
+  // RFC 5890 §2.3.2.1 Fake A-label: LDH-clean, but the Punycode body starts
+  // with the delimiter
+  EXPECT_FALSE(sourcemeta::core::is_hostname("xn---p1ai"));
+}
+
+TEST(xn_fake_body_trailing_basic) {
+  // RFC 5890 §2.3.2.1 Fake A-label: the body does not round-trip through
+  // Punycode
+  EXPECT_FALSE(sourcemeta::core::is_hostname("xn--p1ai-a"));
+}
+
+TEST(xn_valid_a_label_then_ascii) {
+  // a valid A-label followed by an ASCII label
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xn--p1ai.example"));
+}
+
+// Line terminators and surrounding whitespace. RFC 952 ASSUMPTIONS: "No blank
+// or space characters are permitted as part of a name"
+
+TEST(invalid_trailing_newline) {
+  // a trailing newline, the classic line-oriented reader artefact
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\n"));
+}
+
+TEST(invalid_trailing_carriage_return) {
+  // a trailing carriage return
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\r"));
+}
+
+TEST(invalid_trailing_crlf) {
+  // a trailing CRLF pair
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\r\n"));
+}
+
+TEST(invalid_leading_newline) {
+  // a leading newline
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\nexample.com"));
+}
+
+TEST(invalid_newline_only) {
+  // a lone newline
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\n"));
+}
+
+TEST(invalid_trailing_tab) {
+  // a trailing tab
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\t"));
+}
+
+TEST(invalid_leading_space) {
+  // a leading space
+  EXPECT_FALSE(sourcemeta::core::is_hostname(" example.com"));
+}
+
+TEST(invalid_trailing_space) {
+  // a trailing space
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example.com "));
+}
+
+TEST(invalid_space_only) {
+  // a lone space
+  EXPECT_FALSE(sourcemeta::core::is_hostname(" "));
+}
+
+TEST(invalid_interior_newline) {
+  // a newline where the label separator would go
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example\ncom"));
+}
+
+// Embedded NUL. Each of these is passed with an explicit length, so the
+// bytes after the NUL are part of the input rather than being cut off
+
+TEST(invalid_nul_only) {
+  // a lone NUL byte
+  EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view("\0", 1)));
+}
+
+TEST(invalid_trailing_nul) {
+  // a valid name followed by a NUL
+  EXPECT_FALSE(
+      sourcemeta::core::is_hostname(std::string_view("example.com\0", 12)));
+}
+
+TEST(invalid_leading_nul) {
+  // a NUL before a valid name
+  EXPECT_FALSE(
+      sourcemeta::core::is_hostname(std::string_view("\0example.com", 12)));
+}
+
+TEST(invalid_nul_truncation_payload) {
+  // a NUL that would truncate the name in a C string reader
+  EXPECT_FALSE(sourcemeta::core::is_hostname(
+      std::string_view("example.com\0.evil.test", 22)));
+}
+
+// The label alphabet, swept over every byte value. RFC 952 §B builds
+// <name> out of <let>, <let-or-digit> and <let-or-digit-or-hyphen>, and
+// RFC 1123 §2.1 changes only the first-character rule, so the accepted set is
+// closed and can be checked exhaustively rather than sampled
+
+TEST(byte_alphabet_interior_position) {
+  for (int value = 0; value < 256; ++value) {
+    const auto character{static_cast<char>(value)};
+    const bool is_let_dig{(character >= 'a' && character <= 'z') ||
+                          (character >= 'A' && character <= 'Z') ||
+                          (character >= '0' && character <= '9')};
+    std::string candidate{"a"};
+    candidate.push_back(character);
+    candidate.append("b");
+    // an interior hyphen is let-dig-hyp and an interior dot is the label
+    // separator, so both keep the name well formed
+    if (is_let_dig || character == '-' || character == '.') {
+      EXPECT_TRUE(sourcemeta::core::is_hostname(candidate));
+    } else {
+      EXPECT_FALSE(sourcemeta::core::is_hostname(candidate));
+    }
+  }
+}
+
+// RFC 1123 §2.1: the first character of a label must be a letter or a digit,
+// which rules out the hyphen and the dot that the interior position allows
+TEST(byte_alphabet_leading_position) {
+  for (int value = 0; value < 256; ++value) {
+    const auto character{static_cast<char>(value)};
+    const bool is_let_dig{(character >= 'a' && character <= 'z') ||
+                          (character >= 'A' && character <= 'Z') ||
+                          (character >= '0' && character <= '9')};
+    std::string candidate;
+    candidate.push_back(character);
+    candidate.append("ab");
+    if (is_let_dig) {
+      EXPECT_TRUE(sourcemeta::core::is_hostname(candidate));
+    } else {
+      EXPECT_FALSE(sourcemeta::core::is_hostname(candidate));
+    }
+  }
+}
+
+// RFC 952 §B: <name> ends in <let-or-digit>, so a trailing hyphen is out, and
+// a trailing dot is not part of the host name grammar either
+TEST(byte_alphabet_trailing_position) {
+  for (int value = 0; value < 256; ++value) {
+    const auto character{static_cast<char>(value)};
+    const bool is_let_dig{(character >= 'a' && character <= 'z') ||
+                          (character >= 'A' && character <= 'Z') ||
+                          (character >= '0' && character <= '9')};
+    std::string candidate{"ab"};
+    candidate.push_back(character);
+    if (is_let_dig) {
+      EXPECT_TRUE(sourcemeta::core::is_hostname(candidate));
+    } else {
+      EXPECT_FALSE(sourcemeta::core::is_hostname(candidate));
+    }
+  }
+}
+
+// Non-ASCII bytes. RFC 952 ASSUMPTIONS draws the alphabet from "(A-Z), digits
+// (0-9), minus sign (-), and period (.)", so nothing above 0x7F belongs in a
+// host name, however much a codepoint looks or case-folds like ASCII
+
+TEST(invalid_kelvin_sign) {
+  // U+212A KELVIN SIGN, which case-folds to ASCII k
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xe2\x84\xaa"
+                                             "b"));
+}
+
+TEST(invalid_long_s) {
+  // U+017F LATIN SMALL LETTER LONG S, which case-folds to ASCII s
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xc5\xbf"
+                                             "b"));
+}
+
+TEST(invalid_dotless_i) {
+  // U+0131 LATIN SMALL LETTER DOTLESS I
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xc4\xb1"
+                                             "b"));
+}
+
+TEST(invalid_arabic_indic_digit) {
+  // U+0660 ARABIC-INDIC DIGIT ZERO
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xd9\xa0"
+                                             "b"));
+}
+
+TEST(invalid_fullwidth_digit) {
+  // U+FF10 FULLWIDTH DIGIT ZERO
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xef\xbc\x90"
+                                             "b"));
+}
+
+TEST(invalid_devanagari_digit) {
+  // U+0966 DEVANAGARI DIGIT ZERO
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xe0\xa5\xa6"
+                                             "b"));
+}
+
+TEST(invalid_latin_small_e_acute) {
+  // U+00E9, a plain accented Latin letter
+  EXPECT_FALSE(sourcemeta::core::is_hostname("caf\xc3\xa9.test"));
+}
+
+TEST(invalid_non_breaking_space) {
+  // U+00A0 NO-BREAK SPACE
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xc2\xa0"
+                                             "b"));
+}
+
+TEST(invalid_ideographic_full_stop) {
+  // U+3002 IDEOGRAPHIC FULL STOP, an IDNA separator but not an ASCII dot
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example\xe3\x80\x82"
+                                             "com"));
+}
+
+TEST(invalid_halfwidth_ideographic_full_stop) {
+  // U+FF61 HALFWIDTH IDEOGRAPHIC FULL STOP
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example\xef\xbd\xa1"
+                                             "com"));
+}
+
+TEST(invalid_one_dot_leader) {
+  // U+2024 ONE DOT LEADER, a full stop look-alike
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example\xe2\x80\xa4"
+                                             "com"));
+}
+
+TEST(invalid_zero_width_joiner) {
+  // U+200D ZERO WIDTH JOINER
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a\xe2\x80\x8d"
+                                             "b"));
+}
+
+TEST(invalid_high_byte_leading) {
+  // a lone UTF-8 continuation byte in leading position
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x80"
+                                             "ab"));
+}
+
+TEST(invalid_high_byte_trailing) {
+  // 0xFF, which never appears in valid UTF-8
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab\xff"));
+}
+
+TEST(invalid_overlong_full_stop) {
+  // an overlong UTF-8 encoding of the ASCII full stop
+  EXPECT_FALSE(sourcemeta::core::is_hostname("example\xc0\xae"
+                                             "com"));
+}
+
+TEST(invalid_truncated_utf8) {
+  // a truncated two-byte UTF-8 sequence
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab\xc3"));
+}
+
+// Additional valid shapes
+
+TEST(valid_localhost) {
+  // the single-label name every resolver ships with
+  EXPECT_TRUE(sourcemeta::core::is_hostname("localhost"));
+}
+
+TEST(valid_all_numeric_dotted_quad) {
+  // RFC 1123 §2.1 mentions the dotted-decimal form only in a DISCUSSION
+  // block, and the §2.5 requirements table has no entry for it, so the
+  // grammar accepts it
+  EXPECT_TRUE(sourcemeta::core::is_hostname("127.0.0.1"));
+}
+
+TEST(valid_all_numeric_single_label) {
+  // a label with no letters at all
+  EXPECT_TRUE(sourcemeta::core::is_hostname("1234567890"));
+}
+
+TEST(valid_max_dotted_quad) {
+  // the all-numeric form at its widest
+  EXPECT_TRUE(sourcemeta::core::is_hostname("255.255.255.255"));
+}
+
+TEST(valid_digit_first_every_label) {
+  // RFC 1123 §2.1 relaxes the first character to let-dig in every label
+  EXPECT_TRUE(sourcemeta::core::is_hostname("1a.2b.3c"));
+}
+
+TEST(valid_all_digit_label_63) {
+  // 63 digits in a single label
+  EXPECT_TRUE(sourcemeta::core::is_hostname(std::string(63, '1')));
+}
+
+TEST(valid_uppercase_only) {
+  // an entirely uppercase name
+  EXPECT_TRUE(sourcemeta::core::is_hostname("EXAMPLE.COM"));
+}
+
+TEST(valid_single_uppercase_z) {
+  // the top of the uppercase range
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Z"));
+}
+
+TEST(valid_single_lowercase_z) {
+  // the top of the lowercase range
+  EXPECT_TRUE(sourcemeta::core::is_hostname("z"));
+}
+
+TEST(valid_single_digit_nine) {
+  // the top of the digit range
+  EXPECT_TRUE(sourcemeta::core::is_hostname("9"));
+}

--- a/test/dns/hostname_test.cc
+++ b/test/dns/hostname_test.cc
@@ -451,11 +451,7 @@ TEST(invalid_at_sign) {
   EXPECT_FALSE(sourcemeta::core::is_idn_hostname("user@host"));
 }
 
-// Total length cap. RFC 1123 §2.1: "Host software MUST handle host
-// names of up to 63 characters and SHOULD handle host names of up to 255
-// characters." The existing tests only reach the cap through four 63-byte
-// labels, so these reach it through many short ones instead
-
+// RFC 1123 §2.1: 255-byte cap via many short labels, not four long ones
 TEST(valid_total_255_many_short_labels) {
   // 128 single-character labels and 127 dots is 255 bytes, right at the cap
   std::string hostname{"a"};
@@ -466,6 +462,7 @@ TEST(valid_total_255_many_short_labels) {
   EXPECT_TRUE(sourcemeta::core::is_hostname(hostname));
 }
 
+// RFC 1123 §2.1: one byte over the 255 cap, same many-short-labels shape
 TEST(invalid_total_256_many_short_labels) {
   // the same shape one byte over the cap, with every label still well formed
   std::string hostname{"aa"};
@@ -476,15 +473,14 @@ TEST(invalid_total_256_many_short_labels) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(hostname));
 }
 
+// RFC 1123 §2.1: the length check runs before any label scan
 TEST(invalid_total_far_over_cap) {
   // the total-length check runs before any label scan, so an input far past
   // the cap is rejected without walking it
   EXPECT_FALSE(sourcemeta::core::is_hostname(std::string(100000, 'a')));
 }
 
-// Per-label cap in non-leading positions. RFC 1035 §2.3.4 caps a label at 63
-// octets, and the existing tests only exercise the first label
-
+// RFC 1035 §2.3.4: a 63-octet label, not in the first position
 TEST(valid_middle_label_63) {
   // 63-character label between two other labels
   EXPECT_TRUE(
@@ -496,6 +492,7 @@ TEST(valid_last_label_63) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("a." + std::string(63, 'a')));
 }
 
+// RFC 1035 §2.3.4: a 64-octet label, not in the first position
 TEST(invalid_middle_label_64) {
   // 64-character label between two other labels
   EXPECT_FALSE(
@@ -507,10 +504,7 @@ TEST(invalid_last_label_64) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a." + std::string(64, 'a')));
 }
 
-// Hyphen placement. RFC 1123 §2.1 relaxes the first character to a letter or
-// a digit, and RFC 952 ASSUMPTIONS says "The last character must not be a
-// minus sign or period"
-
+// RFC 952 §B: a lone hyphen (or two) has no leading let-dig
 TEST(invalid_hyphen_only) {
   // a lone hyphen has no leading let-dig
   EXPECT_FALSE(sourcemeta::core::is_hostname("-"));
@@ -521,6 +515,7 @@ TEST(invalid_double_hyphen_only) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("--"));
 }
 
+// RFC 952 ASSUMPTIONS + RFC 1123 §2.1: shortest leading/trailing hyphen label
 TEST(invalid_minimal_trailing_hyphen) {
   // shortest label ending in a hyphen
   EXPECT_FALSE(sourcemeta::core::is_hostname("a-"));
@@ -531,6 +526,7 @@ TEST(invalid_minimal_leading_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("-a"));
 }
 
+// RFC 1123 §2.1 + RFC 952 ASSUMPTIONS: the hyphen rule on a non-last label
 TEST(invalid_first_of_two_leading_hyphen) {
   // first label of two starts with a hyphen
   EXPECT_FALSE(sourcemeta::core::is_hostname("-a.b"));
@@ -541,6 +537,7 @@ TEST(invalid_first_of_two_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a-.b"));
 }
 
+// RFC 1123 §2.1 + RFC 952 ASSUMPTIONS: the hyphen rule on the last label
 TEST(invalid_last_label_leading_hyphen) {
   // last label starts with a hyphen
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.-b"));
@@ -551,6 +548,7 @@ TEST(invalid_last_label_trailing_hyphen) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.b-"));
 }
 
+// RFC 952 §B: a whole label that is just a hyphen
 TEST(invalid_hyphen_label_first) {
   // a whole label that is just a hyphen, first
   EXPECT_FALSE(sourcemeta::core::is_hostname("-.a"));
@@ -561,6 +559,7 @@ TEST(invalid_hyphen_label_last) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.-"));
 }
 
+// RFC 952 §B: grammar has no rule against consecutive interior hyphens
 TEST(valid_three_interior_hyphens) {
   // three consecutive interior hyphens
   EXPECT_TRUE(sourcemeta::core::is_hostname("a---b"));
@@ -576,9 +575,7 @@ TEST(valid_hyphen_in_every_label) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("a-b.c-d.e-f"));
 }
 
-// Dot structure. RFC 952 §B: <hname> ::= <name>*["."<name>], so every dot
-// must sit between two non-empty labels
-
+// RFC 952 §B: <hname> requires a <name> between dots
 TEST(invalid_two_dots_only) {
   // two dots with no label anywhere
   EXPECT_FALSE(sourcemeta::core::is_hostname(".."));
@@ -589,6 +586,7 @@ TEST(invalid_three_dots_only) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("..."));
 }
 
+// RFC 952 §B: shortest empty-label forms, leading, trailing and interior
 TEST(invalid_minimal_trailing_dot) {
   // shortest trailing-dot form
   EXPECT_FALSE(sourcemeta::core::is_hostname("a."));
@@ -604,6 +602,7 @@ TEST(invalid_minimal_double_dot) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("a..b"));
 }
 
+// RFC 952 §B: empty-label rule on names with more than one label
 TEST(invalid_fqdn_trailing_dot) {
   // root-anchored FQDN form with three labels
   EXPECT_FALSE(sourcemeta::core::is_hostname("www.example.com."));
@@ -619,27 +618,27 @@ TEST(invalid_double_dot_before_tld) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.com.."));
 }
 
+// RFC 952 §B: <hname> ::= <name>*["."<name>] places no cap on label count
 TEST(valid_twenty_labels) {
   // twenty single-character labels
   EXPECT_TRUE(
       sourcemeta::core::is_hostname("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t"));
 }
 
-// The "xn--" A-label branch. RFC 5890 §2.3.2.1 makes the ACE prefix
-// case-insensitive and calls a label that carries the prefix without being a
-// real Punycode encoding a "Fake A-label"
-
+// RFC 5890 §2.3.2.1: bare ACE prefix caught by the trailing-hyphen rule first
 TEST(xn_prefix_only) {
   // the bare ACE prefix: the trailing-hyphen rule rejects it before the
   // A-label check runs
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--"));
 }
 
+// RFC 5890 §2.3.2.1: the ACE prefix is case-insensitive
 TEST(xn_prefix_only_uppercase) {
   // the same, in uppercase
   EXPECT_FALSE(sourcemeta::core::is_hostname("XN--"));
 }
 
+// too short, or missing, the two-hyphen ACE prefix
 TEST(xn_two_characters) {
   // two characters, too short to carry the ACE prefix
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn"));
@@ -655,16 +654,19 @@ TEST(xn_single_hyphen_at_three) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn-a"));
 }
 
+// RFC 5890 §2.3.2.1: a body that does not decode to a valid U-label
 TEST(xn_body_single_letter) {
   // a one-character Punycode body that does not decode to a U-label
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--a"));
 }
 
+// RFC 5890 §2.3.2.1: the ACE prefix only counts at the start of a label
 TEST(xn_prefix_not_at_label_start) {
   // the ACE prefix only counts at the start of a label
   EXPECT_TRUE(sourcemeta::core::is_hostname("axn--1234"));
 }
 
+// RFC 5890 §2.3.2.1: the case-insensitive ACE prefix, every case combination
 TEST(xn_prefix_mixed_case_lower_body) {
   // mixed-case prefix, lowercase body
   EXPECT_TRUE(sourcemeta::core::is_hostname("Xn--4gbwdl"));
@@ -680,6 +682,7 @@ TEST(xn_prefix_uppercase_lower_body) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("XN--4gbwdl"));
 }
 
+// RFC 5890 §2.3.2.1: a valid A-label, alone and after an ASCII label
 TEST(xn_single_label_valid) {
   // a valid A-label on its own
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn--4gbwdl"));
@@ -690,11 +693,13 @@ TEST(xn_valid_second_label) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("example.xn--wgbh1c"));
 }
 
+// RFC 5890 §2.3.2.1: the A-label check also runs on non-leading labels
 TEST(xn_invalid_second_label) {
   // the A-label check also runs on non-leading labels
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.xn--X"));
 }
 
+// RFC 5890 §2.3.2.1: real A-labels, including two around an ASCII label
 TEST(xn_valid_russian_tld) {
   // the A-label for the Cyrillic .rf top-level domain
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn--p1ai"));
@@ -705,16 +710,19 @@ TEST(xn_valid_two_a_labels_and_ascii) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn--p1ai.example.xn--p1ai"));
 }
 
+// RFC 952 ASSUMPTIONS: the last-character rule runs before the A-label check
 TEST(xn_body_trailing_hyphen) {
   // an ACE-prefixed label ending in a hyphen, rejected by the LDH rule first
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--a-"));
 }
 
+// RFC 5890 §2.3.2.1: the bare ACE prefix as a middle label
 TEST(xn_prefix_only_middle_label) {
   // the bare ACE prefix as a middle label
   EXPECT_FALSE(sourcemeta::core::is_hostname("a.xn--.b"));
 }
 
+// RFC 1035 §2.3.4: a real A-label at the 63-octet cap and one octet past it
 TEST(xn_real_a_label_at_63) {
   // the A-label for 55 letter a followed by U+00E4, exactly at the 63-octet
   // cap
@@ -728,6 +736,7 @@ TEST(xn_real_a_label_at_64) {
       sourcemeta::core::is_hostname("xn--" + std::string(56, 'a') + "-qye"));
 }
 
+// RFC 5890 §2.3.2.1: Fake A-label, LDH-clean but not real Punycode
 TEST(xn_fake_body_leading_delimiter) {
   // RFC 5890 §2.3.2.1 Fake A-label: LDH-clean, but the Punycode body starts
   // with the delimiter
@@ -740,14 +749,13 @@ TEST(xn_fake_body_trailing_basic) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("xn--p1ai-a"));
 }
 
+// RFC 5890 §2.3.2.1: a valid A-label followed by an ASCII label
 TEST(xn_valid_a_label_then_ascii) {
   // a valid A-label followed by an ASCII label
   EXPECT_TRUE(sourcemeta::core::is_hostname("xn--p1ai.example"));
 }
 
-// Line terminators and surrounding whitespace. RFC 952 ASSUMPTIONS: "No blank
-// or space characters are permitted as part of a name"
-
+// RFC 952 ASSUMPTIONS: no blank characters permitted (trailing terminator)
 TEST(invalid_trailing_newline) {
   // a trailing newline, the classic line-oriented reader artefact
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\n"));
@@ -763,6 +771,7 @@ TEST(invalid_trailing_crlf) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\r\n"));
 }
 
+// RFC 952 ASSUMPTIONS: no blank characters permitted (leading newline)
 TEST(invalid_leading_newline) {
   // a leading newline
   EXPECT_FALSE(sourcemeta::core::is_hostname("\nexample.com"));
@@ -773,6 +782,7 @@ TEST(invalid_newline_only) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("\n"));
 }
 
+// RFC 952 ASSUMPTIONS: no blank characters permitted (tab and space)
 TEST(invalid_trailing_tab) {
   // a trailing tab
   EXPECT_FALSE(sourcemeta::core::is_hostname("example.com\t"));
@@ -793,14 +803,13 @@ TEST(invalid_space_only) {
   EXPECT_FALSE(sourcemeta::core::is_hostname(" "));
 }
 
+// RFC 952 ASSUMPTIONS: a newline where the label separator would go
 TEST(invalid_interior_newline) {
   // a newline where the label separator would go
   EXPECT_FALSE(sourcemeta::core::is_hostname("example\ncom"));
 }
 
-// Embedded NUL. Each of these is passed with an explicit length, so the
-// bytes after the NUL are part of the input rather than being cut off
-
+// RFC 952 ASSUMPTIONS: NUL is outside the alphabet, kept at an explicit length
 TEST(invalid_nul_only) {
   // a lone NUL byte
   EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view("\0", 1)));
@@ -824,71 +833,1541 @@ TEST(invalid_nul_truncation_payload) {
       std::string_view("example.com\0.evil.test", 22)));
 }
 
-// The label alphabet, swept over every byte value. RFC 952 §B builds
-// <name> out of <let>, <let-or-digit> and <let-or-digit-or-hyphen>, and
-// RFC 1123 §2.1 changes only the first-character rule, so the accepted set is
-// closed and can be checked exhaustively rather than sampled
-
-TEST(byte_alphabet_interior_position) {
-  for (int value = 0; value < 256; ++value) {
-    const auto character{static_cast<char>(value)};
-    const bool is_let_dig{(character >= 'a' && character <= 'z') ||
-                          (character >= 'A' && character <= 'Z') ||
-                          (character >= '0' && character <= '9')};
-    std::string candidate{"a"};
-    candidate.push_back(character);
-    candidate.append("b");
-    // an interior hyphen is let-dig-hyp and an interior dot is the label
-    // separator, so both keep the name well formed
-    if (is_let_dig || character == '-' || character == '.') {
-      EXPECT_TRUE(sourcemeta::core::is_hostname(candidate));
-    } else {
-      EXPECT_FALSE(sourcemeta::core::is_hostname(candidate));
-    }
-  }
+// RFC 1123 §2.1: leading-position let-dig, every byte value 0x00-0xFF
+TEST(byte_alphabet_leading_0x00_0x1f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view("\x00"
+                                                              "ab",
+                                                              3)));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x01"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x02"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x03"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x04"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x05"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x06"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x07"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x08"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x09"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x0a"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x0b"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x0c"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x0d"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x0e"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x0f"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x10"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x11"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x12"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x13"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x14"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x15"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x16"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x17"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x18"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x19"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x1a"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x1b"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x1c"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x1d"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x1e"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x1f"
+                                             "ab"));
 }
 
-// RFC 1123 §2.1: the first character of a label must be a letter or a digit,
-// which rules out the hyphen and the dot that the interior position allows
-TEST(byte_alphabet_leading_position) {
-  for (int value = 0; value < 256; ++value) {
-    const auto character{static_cast<char>(value)};
-    const bool is_let_dig{(character >= 'a' && character <= 'z') ||
-                          (character >= 'A' && character <= 'Z') ||
-                          (character >= '0' && character <= '9')};
-    std::string candidate;
-    candidate.push_back(character);
-    candidate.append("ab");
-    if (is_let_dig) {
-      EXPECT_TRUE(sourcemeta::core::is_hostname(candidate));
-    } else {
-      EXPECT_FALSE(sourcemeta::core::is_hostname(candidate));
-    }
-  }
+TEST(byte_alphabet_leading_0x20_0x2f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname(" ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("!ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x22"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("#ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("$ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("%ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("&ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("'ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("(ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname(")ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("*ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("+ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname(",ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("-ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname(".ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("/ab"));
 }
 
-// RFC 952 §B: <name> ends in <let-or-digit>, so a trailing hyphen is out, and
-// a trailing dot is not part of the host name grammar either
-TEST(byte_alphabet_trailing_position) {
-  for (int value = 0; value < 256; ++value) {
-    const auto character{static_cast<char>(value)};
-    const bool is_let_dig{(character >= 'a' && character <= 'z') ||
-                          (character >= 'A' && character <= 'Z') ||
-                          (character >= '0' && character <= '9')};
-    std::string candidate{"ab"};
-    candidate.push_back(character);
-    if (is_let_dig) {
-      EXPECT_TRUE(sourcemeta::core::is_hostname(candidate));
-    } else {
-      EXPECT_FALSE(sourcemeta::core::is_hostname(candidate));
-    }
-  }
+TEST(byte_alphabet_leading_0x30_0x39) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("0ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("1ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("2ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("3ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("4ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("5ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("6ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("7ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("8ab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("9ab"));
 }
 
-// Non-ASCII bytes. RFC 952 ASSUMPTIONS draws the alphabet from "(A-Z), digits
-// (0-9), minus sign (-), and period (.)", so nothing above 0x7F belongs in a
-// host name, however much a codepoint looks or case-folds like ASCII
+TEST(byte_alphabet_leading_0x3a_0x40) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname(":ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname(";ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("<ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("=ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname(">ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("?ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("@ab"));
+}
 
+TEST(byte_alphabet_leading_0x41_0x5a) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Aab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Bab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Cab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Dab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Eab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Fab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Gab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Hab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Iab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Jab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Kab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Lab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Mab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Nab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Oab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Pab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Qab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Rab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Sab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Tab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Uab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Vab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Wab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Xab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Yab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("Zab"));
+}
+
+TEST(byte_alphabet_leading_0x5b_0x60) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("[ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x5c"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("]ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("^ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("_ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("`ab"));
+}
+
+TEST(byte_alphabet_leading_0x61_0x7a) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("bab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("cab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("dab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("eab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("fab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("gab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("hab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("iab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("jab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("kab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("lab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("mab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("nab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("oab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("pab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("qab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("rab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("sab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("tab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("uab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("vab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("wab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("xab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("yab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("zab"));
+}
+
+TEST(byte_alphabet_leading_0x7b_0x7f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("{ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("|ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("}ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("~ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x7f"
+                                             "ab"));
+}
+
+TEST(byte_alphabet_leading_0x80_0x9f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x80"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x81"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x82"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x83"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x84"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x85"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x86"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x87"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x88"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x89"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x8a"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x8b"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x8c"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x8d"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x8e"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x8f"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x90"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x91"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x92"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x93"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x94"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x95"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x96"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x97"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x98"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x99"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x9a"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x9b"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x9c"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x9d"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x9e"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\x9f"
+                                             "ab"));
+}
+
+TEST(byte_alphabet_leading_0xa0_0xbf) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa0"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa1"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa2"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa3"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa4"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa5"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa6"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa7"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa8"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xa9"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xaa"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xab"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xac"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xad"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xae"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xaf"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb0"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb1"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb2"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb3"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb4"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb5"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb6"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb7"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb8"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xb9"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xba"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xbb"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xbc"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xbd"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xbe"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xbf"
+                                             "ab"));
+}
+
+TEST(byte_alphabet_leading_0xc0_0xdf) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc0"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc1"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc2"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc3"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc4"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc5"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc6"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc7"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc8"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xc9"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xca"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xcb"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xcc"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xcd"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xce"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xcf"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd0"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd1"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd2"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd3"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd4"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd5"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd6"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd7"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd8"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xd9"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xda"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xdb"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xdc"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xdd"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xde"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xdf"
+                                             "ab"));
+}
+
+TEST(byte_alphabet_leading_0xe0_0xff) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe0"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe1"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe2"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe3"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe4"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe5"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe6"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe7"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe8"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xe9"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xea"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xeb"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xec"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xed"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xee"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xef"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf0"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf1"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf2"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf3"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf4"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf5"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf6"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf7"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf8"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xf9"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xfa"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xfb"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xfc"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xfd"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xfe"
+                                             "ab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("\xff"
+                                             "ab"));
+}
+
+// RFC 952 §B: interior-position let-dig-hyp and the dot, every byte value
+TEST(byte_alphabet_interior_0x00_0x1f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view("a"
+                                                              "\x00"
+                                                              "b",
+                                                              3)));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x01"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x02"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x03"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x04"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x05"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x06"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x07"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x08"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x09"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x0a"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x0b"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x0c"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x0d"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x0e"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x0f"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x10"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x11"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x12"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x13"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x14"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x15"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x16"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x17"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x18"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x19"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x1a"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x1b"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x1c"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x1d"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x1e"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x1f"
+                                             "b"));
+}
+
+TEST(byte_alphabet_interior_0x20_0x2f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a!b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x22"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a#b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a$b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a%b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a&b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a'b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a(b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a)b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a*b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a+b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a,b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a-b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a.b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a/b"));
+}
+
+TEST(byte_alphabet_interior_0x30_0x39) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a0b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a1b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a2b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a3b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a4b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a5b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a6b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a7b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a8b"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("a9b"));
+}
+
+TEST(byte_alphabet_interior_0x3a_0x40) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a:b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a;b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a<b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a=b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a>b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a?b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a@b"));
+}
+
+TEST(byte_alphabet_interior_0x41_0x5a) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aAb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aBb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aCb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aDb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aEb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aFb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aGb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aHb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aIb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aJb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aKb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aLb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aMb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aNb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aOb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aPb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aQb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aRb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aSb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aTb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aUb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aVb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aWb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aXb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aYb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aZb"));
+}
+
+TEST(byte_alphabet_interior_0x5b_0x60) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a[b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x5c"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a]b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a^b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a_b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a`b"));
+}
+
+TEST(byte_alphabet_interior_0x61_0x7a) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aab"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("acb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("adb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aeb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("afb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("agb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ahb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aib"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ajb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("akb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("alb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("amb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("anb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aob"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("apb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aqb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("arb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("asb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("atb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aub"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("avb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("awb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("axb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ayb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("azb"));
+}
+
+TEST(byte_alphabet_interior_0x7b_0x7f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a{b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a|b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a}b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a~b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x7f"
+                                             "b"));
+}
+
+TEST(byte_alphabet_interior_0x80_0x9f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x80"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x81"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x82"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x83"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x84"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x85"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x86"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x87"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x88"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x89"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x8a"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x8b"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x8c"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x8d"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x8e"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x8f"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x90"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x91"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x92"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x93"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x94"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x95"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x96"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x97"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x98"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x99"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x9a"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x9b"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x9c"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x9d"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x9e"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\x9f"
+                                             "b"));
+}
+
+TEST(byte_alphabet_interior_0xa0_0xbf) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa0"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa1"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa2"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa3"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa4"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa5"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa6"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa7"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa8"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xa9"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xaa"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xab"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xac"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xad"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xae"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xaf"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb0"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb1"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb2"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb3"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb4"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb5"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb6"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb7"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb8"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xb9"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xba"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xbb"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xbc"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xbd"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xbe"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xbf"
+                                             "b"));
+}
+
+TEST(byte_alphabet_interior_0xc0_0xdf) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc0"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc1"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc2"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc3"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc4"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc5"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc6"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc7"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc8"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xc9"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xca"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xcb"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xcc"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xcd"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xce"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xcf"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd0"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd1"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd2"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd3"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd4"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd5"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd6"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd7"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd8"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xd9"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xda"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xdb"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xdc"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xdd"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xde"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xdf"
+                                             "b"));
+}
+
+TEST(byte_alphabet_interior_0xe0_0xff) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe0"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe1"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe2"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe3"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe4"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe5"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe6"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe7"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe8"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xe9"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xea"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xeb"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xec"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xed"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xee"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xef"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf0"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf1"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf2"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf3"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf4"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf5"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf6"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf7"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf8"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xf9"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xfa"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xfb"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xfc"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xfd"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xfe"
+                                             "b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("a"
+                                             "\xff"
+                                             "b"));
+}
+
+// RFC 952 §B: trailing-position let-dig, every byte value 0x00-0xFF
+TEST(byte_alphabet_trailing_0x00_0x1f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname(std::string_view("ab"
+                                                              "\x00",
+                                                              3)));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x01"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x02"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x03"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x04"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x05"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x06"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x07"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x08"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x09"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x0a"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x0b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x0c"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x0d"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x0e"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x0f"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x10"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x11"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x12"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x13"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x14"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x15"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x16"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x17"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x18"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x19"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x1a"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x1b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x1c"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x1d"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x1e"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x1f"));
+}
+
+TEST(byte_alphabet_trailing_0x20_0x2f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab "));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab!"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x22"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab#"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab$"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab%"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab&"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab'"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab("));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab)"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab*"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab+"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab,"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab-"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab."));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab/"));
+}
+
+TEST(byte_alphabet_trailing_0x30_0x39) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab0"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab1"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab2"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab3"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab4"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab5"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab6"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab7"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab8"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("ab9"));
+}
+
+TEST(byte_alphabet_trailing_0x3a_0x40) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab:"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab;"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab<"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab="));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab>"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab?"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab@"));
+}
+
+TEST(byte_alphabet_trailing_0x41_0x5a) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abA"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abB"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abC"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abD"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abE"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abF"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abG"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abH"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abI"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abJ"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abK"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abL"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abM"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abN"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abO"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abP"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abQ"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abR"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abS"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abT"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abU"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abV"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abW"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abX"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abY"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abZ"));
+}
+
+TEST(byte_alphabet_trailing_0x5b_0x60) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab["));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x5c"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab]"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab^"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab_"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab`"));
+}
+
+TEST(byte_alphabet_trailing_0x61_0x7a) {
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aba"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abb"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abc"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abd"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abe"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abf"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abg"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abh"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abi"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abj"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abk"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abl"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abm"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abn"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abo"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abp"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abq"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abr"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abs"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abt"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abu"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abv"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abw"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abx"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("aby"));
+  EXPECT_TRUE(sourcemeta::core::is_hostname("abz"));
+}
+
+TEST(byte_alphabet_trailing_0x7b_0x7f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab{"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab|"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab}"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab~"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x7f"));
+}
+
+TEST(byte_alphabet_trailing_0x80_0x9f) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x80"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x81"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x82"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x83"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x84"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x85"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x86"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x87"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x88"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x89"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x8a"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x8b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x8c"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x8d"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x8e"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x8f"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x90"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x91"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x92"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x93"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x94"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x95"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x96"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x97"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x98"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x99"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x9a"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x9b"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x9c"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x9d"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x9e"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\x9f"));
+}
+
+TEST(byte_alphabet_trailing_0xa0_0xbf) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa0"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa1"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa2"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa3"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa4"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa5"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa6"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa7"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa8"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xa9"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xaa"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xab"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xac"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xad"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xae"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xaf"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb0"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb1"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb2"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb3"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb4"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb5"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb6"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb7"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb8"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xb9"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xba"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xbb"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xbc"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xbd"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xbe"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xbf"));
+}
+
+TEST(byte_alphabet_trailing_0xc0_0xdf) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc0"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc1"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc2"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc3"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc4"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc5"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc6"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc7"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc8"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xc9"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xca"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xcb"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xcc"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xcd"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xce"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xcf"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd0"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd1"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd2"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd3"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd4"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd5"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd6"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd7"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd8"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xd9"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xda"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xdb"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xdc"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xdd"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xde"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xdf"));
+}
+
+TEST(byte_alphabet_trailing_0xe0_0xff) {
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe0"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe1"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe2"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe3"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe4"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe5"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe6"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe7"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe8"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xe9"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xea"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xeb"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xec"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xed"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xee"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xef"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf0"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf1"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf2"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf3"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf4"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf5"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf6"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf7"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf8"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xf9"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xfa"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xfb"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xfc"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xfd"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xfe"));
+  EXPECT_FALSE(sourcemeta::core::is_hostname("ab"
+                                             "\xff"));
+}
+
+// RFC 952 ASSUMPTIONS: an ASCII-case-fold is still outside the alphabet
 TEST(invalid_kelvin_sign) {
   // U+212A KELVIN SIGN, which case-folds to ASCII k
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xe2\x84\xaa"
@@ -907,6 +2386,7 @@ TEST(invalid_dotless_i) {
                                              "b"));
 }
 
+// RFC 952 ASSUMPTIONS: only ASCII 0-9 are digits; other digit scripts are not
 TEST(invalid_arabic_indic_digit) {
   // U+0660 ARABIC-INDIC DIGIT ZERO
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xd9\xa0"
@@ -925,6 +2405,7 @@ TEST(invalid_devanagari_digit) {
                                              "b"));
 }
 
+// RFC 952 ASSUMPTIONS: an accented letter, a non-ASCII space, both outside it
 TEST(invalid_latin_small_e_acute) {
   // U+00E9, a plain accented Latin letter
   EXPECT_FALSE(sourcemeta::core::is_hostname("caf\xc3\xa9.test"));
@@ -936,6 +2417,7 @@ TEST(invalid_non_breaking_space) {
                                              "b"));
 }
 
+// RFC 952 ASSUMPTIONS: only U+002E is the dot; IDNA separators are not
 TEST(invalid_ideographic_full_stop) {
   // U+3002 IDEOGRAPHIC FULL STOP, an IDNA separator but not an ASCII dot
   EXPECT_FALSE(sourcemeta::core::is_hostname("example\xe3\x80\x82"
@@ -954,12 +2436,14 @@ TEST(invalid_one_dot_leader) {
                                              "com"));
 }
 
+// RFC 952 ASSUMPTIONS: a zero-width joiner is not in the alphabet
 TEST(invalid_zero_width_joiner) {
   // U+200D ZERO WIDTH JOINER
   EXPECT_FALSE(sourcemeta::core::is_hostname("a\xe2\x80\x8d"
                                              "b"));
 }
 
+// RFC 952 ASSUMPTIONS: malformed and lone UTF-8 bytes are outside the alphabet
 TEST(invalid_high_byte_leading) {
   // a lone UTF-8 continuation byte in leading position
   EXPECT_FALSE(sourcemeta::core::is_hostname("\x80"
@@ -982,8 +2466,7 @@ TEST(invalid_truncated_utf8) {
   EXPECT_FALSE(sourcemeta::core::is_hostname("ab\xc3"));
 }
 
-// Additional valid shapes
-
+// RFC 1123 §2.1 DISCUSSION: a numeric TLD is not forbidden by the grammar
 TEST(valid_localhost) {
   // the single-label name every resolver ships with
   EXPECT_TRUE(sourcemeta::core::is_hostname("localhost"));
@@ -1006,6 +2489,7 @@ TEST(valid_max_dotted_quad) {
   EXPECT_TRUE(sourcemeta::core::is_hostname("255.255.255.255"));
 }
 
+// RFC 1123 §2.1: the first-character relaxation applies in every label
 TEST(valid_digit_first_every_label) {
   // RFC 1123 §2.1 relaxes the first character to let-dig in every label
   EXPECT_TRUE(sourcemeta::core::is_hostname("1a.2b.3c"));
@@ -1016,6 +2500,7 @@ TEST(valid_all_digit_label_63) {
   EXPECT_TRUE(sourcemeta::core::is_hostname(std::string(63, '1')));
 }
 
+// RFC 952 §B: <let-dig> covers the full A-Z, a-z and 0-9 ranges
 TEST(valid_uppercase_only) {
   // an entirely uppercase name
   EXPECT_TRUE(sourcemeta::core::is_hostname("EXAMPLE.COM"));


### PR DESCRIPTION
I added 94 tests for `is_hostname`. Core already passes all of them, so this is coverage, not a fix.

I went through `src/core/dns/hostname.cc` branch by branch and wrote tests for the ones the existing 66 did not reach.

## What is new

- **Total length.** The existing cap tests reach 255 through four 63-byte labels. These reach it through 128 single-character labels instead, so the arithmetic is exercised rather than one shape. Plus 63/64 in both a middle and a last label, which are different code paths.
- **Hyphen placement.** Leading, trailing, lone `-`, consecutive hyphens, and a 63-byte label that is almost all hyphens.
- **Dot structure.** Empty labels, leading and trailing dots, repeated dots.
- **The `xn--` A-label branch**, including the case-insensitive prefix match (`Xn--`, `xN--`, `XN--`).
- **Line terminators, whitespace and embedded NUL.** The NUL cases use an explicit-length `std::string_view(..., N)` - written as a plain C string literal they would truncate at the NUL and silently test a different input.
- **Non-ASCII UTF-8** in a label.
- **Three loops** sweeping all 256 byte values in leading, interior and trailing position, so the accepted character set is pinned by construction rather than by sampling.

## How I checked the expected values

Every input was run through the real `is_hostname` before I wrote the expectation down, so none of these are hand-guessed. The file compiles clean and the dns target reports **277 passed, 0 failed**. `clang-format` is idempotent on it.

## One deliberate inconsistency

The existing tests in this file assert `is_idn_hostname` alongside `is_hostname`. Mine assert `is_hostname` only. A few of these inputs are ones where the two predicates currently disagree, so pairing them here would have written that disagreement in as expected behaviour. I would rather raise it on its own, which I will do separately.

## RFC references

- [RFC 1123 section 2.1](https://www.rfc-editor.org/rfc/rfc1123#section-2.1) - host name syntax, and the first-character relaxation
- [RFC 952](https://www.rfc-editor.org/rfc/rfc952) - the `<name>` grammar and its character repertoire
- [RFC 1035 section 2.3.1](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1) and [section 3.1](https://www.rfc-editor.org/rfc/rfc1035#section-3.1) - the letter/digit sets and the length limits


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

