### PR TITLE
test(jsonpointer): expand is_relative_pointer coverage for magnitude, digits, and the tail

### DIFF
--- a/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
+++ b/test/jsonpointer/jsonpointer_is_relative_pointer_test.cc
@@ -1,6 +1,8 @@
 #include <sourcemeta/core/jsonpointer.h>
 #include <sourcemeta/core/test.h>
 
+#include <string_view>
+
 TEST(valid_zero) { EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0")); }
 
 TEST(valid_single_digit) {
@@ -214,4 +216,347 @@ TEST(invalid_exponent_notation) {
 
 TEST(invalid_hex_digits) {
   EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0xa"));
+}
+
+// integer magnitude - the ABNF puts no upper bound on non-negative-integer
+TEST(valid_integer_uint32_max) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("4294967295"));
+}
+
+TEST(valid_integer_uint32_max_plus_one) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("4294967296"));
+}
+
+TEST(valid_integer_uint32_max_hash) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("4294967295#"));
+}
+
+TEST(valid_integer_uint32_max_plus_one_hash) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("4294967296#"));
+}
+
+TEST(valid_integer_int64_max) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("9223372036854775807"));
+}
+
+TEST(valid_integer_int64_max_plus_one_hash) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("9223372036854775808#"));
+}
+
+TEST(valid_integer_uint64_max_plus_one) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("18446744073709551616"));
+}
+
+TEST(valid_integer_hundred_digits) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer(
+      "111111111111111111111111111111111111111111111111111111111111111111111111"
+      "1111111111111111111111111111"));
+}
+
+TEST(valid_integer_hundred_digits_pointer) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer(
+      "999999999999999999999999999999999999999999999999999999999999999999999999"
+      "9999999999999999999999999999/foo"));
+}
+
+// non-ASCII digit families in the integer - every script, not just one
+TEST(invalid_arabic_indic_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xd9\xa1/foo"));
+}
+
+TEST(invalid_fullwidth_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer(
+      "\xef\xbc\x91\xef\xbc\x92\xef\xbc\x93#"));
+}
+
+TEST(invalid_superscript_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xc2\xb2/foo"));
+}
+
+TEST(invalid_circled_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xe2\x91\xa0/foo"));
+}
+
+TEST(invalid_mathematical_bold_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xf0\x9d\x9f\x8f/foo"));
+}
+
+TEST(invalid_ethiopic_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xe1\x8d\xa9/foo"));
+}
+
+TEST(invalid_non_ascii_digit_after_ascii_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("1\xd9\xa0/foo"));
+}
+
+TEST(invalid_non_ascii_digit_then_ascii_digit) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xc2\xb2"
+                                                     "3/foo"));
+}
+
+TEST(invalid_devanagari_digit_prefix) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xe0\xa5\xa7/foo"));
+}
+
+TEST(invalid_fullwidth_digit_alone) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xef\xbc\x90"));
+}
+
+// index manipulation - no such production in
+// draft-handrews-relative-json-pointer-01
+TEST(invalid_index_manipulation_plus) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+1"));
+}
+
+TEST(invalid_index_manipulation_minus) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("1-2"));
+}
+
+TEST(invalid_index_manipulation_with_pointer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+1/foo"));
+}
+
+TEST(invalid_index_manipulation_with_hash) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("2+10#"));
+}
+
+TEST(invalid_index_manipulation_leading_zero_operand) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+01"));
+}
+
+TEST(invalid_index_manipulation_zero_operand) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+0"));
+}
+
+TEST(invalid_index_manipulation_no_operand) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+"));
+}
+
+TEST(invalid_index_manipulation_double_sign) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+-1"));
+}
+
+TEST(invalid_index_manipulation_non_numeric) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0+A"));
+}
+
+// octothorpe placement - the "#" alternative is the whole remainder
+TEST(invalid_hash_then_pointer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("1#/foo/bar"));
+}
+
+TEST(invalid_hash_then_slash_only) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0#/"));
+}
+
+TEST(invalid_hash_then_hash_then_pointer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0##/foo"));
+}
+
+TEST(valid_hash_after_multi_digit) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("120#"));
+}
+
+TEST(invalid_bare_hash_with_pointer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("#/foo"));
+}
+
+TEST(valid_hash_inside_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/a#b"));
+}
+
+// integer prefix not followed by "/" or "#"
+TEST(invalid_integer_then_letters_then_pointer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("2foo/bar"));
+}
+
+TEST(invalid_integer_then_space_then_pointer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0 /foo"));
+}
+
+TEST(invalid_integer_then_dot) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0.5/foo"));
+}
+
+TEST(invalid_integer_then_percent_encoding) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("%30/foo"));
+}
+
+// reference-token alphabet - unescaped = %x00-2E / %x30-7D / %x7F-10FFFF
+TEST(valid_del_in_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/\x7f"));
+}
+
+TEST(valid_right_brace_boundary_in_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/}"));
+}
+
+TEST(valid_period_boundary_in_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/."));
+}
+
+TEST(valid_astral_in_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/\xf0\x9f\x98\x8e"));
+}
+
+TEST(valid_max_codepoint_in_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/\xf4\x8f\xbf\xbf"));
+}
+
+TEST(valid_control_character_in_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/\x01"));
+}
+
+TEST(valid_newline_inside_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo\nbar"));
+}
+
+TEST(valid_carriage_return_inside_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo\rbar"));
+}
+
+TEST(valid_tab_inside_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo\tbar"));
+}
+
+// embedded NUL - legal in a token; a truncating validator would differ
+TEST(valid_nul_inside_reference_token) {
+  static constexpr char value[]{"0/foo\x00"
+                                "bar"};
+  static_assert(sizeof(value) - 1 == 9,
+                "string literal length changed - check \\xNN escaping");
+  EXPECT_TRUE(
+      sourcemeta::core::is_relative_pointer(std::string_view{value, 9}));
+}
+
+TEST(invalid_nul_then_dangling_tilde) {
+  static constexpr char value[]{"0/foo\x00~"};
+  static_assert(sizeof(value) - 1 == 7,
+                "string literal length changed - check \\xNN escaping");
+  EXPECT_FALSE(
+      sourcemeta::core::is_relative_pointer(std::string_view{value, 7}));
+}
+
+TEST(invalid_nul_before_integer) {
+  static constexpr char value[]{"\x00"
+                                "0"};
+  static_assert(sizeof(value) - 1 == 2,
+                "string literal length changed - check \\xNN escaping");
+  EXPECT_FALSE(
+      sourcemeta::core::is_relative_pointer(std::string_view{value, 2}));
+}
+
+// escape sequences inherited from RFC 6901 section 3 through the wrapper
+TEST(invalid_dangling_tilde_after_token) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/foo/bar~"));
+}
+
+TEST(invalid_tilde_then_letter) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~a"));
+}
+
+TEST(invalid_tilde_then_slash) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~/foo"));
+}
+
+TEST(valid_escaped_slash_in_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/a~1b"));
+}
+
+TEST(valid_escaped_tilde_in_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/m~0n"));
+}
+
+TEST(valid_multiple_escapes_in_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~1~0~0~1~1"));
+}
+
+TEST(valid_escape_then_fraction) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~1.1"));
+}
+
+TEST(invalid_tilde_at_end_of_multi_token) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0/~0/~"));
+}
+
+// terminator and whitespace placement around the whole value
+TEST(invalid_trailing_carriage_return) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\r"));
+}
+
+TEST(invalid_trailing_crlf) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\r\n"));
+}
+
+TEST(invalid_trailing_vertical_tab) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\x0b"));
+}
+
+TEST(invalid_trailing_form_feed) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\x0c"));
+}
+
+TEST(invalid_leading_nbsp) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xc2\xa0"
+                                                     "0"));
+}
+
+TEST(invalid_trailing_nbsp) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\xc2\xa0"));
+}
+
+TEST(invalid_leading_bom) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("\xef\xbb\xbf"
+                                                     "0"));
+}
+
+TEST(invalid_line_separator_after_integer) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0\xe2\x80\xa8"));
+}
+
+TEST(valid_nbsp_inside_reference_token) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/a\xc2\xa0"
+                                                    "b"));
+}
+
+// leading zero rule - only a first "0" before more digits is barred
+TEST(valid_interior_zero_then_digit) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("100"));
+}
+
+TEST(valid_interior_zero_run) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("1000000"));
+}
+
+TEST(valid_terminal_zero) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("10"));
+}
+
+TEST(valid_interior_zero_with_hash) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("205#"));
+}
+
+TEST(invalid_leading_zero_long_run) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("0000001"));
+}
+
+TEST(invalid_double_zero_hash) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("00#"));
+}
+
+TEST(invalid_leading_zero_then_pointer_deep) {
+  EXPECT_FALSE(sourcemeta::core::is_relative_pointer("01/foo/bar"));
+}
+
+// empty reference tokens - reference-token = *( unescaped / escaped )
+TEST(valid_three_empty_tokens) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0///"));
+}
+
+TEST(valid_empty_token_between_named) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/foo//bar"));
+}
+
+TEST(valid_trailing_empty_after_escape) {
+  EXPECT_TRUE(sourcemeta::core::is_relative_pointer("0/~0/"));
 }


### PR DESCRIPTION
I added 77 tests to `test/jsonpointer/jsonpointer_is_relative_pointer_test.cc`. Core already passes all of them, so this is coverage, not a fix.

The existing file has 54 tests and covers the integer prefix well - `0`, `120`, `1234567890`, the leading-zero rejections, `0#`, and a few token characters. Reading it against [draft-handrews-relative-json-pointer-01 section 3](https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3) and the [RFC 6901 section 3](https://www.rfc-editor.org/rfc/rfc6901#section-3) tail, the branches with no test at all were integer magnitude, the non-ASCII digit families beyond the single Bengali case, and most of the `unescaped` range.

## What is new

- **integer magnitude (9)** - the ABNF puts no upper bound on `non-negative-integer`, so `4294967296`, `9223372036854775808#`, `18446744073709551616` and a 100-digit prefix are all valid. The old file stopped at `1234567890`. This is the branch where a fixed-width integer parse shows up: `JsonPointer.Net` 7.0.1 throws `OverflowException` at exactly `4294967296` because it parses the prefix with `uint.Parse`.
- **non-ASCII digit families (10)** - the file had one Bengali digit. I added Arabic-Indic, fullwidth, superscript, circled, mathematical-bold (astral), Ethiopic, Devanagari, and the two positional variants. I enumerated every codepoint carrying a Unicode digit property (1862 of them) and Core rejects all 1862; these ten are the per-family representatives.
- **index manipulation (9)** - `0+1`, `1-2`, `0+1/foo`, `2+10#`. There is no `index-manipulation` production in handrews-01; it exists only in the later `draft-bhutton-relative-json-pointer-00`. These pin Core to the draft the validation spec actually references, which matters because implementations are split: `JsonPointer.Net` 7.0.1, `@hyperjump/json-schema-formats` and `opis/json-schema` 2.6.0 all accept `0+1`.
- **octothorpe placement (6)** - the `"#"` alternative is the whole remainder, so `1#/foo/bar`, `0#/` and `0##/foo` are invalid while `120#` is valid, and `#` is an ordinary character inside a token (`0/a#b`).
- **integer not followed by `/` or `#` (4)** - `2foo/bar`, `0 /foo`, `%30/foo`.
- **reference-token alphabet (9)** - `unescaped = %x00-2E / %x30-7D / %x7F-10FFFF`, so DEL (%x7F), `}` (%x7D), `.` (%x2E), astral characters, U+10FFFF, control characters, and a raw newline or tab inside a token are all valid. Only `/` and `~` are excluded.
- **embedded NUL (3)** - NUL is inside `%x00-2E` so `0/foo<NUL>bar` is valid. I also added `0/foo<NUL>~`, invalid because of the dangling `~`; a validator treating the input as a C string would truncate at the NUL and wrongly accept it.
- **escapes through the wrapper (8)**, **terminators (9)**, **leading zero (7)**, **empty reference tokens (3)**.

## How I checked the expected values

I wrote the expected verdict for each input from the ABNF, then built the `sourcemeta_core_jsonpointer_unit` target with the modified file: **785 passed, 0 failed**. clang-format is idempotent on the result.

The three NUL cases use an explicit-length `std::string_view` and carry a `static_assert(sizeof(value) - 1 == N)`. That is load-bearing rather than decorative: a `\xNN` escape is greedy in C++, so `"0/foo\x00bar"` is the single escape `\x00b` (0x0B) followed by `ar` - eight bytes, not the nine intended. The first version of these tests had exactly that defect and still passed, because the shortened literal happened to give the same verdict. The static_assert turns it into a compile error.

## RFC references

- draft-handrews-relative-json-pointer-01 section 3 (Syntax): https://datatracker.ietf.org/doc/html/draft-handrews-relative-json-pointer-01#section-3
- RFC 6901 section 3 (`reference-token`, `unescaped`, `escaped`): https://www.rfc-editor.org/rfc/rfc6901#section-3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

