### PR TITLE
Validate provider metadata endpoints on the parse path

### DIFF
--- a/src/core/crypto/crypto_helpers.h
+++ b/src/core/crypto/crypto_helpers.h
@@ -80,14 +80,21 @@ inline auto octets_below_fixed(const std::string_view value,
   return borrow == 1;
 }
 
-// Whether a signature representative, as a big-endian integer, is strictly
-// less than the modulus. RFC 8017 Section 5.2.2 requires this range check, so
-// that an unreduced signature, which an attacker forges by adding the modulus
-// without changing the modular exponentiation result, is rejected
-inline auto rsa_signature_in_range(const std::string_view signature,
-                                   const std::string_view modulus) noexcept
+// Whether a signature is a well-formed representative for the modulus. RFC 8017
+// Section 8.2.2 step 1 and Section 8.1.2 step 1: "If the length of the
+// signature S is not k octets, output "invalid signature" and stop". The length
+// is checked because the range comparison reads both operands as bare integers,
+// so a signature that merely dropped a leading zero octet would denote the same
+// value and verify, giving a second encoding of one signature. Section 5.2.2
+// then requires the range check, so that an unreduced signature, which an
+// attacker forges by adding the modulus without changing the modular
+// exponentiation result, is rejected. The modulus is stripped for the length so
+// that a stored ASN.1 sign octet cannot inflate k
+inline auto rsa_signature_acceptable(const std::string_view signature,
+                                     const std::string_view modulus) noexcept
     -> bool {
-  return octets_below(signature, modulus);
+  return signature.size() == strip_left(modulus, '\x00').size() &&
+         octets_below(signature, modulus);
 }
 
 // Whether an RSA public exponent is acceptable for the modulus: odd and in the

--- a/src/core/crypto/crypto_rsa_oaep_apple.cc
+++ b/src/core/crypto/crypto_rsa_oaep_apple.cc
@@ -69,6 +69,14 @@ auto rsa_oaep_decrypt(const PrivateKey &key, const RSAOAEPHash hash,
     return std::nullopt;
   }
 
+  // RFC 8017 Section 7.1.2: "If the length of the ciphertext C is not k octets,
+  // output "decryption error" and stop". The framework reads the ciphertext as
+  // a raw integer, so an input with a dropped or added leading zero would
+  // otherwise decrypt as the same value
+  if (ciphertext.size() != SecKeyGetBlockSize(internal->key)) {
+    return std::nullopt;
+  }
+
   auto ciphertext_data{make_data(ciphertext)};
   if (ciphertext_data == nullptr) {
     return std::nullopt;

--- a/src/core/crypto/crypto_verify_apple.cc
+++ b/src/core/crypto/crypto_verify_apple.cc
@@ -298,7 +298,7 @@ auto rsassa_pkcs1_v15_verify(const PublicKey &key,
                              const std::string_view signature) -> bool {
   const auto *internal{key.internal()};
   if (internal == nullptr || internal->kind != PublicKey::Type::RSA ||
-      !rsa_signature_in_range(signature, internal->modulus)) {
+      !rsa_signature_acceptable(signature, internal->modulus)) {
     return false;
   }
 
@@ -311,7 +311,7 @@ auto rsassa_pss_verify(const PublicKey &key, const SignatureHashFunction hash,
                        const std::string_view signature) -> bool {
   const auto *internal{key.internal()};
   if (internal == nullptr || internal->kind != PublicKey::Type::RSA ||
-      !rsa_signature_in_range(signature, internal->modulus)) {
+      !rsa_signature_acceptable(signature, internal->modulus)) {
     return false;
   }
 

--- a/src/core/crypto/crypto_verify_openssl.cc
+++ b/src/core/crypto/crypto_verify_openssl.cc
@@ -311,7 +311,7 @@ auto rsassa_pkcs1_v15_verify(const PublicKey &key,
                              const std::string_view signature) -> bool {
   const auto *internal{key.internal()};
   if (internal == nullptr || internal->kind != PublicKey::Type::RSA ||
-      !rsa_signature_in_range(signature, internal->modulus)) {
+      !rsa_signature_acceptable(signature, internal->modulus)) {
     return false;
   }
 
@@ -323,7 +323,7 @@ auto rsassa_pss_verify(const PublicKey &key, const SignatureHashFunction hash,
                        const std::string_view signature) -> bool {
   const auto *internal{key.internal()};
   if (internal == nullptr || internal->kind != PublicKey::Type::RSA ||
-      !rsa_signature_in_range(signature, internal->modulus)) {
+      !rsa_signature_acceptable(signature, internal->modulus)) {
     return false;
   }
 

--- a/src/core/crypto/crypto_verify_windows.cc
+++ b/src/core/crypto/crypto_verify_windows.cc
@@ -298,7 +298,7 @@ auto rsassa_pkcs1_v15_verify(const PublicKey &key,
                              const std::string_view signature) -> bool {
   const auto *internal{key.internal()};
   if (internal == nullptr || internal->kind != PublicKey::Type::RSA ||
-      !rsa_signature_in_range(signature, internal->modulus)) {
+      !rsa_signature_acceptable(signature, internal->modulus)) {
     return false;
   }
 
@@ -310,7 +310,7 @@ auto rsassa_pss_verify(const PublicKey &key, const SignatureHashFunction hash,
                        const std::string_view signature) -> bool {
   const auto *internal{key.internal()};
   if (internal == nullptr || internal->kind != PublicKey::Type::RSA ||
-      !rsa_signature_in_range(signature, internal->modulus)) {
+      !rsa_signature_acceptable(signature, internal->modulus)) {
     return false;
   }
 

--- a/src/core/crypto/include/sourcemeta/core/crypto_secure.h
+++ b/src/core/crypto/include/sourcemeta/core/crypto_secure.h
@@ -194,6 +194,11 @@ public:
     this->buffer_.reserve(capacity);
   }
 
+  /// The number of bytes that can be held before growing the storage.
+  [[nodiscard]] auto capacity() const noexcept -> size_type {
+    return this->buffer_.capacity();
+  }
+
   /// Resize to the given number of bytes, padding new ones with the given
   /// value.
   auto resize(const size_type count, const char value) -> void {

--- a/src/core/oauth/oauth_assertion.cc
+++ b/src/core/oauth/oauth_assertion.cc
@@ -137,7 +137,9 @@ auto verify_assertion(
     if (identifier.has_value() && expiration.has_value()) {
       // The skew is clamped to the same non-negative bounded range the claim
       // check applies, so a negative value cannot shorten the window below the
-      // acceptance window and a large one cannot overflow the store's expiry
+      // acceptance window. The window as a whole is still attacker-influenced,
+      // since the remaining lifetime comes from the token's own expiration, so
+      // the store saturates rather than trusting it to fit
       const auto skew{std::clamp(options.clock_skew,
                                  std::chrono::seconds::zero(),
                                  std::chrono::seconds{31556952})};

--- a/src/core/oauth/oauth_decode.h
+++ b/src/core/oauth/oauth_decode.h
@@ -53,6 +53,15 @@ inline auto oauth_form_decode_into(const std::string_view value,
 inline auto oauth_form_decode_into_secure(const std::string_view value,
                                           SecureString &arena,
                                           std::string_view &result) -> bool {
+  // The same reservation contract the borrowing variant enforces, checked the
+  // same way. The assert catches a violation loudly under test, and the guard
+  // fails closed rather than dangle a view into the arena holding the secrets
+  // if the contract is ever broken in a release build
+  assert(arena.capacity() - arena.size() >= value.size());
+  if (arena.capacity() - arena.size() < value.size()) {
+    return false;
+  }
+
   const auto base{arena.size()};
   if (!URI::unescape_form(value, arena)) {
     return false;

--- a/src/core/oauth/oauth_dpop.cc
+++ b/src/core/oauth/oauth_dpop.cc
@@ -29,6 +29,27 @@ namespace {
 
 using namespace std::literals::string_view_literals;
 
+// When an entry stops guarding against a replay, saturating at the newest
+// instant the clock can express. A caller derives the window from a token
+// lifetime, so the value is attacker-influenced and adding it to the clock
+// unchecked would overflow, wrap negative, and have the entry pruned on the
+// very next call, silently disabling the replay guard it was inserted for
+[[maybe_unused]] auto
+replay_expiry(const std::chrono::system_clock::time_point now,
+              const std::chrono::seconds window)
+    -> std::chrono::system_clock::time_point {
+  using Clock = std::chrono::system_clock;
+  constexpr auto limit{
+      std::chrono::duration_cast<std::chrono::seconds>(Clock::duration::max())};
+  const auto ticks{std::chrono::duration_cast<Clock::duration>(
+      std::clamp(window, std::chrono::seconds::zero(), limit))};
+  if (now.time_since_epoch() > Clock::duration::max() - ticks) {
+    return Clock::time_point{Clock::duration::max()};
+  }
+
+  return now + ticks;
+}
+
 constexpr auto HASH_TYP{JSON::Object::hash("typ"sv)};
 constexpr auto HASH_ALG{JSON::Object::hash("alg"sv)};
 constexpr auto HASH_JWK{JSON::Object::hash("jwk"sv)};
@@ -403,7 +424,8 @@ auto OAuthDPoPReplayStore::check_and_insert(
     return false;
   }
 
-  this->entries_.push_back(Entry{.digest = digest, .expiry = now + window});
+  this->entries_.push_back(
+      Entry{.digest = digest, .expiry = replay_expiry(now, window)});
   return true;
 }
 

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -71,6 +71,23 @@ auto string_member(const JSON &data, const JSON::StringView name,
   return std::string_view{member->to_string()};
 }
 
+// An advertised endpoint is a location the client dereferences with its
+// credentials, so a document naming a cleartext one would direct those
+// credentials there. A member that is present but is not a valid https URL
+// fails the parse rather than being ignored, since an accessor would otherwise
+// report a malformed member as an absent one
+auto validate_endpoint(const JSON &data, const JSON::StringView name,
+                       const JSON::Object::hash_type hash) -> void {
+  const auto *member{data.try_at(name, hash)};
+  if (member == nullptr) {
+    return;
+  }
+
+  if (!member->is_string() || !oauth_is_endpoint_url(member->to_string())) {
+    throw OAuthMetadataParseError{};
+  }
+}
+
 auto validated_server_metadata(JSON &&data, const std::string_view issuer)
     -> JSON {
   if (!data.is_object()) {
@@ -82,12 +99,42 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
     throw OAuthMetadataParseError{};
   }
 
-  // RFC 8414 Section 3.3: the issuer in the document must be identical by code
-  // points to the one the document was retrieved for, the impersonation defense
+  // RFC 8414 Section 3.3: the issuer in the document "MUST be identical to the
+  // authorization server's issuer identifier value into which the well-known
+  // URI string was inserted", the impersonation defense, and Section 4 fixes
+  // how that comparison runs, as "a Unicode code-point-to-code-point equality
+  // comparison"
   const auto issuer_value{std::string_view{issuer_member->to_string()}};
   if (issuer_value != issuer || !oauth_is_issuer_identifier(issuer_value)) {
     throw OAuthMetadataParseError{};
   }
+
+  // Each advertised endpoint carries its own transport requirement, and the
+  // document arrives from the party the client is still deciding whether to
+  // trust, so the rule is enforced when the document is read and not only when
+  // one is built. Some of these sources mandate the scheme outright and the
+  // rest mandate the transport, which over HTTP is the same demand. RFC 8414
+  // Section 2 on jwks_uri: "This URL MUST use the "https" scheme". RFC 9126
+  // Section 2: "The PAR endpoint URL MUST use the "https" scheme". RFC 7009
+  // Section 2: "URLs for token revocation endpoints MUST be HTTPS URLs" and,
+  // addressed at this side of the exchange, "Clients MUST verify that the URL
+  // is an HTTPS URL". RFC 6749 Section 3.1 and Section 3.2: "the authorization
+  // server MUST require the use of TLS" for the authorization and token
+  // endpoints. RFC 7591 Section 3: the "registration endpoint MUST be protected
+  // by a transport-layer security mechanism". RFC 7662 Section 2: "The
+  // introspection endpoint MUST be protected by a transport-layer security
+  // mechanism"
+  validate_endpoint(data, "authorization_endpoint"sv,
+                    HASH_AUTHORIZATION_ENDPOINT);
+  validate_endpoint(data, "token_endpoint"sv, HASH_TOKEN_ENDPOINT);
+  validate_endpoint(data, "registration_endpoint"sv,
+                    HASH_REGISTRATION_ENDPOINT);
+  validate_endpoint(data, "pushed_authorization_request_endpoint"sv,
+                    HASH_PAR_ENDPOINT);
+  validate_endpoint(data, "revocation_endpoint"sv, HASH_REVOCATION_ENDPOINT);
+  validate_endpoint(data, "introspection_endpoint"sv,
+                    HASH_INTROSPECTION_ENDPOINT);
+  validate_endpoint(data, "jwks_uri"sv, HASH_JWKS_URI);
 
   // RFC 8414 Section 2: response_types_supported is REQUIRED, and Section 3.2:
   // "Claims with zero elements MUST be omitted from the response", so a
@@ -130,13 +177,40 @@ auto validated_resource_metadata(JSON &&data, const std::string_view resource)
     throw OAuthMetadataParseError{};
   }
 
-  // RFC 9728 Section 3.3: the resource in the document must be a valid resource
-  // identifier and identical by code points to the one the document was
-  // retrieved for, the impersonation defense
+  // RFC 9728 Section 3.3: the resource in the document "MUST be identical to
+  // the protected resource's resource identifier value into which the
+  // well-known URI path suffix was inserted", the impersonation defense, and
+  // Section 6 fixes how that comparison runs, as "a Unicode
+  // code-point-to-code-point equality comparison". It must also be a valid
+  // resource identifier in the first place
   const auto resource_value{std::string_view{resource_member->to_string()}};
   if (resource_value != resource ||
       !oauth_is_resource_identifier(resource_value)) {
     throw OAuthMetadataParseError{};
+  }
+
+  // RFC 9728 Section 2 on jwks_uri: "This URL MUST use the https scheme"
+  validate_endpoint(data, "jwks_uri"sv, HASH_JWKS_URI);
+
+  // RFC 9728 Section 2: the authorization servers are "OAuth authorization
+  // server issuer identifiers, as defined in [RFC8414]", and each one is where
+  // the client starts its next discovery request, so an entry that is not a
+  // valid issuer identifier is rejected rather than handed onwards. Section
+  // 3.2: "Parameters with zero values MUST be omitted from the response", so a
+  // present but empty array is a malformed document
+  const auto *authorization_servers{
+      data.try_at("authorization_servers"sv, HASH_AUTHORIZATION_SERVERS)};
+  if (authorization_servers != nullptr) {
+    if (!authorization_servers->is_array() || authorization_servers->empty()) {
+      throw OAuthMetadataParseError{};
+    }
+
+    for (const auto &element : authorization_servers->as_array()) {
+      if (!element.is_string() ||
+          !oauth_is_issuer_identifier(element.to_string())) {
+        throw OAuthMetadataParseError{};
+      }
+    }
   }
 
   // RFC 9728 Section 2: "none" MUST NOT appear in the resource signing
@@ -389,17 +463,14 @@ auto OAuthResourceMetadata::first_authorization_server() const
 
   const auto *member{this->data_.try_at("authorization_servers"sv,
                                         HASH_AUTHORIZATION_SERVERS)};
-  if (member == nullptr || !member->is_array()) {
+  if (member == nullptr) {
     return std::nullopt;
   }
 
-  for (const auto &element : member->as_array()) {
-    if (element.is_string()) {
-      return std::string_view{element.to_string()};
-    }
-  }
-
-  return std::nullopt;
+  // Construction rejects a document whose authorization servers are anything
+  // other than a non-empty array of issuer identifiers, so the first element is
+  // a string and needs no search past a malformed one
+  return std::string_view{member->front().to_string()};
 }
 
 auto OAuthResourceMetadata::supports_authorization_server(
@@ -459,7 +530,8 @@ auto oauth_make_server_metadata(const OAuthServerMetadataConfig &config)
   // type is advertised, and the token endpoint unless the only grant type is
   // the implicit one, and every advertised URL is an https location. A present
   // scalar that is not a valid https URL, or a missing required endpoint, would
-  // yield an unusable discovery document
+  // yield an unusable discovery document. The same predicate the parse path
+  // applies is used here, so a document this builder emits always parses back
   const bool token_endpoint_needed{
       config.grant_types_supported.empty() ||
       std::ranges::any_of(config.grant_types_supported,
@@ -467,19 +539,16 @@ auto oauth_make_server_metadata(const OAuthServerMetadataConfig &config)
                             return grant != "implicit";
                           })};
   const bool token_endpoint_required_and_valid{
-      token_endpoint_needed
-          ? oauth_is_resource_identifier(config.token_endpoint)
-          : config.token_endpoint.empty() ||
-                oauth_is_resource_identifier(config.token_endpoint)};
-  if (!oauth_is_resource_identifier(config.authorization_endpoint) ||
+      token_endpoint_needed ? oauth_is_endpoint_url(config.token_endpoint)
+                            : config.token_endpoint.empty() ||
+                                  oauth_is_endpoint_url(config.token_endpoint)};
+  if (!oauth_is_endpoint_url(config.authorization_endpoint) ||
       !token_endpoint_required_and_valid ||
       (!config.registration_endpoint.empty() &&
-       !oauth_is_resource_identifier(config.registration_endpoint)) ||
+       !oauth_is_endpoint_url(config.registration_endpoint)) ||
       (!config.pushed_authorization_request_endpoint.empty() &&
-       !oauth_is_resource_identifier(
-           config.pushed_authorization_request_endpoint)) ||
-      (!config.jwks_uri.empty() &&
-       !oauth_is_resource_identifier(config.jwks_uri))) {
+       !oauth_is_endpoint_url(config.pushed_authorization_request_endpoint)) ||
+      (!config.jwks_uri.empty() && !oauth_is_endpoint_url(config.jwks_uri))) {
     return std::nullopt;
   }
 

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -29,6 +29,8 @@ constexpr auto HASH_PAR_ENDPOINT{
     JSON::Object::hash("pushed_authorization_request_endpoint"sv)};
 constexpr auto HASH_REQUIRE_PAR{
     JSON::Object::hash("require_pushed_authorization_requests"sv)};
+constexpr auto HASH_DEVICE_AUTHORIZATION_ENDPOINT{
+    JSON::Object::hash("device_authorization_endpoint"sv)};
 constexpr auto HASH_REVOCATION_ENDPOINT{
     JSON::Object::hash("revocation_endpoint"sv)};
 constexpr auto HASH_INTROSPECTION_ENDPOINT{
@@ -123,7 +125,10 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
   // endpoints. RFC 7591 Section 3: the "registration endpoint MUST be protected
   // by a transport-layer security mechanism". RFC 7662 Section 2: "The
   // introspection endpoint MUST be protected by a transport-layer security
-  // mechanism"
+  // mechanism". RFC 8628 Section 3.1 on the device authorization endpoint:
+  // "All requests from the device MUST use the Transport Layer Security (TLS)
+  // protocol", and the client authentication rules of RFC 6749 Section 3.2.1
+  // apply there too, so it carries credentials just as the token endpoint does
   validate_endpoint(data, "authorization_endpoint"sv,
                     HASH_AUTHORIZATION_ENDPOINT);
   validate_endpoint(data, "token_endpoint"sv, HASH_TOKEN_ENDPOINT);
@@ -131,6 +136,8 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
                     HASH_REGISTRATION_ENDPOINT);
   validate_endpoint(data, "pushed_authorization_request_endpoint"sv,
                     HASH_PAR_ENDPOINT);
+  validate_endpoint(data, "device_authorization_endpoint"sv,
+                    HASH_DEVICE_AUTHORIZATION_ENDPOINT);
   validate_endpoint(data, "revocation_endpoint"sv, HASH_REVOCATION_ENDPOINT);
   validate_endpoint(data, "introspection_endpoint"sv,
                     HASH_INTROSPECTION_ENDPOINT);
@@ -195,7 +202,9 @@ auto validated_resource_metadata(JSON &&data, const std::string_view resource)
   // RFC 9728 Section 2: the authorization servers are "OAuth authorization
   // server issuer identifiers, as defined in [RFC8414]", and each one is where
   // the client starts its next discovery request, so an entry that is not a
-  // valid issuer identifier is rejected rather than handed onwards. Section
+  // valid issuer identifier is rejected rather than handed onwards. RFC 8414
+  // Section 2 requires the https scheme, a host, and no query or fragment,
+  // while leaving the scheme case-insensitive for an advertised value. Section
   // 3.2: "Parameters with zero values MUST be omitted from the response", so a
   // present but empty array is a malformed document
   const auto *authorization_servers{
@@ -207,7 +216,7 @@ auto validated_resource_metadata(JSON &&data, const std::string_view resource)
 
     for (const auto &element : authorization_servers->as_array()) {
       if (!element.is_string() ||
-          !oauth_is_issuer_identifier(element.to_string())) {
+          !oauth_is_advertised_issuer(element.to_string())) {
         throw OAuthMetadataParseError{};
       }
     }

--- a/src/core/oauth/oauth_registration.cc
+++ b/src/core/oauth/oauth_registration.cc
@@ -106,6 +106,21 @@ auto validated_client_metadata(JSON &&data) -> JSON {
     throw OAuthRegistrationParseError{};
   }
 
+  // RFC 7592 Section 2: "The client configuration endpoint MUST be protected by
+  // a transport-layer security mechanism", and the client "MUST use its
+  // registration access token in all calls to this endpoint as an OAuth 2.0
+  // Bearer Token", so a cleartext location here would carry that credential in
+  // the clear. RFC 7591 Section 3.2.1 makes this member server-assigned, so a
+  // registration request never carries one and validating it cannot reject a
+  // well-formed request
+  const auto *management_uri{
+      data.try_at("registration_client_uri"sv, HASH_REGISTRATION_CLIENT_URI)};
+  if (management_uri != nullptr &&
+      (!management_uri->is_string() ||
+       !oauth_is_endpoint_url(management_uri->to_string()))) {
+    throw OAuthRegistrationParseError{};
+  }
+
   return std::move(data);
 }
 
@@ -430,9 +445,11 @@ auto oauth_make_registration_response(
   }
 
   // RFC 7592 Section 3: the registration management location is a fully
-  // qualified URL
+  // qualified URL, and Section 2 requires the endpoint it names to be protected
+  // by a transport-layer security mechanism, so the same predicate the parse
+  // path applies is used here
   if (!result.registration_client_uri.empty() &&
-      !oauth_try_parse_uri(result.registration_client_uri).has_value()) {
+      !oauth_is_endpoint_url(result.registration_client_uri)) {
     return std::nullopt;
   }
 

--- a/src/core/oauth/oauth_registration.cc
+++ b/src/core/oauth/oauth_registration.cc
@@ -110,9 +110,11 @@ auto validated_client_metadata(JSON &&data) -> JSON {
   // a transport-layer security mechanism", and the client "MUST use its
   // registration access token in all calls to this endpoint as an OAuth 2.0
   // Bearer Token", so a cleartext location here would carry that credential in
-  // the clear. RFC 7591 Section 3.2.1 makes this member server-assigned, so a
-  // registration request never carries one and validating it cannot reject a
-  // well-formed request
+  // the clear. This record is read in both directions, but Section 2.2 keeps a
+  // request from carrying the member at all, since an update "MUST NOT include
+  // the "registration_access_token", "registration_client_uri",
+  // "client_secret_expires_at", or "client_id_issued_at" fields", so validating
+  // it cannot reject a well-formed request
   const auto *management_uri{
       data.try_at("registration_client_uri"sv, HASH_REGISTRATION_CLIENT_URI)};
   if (management_uri != nullptr &&

--- a/src/core/oauth/oauth_syntax.h
+++ b/src/core/oauth/oauth_syntax.h
@@ -46,6 +46,23 @@ inline auto oauth_is_resource_identifier(const std::string_view value) -> bool {
          !uri->host().value().empty() && !uri->fragment().has_value();
 }
 
+// RFC 6749 Section 3.1: "the authorization server MUST require the use of TLS
+// as described in Section 1.6 when sending requests to the authorization
+// endpoint", which over HTTP means the https scheme, and "The endpoint URI MUST
+// NOT include a fragment component", while it "MAY include an
+// "application/x-www-form-urlencoded" formatted (per Appendix B) query
+// component". Unlike an identifier, which RFC 8414 Section 4 compares as "a
+// Unicode code-point-to-code-point equality comparison", an endpoint is a
+// location to dereference, so RFC 3986 Section 3.1 governs and makes its scheme
+// case-insensitive
+inline auto oauth_is_endpoint_url(const std::string_view value) -> bool {
+  const auto uri{oauth_try_parse_uri(value)};
+  return uri.has_value() && uri->scheme().has_value() &&
+         equals_ignore_case(uri->scheme().value(), "https") &&
+         uri->host().has_value() && !uri->host().value().empty() &&
+         !uri->fragment().has_value();
+}
+
 // RFC 3986 Section 2.3: "unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"",
 // the character set RFC 7636 reuses for the PKCE verifier and challenge
 inline auto oauth_is_unreserved(const char character) noexcept -> bool {

--- a/src/core/oauth/oauth_syntax.h
+++ b/src/core/oauth/oauth_syntax.h
@@ -46,6 +46,20 @@ inline auto oauth_is_resource_identifier(const std::string_view value) -> bool {
          !uri->host().value().empty() && !uri->fragment().has_value();
 }
 
+// An issuer identifier a document advertises for someone else, rather than the
+// one the document was retrieved for. RFC 8414 Section 2 gives it the same
+// shape, but Section 4 scopes code-point comparison to "comparing values in the
+// messages to known values", and an advertised issuer is matched against
+// nothing at parse time. Its validity therefore follows RFC 3986 Section 3.1,
+// which makes the scheme case-insensitive
+inline auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
+  const auto uri{oauth_try_parse_uri(value)};
+  return uri.has_value() && uri->scheme().has_value() &&
+         equals_ignore_case(uri->scheme().value(), "https") &&
+         uri->host().has_value() && !uri->host().value().empty() &&
+         !uri->query().has_value() && !uri->fragment().has_value();
+}
+
 // RFC 6749 Section 3.1: "the authorization server MUST require the use of TLS
 // as described in Section 1.6 when sending requests to the authorization
 // endpoint", which over HTTP means the https scheme, and "The endpoint URI MUST

--- a/src/core/oidc/CMakeLists.txt
+++ b/src/core/oidc/CMakeLists.txt
@@ -4,8 +4,8 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME oidc
     request_object.h logout.h encryption.h profile.h
   SOURCES oidc_error.cc oidc_metadata.cc oidc_discovery.cc oidc_hash.cc
     oidc_id_token.cc oidc_authentication.cc oidc_claims.cc oidc_userinfo.cc
-    oidc_registration.cc oidc_subject.cc oidc_verify.h oidc_request_object.cc
-    oidc_logout.cc oidc_encryption.cc)
+    oidc_registration.cc oidc_subject.cc oidc_verify.h oidc_time.h
+    oidc_request_object.cc oidc_logout.cc oidc_encryption.cc)
 
 target_link_libraries(sourcemeta_core_oidc
   PUBLIC sourcemeta::core::json)

--- a/src/core/oidc/oidc_id_token.cc
+++ b/src/core/oidc/oidc_id_token.cc
@@ -6,6 +6,8 @@
 #include <sourcemeta/core/oidc_hash.h>
 #include <sourcemeta/core/time.h>
 
+#include "oidc_time.h"
+
 #include <chrono> // std::chrono::system_clock, std::chrono::seconds, std::chrono::duration, std::chrono::duration_cast
 #include <cstdint>     // std::int64_t
 #include <optional>    // std::optional, std::nullopt
@@ -103,7 +105,8 @@ auto oidc_id_token_checks(const JWT &token, const std::string_view issuer,
   // OpenID Connect Core 1.0 Section 3.1.3.7 step 10: the optional issued-at age
   // policy
   if (options.maximum_issued_at_age.has_value() &&
-      now - issued_at.value() > options.maximum_issued_at_age.value()) {
+      issued_at.value() <
+          oidc_shift_backward(now, options.maximum_issued_at_age.value())) {
     return std::nullopt;
   }
 
@@ -150,8 +153,9 @@ auto oidc_id_token_checks(const JWT &token, const std::string_view issuer,
     // An authentication time in the future has not happened yet, so it cannot
     // satisfy a freshness window and is rejected before the age comparison
     if (!authentication_time.has_value() || authentication_time.value() > now ||
-        now - authentication_time.value() >
-            options.maximum_authentication_age.value()) {
+        authentication_time.value() <
+            oidc_shift_backward(now,
+                                options.maximum_authentication_age.value())) {
       return std::nullopt;
     }
   }

--- a/src/core/oidc/oidc_logout.cc
+++ b/src/core/oidc/oidc_logout.cc
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/uri.h>
 
+#include "oidc_time.h"
 #include "oidc_verify.h"
 
 #include <chrono>      // std::chrono::system_clock
@@ -107,10 +108,12 @@ auto oidc_validate_logout_token(
   }
 
   // OpenID Connect Back-Channel Logout 1.0 Section 2.4: iat is REQUIRED and
-  // must not be in the future
+  // must not be in the future. The skew shifts the server clock rather than the
+  // claim, so a NumericDate near the representable bound cannot overflow the
+  // comparison
   const auto issued_at{token.issued_at()};
   if (!issued_at.has_value() ||
-      issued_at.value() > now + clock_skew.issued_at) {
+      issued_at.value() > oidc_shift_forward(now, clock_skew.issued_at)) {
     return false;
   }
 
@@ -119,7 +122,7 @@ auto oidc_validate_logout_token(
   // skew) is rejected
   const auto expires_at{token.expires_at()};
   if (!expires_at.has_value() ||
-      now >= expires_at.value() + clock_skew.expiration) {
+      oidc_shift_backward(now, clock_skew.expiration) >= expires_at.value()) {
     return false;
   }
 

--- a/src/core/oidc/oidc_metadata.cc
+++ b/src/core/oidc/oidc_metadata.cc
@@ -80,6 +80,38 @@ auto is_required_string_array(const JSON *member) -> bool {
   return member != nullptr && member->is_array_of_strings() && !member->empty();
 }
 
+auto is_https_url(const std::string_view value) -> bool {
+  // OpenID Connect Discovery 1.0 Section 3: every advertised endpoint is a URL
+  // using the https scheme
+  try {
+    const URI uri{value};
+    // A fragment is never sent in an HTTP request, so an endpoint carrying one
+    // would advertise a location clients cannot reach and is rejected. RFC 3986
+    // Section 3.1 makes the scheme case-insensitive
+    return uri.scheme().has_value() &&
+           equals_ignore_case(uri.scheme().value(), "https") &&
+           uri.host().has_value() && !uri.host().value().empty() &&
+           !uri.fragment().has_value();
+  } catch (const URIParseError &) {
+    return false;
+  }
+}
+
+// A member that is present but is not a valid https URL fails the parse rather
+// than being ignored, since an accessor would otherwise report a malformed
+// member as an absent one
+auto validate_endpoint(const JSON &data, const JSON::StringView name,
+                       const JSON::Object::hash_type hash) -> void {
+  const auto *member{data.try_at(name, hash)};
+  if (member == nullptr) {
+    return;
+  }
+
+  if (!member->is_string() || !is_https_url(member->to_string())) {
+    throw OIDCMetadataParseError{};
+  }
+}
+
 auto validate_provider_metadata(const OAuthServerMetadata &oauth) -> void {
   const auto &data{oauth.data()};
 
@@ -109,23 +141,17 @@ auto validate_provider_metadata(const OAuthServerMetadata &oauth) -> void {
       !id_token_algs->contains("RS256")) {
     throw OIDCMetadataParseError{};
   }
-}
 
-auto is_https_url(const std::string_view value) -> bool {
-  // OpenID Connect Discovery 1.0 Section 3: every advertised endpoint is a URL
-  // using the https scheme
-  try {
-    const URI uri{value};
-    // A fragment is never sent in an HTTP request, so an endpoint carrying one
-    // would advertise a location clients cannot reach and is rejected. RFC 3986
-    // Section 3.1 makes the scheme case-insensitive
-    return uri.scheme().has_value() &&
-           equals_ignore_case(uri.scheme().value(), "https") &&
-           uri.host().has_value() && !uri.host().value().empty() &&
-           !uri.fragment().has_value();
-  } catch (const URIParseError &) {
-    return false;
-  }
+  // The endpoints the OAuth layer does not know about. OpenID Connect Discovery
+  // 1.0 Section 3 on userinfo_endpoint, OpenID Connect RP-Initiated Logout 1.0
+  // Section 2.1 on end_session_endpoint, and OpenID Connect Session Management
+  // 1.0 Section 3.3 on check_session_iframe all carry the same requirement:
+  // "This URL MUST use the https scheme and MAY contain port, path, and query
+  // parameter components". The endpoints shared with OAuth are already covered
+  // when that document is validated, which happens before this runs
+  validate_endpoint(data, "userinfo_endpoint"sv, HASH_USERINFO_ENDPOINT);
+  validate_endpoint(data, "end_session_endpoint"sv, HASH_END_SESSION_ENDPOINT);
+  validate_endpoint(data, "check_session_iframe"sv, HASH_CHECK_SESSION_IFRAME);
 }
 
 } // namespace

--- a/src/core/oidc/oidc_metadata.cc
+++ b/src/core/oidc/oidc_metadata.cc
@@ -85,9 +85,11 @@ auto is_https_url(const std::string_view value) -> bool {
   // using the https scheme
   try {
     const URI uri{value};
-    // A fragment is never sent in an HTTP request, so an endpoint carrying one
-    // would advertise a location clients cannot reach and is rejected. RFC 3986
-    // Section 3.1 makes the scheme case-insensitive
+    // Section 3 enumerates what an endpoint may carry as "port, path, and query
+    // parameter components", so a fragment is refused as outside that list
+    // rather than because it could not be dereferenced, which would be the
+    // wrong reason for the two endpoints a user agent loads. RFC 3986 Section
+    // 3.1 makes the scheme case-insensitive
     return uri.scheme().has_value() &&
            equals_ignore_case(uri.scheme().value(), "https") &&
            uri.host().has_value() && !uri.host().value().empty() &&

--- a/src/core/oidc/oidc_registration.cc
+++ b/src/core/oidc/oidc_registration.cc
@@ -33,6 +33,7 @@ constexpr auto HASH_USERINFO_SIGNED_ALG{
 constexpr auto HASH_DEFAULT_MAX_AGE{JSON::Object::hash("default_max_age"sv)};
 constexpr auto HASH_REQUIRE_AUTH_TIME{
     JSON::Object::hash("require_auth_time"sv)};
+constexpr auto HASH_JWKS_URI{JSON::Object::hash("jwks_uri"sv)};
 constexpr auto HASH_INITIATE_LOGIN_URI{
     JSON::Object::hash("initiate_login_uri"sv)};
 constexpr auto HASH_POST_LOGOUT_REDIRECT_URIS{
@@ -140,6 +141,20 @@ auto validate_client_metadata(const OAuthClientMetadata &oauth) -> void {
       data.try_at("sector_identifier_uri"sv, HASH_SECTOR_IDENTIFIER_URI)};
   if (sector != nullptr &&
       (!sector->is_string() || !is_https_url_with_host(sector->to_string()))) {
+    throw OIDCRegistrationParseError{};
+  }
+
+  // OpenID Connect Dynamic Client Registration 1.0 Section 2: the jwks_uri is a
+  // "URL for the Client's JWK Set document, which MUST use the https scheme".
+  // The provider fetches it to obtain the keys that authenticate the client, so
+  // over cleartext an attacker substitutes them and impersonates the client.
+  // Note that request_uris carries the neighbouring rule conditionally, "unless
+  // the target Request Object is signed in a way that is verifiable by the OP",
+  // which is not knowable here, so it is deliberately left unchecked
+  const auto *client_keys{data.try_at("jwks_uri"sv, HASH_JWKS_URI)};
+  if (client_keys != nullptr &&
+      (!client_keys->is_string() ||
+       !is_https_url_with_host(client_keys->to_string()))) {
     throw OIDCRegistrationParseError{};
   }
 

--- a/src/core/oidc/oidc_time.h
+++ b/src/core/oidc/oidc_time.h
@@ -1,0 +1,54 @@
+#ifndef SOURCEMETA_CORE_OIDC_TIME_H_
+#define SOURCEMETA_CORE_OIDC_TIME_H_
+
+#include <algorithm> // std::clamp
+#include <chrono> // std::chrono::system_clock, std::chrono::seconds, std::chrono::duration_cast
+
+namespace sourcemeta::core {
+
+// The widest span the clock's tick type can express, truncated toward zero so
+// converting it back to ticks can never exceed the representable range
+inline auto oidc_bounded_ticks(const std::chrono::seconds span)
+    -> std::chrono::system_clock::duration {
+  using Clock = std::chrono::system_clock;
+  constexpr auto limit{
+      std::chrono::duration_cast<std::chrono::seconds>(Clock::duration::max())};
+  return std::chrono::duration_cast<Clock::duration>(
+      std::clamp(span, std::chrono::seconds::zero(), limit));
+}
+
+// Move the server clock back by a span, saturating at the oldest representable
+// instant. Every freshness comparison shifts this reading rather than adding to
+// or subtracting from the claim under test, because a NumericDate near the
+// representable bound would otherwise overflow the arithmetic, which is the
+// discipline the base JSON Web Token verification already follows. A negative
+// span is treated as no span at all, so a nonsensical window fails closed
+inline auto oidc_shift_backward(const std::chrono::system_clock::time_point now,
+                                const std::chrono::seconds span)
+    -> std::chrono::system_clock::time_point {
+  using Clock = std::chrono::system_clock;
+  const auto ticks{oidc_bounded_ticks(span)};
+  if (now.time_since_epoch() < Clock::duration::min() + ticks) {
+    return Clock::time_point{Clock::duration::min()};
+  }
+
+  return now - ticks;
+}
+
+// Move the server clock forward by a span, saturating at the newest
+// representable instant
+inline auto oidc_shift_forward(const std::chrono::system_clock::time_point now,
+                               const std::chrono::seconds span)
+    -> std::chrono::system_clock::time_point {
+  using Clock = std::chrono::system_clock;
+  const auto ticks{oidc_bounded_ticks(span)};
+  if (now.time_since_epoch() > Clock::duration::max() - ticks) {
+    return Clock::time_point{Clock::duration::max()};
+  }
+
+  return now + ticks;
+}
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oidc/oidc_time.h
+++ b/src/core/oidc/oidc_time.h
@@ -3,8 +3,16 @@
 
 #include <algorithm> // std::clamp
 #include <chrono> // std::chrono::system_clock, std::chrono::seconds, std::chrono::duration_cast
+#include <ratio> // std::ratio, std::ratio_less_equal_v
 
 namespace sourcemeta::core {
+
+// Expressing the clock's widest span in seconds is a division only while a tick
+// is no coarser than a second, which holds for every standard library this
+// builds against. A coarser tick would turn it into a multiplication that
+// overflows, so the assumption is stated here rather than left to be discovered
+static_assert(
+    std::ratio_less_equal_v<std::chrono::system_clock::period, std::ratio<1>>);
 
 // The widest span the clock's tick type can express, truncated toward zero so
 // converting it back to ticks can never exceed the representable range
@@ -22,7 +30,9 @@ inline auto oidc_bounded_ticks(const std::chrono::seconds span)
 // or subtracting from the claim under test, because a NumericDate near the
 // representable bound would otherwise overflow the arithmetic, which is the
 // discipline the base JSON Web Token verification already follows. A negative
-// span is treated as no span at all, so a nonsensical window fails closed
+// span is treated as no span at all, since a window that runs backwards has no
+// meaning, which leaves a nonsensical caller value behaving as if none was
+// given rather than shifting the clock the wrong way
 inline auto oidc_shift_backward(const std::chrono::system_clock::time_point now,
                                 const std::chrono::seconds span)
     -> std::chrono::system_clock::time_point {

--- a/test/crypto/crypto_rsa_oaep_test.cc
+++ b/test/crypto/crypto_rsa_oaep_test.cc
@@ -71,6 +71,20 @@ zz/p2wIRJlfNHxRap+Q=
 -----END PRIVATE KEY-----
 )"};
 
+// A ciphertext of "hello" under the test key above whose leading octet is zero,
+// which holds for roughly one ciphertext in 256. Encrypting cannot be asked for
+// that property, so a known one is pinned to keep the truncation case
+// deterministic rather than a rare coincidence
+static constexpr std::string_view LEADING_ZERO_CIPHERTEXT_HEX{
+    "00baf76551170422f767d2e90f80eb09304e0424030106bca40fc766c8b7adc200373"
+    "59ef47ba652354d47719619db6a9243732c3c13fd4122b9f961fe4c9a3bcbb82d72a1"
+    "64e91a718a35dc0124e6a1ee83a50ca22588e30a5291a8f2c4a374744bad2849f9e88"
+    "bb542a9447f7763e4688009a6a5565a3cc3adcdd39cb73cc9c50dbe91cdf7a9b618b9"
+    "b8d3496c73d0f9a984d41684d6b4c41152dd9a14e76c888d513e1e724339628e3b226"
+    "07899a7ab76125f7504c2848e7c2bb61353bce525512c5060244e79a174b200392453"
+    "5456091a4e873dbf8060a52422a3b8a777e1c99c1af2670e93757692440bdd17a765c"
+    "4356aa111d21eca7e241151bd1601"};
+
 TEST(rsa_oaep_round_trips_with_sha256) {
   const std::string_view plaintext{"a content encryption key"};
   const auto private_key{sourcemeta::core::make_private_key(PRIVATE_KEY_PEM)};
@@ -189,20 +203,6 @@ TEST(rsa_oaep_decrypt_rejects_a_ciphertext_of_the_wrong_length) {
           private_key.value(), sourcemeta::core::RSAOAEPHash::SHA256, truncated)
           .has_value());
 }
-
-// A ciphertext of "hello" under the test key above whose leading octet is zero,
-// which holds for roughly one ciphertext in 256. Encrypting cannot be asked for
-// that property, so a known one is pinned here to make the case below
-// deterministic rather than a rare coincidence
-static constexpr std::string_view LEADING_ZERO_CIPHERTEXT_HEX{
-    "00baf76551170422f767d2e90f80eb09304e0424030106bca40fc766c8b7adc200373"
-    "59ef47ba652354d47719619db6a9243732c3c13fd4122b9f961fe4c9a3bcbb82d72a1"
-    "64e91a718a35dc0124e6a1ee83a50ca22588e30a5291a8f2c4a374744bad2849f9e88"
-    "bb542a9447f7763e4688009a6a5565a3cc3adcdd39cb73cc9c50dbe91cdf7a9b618b9"
-    "b8d3496c73d0f9a984d41684d6b4c41152dd9a14e76c888d513e1e724339628e3b226"
-    "07899a7ab76125f7504c2848e7c2bb61353bce525512c5060244e79a174b200392453"
-    "5456091a4e873dbf8060a52422a3b8a777e1c99c1af2670e93757692440bdd17a765c"
-    "4356aa111d21eca7e241151bd1601"};
 
 TEST(rsa_oaep_decrypt_rejects_a_ciphertext_missing_a_leading_zero) {
   // A ciphertext is a big-endian integer, so dropping a leading zero octet

--- a/test/crypto/crypto_rsa_oaep_test.cc
+++ b/test/crypto/crypto_rsa_oaep_test.cc
@@ -1,5 +1,6 @@
 #include <sourcemeta/core/crypto.h>
 #include <sourcemeta/core/test.h>
+#include <sourcemeta/core/text.h>
 
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -186,6 +187,77 @@ TEST(rsa_oaep_decrypt_rejects_a_ciphertext_of_the_wrong_length) {
   EXPECT_FALSE(
       sourcemeta::core::rsa_oaep_decrypt(
           private_key.value(), sourcemeta::core::RSAOAEPHash::SHA256, truncated)
+          .has_value());
+}
+
+// A ciphertext of "hello" under the test key above whose leading octet is zero,
+// which holds for roughly one ciphertext in 256. Encrypting cannot be asked for
+// that property, so a known one is pinned here to make the case below
+// deterministic rather than a rare coincidence
+static constexpr std::string_view LEADING_ZERO_CIPHERTEXT_HEX{
+    "00baf76551170422f767d2e90f80eb09304e0424030106bca40fc766c8b7adc200373"
+    "59ef47ba652354d47719619db6a9243732c3c13fd4122b9f961fe4c9a3bcbb82d72a1"
+    "64e91a718a35dc0124e6a1ee83a50ca22588e30a5291a8f2c4a374744bad2849f9e88"
+    "bb542a9447f7763e4688009a6a5565a3cc3adcdd39cb73cc9c50dbe91cdf7a9b618b9"
+    "b8d3496c73d0f9a984d41684d6b4c41152dd9a14e76c888d513e1e724339628e3b226"
+    "07899a7ab76125f7504c2848e7c2bb61353bce525512c5060244e79a174b200392453"
+    "5456091a4e873dbf8060a52422a3b8a777e1c99c1af2670e93757692440bdd17a765c"
+    "4356aa111d21eca7e241151bd1601"};
+
+TEST(rsa_oaep_decrypt_rejects_a_ciphertext_missing_a_leading_zero) {
+  // A ciphertext is a big-endian integer, so dropping a leading zero octet
+  // leaves the same value and a backend that reads it as a bare number decrypts
+  // it happily. RFC 8017 Section 7.1.2 requires the length to be exactly the
+  // modulus size, which is what refuses it
+  const auto private_key{sourcemeta::core::make_private_key(PRIVATE_KEY_PEM)};
+  EXPECT_TRUE(private_key.has_value());
+  const auto ciphertext{
+      sourcemeta::core::hex_to_bytes(LEADING_ZERO_CIPHERTEXT_HEX)};
+  EXPECT_TRUE(ciphertext.has_value());
+  EXPECT_EQ(ciphertext.value().size(), std::string::size_type{256});
+  EXPECT_EQ(ciphertext.value().front(), '\x00');
+
+  // The pinned ciphertext is genuinely valid at its full length
+  const auto whole{sourcemeta::core::rsa_oaep_decrypt(
+      private_key.value(), sourcemeta::core::RSAOAEPHash::SHA256,
+      ciphertext.value())};
+  EXPECT_TRUE(whole.has_value());
+  EXPECT_EQ(whole.value(), "hello");
+
+  const std::string truncated{ciphertext.value().substr(1)};
+  EXPECT_EQ(truncated.size(), std::string::size_type{255});
+  EXPECT_FALSE(
+      sourcemeta::core::rsa_oaep_decrypt(
+          private_key.value(), sourcemeta::core::RSAOAEPHash::SHA256, truncated)
+          .has_value());
+}
+
+TEST(rsa_oaep_decrypt_rejects_a_zero_padded_ciphertext) {
+  // The same rule in the other direction, where a leading zero octet is added
+  // rather than removed
+  const auto private_key{sourcemeta::core::make_private_key(PRIVATE_KEY_PEM)};
+  EXPECT_TRUE(private_key.has_value());
+  const auto public_key{
+      sourcemeta::core::derive_public_key(private_key.value())};
+  EXPECT_TRUE(public_key.has_value());
+  const auto wrapped{sourcemeta::core::rsa_oaep_encrypt(
+      public_key.value(), sourcemeta::core::RSAOAEPHash::SHA256, "hello")};
+  EXPECT_TRUE(wrapped.has_value());
+
+  const std::string padded{std::string(1, '\x00') + wrapped.value()};
+  EXPECT_EQ(padded.size(), wrapped.value().size() + 1);
+  EXPECT_FALSE(
+      sourcemeta::core::rsa_oaep_decrypt(
+          private_key.value(), sourcemeta::core::RSAOAEPHash::SHA256, padded)
+          .has_value());
+}
+
+TEST(rsa_oaep_decrypt_rejects_an_empty_ciphertext) {
+  const auto private_key{sourcemeta::core::make_private_key(PRIVATE_KEY_PEM)};
+  EXPECT_TRUE(private_key.has_value());
+  EXPECT_FALSE(
+      sourcemeta::core::rsa_oaep_decrypt(
+          private_key.value(), sourcemeta::core::RSAOAEPHash::SHA256, "")
           .has_value());
 }
 

--- a/test/crypto/crypto_rsassa_pkcs1_v15_test.cc
+++ b/test/crypto/crypto_rsassa_pkcs1_v15_test.cc
@@ -212,3 +212,25 @@ TEST(verify_rejects_oversized_exponent) {
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(), exponent, MESSAGE,
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
+
+TEST(verify_rejects_a_zero_padded_signature) {
+  // A signature is a big-endian integer, so a leading zero octet denotes the
+  // same value and the range comparison strips it. RFC 8017 Section 8.2.2 step
+  // 1 requires the length to be exactly the modulus size, which is what refuses
+  // a second encoding of one signature
+  EXPECT_FALSE(verify_pkcs1(
+      sourcemeta::core::SignatureHashFunction::SHA256,
+      sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
+      sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(), MESSAGE,
+      sourcemeta::core::hex_to_bytes("00" + SIGNATURE_SHA256_HEX).value()));
+}
+
+TEST(verify_rejects_a_truncated_signature) {
+  const auto signature{
+      sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
+  EXPECT_FALSE(
+      verify_pkcs1(sourcemeta::core::SignatureHashFunction::SHA256,
+                   sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
+                   sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(),
+                   MESSAGE, signature.substr(1)));
+}

--- a/test/crypto/crypto_rsassa_pss_test.cc
+++ b/test/crypto/crypto_rsassa_pss_test.cc
@@ -219,3 +219,23 @@ TEST(verify_rejects_oversized_exponent) {
       sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(), exponent, MESSAGE,
       sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()));
 }
+
+TEST(verify_rejects_a_zero_padded_signature) {
+  // RFC 8017 Section 8.1.2 step 1, the same length rule the PKCS1-v1_5
+  // verification follows, so a leading zero octet cannot give a signature a
+  // second encoding
+  EXPECT_FALSE(verify_pss(
+      sourcemeta::core::SignatureHashFunction::SHA256,
+      sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
+      sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(), MESSAGE,
+      sourcemeta::core::hex_to_bytes("00" + SIGNATURE_SHA256_HEX).value()));
+}
+
+TEST(verify_rejects_a_truncated_signature) {
+  const auto signature{
+      sourcemeta::core::hex_to_bytes(SIGNATURE_SHA256_HEX).value()};
+  EXPECT_FALSE(verify_pss(sourcemeta::core::SignatureHashFunction::SHA256,
+                          sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
+                          sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value(),
+                          MESSAGE, signature.substr(1)));
+}

--- a/test/crypto/crypto_secure_test.cc
+++ b/test/crypto/crypto_secure_test.cc
@@ -63,8 +63,12 @@ TEST(secure_string_grows_across_a_reallocation) {
 }
 
 TEST(secure_string_capacity_of_an_empty_string) {
+  // How much a fresh string reserves is an implementation choice, so the
+  // assertion is the invariant the arena headroom arithmetic relies on rather
+  // than a particular capacity
   const sourcemeta::core::SecureString secret;
-  EXPECT_EQ(secret.capacity(), 0);
+  EXPECT_EQ(secret.size(), 0);
+  EXPECT_TRUE(secret.capacity() >= secret.size());
 }
 
 TEST(secure_string_capacity_covers_the_held_bytes) {

--- a/test/crypto/crypto_secure_test.cc
+++ b/test/crypto/crypto_secure_test.cc
@@ -62,6 +62,41 @@ TEST(secure_string_grows_across_a_reallocation) {
   EXPECT_EQ(secret.back(), 'b');
 }
 
+TEST(secure_string_capacity_of_an_empty_string) {
+  const sourcemeta::core::SecureString secret;
+  EXPECT_EQ(secret.capacity(), 0);
+}
+
+TEST(secure_string_capacity_covers_the_held_bytes) {
+  const sourcemeta::core::SecureString secret{"hunter2"};
+  EXPECT_TRUE(secret.capacity() >= secret.size());
+  EXPECT_EQ(secret.size(), 7);
+}
+
+TEST(secure_string_capacity_reflects_a_reservation) {
+  sourcemeta::core::SecureString secret{"hunter2"};
+  secret.reserve(64);
+  EXPECT_TRUE(secret.capacity() >= 64);
+  EXPECT_EQ(secret.size(), 7);
+}
+
+TEST(secure_string_capacity_survives_an_append_within_the_reservation) {
+  sourcemeta::core::SecureString secret{"hunter2"};
+  secret.reserve(64);
+  const auto reserved{secret.capacity()};
+  secret.append("!");
+  EXPECT_EQ(secret.capacity(), reserved);
+  EXPECT_EQ(secret.size(), 8);
+}
+
+TEST(secure_string_capacity_does_not_shrink_on_a_smaller_reservation) {
+  sourcemeta::core::SecureString secret{"hunter2"};
+  secret.reserve(64);
+  const auto reserved{secret.capacity()};
+  secret.reserve(2);
+  EXPECT_EQ(secret.capacity(), reserved);
+}
+
 TEST(secure_string_appends_a_view_of_itself) {
   sourcemeta::core::SecureString secret{"hunter2"};
   secret.reserve(14);

--- a/test/crypto/crypto_sign_test.cc
+++ b/test/crypto/crypto_sign_test.cc
@@ -75,6 +75,21 @@ DfTWodnkF5l+wSvP3gkiTAD453bpHdTsxVthAoGAB3Um+ocT8vaeV1PaS90Ztll1
 zz/p2wIRJlfNHxRap+Q=
 -----END PRIVATE KEY-----)"};
 
+// A PKCS1-v1_5 signature over LEADING_ZERO_MESSAGE under the key above whose
+// leading octet is zero, which holds for roughly one signature in 256. Signing
+// cannot be asked for that property, so a known pair is pinned to keep the
+// truncation case deterministic rather than a rare coincidence
+static const std::string LEADING_ZERO_MESSAGE{"probe-962"};
+static const std::string LEADING_ZERO_SIGNATURE_HEX{
+    "006dd09d02b89420a6485f64197ae248fceb2bfdc83ea36a544c92317c04b64c"
+    "304f5d204a8c85f79d78b6a234d1b8e47b1b79331d835862f8096fa2524f0c9a"
+    "728d6b0872d04198fed0c2d9790281a018482ff072f7ad4113b5a05fb3d034b6"
+    "bfe171f3b8ea32b7debf07607736b49f4de633849835894a34340452b6fa3082"
+    "b5990771e168c0606d03f7a4efcf88dd3d92f2a07b9c0127b33c89c21169fbd9"
+    "466b5af8a451768a629d42a64fc7283f7682e734da3374a654b6d2c75c0f4867"
+    "38b4745418e788ecb037d9ca714b53e546d5dfacfe4a8fcf9af095ae5f581960"
+    "bc91c2b308b65aac038b12de9275bad0020e8ea11bf788402c506920c5f4dc60"};
+
 static const std::string MODULUS_HEX{
     "9fe8af58b37409348b5dcec635c1c63ae64776ee907064f74a515369fd9c9312"
     "d51037005387c87b3eeb2adbd9682ce9289e9c6f92999c37089fe80e0ab13414"
@@ -711,4 +726,40 @@ TEST(make_rsa_public_key_rejects_exponent_at_or_above_modulus) {
   EXPECT_FALSE(sourcemeta::core::make_rsa_public_key(std::string{'\x05'},
                                                      std::string{'\x07'})
                    .has_value());
+}
+
+TEST(verify_rejects_a_signature_missing_a_leading_zero) {
+  // A signature is a big-endian integer, so dropping a leading zero octet
+  // leaves the same value and a range check that strips leading zeros accepts
+  // it. RFC 8017 Section 8.2.2 step 1 requires the length to be exactly the
+  // modulus size, which is what refuses the second encoding
+  const auto key{sourcemeta::core::make_rsa_public_key(
+      sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
+      sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value())};
+  EXPECT_TRUE(key.has_value());
+  const auto signature{
+      sourcemeta::core::hex_to_bytes(LEADING_ZERO_SIGNATURE_HEX).value()};
+  EXPECT_EQ(signature.size(), std::string::size_type{256});
+  EXPECT_EQ(signature.front(), '\x00');
+
+  // The pinned signature is genuinely valid at its full length
+  EXPECT_TRUE(sourcemeta::core::rsassa_pkcs1_v15_verify(
+      key.value(), sourcemeta::core::SignatureHashFunction::SHA256,
+      LEADING_ZERO_MESSAGE, signature));
+
+  EXPECT_FALSE(sourcemeta::core::rsassa_pkcs1_v15_verify(
+      key.value(), sourcemeta::core::SignatureHashFunction::SHA256,
+      LEADING_ZERO_MESSAGE, signature.substr(1)));
+}
+
+TEST(verify_rejects_a_zero_padded_signature) {
+  const auto key{sourcemeta::core::make_rsa_public_key(
+      sourcemeta::core::hex_to_bytes(MODULUS_HEX).value(),
+      sourcemeta::core::hex_to_bytes(EXPONENT_HEX).value())};
+  EXPECT_TRUE(key.has_value());
+  EXPECT_FALSE(sourcemeta::core::rsassa_pkcs1_v15_verify(
+      key.value(), sourcemeta::core::SignatureHashFunction::SHA256,
+      LEADING_ZERO_MESSAGE,
+      sourcemeta::core::hex_to_bytes("00" + LEADING_ZERO_SIGNATURE_HEX)
+          .value()));
 }

--- a/test/oauth/oauth_dpop_test.cc
+++ b/test/oauth/oauth_dpop_test.cc
@@ -1094,3 +1094,26 @@ TEST(proof_thumbprint_rejects_a_private_key_in_the_header) {
   EXPECT_FALSE(
       sourcemeta::core::oauth_dpop_proof_thumbprint(proof.value()).has_value());
 }
+
+TEST(replay_store_saturates_an_enormous_window) {
+  // A window derived from a token lifetime is attacker-influenced, so adding it
+  // to the clock unchecked would wrap negative and have the entry pruned on the
+  // very next call, silently disabling the guard it was inserted for
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME, std::chrono::seconds::max()));
+  EXPECT_EQ(store.size(FIXED_TIME), std::size_t{1});
+  EXPECT_FALSE(store.check_and_insert("id", "https://server.example.com/token",
+                                      FIXED_TIME, std::chrono::seconds::max()));
+}
+
+TEST(replay_store_saturates_a_window_beyond_the_clock) {
+  sourcemeta::core::OAuthDPoPReplayStore store;
+  const auto window{std::chrono::duration_cast<std::chrono::seconds>(
+      std::chrono::system_clock::duration::max())};
+  EXPECT_TRUE(store.check_and_insert("id", "https://server.example.com/token",
+                                     FIXED_TIME, window));
+  EXPECT_EQ(store.size(FIXED_TIME), std::size_t{1});
+  EXPECT_FALSE(store.check_and_insert("id", "https://server.example.com/token",
+                                      FIXED_TIME, window));
+}

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -515,6 +515,42 @@ TEST(server_metadata_rejects_a_cleartext_par_endpoint) {
   EXPECT_FALSE(metadata.has_value());
 }
 
+TEST(server_metadata_rejects_a_cleartext_device_authorization_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "device_authorization_endpoint": "http://example.com/device"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_non_string_device_authorization_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "device_authorization_endpoint": 42
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_accepts_an_https_device_authorization_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "device_authorization_endpoint": "https://example.com/device"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(
+      metadata.value().data().at("device_authorization_endpoint").to_string(),
+      "https://example.com/device");
+}
+
 TEST(server_metadata_rejects_a_cleartext_revocation_endpoint) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "issuer": "https://example.com",
@@ -1155,6 +1191,38 @@ TEST(resource_metadata_rejects_an_authorization_server_with_a_fragment) {
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
+  // An advertised issuer is matched against nothing at parse time, so its
+  // scheme is case-insensitive, unlike the resource identifier the document is
+  // checked against
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "HTTPS://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "HTTPS://auth.example.com");
+}
+
+TEST(
+    resource_metadata_uppercase_authorization_server_does_not_match_lowercase) {
+  // The membership test compares by code points, so a case-varied entry never
+  // reports a false match for a caller holding the canonical form
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "HTTPS://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://auth.example.com"));
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "HTTPS://auth.example.com"));
 }
 
 TEST(resource_metadata_accepts_multiple_authorization_servers) {

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -471,6 +471,395 @@ TEST(server_metadata_rejects_an_empty_signing_alg_list) {
   EXPECT_FALSE(metadata.has_value());
 }
 
+TEST(server_metadata_rejects_a_cleartext_authorization_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_endpoint": "http://example.com/authorize"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "http://example.com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_registration_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "registration_endpoint": "http://example.com/register"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_par_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "pushed_authorization_request_endpoint": "http://example.com/par"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_revocation_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "revocation_endpoint": "http://example.com/revoke"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_introspection_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "introspection_endpoint": "http://example.com/introspect"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "jwks_uri": "http://example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cleartext_endpoint_under_an_https_issuer) {
+  // The shape a provider behind a misconfigured reverse proxy advertises, an
+  // https issuer alongside cleartext endpoints
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "http://internal.example.com:8080/token",
+    "jwks_uri": "https://example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_accepts_every_https_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "registration_endpoint": "https://example.com/register",
+    "pushed_authorization_request_endpoint": "https://example.com/par",
+    "revocation_endpoint": "https://example.com/revoke",
+    "introspection_endpoint": "https://example.com/introspect",
+    "jwks_uri": "https://example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://example.com/authorize");
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://example.com/token");
+  EXPECT_EQ(metadata.value().registration_endpoint().value(),
+            "https://example.com/register");
+  EXPECT_EQ(metadata.value().pushed_authorization_request_endpoint().value(),
+            "https://example.com/par");
+  EXPECT_EQ(metadata.value().revocation_endpoint().value(),
+            "https://example.com/revoke");
+  EXPECT_EQ(metadata.value().introspection_endpoint().value(),
+            "https://example.com/introspect");
+  EXPECT_EQ(metadata.value().jwks_uri().value(), "https://example.com/jwks");
+}
+
+TEST(server_metadata_rejects_a_token_endpoint_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https://example.com/token#section"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_jwks_uri_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "jwks_uri": "https://example.com/jwks#keys"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_accepts_a_token_endpoint_with_a_query) {
+  // RFC 6749 Section 3.2: the endpoint URI "MAY include an
+  // "application/x-www-form-urlencoded" formatted query component"
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https://example.com/token?tenant=1"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://example.com/token?tenant=1");
+}
+
+TEST(server_metadata_accepts_a_token_endpoint_with_a_port) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https://example.com:8443/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://example.com:8443/token");
+}
+
+TEST(server_metadata_accepts_an_uppercase_endpoint_scheme) {
+  // RFC 3986 Section 3.1 makes the scheme case-insensitive, and unlike the
+  // issuer an endpoint is a location rather than an identifier compared by code
+  // points
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "HTTPS://example.com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "HTTPS://example.com/token");
+}
+
+TEST(server_metadata_accepts_a_mixed_case_endpoint_scheme) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "HtTpS://example.com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_non_string_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": 42
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_null_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": null
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_an_object_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": { "url": "https://example.com/token" }
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_an_empty_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": ""
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_relative_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_scheme_relative_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "//example.com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_token_endpoint_without_a_host) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https:///token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_token_endpoint_with_an_empty_authority) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https://:8443/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_malformed_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "https://example com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_file_scheme_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "file://example.com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_javascript_scheme_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "javascript:alert(1)"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_an_https_prefixed_scheme_token_endpoint) {
+  // A scheme merely starting with the expected one is a different scheme
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "token_endpoint": "httpsx://example.com/token"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_cross_origin_cleartext_jwks_uri) {
+  // The key set authenticates every assertion the server makes, so a cleartext
+  // location on an unrelated host is refused even when everything else is https
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "response_types_supported": [ "code" ],
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "jwks_uri": "http://attacker.example.net/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_cleartext_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "http://api.example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_jwks_uri_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "https://api.example.com/jwks#keys"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": 42
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_an_https_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "https://api.example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().jwks_uri().value(),
+            "https://api.example.com/jwks");
+}
+
 TEST(resource_metadata_parses_a_valid_document) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com",
@@ -677,12 +1066,102 @@ TEST(resource_metadata_rejects_a_resource_with_a_space) {
   EXPECT_FALSE(metadata.has_value());
 }
 
-TEST(resource_metadata_first_authorization_server_skips_non_strings) {
-  // The first string element is returned, so a leading non-string is skipped
-  // rather than aborting the search
+TEST(resource_metadata_rejects_a_non_string_authorization_server) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com",
     "authorization_servers": [ 42, "https://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_trailing_non_string_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com", 42 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_all_non_string_authorization_servers) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ 1, 2, 3 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_empty_authorization_server_array) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_array_authorization_servers) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": "https://auth.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_cleartext_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "http://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_second_cleartext_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [
+      "https://auth.example.com", "http://evil.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_authorization_server_with_a_query) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com?tenant=1" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_authorization_server_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com#tenant" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_multiple_authorization_servers) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [
+      "https://auth.example.com", "https://other.example.net/issuer" ]
   })JSON")};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
@@ -690,28 +1169,8 @@ TEST(resource_metadata_first_authorization_server_skips_non_strings) {
   EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "https://auth.example.com");
-}
-
-TEST(resource_metadata_first_authorization_server_all_non_strings) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ 1, 2, 3 ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
-}
-
-TEST(resource_metadata_first_authorization_server_empty_array) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": []
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://other.example.net/issuer"));
 }
 
 TEST(resource_metadata_rejects_a_non_object) {

--- a/test/oauth/oauth_registration_test.cc
+++ b/test/oauth/oauth_registration_test.cc
@@ -293,6 +293,71 @@ TEST(client_metadata_reads_the_response_only_fields) {
             "https://server.example/register/s6BhdRkqt3");
 }
 
+TEST(client_metadata_rejects_a_cleartext_management_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "client_id": "s6BhdRkqt3",
+    "registration_access_token": "reg-23410913-abewfq",
+    "registration_client_uri": "http://server.example/register/s6BhdRkqt3"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(client_metadata_rejects_a_management_uri_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "client_id": "s6BhdRkqt3",
+    "registration_client_uri": "https://server.example/register#s6BhdRkqt3"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(client_metadata_rejects_a_non_string_management_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "client_id": "s6BhdRkqt3",
+    "registration_client_uri": 42
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(client_metadata_rejects_a_relative_management_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "client_id": "s6BhdRkqt3",
+    "registration_client_uri": "/register/s6BhdRkqt3"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(client_metadata_accepts_an_uppercase_management_uri_scheme) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "client_id": "s6BhdRkqt3",
+    "registration_client_uri": "HTTPS://server.example/register/s6BhdRkqt3"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthClientMetadata::from(std::move(document))};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().registration_client_uri().value(),
+            "HTTPS://server.example/register/s6BhdRkqt3");
+}
+
+TEST(client_metadata_accepts_a_management_uri_with_a_query) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "client_id": "s6BhdRkqt3",
+    "registration_client_uri": "https://server.example/register?id=s6BhdRkqt3"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OAuthClientMetadata::from(std::move(document))};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().registration_client_uri().value(),
+            "https://server.example/register?id=s6BhdRkqt3");
+}
+
 TEST(client_metadata_absent_response_only_fields_are_empty) {
   auto document{sourcemeta::core::parse_json(R"JSON({})JSON")};
   const auto metadata{
@@ -788,6 +853,39 @@ TEST(make_registration_response_rejects_a_malformed_management_uri) {
   result.client_id = "s6BhdRkqt3";
   result.registration_access_token = "reg-23410913-abewfq";
   result.registration_client_uri = "not a uri";
+  const auto body{
+      sourcemeta::core::oauth_make_registration_response(metadata, result)};
+  EXPECT_FALSE(body.has_value());
+}
+
+TEST(make_registration_response_rejects_a_cleartext_management_uri) {
+  const auto metadata{sourcemeta::core::parse_json(R"JSON({})JSON")};
+  sourcemeta::core::OAuthClientRegistrationResult result;
+  result.client_id = "s6BhdRkqt3";
+  result.registration_access_token = "reg-23410913-abewfq";
+  result.registration_client_uri = "http://server.example/register/s6BhdRkqt3";
+  const auto body{
+      sourcemeta::core::oauth_make_registration_response(metadata, result)};
+  EXPECT_FALSE(body.has_value());
+}
+
+TEST(make_registration_response_rejects_a_fragment_bearing_management_uri) {
+  const auto metadata{sourcemeta::core::parse_json(R"JSON({})JSON")};
+  sourcemeta::core::OAuthClientRegistrationResult result;
+  result.client_id = "s6BhdRkqt3";
+  result.registration_access_token = "reg-23410913-abewfq";
+  result.registration_client_uri = "https://server.example/register#s6BhdRkqt3";
+  const auto body{
+      sourcemeta::core::oauth_make_registration_response(metadata, result)};
+  EXPECT_FALSE(body.has_value());
+}
+
+TEST(make_registration_response_rejects_a_relative_management_uri) {
+  const auto metadata{sourcemeta::core::parse_json(R"JSON({})JSON")};
+  sourcemeta::core::OAuthClientRegistrationResult result;
+  result.client_id = "s6BhdRkqt3";
+  result.registration_access_token = "reg-23410913-abewfq";
+  result.registration_client_uri = "/register/s6BhdRkqt3";
   const auto body{
       sourcemeta::core::oauth_make_registration_response(metadata, result)};
   EXPECT_FALSE(body.has_value());

--- a/test/oidc/oidc_id_token_test.cc
+++ b/test/oidc/oidc_id_token_test.cc
@@ -27,11 +27,16 @@ static auto oct_key_set() -> sourcemeta::core::JWKS {
       .value();
 }
 
-static auto sign_id_token(const std::string_view payload) -> std::string {
+static auto sign_id_token(const sourcemeta::core::JSON &payload)
+    -> std::string {
   return sourcemeta::core::jwt_sign(
              sourcemeta::core::parse_json(R"JSON({ "alg": "HS256" })JSON"),
-             sourcemeta::core::parse_json(payload), oct_private_key())
+             payload, oct_private_key())
       .value();
+}
+
+static auto sign_id_token(const std::string_view payload) -> std::string {
+  return sign_id_token(sourcemeta::core::parse_json(payload));
 }
 
 static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
@@ -40,6 +45,40 @@ static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
 // A fixed reference time, 2023-11-14T22:13:20Z
 static const auto reference_now{
     std::chrono::system_clock::from_time_t(1700000000)};
+
+// The oldest whole second the clock can represent and a conversion still
+// admits. The tick period differs across standard libraries, so the bound is
+// derived rather than written out
+static auto lowest_representable_second() -> std::int64_t {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::system_clock::duration::min())
+             .count() +
+         2;
+}
+
+static auto id_token_claims() -> sourcemeta::core::JSON {
+  auto payload{sourcemeta::core::JSON::make_object()};
+  payload.assign("iss", sourcemeta::core::JSON{"https://issuer.example"});
+  payload.assign("sub", sourcemeta::core::JSON{"user-1"});
+  payload.assign("aud", sourcemeta::core::JSON{"client-id"});
+  payload.assign("exp", sourcemeta::core::JSON{std::int64_t{2000000000}});
+  return payload;
+}
+
+static auto id_token_issued_at(const std::int64_t issued_at)
+    -> sourcemeta::core::JSON {
+  auto payload{id_token_claims()};
+  payload.assign("iat", sourcemeta::core::JSON{issued_at});
+  return payload;
+}
+
+static auto id_token_authenticated_at(const std::int64_t authenticated_at)
+    -> sourcemeta::core::JSON {
+  auto payload{id_token_claims()};
+  payload.assign("iat", sourcemeta::core::JSON{std::int64_t{1699996400}});
+  payload.assign("auth_time", sourcemeta::core::JSON{authenticated_at});
+  return payload;
+}
 
 TEST(mint_and_validate_round_trip) {
   sourcemeta::core::OIDCIdTokenClaims claims;
@@ -390,38 +429,6 @@ TEST(validate_rejects_a_future_auth_time) {
       token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
       "client-id", reference_now, options)};
   EXPECT_FALSE(identity.has_value());
-}
-
-// The oldest whole second the clock can represent and a conversion still
-// admits. The tick period differs across standard libraries, so the bound is
-// derived rather than written out
-static auto lowest_representable_second() -> std::int64_t {
-  return std::chrono::duration_cast<std::chrono::seconds>(
-             std::chrono::system_clock::duration::min())
-             .count() +
-         2;
-}
-
-static auto id_token_issued_at(const std::int64_t issued_at) -> std::string {
-  return std::string{R"JSON({
-    "iss": "https://issuer.example",
-    "sub": "user-1",
-    "aud": "client-id",
-    "exp": 2000000000,
-    "iat": )JSON"} +
-         std::to_string(issued_at) + "\n  }";
-}
-
-static auto id_token_authenticated_at(const std::int64_t authenticated_at)
-    -> std::string {
-  return std::string{R"JSON({
-    "iss": "https://issuer.example",
-    "sub": "user-1",
-    "aud": "client-id",
-    "exp": 2000000000,
-    "iat": 1699996400,
-    "auth_time": )JSON"} +
-         std::to_string(authenticated_at) + "\n  }";
 }
 
 TEST(validate_enforces_the_maximum_issued_at_age) {

--- a/test/oidc/oidc_id_token_test.cc
+++ b/test/oidc/oidc_id_token_test.cc
@@ -5,6 +5,7 @@
 
 #include <array>       // std::array
 #include <chrono>      // std::chrono
+#include <cstdint>     // std::int64_t
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -389,6 +390,147 @@ TEST(validate_rejects_a_future_auth_time) {
       token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
       "client-id", reference_now, options)};
   EXPECT_FALSE(identity.has_value());
+}
+
+// The oldest whole second the clock can represent and a conversion still
+// admits. The tick period differs across standard libraries, so the bound is
+// derived rather than written out
+static auto lowest_representable_second() -> std::int64_t {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::system_clock::duration::min())
+             .count() +
+         2;
+}
+
+static auto id_token_issued_at(const std::int64_t issued_at) -> std::string {
+  return std::string{R"JSON({
+    "iss": "https://issuer.example",
+    "sub": "user-1",
+    "aud": "client-id",
+    "exp": 2000000000,
+    "iat": )JSON"} +
+         std::to_string(issued_at) + "\n  }";
+}
+
+static auto id_token_authenticated_at(const std::int64_t authenticated_at)
+    -> std::string {
+  return std::string{R"JSON({
+    "iss": "https://issuer.example",
+    "sub": "user-1",
+    "aud": "client-id",
+    "exp": 2000000000,
+    "iat": 1699996400,
+    "auth_time": )JSON"} +
+         std::to_string(authenticated_at) + "\n  }";
+}
+
+TEST(validate_enforces_the_maximum_issued_at_age) {
+  const auto compact{sign_id_token(id_token_issued_at(1699996400))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_issued_at_age = std::chrono::minutes{5};
+  const auto rejected{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_FALSE(rejected.has_value());
+
+  options.maximum_issued_at_age = std::chrono::hours{2};
+  const auto accepted{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_TRUE(accepted.has_value());
+}
+
+TEST(validate_accepts_an_issued_at_exactly_at_the_age_boundary) {
+  const auto compact{sign_id_token(id_token_issued_at(1699996400))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_issued_at_age = std::chrono::seconds{3600};
+  const auto accepted{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_TRUE(accepted.has_value());
+
+  options.maximum_issued_at_age = std::chrono::seconds{3599};
+  const auto rejected{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_FALSE(rejected.has_value());
+}
+
+TEST(validate_rejects_an_issued_at_near_the_representable_bound) {
+  // Subtracting a claim this far in the past from the server clock
+  // overflows the tick type, so the window is applied to the clock instead
+  // and the stale token is still refused
+  const auto compact{
+      sign_id_token(id_token_issued_at(lowest_representable_second()))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_issued_at_age = std::chrono::minutes{5};
+  const auto rejected{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_FALSE(rejected.has_value());
+}
+
+TEST(validate_rejects_an_auth_time_near_the_representable_bound) {
+  const auto compact{
+      sign_id_token(id_token_authenticated_at(lowest_representable_second()))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_authentication_age = std::chrono::minutes{5};
+  const auto rejected{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_FALSE(rejected.has_value());
+}
+
+TEST(validate_accepts_a_recent_issued_at_under_an_unbounded_age) {
+  // A window wider than the clock saturates to the oldest representable
+  // instant rather than wrapping, so nothing is rejected for being too old
+  const auto compact{sign_id_token(id_token_issued_at(1699996400))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_issued_at_age = std::chrono::seconds::max();
+  const auto accepted{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_TRUE(accepted.has_value());
+}
+
+TEST(validate_rejects_an_ancient_issued_at_under_an_unbounded_age) {
+  // Even the widest window the clock can express is measured back from now, so
+  // its oldest instant is later than the oldest the clock can represent and a
+  // claim at that floor stays too old rather than wrapping into acceptance
+  const auto compact{
+      sign_id_token(id_token_issued_at(lowest_representable_second()))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_issued_at_age = std::chrono::seconds::max();
+  const auto rejected{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_FALSE(rejected.has_value());
+}
+
+TEST(validate_rejects_a_stale_issued_at_under_a_negative_age) {
+  // A window that runs backwards cannot admit anything issued before now,
+  // so it fails closed rather than wrapping into an unbounded window
+  const auto compact{sign_id_token(id_token_issued_at(1699996400))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  sourcemeta::core::OIDCValidationOptions options;
+  options.maximum_issued_at_age = std::chrono::seconds::min();
+  const auto rejected{sourcemeta::core::oidc_validate_id_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, options)};
+  EXPECT_FALSE(rejected.has_value());
 }
 
 TEST(validate_rejects_an_algorithm_outside_the_allow_list) {

--- a/test/oidc/oidc_logout_test.cc
+++ b/test/oidc/oidc_logout_test.cc
@@ -22,13 +22,19 @@ static auto oct_key_set() -> sourcemeta::core::JWKS {
 }
 
 static auto sign_logout_token(const std::string_view header,
-                              const std::string_view payload) -> std::string {
+                              const sourcemeta::core::JSON &payload)
+    -> std::string {
   return sourcemeta::core::jwt_sign(sourcemeta::core::parse_json(header),
-                                    sourcemeta::core::parse_json(payload),
+                                    payload,
                                     sourcemeta::core::JWKPrivate::from(
                                         sourcemeta::core::parse_json(OCT_JWK))
                                         .value())
       .value();
+}
+
+static auto sign_logout_token(const std::string_view header,
+                              const std::string_view payload) -> std::string {
+  return sign_logout_token(header, sourcemeta::core::parse_json(payload));
 }
 
 static constexpr std::array<sourcemeta::core::JWSAlgorithm, 1> allowed_hs256{
@@ -52,6 +58,32 @@ static constexpr std::string_view VALID_PAYLOAD{R"JSON({
     "http://schemas.openid.net/event/backchannel-logout": {}
   }
 })JSON"};
+
+// The newest whole second the clock can represent and a conversion still
+// admits. The tick period differs across standard libraries, so the bound is
+// derived rather than written out
+static auto highest_representable_second() -> std::int64_t {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::system_clock::duration::max())
+             .count() -
+         2;
+}
+
+static auto logout_token_expiring_at(const std::int64_t expiration)
+    -> sourcemeta::core::JSON {
+  auto events{sourcemeta::core::JSON::make_object()};
+  events.assign("http://schemas.openid.net/event/backchannel-logout",
+                sourcemeta::core::JSON::make_object());
+  auto payload{sourcemeta::core::JSON::make_object()};
+  payload.assign("iss", sourcemeta::core::JSON{"https://issuer.example"});
+  payload.assign("aud", sourcemeta::core::JSON{"client-id"});
+  payload.assign("iat", sourcemeta::core::JSON{std::int64_t{1700000000}});
+  payload.assign("jti", sourcemeta::core::JSON{"logout-1"});
+  payload.assign("sub", sourcemeta::core::JSON{"user-1"});
+  payload.assign("events", std::move(events));
+  payload.assign("exp", sourcemeta::core::JSON{expiration});
+  return payload;
+}
 
 TEST(build_logout_url_includes_the_parameters) {
   sourcemeta::core::OIDCLogoutRequest request;
@@ -265,31 +297,6 @@ TEST(validate_logout_token_rejects_an_exp_at_the_boundary) {
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
       token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
       "client-id", reference_now));
-}
-
-// The newest whole second the clock can represent and a conversion still
-// admits. The tick period differs across standard libraries, so the bound is
-// derived rather than written out
-static auto highest_representable_second() -> std::int64_t {
-  return std::chrono::duration_cast<std::chrono::seconds>(
-             std::chrono::system_clock::duration::max())
-             .count() -
-         2;
-}
-
-static auto logout_token_expiring_at(const std::int64_t expiration)
-    -> std::string {
-  return std::string{R"JSON({
-    "iss": "https://issuer.example",
-    "aud": "client-id",
-    "iat": 1700000000,
-    "jti": "logout-1",
-    "sub": "user-1",
-    "events": {
-      "http://schemas.openid.net/event/backchannel-logout": {}
-    },
-    "exp": )JSON"} +
-         std::to_string(expiration) + "\n  }";
 }
 
 TEST(validate_logout_token_accepts_an_exp_near_the_representable_bound) {

--- a/test/oidc/oidc_logout_test.cc
+++ b/test/oidc/oidc_logout_test.cc
@@ -5,6 +5,7 @@
 
 #include <array>       // std::array
 #include <chrono>      // std::chrono
+#include <cstdint>     // std::int64_t
 #include <string>      // std::string
 #include <string_view> // std::string_view
 
@@ -264,6 +265,117 @@ TEST(validate_logout_token_rejects_an_exp_at_the_boundary) {
   EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
       token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
       "client-id", reference_now));
+}
+
+// The newest whole second the clock can represent and a conversion still
+// admits. The tick period differs across standard libraries, so the bound is
+// derived rather than written out
+static auto highest_representable_second() -> std::int64_t {
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::system_clock::duration::max())
+             .count() -
+         2;
+}
+
+static auto logout_token_expiring_at(const std::int64_t expiration)
+    -> std::string {
+  return std::string{R"JSON({
+    "iss": "https://issuer.example",
+    "aud": "client-id",
+    "iat": 1700000000,
+    "jti": "logout-1",
+    "sub": "user-1",
+    "events": {
+      "http://schemas.openid.net/event/backchannel-logout": {}
+    },
+    "exp": )JSON"} +
+         std::to_string(expiration) + "\n  }";
+}
+
+TEST(validate_logout_token_accepts_an_exp_near_the_representable_bound) {
+  // Adding the skew to a claim this far in the future overflows the tick type,
+  // so the skew shifts the server clock instead and the token still validates
+  const auto compact{sign_logout_token(
+      VALID_HEADER, logout_token_expiring_at(highest_representable_second()))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, std::chrono::seconds{60}));
+}
+
+TEST(validate_logout_token_accepts_an_exp_near_the_bound_without_skew) {
+  const auto compact{sign_logout_token(
+      VALID_HEADER, logout_token_expiring_at(highest_representable_second()))};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now));
+}
+
+TEST(validate_logout_token_rejects_an_expired_token_under_a_skew) {
+  const auto compact{sign_logout_token(VALID_HEADER, R"JSON({
+    "iss": "https://issuer.example",
+    "aud": "client-id",
+    "iat": 1600000000,
+    "exp": 1699999000,
+    "jti": "logout-1",
+    "sub": "user-1",
+    "events": {
+      "http://schemas.openid.net/event/backchannel-logout": {}
+    }
+  })JSON")};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, std::chrono::seconds{60}));
+  // The same token is inside the window once the tolerance covers the gap
+  EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, std::chrono::seconds{2000}));
+}
+
+TEST(validate_logout_token_rejects_a_future_iat_beyond_the_skew) {
+  const auto compact{sign_logout_token(VALID_HEADER, R"JSON({
+    "iss": "https://issuer.example",
+    "aud": "client-id",
+    "iat": 1700001000,
+    "exp": 2000000000,
+    "jti": "logout-1",
+    "sub": "user-1",
+    "events": {
+      "http://schemas.openid.net/event/backchannel-logout": {}
+    }
+  })JSON")};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_FALSE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, std::chrono::seconds{60}));
+  EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, std::chrono::seconds{2000}));
+}
+
+TEST(validate_logout_token_tolerates_a_saturating_skew) {
+  const auto compact{sign_logout_token(VALID_HEADER, R"JSON({
+    "iss": "https://issuer.example",
+    "aud": "client-id",
+    "iat": 1700000000,
+    "exp": 2000000000,
+    "jti": "logout-1",
+    "sub": "user-1",
+    "events": {
+      "http://schemas.openid.net/event/backchannel-logout": {}
+    }
+  })JSON")};
+  const auto token{sourcemeta::core::JWT::from(compact)};
+  EXPECT_TRUE(token.has_value());
+  EXPECT_TRUE(sourcemeta::core::oidc_validate_logout_token(
+      token.value(), oct_key_set(), allowed_hs256, "https://issuer.example",
+      "client-id", reference_now, std::chrono::seconds::max()));
 }
 
 TEST(validate_logout_token_rejects_a_non_string_subject) {

--- a/test/oidc/oidc_metadata_test.cc
+++ b/test/oidc/oidc_metadata_test.cc
@@ -4,6 +4,7 @@
 
 #include <array>       // std::array
 #include <string_view> // std::string_view
+#include <utility>     // std::move
 
 static const auto VALID_PROVIDER_DOCUMENT{sourcemeta::core::parse_json(R"JSON({
   "issuer": "https://example.com",
@@ -189,6 +190,302 @@ TEST(from_rejects_a_list_without_rs256) {
   EXPECT_FALSE(sourcemeta::core::OIDCProviderMetadata::from(
                    std::move(document), "https://example.com")
                    .has_value());
+}
+
+TEST(from_rejects_a_cleartext_authorization_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "http://example.com/authorize",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_token_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "token_endpoint": "http://example.com/token",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_userinfo_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "http://example.com/userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_registration_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "registration_endpoint": "http://example.com/register",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "jwks_uri": "http://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_end_session_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "end_session_endpoint": "http://example.com/logout",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_check_session_iframe) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "check_session_iframe": "http://example.com/checksession",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_endpoint_under_an_https_issuer) {
+  // The shape a provider behind a misconfigured reverse proxy advertises, an
+  // https issuer alongside a cleartext endpoint that would receive the client
+  // secret and the authorization code
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "http://internal.example.com:8080/token",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_cleartext_jwks_uri_on_another_host) {
+  // The key set authenticates every user, so a cleartext location on an
+  // unrelated host is refused even when every other endpoint is https
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "jwks_uri": "http://attacker.example.net/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_accepts_every_https_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "userinfo_endpoint": "https://example.com/userinfo",
+    "registration_endpoint": "https://example.com/register",
+    "end_session_endpoint": "https://example.com/logout",
+    "check_session_iframe": "https://example.com/checksession",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://example.com/authorize");
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://example.com/token");
+  EXPECT_EQ(metadata.value().userinfo_endpoint().value(),
+            "https://example.com/userinfo");
+  EXPECT_EQ(metadata.value().registration_endpoint().value(),
+            "https://example.com/register");
+  EXPECT_EQ(metadata.value().end_session_endpoint().value(),
+            "https://example.com/logout");
+  EXPECT_EQ(metadata.value().check_session_iframe().value(),
+            "https://example.com/checksession");
+  EXPECT_EQ(metadata.value().jwks_uri(), "https://example.com/jwks");
+}
+
+TEST(from_rejects_a_userinfo_endpoint_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "https://example.com/userinfo#profile",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_accepts_a_userinfo_endpoint_with_a_query) {
+  // OpenID Connect Discovery 1.0 Section 3: the endpoint "MAY contain port,
+  // path, and query parameter components"
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "https://example.com:8443/userinfo?tenant=1",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().userinfo_endpoint().value(),
+            "https://example.com:8443/userinfo?tenant=1");
+}
+
+TEST(from_accepts_an_uppercase_userinfo_scheme) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "HTTPS://example.com/userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().userinfo_endpoint().value(),
+            "HTTPS://example.com/userinfo");
+}
+
+TEST(from_rejects_a_non_string_userinfo_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": 42,
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_null_userinfo_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": null,
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_relative_userinfo_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "/userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_userinfo_endpoint_without_a_host) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "https:///userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_malformed_userinfo_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "https://example com/userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_javascript_scheme_userinfo_endpoint) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "javascript:alert(1)",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
 }
 
 TEST(make_builds_a_minimal_provider_document) {

--- a/test/oidc/oidc_metadata_test.cc
+++ b/test/oidc/oidc_metadata_test.cc
@@ -474,6 +474,22 @@ TEST(from_rejects_a_malformed_userinfo_endpoint) {
   EXPECT_FALSE(metadata.has_value());
 }
 
+TEST(from_rejects_a_userinfo_endpoint_with_a_template_placeholder) {
+  // Braces are outside the RFC 3986 grammar, so this must be refused on the
+  // same terms as the endpoints the OAuth layer validates
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "userinfo_endpoint": "https://example.com/{tenant}/userinfo",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
 TEST(from_rejects_a_javascript_scheme_userinfo_endpoint) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "issuer": "https://example.com",

--- a/test/oidc/oidc_registration_test.cc
+++ b/test/oidc/oidc_registration_test.cc
@@ -165,3 +165,58 @@ TEST(sector_identifier_rejects_a_non_array_document) {
   EXPECT_FALSE(
       sourcemeta::core::oidc_sector_identifier_contains(document, registered));
 }
+
+TEST(from_rejects_a_cleartext_client_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "redirect_uris": [ "https://client.example/cb" ],
+    "jwks_uri": "http://client.example/jwks"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OIDCClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_non_string_client_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "redirect_uris": [ "https://client.example/cb" ],
+    "jwks_uri": 42
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OIDCClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_rejects_a_hostless_client_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "redirect_uris": [ "https://client.example/cb" ],
+    "jwks_uri": "https:///jwks"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OIDCClientMetadata::from(std::move(document))};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(from_accepts_an_https_client_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "redirect_uris": [ "https://client.example/cb" ],
+    "jwks_uri": "https://client.example/jwks"
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OIDCClientMetadata::from(std::move(document))};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().oauth().jwks_uri().value(),
+            "https://client.example/jwks");
+}
+
+TEST(from_accepts_a_cleartext_request_uri) {
+  // OpenID Connect Dynamic Client Registration 1.0 Section 2 makes the https
+  // rule for request_uris conditional, "unless the target Request Object is
+  // signed in a way that is verifiable by the OP", which is not knowable here
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "redirect_uris": [ "https://client.example/cb" ],
+    "request_uris": [ "http://client.example/request.jwt" ]
+  })JSON")};
+  const auto metadata{
+      sourcemeta::core::OIDCClientMetadata::from(std::move(document))};
+  EXPECT_TRUE(metadata.has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

