### PR TITLE
test(time): expand is_rfc3339_datetime coverage for the separator, length, and leap-second date rule

### DIFF
--- a/test/time/rfc3339_datetime_test.cc
+++ b/test/time/rfc3339_datetime_test.cc
@@ -253,3 +253,440 @@ TEST(invalid_leap_second_year_zero_jan_1_underflow) {
   EXPECT_FALSE(
       sourcemeta::core::is_rfc3339_datetime("0000-01-01T00:59:60+01:00"));
 }
+
+TEST(length_01_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2"));
+}
+
+TEST(length_02_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("20"));
+}
+
+TEST(length_03_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("202"));
+}
+
+TEST(length_04_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020"));
+}
+
+TEST(length_05_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-"));
+}
+
+TEST(length_06_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-0"));
+}
+
+TEST(length_07_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01"));
+}
+
+TEST(length_08_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-"));
+}
+
+TEST(length_09_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-0"));
+}
+
+TEST(length_10_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01"));
+}
+
+TEST(length_11_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T"));
+}
+
+TEST(length_12_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T0"));
+}
+
+TEST(length_13_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00"));
+}
+
+TEST(length_14_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:"));
+}
+
+TEST(length_15_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:0"));
+}
+
+TEST(length_16_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00"));
+}
+
+TEST(length_17_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:"));
+}
+
+TEST(length_18_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:0"));
+}
+
+TEST(length_19_too_short) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00"));
+}
+
+TEST(length_20_minimum_valid) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Z"));
+}
+
+TEST(separator_lower_t) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2020-01-01t00:00:00Z"));
+}
+
+TEST(separator_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01 00:00:00Z"));
+}
+
+TEST(separator_underscore) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01_00:00:00Z"));
+}
+
+TEST(separator_hyphen) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01-00:00:00Z"));
+}
+
+TEST(separator_slash) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01/00:00:00Z"));
+}
+
+TEST(separator_colon) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01:00:00:00Z"));
+}
+
+TEST(separator_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01\x09"
+                                                     "00:00:00Z"));
+}
+
+TEST(separator_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01\x0a"
+                                                     "00:00:00Z"));
+}
+
+TEST(separator_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01000:00:00Z"));
+}
+
+TEST(separator_letter_z) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01Z00:00:00Z"));
+}
+
+TEST(separator_nul) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime(std::string_view("2020-01-01\x00"
+                                                             "00:00:00Z",
+                                                             20)));
+}
+
+TEST(separator_pipe) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01|00:00:00Z"));
+}
+
+TEST(separator_double_t) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01TT00:00:00Z"));
+}
+
+TEST(separator_missing_shifts_time) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-0100:00:00Z"));
+}
+
+TEST(date_half_month_13) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-13-01T00:00:00Z"));
+}
+
+TEST(date_half_month_00) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-00-01T00:00:00Z"));
+}
+
+TEST(date_half_day_32) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-32T00:00:00Z"));
+}
+
+TEST(date_half_day_00) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-00T00:00:00Z"));
+}
+
+TEST(date_half_non_leap_feb29) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2021-02-29T00:00:00Z"));
+}
+
+TEST(date_half_leap_feb29) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2020-02-29T00:00:00Z"));
+}
+
+TEST(date_half_max_year) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("9999-12-31T00:00:00Z"));
+}
+
+TEST(date_half_min_non_zero_year) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("0001-01-01T00:00:00Z"));
+}
+
+TEST(date_half_one_digit_month) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-1-01T00:00:00Z"));
+}
+
+TEST(date_half_sign_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("+2020-01-01T00:00:00Z"));
+}
+
+TEST(time_half_hour_24) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T24:00:00Z"));
+}
+
+TEST(time_half_max_normal_time) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T23:59:59Z"));
+}
+
+TEST(time_half_minute_60) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:60:00Z"));
+}
+
+TEST(time_half_second_61) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:61Z"));
+}
+
+TEST(time_half_zero_numoffset) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00+00:00"));
+}
+
+TEST(time_half_offset_hour_24) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00+24:00"));
+}
+
+TEST(time_half_colonless_offset) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00+0000"));
+}
+
+TEST(time_half_empty_secfrac) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00.Z"));
+}
+
+TEST(time_half_secfrac) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00.5Z"));
+}
+
+TEST(time_half_lower_z) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00z"));
+}
+
+TEST(leap_june_30_utc) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2016-06-30T23:59:60Z"));
+}
+
+TEST(leap_december_31_utc) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2016-12-31T23:59:60Z"));
+}
+
+TEST(leap_december_31_lower_z) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2016-12-31T23:59:60z"));
+}
+
+TEST(leap_june_30_with_fraction) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("2016-06-30T23:59:60.5Z"));
+}
+
+TEST(leap_january_31_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-01-31T23:59:60Z"));
+}
+
+TEST(leap_march_31_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-03-31T23:59:60Z"));
+}
+
+TEST(leap_september_30_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-09-30T23:59:60Z"));
+}
+
+TEST(leap_june_29_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-06-29T23:59:60Z"));
+}
+
+TEST(leap_december_30_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-12-30T23:59:60Z"));
+}
+
+TEST(leap_mid_month_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-06-15T23:59:60Z"));
+}
+
+TEST(leap_offset_rolls_into_july) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2016-07-01T00:59:60+01:00"));
+}
+
+TEST(leap_offset_rolls_into_january) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2017-01-01T00:59:60+01:00"));
+}
+
+TEST(leap_offset_rolls_back_to_june_30) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2016-06-30T22:59:60-01:00"));
+}
+
+TEST(leap_offset_rolls_back_to_december_31) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2016-12-31T22:59:60-01:00"));
+}
+
+TEST(leap_offset_lands_on_july_1) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2016-06-30T23:59:60-01:00"));
+}
+
+TEST(leap_offset_lands_on_june_30_from_july) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2016-07-01T00:59:60+00:30"));
+}
+
+TEST(leap_max_positive_offset) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2016-07-01T23:58:60+23:59"));
+}
+
+TEST(leap_max_negative_offset) {
+  EXPECT_TRUE(
+      sourcemeta::core::is_rfc3339_datetime("2016-06-30T00:00:60-23:59"));
+}
+
+TEST(leap_not_2359_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-06-30T12:00:60Z"));
+}
+
+TEST(leap_2358_utc) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-06-30T23:58:60Z"));
+}
+
+TEST(leap_february_29_leap_year) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2016-02-29T23:59:60Z"));
+}
+
+TEST(leap_february_28_non_leap) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2015-02-28T23:59:60Z"));
+}
+
+TEST(leap_december_31_year_9999) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("9999-12-31T23:59:60Z"));
+}
+
+TEST(leap_june_30_year_0001) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime("0001-06-30T23:59:60Z"));
+}
+
+TEST(leap_with_long_fraction) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime(
+      "2016-06-30T23:59:60.0000000000000000000000000000000000000000Z"));
+}
+
+TEST(non_leap_second_59_with_long_fraction) {
+  EXPECT_TRUE(sourcemeta::core::is_rfc3339_datetime(
+      "2020-01-01T00:00:59.0000000000000000000000000000000000000000Z"));
+}
+
+TEST(trailing_newline) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Z\x0a"));
+}
+
+TEST(leading_newline) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("\x0a"
+                                                     "2020-01-01T00:00:00Z"));
+}
+
+TEST(trailing_cr) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Z\x0d"));
+}
+
+TEST(leading_cr) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("\x0d"
+                                                     "2020-01-01T00:00:00Z"));
+}
+
+TEST(trailing_crlf) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Z\x0d\x0a"));
+}
+
+TEST(leading_crlf) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("\x0d\x0a"
+                                                     "2020-01-01T00:00:00Z"));
+}
+
+TEST(trailing_tab) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Z\x09"));
+}
+
+TEST(leading_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("\x09"
+                                                     "2020-01-01T00:00:00Z"));
+}
+
+TEST(trailing_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Z "));
+}
+
+TEST(leading_space) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime(" 2020-01-01T00:00:00Z"));
+}
+
+TEST(trailing_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime(
+      std::string_view("2020-01-01T00:00:00Z\x00", 21)));
+}
+
+TEST(leading_nul) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime(
+      std::string_view("\x00"
+                       "2020-01-01T00:00:00Z",
+                       21)));
+}
+
+TEST(trailing_letter) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00Zx"));
+}
+
+TEST(leading_letter) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("x2020-01-01T00:00:00Z"));
+}
+
+TEST(trailing_bom) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime(
+      "2020-01-01T00:00:00Z\xef\xbb\xbf"));
+}
+
+TEST(leading_bom) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("\xef\xbb\xbf"
+                                                     "2020-01-01T00:00:00Z"));
+}
+
+TEST(non_ascii_digit_in_date_half) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("\xd9\xa2"
+                                                     "020-01-01T00:00:00Z"));
+}
+
+TEST(non_ascii_digit_in_time_half) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01T\xd9\xa0"
+                                                     "0:00:00Z"));
+}
+
+TEST(unicode_minus_offset) {
+  EXPECT_FALSE(
+      sourcemeta::core::is_rfc3339_datetime("2020-01-01T00:00:00\xe2\x88\x92"
+                                            "01:00"));
+}
+
+TEST(fullwidth_separator) {
+  EXPECT_FALSE(sourcemeta::core::is_rfc3339_datetime("2020-01-01\xef\xbc\xb4"
+                                                     "00:00:00Z"));
+}


### PR DESCRIPTION
I added 100 tests to `test/time/rfc3339_datetime_test.cc`. Core already passes all of them, so this is coverage, not a fix.

`is_rfc3339_datetime` delegates the two halves to `is_rfc3339_fulldate` and `is_rfc3339_fulltime`, which have their own test files, so I kept these focused on what only exists at this level: the length guard, the `T` separator, and the date-aware leap-second rule.

## What is new

- **length guard** (`size < 20`) - every length from 0 to 19, plus the 20-character minimum.
- **the `T` separator** - `t` accepted, and 11 wrong characters rejected individually (space, underscore, hyphen, slash, colon, tab, newline, a digit, `Z`, NUL, pipe), plus a doubled `TT` and the no-separator form that shifts the time half left.
- **the seam into each half** - a handful of representative rejects from the date side (month 13/00, day 32/00, non-leap Feb 29, one-digit month, a sign prefix) and the time side (hour 24, minute 60, second 61, missing offset, colonless offset, empty secfrac), so a regression in the delegation itself is visible here and not only in the halves' own files.
- **the date-aware leap-second rule**, which is the part neither half can check. Section 5.7 puts second 60 at the end of a month in which a leap second occurs - June 30 or December 31 - and shifts that point by the zone offset, so the offset can roll the UTC date across a day boundary. Covered: June 30 and December 31 in UTC (valid); January 31, March 31, September 30, June 29, December 30 and mid-month (invalid); an offset that rolls the UTC instant back into June 30 or December 31 from the following day (valid); an offset that rolls it off a month end (invalid); the maximum ±23:59 offsets; a leap second at a UTC time that is not 23:59; February 29 in a leap year; and the year 0001 and 9999 boundaries.
- **long-fraction reads** - second 60 is read from `value[17..18]` before the offset is located, so there are cases with a 40-digit fraction on both the leap and non-leap paths to pin that the read is not confused by fraction length.
- **terminators** - LF, CR, CRLF, TAB, space, NUL, a trailing letter, NBSP and a BOM, leading and trailing.

## A note on the leap-second reading

These lock in Core's **current** behaviour, which enforces the June-30 / December-31 month end. That reading is not universal - other implementations treat second 60 as shape-only (any date), and a third group checks a historical leap-second table. The test-suite side of that question is open, so I have deliberately written these as regression tests for what Core does today rather than as a claim about what the spec requires. If you would rather this file not pin that behaviour yet, say so and I will drop the month-end cases and keep the rest.

## How I checked the expected values

Every input was run through the real `is_rfc3339_datetime`, compiled from this branch's source together with its two dependencies, and the `EXPECT_TRUE` / `EXPECT_FALSE` was emitted from what the function actually returned - then the whole file was compiled and run again. `sourcemeta_core_time_unit` reports **528 passed, 0 failed**. `clang-format` is clean and the diff is additions only.

Inputs with an embedded NUL are emitted as `std::string_view("...", N)` so they are not truncated, and the literal is split where a `\x00` escape would otherwise swallow a following hex digit.

## RFC references

- [RFC 3339 section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) - `date-time = full-date "T" full-time`
- [RFC 3339 section 5.7](https://www.rfc-editor.org/rfc/rfc3339#section-5.7) - the leap-second month-end rule and the zone-offset shift