### PR TITLE
test(time): expand is_rfc3339_fulltime coverage for offset, secfrac, and leap-second branches

### DIFF
--- a/test/time/rfc3339_fulltime_test.cc
+++ b/test/time/rfc3339_fulltime_test.cc
@@ -227,3 +227,674 @@ TEST(suite_invalid_letters) {
 TEST(suite_invalid_datetime_passed_in) {
   EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("2020-11-28T23:55:45Z"));
 }
+
+TEST(length_01_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0"));
+}
+
+TEST(length_02_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08"));
+}
+
+TEST(length_03_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:"));
+}
+
+TEST(length_04_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:3"));
+}
+
+TEST(length_05_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30"));
+}
+
+TEST(length_06_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:"));
+}
+
+TEST(length_07_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:0"));
+}
+
+TEST(length_08_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06"));
+}
+
+TEST(hour_value_00) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("00:30:06Z"));
+}
+
+TEST(hour_value_01) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("01:30:06Z"));
+}
+
+TEST(hour_value_09) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("09:30:06Z"));
+}
+
+TEST(hour_value_10) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("10:30:06Z"));
+}
+
+TEST(hour_value_19) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("19:30:06Z"));
+}
+
+TEST(hour_value_20) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("20:30:06Z"));
+}
+
+TEST(hour_value_23) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:30:06Z"));
+}
+
+TEST(hour_value_24) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("24:30:06Z"));
+}
+
+TEST(hour_value_25) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("25:30:06Z"));
+}
+
+TEST(hour_value_29) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("29:30:06Z"));
+}
+
+TEST(hour_value_30) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("30:30:06Z"));
+}
+
+TEST(hour_value_59) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("59:30:06Z"));
+}
+
+TEST(hour_value_90) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("90:30:06Z"));
+}
+
+TEST(hour_value_99) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("99:30:06Z"));
+}
+
+TEST(hour_first_digit_alpha) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("a8:30:06Z"));
+}
+
+TEST(hour_second_digit_alpha) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0a:30:06Z"));
+}
+
+TEST(hour_first_digit_hyphen) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("-8:30:06Z"));
+}
+
+TEST(hour_second_digit_hyphen) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0-:30:06Z"));
+}
+
+TEST(hour_first_digit_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(" 8:30:06Z"));
+}
+
+TEST(hour_second_digit_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0 :30:06Z"));
+}
+
+TEST(hour_first_digit_plus) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("+8:30:06Z"));
+}
+
+TEST(hour_second_digit_plus) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0+:30:06Z"));
+}
+
+TEST(hour_first_digit_nul) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_fulltime(std::string_view("\x00"
+                                                             "8:30:06Z",
+                                                             9)));
+}
+
+TEST(hour_second_digit_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(
+      std::string_view("0\x00:30:06Z", 9)));
+}
+
+TEST(hour_first_digit_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(":8:30:06Z"));
+}
+
+TEST(hour_second_digit_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0::30:06Z"));
+}
+
+TEST(hour_second_digit_semicolon_lands_in_range) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0;:30:06Z"));
+}
+
+TEST(hour_second_digit_less_than_lands_in_range) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0<:30:06Z"));
+}
+
+TEST(first_separator_dot) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08.30:06Z"));
+}
+
+TEST(second_separator_dot) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30.06Z"));
+}
+
+TEST(first_separator_hyphen) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08-30:06Z"));
+}
+
+TEST(second_separator_hyphen) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30-06Z"));
+}
+
+TEST(first_separator_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08 30:06Z"));
+}
+
+TEST(second_separator_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30 06Z"));
+}
+
+TEST(first_separator_underscore) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08_30:06Z"));
+}
+
+TEST(second_separator_underscore) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30_06Z"));
+}
+
+TEST(first_separator_slash) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08/30:06Z"));
+}
+
+TEST(second_separator_slash) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30/06Z"));
+}
+
+TEST(first_separator_comma) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08,30:06Z"));
+}
+
+TEST(second_separator_comma) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30,06Z"));
+}
+
+TEST(first_separator_missing) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("0830:06Z"));
+}
+
+TEST(second_separator_missing) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:3006Z"));
+}
+
+TEST(first_separator_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(std::string_view("08\x00"
+                                                                      "30:06Z",
+                                                                      9)));
+}
+
+TEST(second_separator_nul) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_fulltime(std::string_view("08:30\x00"
+                                                             "06Z",
+                                                             9)));
+}
+
+TEST(first_separator_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08030:06Z"));
+}
+
+TEST(second_separator_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30006Z"));
+}
+
+TEST(first_separator_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08\x09"
+                                                     "30:06Z"));
+}
+
+TEST(second_separator_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30\x09"
+                                                     "06Z"));
+}
+
+TEST(minute_value_00) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:00:06Z"));
+}
+
+TEST(minute_value_01) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:01:06Z"));
+}
+
+TEST(minute_value_59) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:59:06Z"));
+}
+
+TEST(minute_value_60) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:60:06Z"));
+}
+
+TEST(minute_value_61) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:61:06Z"));
+}
+
+TEST(minute_value_90) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:90:06Z"));
+}
+
+TEST(minute_value_99) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:99:06Z"));
+}
+
+TEST(minute_first_digit_alpha) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:a0:06Z"));
+}
+
+TEST(minute_second_digit_alpha) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:3a:06Z"));
+}
+
+TEST(minute_first_digit_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08: 0:06Z"));
+}
+
+TEST(minute_second_digit_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:3 :06Z"));
+}
+
+TEST(minute_first_digit_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(std::string_view("08:\x00"
+                                                                      "0:06Z",
+                                                                      9)));
+}
+
+TEST(minute_second_digit_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(
+      std::string_view("08:3\x00:06Z", 9)));
+}
+
+TEST(minute_second_digit_colon_lands_in_range) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:3::06Z"));
+}
+
+TEST(minute_second_digit_semicolon_lands_in_range) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:3;:06Z"));
+}
+
+TEST(second_value_00) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:00Z"));
+}
+
+TEST(second_value_01) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:01Z"));
+}
+
+TEST(second_value_58) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:58Z"));
+}
+
+TEST(second_value_61) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:61Z"));
+}
+
+TEST(second_value_90) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:90Z"));
+}
+
+TEST(second_value_99) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:99Z"));
+}
+
+TEST(second_first_digit_alpha) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:a6Z"));
+}
+
+TEST(second_second_digit_alpha) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:0aZ"));
+}
+
+TEST(second_first_digit_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30: 6Z"));
+}
+
+TEST(second_second_digit_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:0 Z"));
+}
+
+TEST(second_first_digit_nul) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_fulltime(std::string_view("08:30:\x00"
+                                                             "6Z",
+                                                             9)));
+}
+
+TEST(second_second_digit_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(
+      std::string_view("08:30:0\x00Z", 9)));
+}
+
+TEST(second_second_digit_colon_lands_in_range) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:0:Z"));
+}
+
+TEST(second_second_digit_semicolon_lands_in_range) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:0;Z"));
+}
+
+TEST(secfrac_single_digit) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.1Z"));
+}
+
+TEST(secfrac_empty) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.Z"));
+}
+
+TEST(secfrac_empty_no_offset) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06."));
+}
+
+TEST(secfrac_all_zero) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.000Z"));
+}
+
+TEST(secfrac_nine_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.123456789Z"));
+}
+
+TEST(secfrac_thirty_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime(
+      "08:30:06.111111111111111111111111111111Z"));
+}
+
+TEST(secfrac_three_hundred_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime(
+      "08:30:06."
+      "999999999999999999999999999999999999999999999999999999999999999999999999"
+      "999999999999999999999999999999999999999999999999999999999999999999999999"
+      "999999999999999999999999999999999999999999999999999999999999999999999999"
+      "999999999999999999999999999999999999999999999999999999999999999999999999"
+      "999999999999Z"));
+}
+
+TEST(secfrac_double_dot) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06..1Z"));
+}
+
+TEST(secfrac_two_fractions) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.1.2Z"));
+}
+
+TEST(secfrac_comma_separator) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06,1Z"));
+}
+
+TEST(secfrac_non_ascii_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.\xd9\xa1Z"));
+}
+
+TEST(secfrac_sign_in_fraction) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.+1Z"));
+}
+
+TEST(secfrac_then_nothing) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06.1"));
+}
+
+TEST(offset_lower_z) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06z"));
+}
+
+TEST(offset_char_letter_y) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Y"));
+}
+
+TEST(offset_char_letter_u) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06U"));
+}
+
+TEST(offset_char_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06 "));
+}
+
+TEST(offset_char_asterisk) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06*"));
+}
+
+TEST(offset_char_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(
+      std::string_view("08:30:06\x00", 9)));
+}
+
+TEST(offset_char_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06\x0a"));
+}
+
+TEST(offset_z_then_trailing) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Zx"));
+}
+
+TEST(offset_z_then_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\x0a"));
+}
+
+TEST(offset_z_then_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z "));
+}
+
+TEST(offset_double_z) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06ZZ"));
+}
+
+TEST(numoffset_plus_zero) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:00"));
+}
+
+TEST(numoffset_minus_zero) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06-00:00"));
+}
+
+TEST(numoffset_max_hour) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+23:59"));
+}
+
+TEST(numoffset_hour_24) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+24:00"));
+}
+
+TEST(numoffset_hour_99) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+99:00"));
+}
+
+TEST(numoffset_minute_60) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:60"));
+}
+
+TEST(numoffset_minute_99) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:99"));
+}
+
+TEST(numoffset_no_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+0000"));
+}
+
+TEST(numoffset_one_digit_hour) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+0:00"));
+}
+
+TEST(numoffset_one_digit_minute) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:0"));
+}
+
+TEST(numoffset_hour_only) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00"));
+}
+
+TEST(numoffset_truncated) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+0"));
+}
+
+TEST(numoffset_double_sign) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06++00:00"));
+}
+
+TEST(numoffset_sign_then_letter) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+ab:00"));
+}
+
+TEST(numoffset_dot_separator) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00.00"));
+}
+
+TEST(numoffset_trailing_content) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:00x"));
+}
+
+TEST(numoffset_then_z) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+00:00Z"));
+}
+
+TEST(numoffset_unicode_minus) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06\xe2\x88\x92"
+                                                     "00:00"));
+}
+
+TEST(numoffset_beyond_18_hours) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("08:30:06+19:00"));
+}
+
+TEST(leading_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\x0a"
+                                                     "08:30:06Z"));
+}
+
+TEST(trailing_cr) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\x0d"));
+}
+
+TEST(leading_cr) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\x0d"
+                                                     "08:30:06Z"));
+}
+
+TEST(trailing_crlf) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\x0d\x0a"));
+}
+
+TEST(leading_crlf) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\x0d\x0a"
+                                                     "08:30:06Z"));
+}
+
+TEST(trailing_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\x09"));
+}
+
+TEST(leading_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\x09"
+                                                     "08:30:06Z"));
+}
+
+TEST(leading_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(" 08:30:06Z"));
+}
+
+TEST(trailing_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(
+      std::string_view("08:30:06Z\x00", 10)));
+}
+
+TEST(leading_nul) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_fulltime(std::string_view("\x00"
+                                                             "08:30:06Z",
+                                                             10)));
+}
+
+TEST(trailing_nbsp) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\xc2\xa0"));
+}
+
+TEST(leading_nbsp) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\xc2\xa0"
+                                                     "08:30:06Z"));
+}
+
+TEST(trailing_line_separator) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\xe2\x80\xa8"));
+}
+
+TEST(leading_line_separator) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\xe2\x80\xa8"
+                                                     "08:30:06Z"));
+}
+
+TEST(trailing_bom) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:06Z\xef\xbb\xbf"));
+}
+
+TEST(leading_bom) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\xef\xbb\xbf"
+                                                     "08:30:06Z"));
+}
+
+TEST(leap_utc_2359_lower_z) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:60z"));
+}
+
+TEST(leap_not_2359_z) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:30:60Z"));
+}
+
+TEST(leap_0059_plus_0100) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("00:59:60+01:00"));
+}
+
+TEST(leap_2259_minus_0100) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("22:59:60-01:00"));
+}
+
+TEST(leap_offset_wraps_backward) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("00:29:60+00:30"));
+}
+
+TEST(leap_offset_wraps_forward) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:29:60-00:30"));
+}
+
+TEST(leap_wrong_minute_with_offset) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("00:58:60+01:00"));
+}
+
+TEST(leap_with_fraction) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_fulltime("23:59:60.5Z"));
+}
+
+TEST(leap_max_offset) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("23:59:60+23:59"));
+}
+
+TEST(non_ascii_digit_in_hour) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\xd9\xa0"
+                                                     "8:30:06Z"));
+}
+
+TEST(non_ascii_digit_in_minute) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("08:\xd9\xa3"
+                                                     "0:06Z"));
+}
+
+TEST(fullwidth_all) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime(
+      "\xef\xbc\x90\xef\xbc\x98:\xef\xbc\x93\xef\xbc\x90:"
+      "\xef\xbc\x90\xef\xbc\x96Z"));
+}
+
+TEST(astral_digit_in_hour) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_fulltime("\xf0\x9d\x9f\x98"
+                                                     "0:30:06Z"));
+}


### PR DESCRIPTION
I added 157 tests to `test/time/rfc3339_fulltime_test.cc`. Core already passes all of them, so this is coverage, not a fix. I organised them by the branches in `src/core/time/rfc3339_fulltime.cc` rather than by input shape, so every `if` in the scanner has assertions on both sides.

## What is new

- **length guard** (`size < 9`) - every length from 0 to 8, plus the 9-character minimum and the 8-character "valid partial-time, no offset" case.
- **`time-hour`** - 00, 01, 09, 10, 19, 20, 23 valid and 24, 25, 29, 30, 59, 90, 99 invalid, plus a non-digit at each of the two positions individually.
- **`time-minute` / `time-second`** - the same treatment: the range boundary either side, and each digit position broken on its own.
- **the second digit of each 2DIGIT field, specifically.** A scanner that checks only the first digit and then computes `(a - '0') * 10 + (b - '0')` is not caught by an alphabetic probe, because `'a' - '0'` is 49 and the field lands far out of range and is rejected anyway. The characters just above `'9'` are the ones that land it back INSIDE the range: `':' - '0'` is 10, `';'` is 11, `'<'` is 12. Those are the inputs that distinguish "checks both digits" from "checks the first".
- **both `:` separators, each on its own** - 10 wrong characters at position 2 alone and at position 5 alone, so neither check is load-bearing for the other.
- **`time-secfrac`** - the `.`-then-`1*DIGIT` rule from both sides: a single digit, an empty fraction with and without an offset, all-zero, 9 / 30 / 300 digits, a double dot, two fractions, a comma instead of a dot, a non-ASCII digit, and a sign.
- **`time-offset`** - `Z`, `z`, missing, and six wrong characters; plus trailing content after `Z`.
- **`time-numoffset`** - offset hour 23 valid and 24 / 99 invalid, offset minute 59 valid and 60 / 99 invalid, the required `:` (including the colonless `+0000` form), one-digit hour and minute, a truncated offset, a double sign, a dot separator, trailing content, and `+19:00` (grammar-legal, beyond the usual ±18h convention).
- **trailing and leading terminators** - LF, CR, CRLF, TAB, space, NUL, NBSP, U+2028 and a BOM, in both positions.
- **the section 5.7 leap-second rule** - `23:59:60Z` valid, and the offset arithmetic from both directions: `00:59:60+01:00` and `22:59:60-01:00` valid, the wrap-around cases, a leap second at a UTC time that is not 23:59 invalid, with a fraction, and at the maximum offset.

## How I checked the expected values

I did not write the expected verdicts by hand. Every input was run through the real `is_rfc3339_fulltime`, compiled straight from this branch's source, and the `EXPECT_TRUE` / `EXPECT_FALSE` was emitted from what the function actually returned. The whole file was then compiled and run again to confirm. `sourcemeta_core_time_unit` reports **585 passed, 0 failed**. `clang-format` is clean and the diff is additions only.

Eleven inputs contain an embedded NUL and are emitted as `std::string_view("...", N)` rather than a plain literal, because a plain literal truncates at the NUL and the test would silently assert on a shorter input. Where a `\x00` escape is followed by a hex digit the literal is also split - `"\x00" "8:30:06Z"` rather than `"\x008:30:06Z"`, since C++ hex escapes are greedy and the latter is the single byte `0x08`.

## RFC references

- [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) - `full-time = partial-time time-offset`
- [RFC 3339 section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) - the `time-second` leap rule and the zone-offset shift
- [RFC 5234 section 3.4](https://www.rfc-editor.org/rfc/rfc5234#section-3.4) - `DIGIT = %x30-39`