### PR TITLE
Add loopback and HTTP/S utility helpers to `URI`

### DIFF
--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -248,10 +248,8 @@ auto validated_resource_metadata(JSON &&data, const std::string_view resource)
 // case-insensitive
 auto oauth_is_endpoint_url(const std::string_view value) -> bool {
   const auto uri{oauth_try_parse_uri(value)};
-  return uri.has_value() && uri->scheme().has_value() &&
-         equals_ignore_case(uri->scheme().value(), "https") &&
-         uri->host().has_value() && !uri->host().value().empty() &&
-         !uri->fragment().has_value();
+  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
+         !uri->host().value().empty() && !uri->fragment().has_value();
 }
 
 auto oauth_well_known_url(const std::string_view identifier,

--- a/src/core/oauth/oauth_syntax.h
+++ b/src/core/oauth/oauth_syntax.h
@@ -54,10 +54,9 @@ inline auto oauth_is_resource_identifier(const std::string_view value) -> bool {
 // which makes the scheme case-insensitive
 inline auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
   const auto uri{oauth_try_parse_uri(value)};
-  return uri.has_value() && uri->scheme().has_value() &&
-         equals_ignore_case(uri->scheme().value(), "https") &&
-         uri->host().has_value() && !uri->host().value().empty() &&
-         !uri->query().has_value() && !uri->fragment().has_value();
+  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
+         !uri->host().value().empty() && !uri->query().has_value() &&
+         !uri->fragment().has_value();
 }
 
 // RFC 3986 Section 2.3: "unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"",

--- a/src/core/oidc/oidc_discovery.cc
+++ b/src/core/oidc/oidc_discovery.cc
@@ -23,15 +23,13 @@ constexpr std::string_view ISSUER_RELATION{
     "http://openid.net/specs/connect/1.0/issuer"};
 
 // OpenID Connect Discovery 1.0 Section 2: an issuer identifier is an https URL
-// with a host and no query or fragment. RFC 3986 Section 3.1 makes the scheme
-// case-insensitive
+// with a host and no query or fragment
 auto is_issuer_identifier(const std::string_view value) -> bool {
   try {
     const URI uri{value};
-    return uri.scheme().has_value() &&
-           equals_ignore_case(uri.scheme().value(), "https") &&
-           uri.host().has_value() && !uri.host().value().empty() &&
-           !uri.query().has_value() && !uri.fragment().has_value();
+    return uri.is_https() && uri.host().has_value() &&
+           !uri.host().value().empty() && !uri.query().has_value() &&
+           !uri.fragment().has_value();
   } catch (const URIParseError &) {
     return false;
   }
@@ -88,11 +86,9 @@ auto oidc_webfinger_request(const std::string_view identifier)
     try {
       const URI resource{request.resource};
       // OpenID Connect Discovery 1.0 Section 2.1: a URL resource uses the https
-      // scheme and carries a host, so a non-https URL identifier is rejected.
-      // RFC 3986 Section 3.1 makes the scheme case-insensitive
-      if (!resource.scheme().has_value() ||
-          !equals_ignore_case(resource.scheme().value(), "https") ||
-          !resource.host().has_value() || resource.host().value().empty()) {
+      // scheme and carries a host, so a non-https URL identifier is rejected
+      if (!resource.is_https() || !resource.host().has_value() ||
+          resource.host().value().empty()) {
         return std::nullopt;
       }
 

--- a/src/core/oidc/oidc_metadata.cc
+++ b/src/core/oidc/oidc_metadata.cc
@@ -3,7 +3,6 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/oauth.h>
 #include <sourcemeta/core/oidc_error.h>
-#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include <optional>    // std::optional, std::nullopt
@@ -88,12 +87,9 @@ auto is_https_url(const std::string_view value) -> bool {
     // Section 3 enumerates what an endpoint may carry as "port, path, and query
     // parameter components", so a fragment is refused as outside that list
     // rather than because it could not be dereferenced, which would be the
-    // wrong reason for the two endpoints a user agent loads. RFC 3986 Section
-    // 3.1 makes the scheme case-insensitive
-    return uri.scheme().has_value() &&
-           equals_ignore_case(uri.scheme().value(), "https") &&
-           uri.host().has_value() && !uri.host().value().empty() &&
-           !uri.fragment().has_value();
+    // wrong reason for the two endpoints a user agent loads
+    return uri.is_https() && uri.host().has_value() &&
+           !uri.host().value().empty() && !uri.fragment().has_value();
   } catch (const URIParseError &) {
     return false;
   }

--- a/src/core/oidc/oidc_registration.cc
+++ b/src/core/oidc/oidc_registration.cc
@@ -3,7 +3,6 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/oauth.h>
 #include <sourcemeta/core/oidc_error.h>
-#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include <chrono>      // std::chrono::seconds
@@ -72,11 +71,8 @@ auto is_absolute_uri_without_fragment(const std::string_view value) -> bool {
 auto is_https_url_with_host(const std::string_view value) -> bool {
   try {
     const URI uri{value};
-    // RFC 3986 Section 3.1: the scheme is case-insensitive, so an uppercase or
-    // mixed-case HTTPS is still https
-    return uri.scheme().has_value() &&
-           equals_ignore_case(uri.scheme().value(), "https") &&
-           uri.host().has_value() && !uri.host().value().empty();
+    return uri.is_https() && uri.host().has_value() &&
+           !uri.host().value().empty();
   } catch (const URIParseError &) {
     return false;
   }

--- a/src/core/uri/accessors.cc
+++ b/src/core/uri/accessors.cc
@@ -69,7 +69,10 @@ auto URI::is_loopback() const -> bool {
 }
 
 auto URI::is_localhost() const -> bool {
-  if (!this->host_.has_value()) {
+  // RFC 3986 Section 3.2.2 separates an IP literal from a registered name, and
+  // only the latter can be a domain name, so a bracketed host such as an
+  // IPvFuture ending in the reserved labels does not qualify
+  if (!this->host_.has_value() || this->ip_literal_) {
     return false;
   }
 

--- a/src/core/uri/accessors.cc
+++ b/src/core/uri/accessors.cc
@@ -1,4 +1,5 @@
 #include <sourcemeta/core/ip.h>
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include <cstdint>     // std::uint32_t
@@ -35,6 +36,19 @@ auto URI::is_file() const -> bool {
   return scheme.has_value() && scheme.value() == "file";
 }
 
+// RFC 3986 Section 3.1: "an implementation should accept uppercase letters as
+// equivalent to lowercase in scheme names"
+
+auto URI::is_http() const -> bool {
+  const auto scheme{this->scheme()};
+  return scheme.has_value() && equals_ignore_case(scheme.value(), "http");
+}
+
+auto URI::is_https() const -> bool {
+  const auto scheme{this->scheme()};
+  return scheme.has_value() && equals_ignore_case(scheme.value(), "https");
+}
+
 auto URI::is_ipv4() const -> bool {
   return this->host_.has_value() &&
          sourcemeta::core::is_ipv4(this->host_.value());
@@ -43,6 +57,40 @@ auto URI::is_ipv4() const -> bool {
 auto URI::is_ipv6() const -> bool {
   return this->host_.has_value() &&
          sourcemeta::core::is_ipv6(this->host_.value());
+}
+
+auto URI::is_loopback() const -> bool {
+  if (!this->host_.has_value()) {
+    return false;
+  }
+
+  return ipv4_classify(this->host_.value()) == IPAddressClass::Loopback ||
+         ipv6_classify(this->host_.value()) == IPAddressClass::Loopback;
+}
+
+auto URI::is_localhost() const -> bool {
+  if (!this->host_.has_value()) {
+    return false;
+  }
+
+  // RFC 6761 Section 6.3 reserves "The domain 'localhost.' and any names
+  // falling within '.localhost.'", where the trailing dot marks the absolute
+  // form of a name that compares case-insensitively (RFC 4343 Section 2)
+  std::string_view host{this->host_.value()};
+  if (host.ends_with('.')) {
+    host.remove_suffix(1);
+  }
+
+  constexpr std::string_view name{"localhost"};
+  if (host.size() < name.size()) {
+    return false;
+  }
+
+  if (host.size() > name.size() && host[host.size() - name.size() - 1] != '.') {
+    return false;
+  }
+
+  return equals_ignore_case(host.substr(host.size() - name.size()), name);
 }
 
 auto URI::is_fragment_only() const -> bool {

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -206,9 +206,11 @@ public:
   [[nodiscard]] auto is_ipv6() const -> bool;
 
   /// Check if the host is a loopback IP literal, any address in `127.0.0.0/8`
-  /// (RFC 1122 Section 3.2.1.3) or `::1` (RFC 4291 Section 2.5.3). The name
-  /// `localhost` is deliberately not a loopback host, as it usually resolves
-  /// to one but that is a different claim (RFC 8252 Section 8.3). For example:
+  /// (RFC 1122 Section 3.2.1.3), `::1` (RFC 4291 Section 2.5.3), or an
+  /// IPv4-mapped or IPv4-compatible IPv6 address embedding a `127.0.0.0/8`
+  /// address (RFC 4291 Section 2.5.5). The name `localhost` is deliberately
+  /// not a loopback host, as it usually resolves to one but that is a
+  /// different claim (RFC 8252 Section 8.3). For example:
   ///
   /// ```cpp
   /// #include <sourcemeta/core/uri.h>

--- a/src/core/uri/include/sourcemeta/core/uri.h
+++ b/src/core/uri/include/sourcemeta/core/uri.h
@@ -137,6 +137,30 @@ public:
   /// ```
   [[nodiscard]] auto is_file() const -> bool;
 
+  /// Check if the URI has the `http` scheme (RFC 9110 Section 4.2.1),
+  /// accepting any scheme case (RFC 3986 Section 3.1). For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::URI uri{"http://www.sourcemeta.com"};
+  /// assert(uri.is_http());
+  /// ```
+  [[nodiscard]] auto is_http() const -> bool;
+
+  /// Check if the URI has the `https` scheme (RFC 9110 Section 4.2.2),
+  /// accepting any scheme case (RFC 3986 Section 3.1). For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
+  /// assert(uri.is_https());
+  /// ```
+  [[nodiscard]] auto is_https() const -> bool;
+
   /// Check if the URI only consists of a fragment. For example:
   ///
   /// ```cpp
@@ -180,6 +204,38 @@ public:
   /// assert(uri.is_ipv6());
   /// ```
   [[nodiscard]] auto is_ipv6() const -> bool;
+
+  /// Check if the host is a loopback IP literal, any address in `127.0.0.0/8`
+  /// (RFC 1122 Section 3.2.1.3) or `::1` (RFC 4291 Section 2.5.3). The name
+  /// `localhost` is deliberately not a loopback host, as it usually resolves
+  /// to one but that is a different claim (RFC 8252 Section 8.3). For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::URI uri{"http://127.0.0.1:8000"};
+  /// assert(uri.is_loopback());
+  /// sourcemeta::core::URI name{"http://localhost:8000"};
+  /// assert(!name.is_loopback());
+  /// ```
+  [[nodiscard]] auto is_loopback() const -> bool;
+
+  /// Check if the host is the special-use domain name `localhost` or a name
+  /// falling within it, such as `foo.localhost`, in any case and with or
+  /// without the trailing dot of the absolute form (RFC 6761 Section 6.3). A
+  /// loopback IP literal is not a localhost name. For example:
+  ///
+  /// ```cpp
+  /// #include <sourcemeta/core/uri.h>
+  /// #include <cassert>
+  ///
+  /// sourcemeta::core::URI uri{"http://localhost:8000"};
+  /// assert(uri.is_localhost());
+  /// sourcemeta::core::URI address{"http://127.0.0.1:8000"};
+  /// assert(!address.is_localhost());
+  /// ```
+  [[nodiscard]] auto is_localhost() const -> bool;
 
   /// Check if the URI corresponds to the empty URI. For example:
   ///

--- a/test/uri/CMakeLists.txt
+++ b/test/uri/CMakeLists.txt
@@ -22,6 +22,10 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME uri
     uri_is_file_test.cc
     uri_is_ipv4_test.cc
     uri_is_ipv6_test.cc
+    uri_is_loopback_test.cc
+    uri_is_localhost_test.cc
+    uri_is_http_test.cc
+    uri_is_https_test.cc
     uri_rebase_test.cc
     uri_rebase_path_test.cc
     uri_strip_path_prefix_test.cc

--- a/test/uri/uri_is_http_test.cc
+++ b/test/uri/uri_is_http_test.cc
@@ -1,0 +1,77 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(lowercase) {
+  const sourcemeta::core::URI uri{"http://www.sourcemeta.com"};
+  EXPECT_TRUE(uri.is_http());
+}
+
+TEST(lowercase_with_port_and_path) {
+  const sourcemeta::core::URI uri{"http://www.sourcemeta.com:8000/path"};
+  EXPECT_TRUE(uri.is_http());
+}
+
+TEST(uppercase) {
+  const sourcemeta::core::URI uri{"HTTP://www.sourcemeta.com"};
+  EXPECT_TRUE(uri.is_http());
+}
+
+TEST(mixed_case) {
+  const sourcemeta::core::URI uri{"Http://www.sourcemeta.com"};
+  EXPECT_TRUE(uri.is_http());
+}
+
+TEST(localhost) {
+  const sourcemeta::core::URI uri{"http://localhost:8000"};
+  EXPECT_TRUE(uri.is_http());
+}
+
+TEST(ipv4_host) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1:8000"};
+  EXPECT_TRUE(uri.is_http());
+}
+
+TEST(https) {
+  const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(scheme_with_suffix) {
+  const sourcemeta::core::URI uri{"httpx://www.sourcemeta.com"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(file) {
+  const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(mailto) {
+  const sourcemeta::core::URI uri{"mailto:jdoe@mail.com"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(urn) {
+  const sourcemeta::core::URI uri{"urn:example:schema"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(relative) {
+  const sourcemeta::core::URI uri{"../foo"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(no_scheme_network_path) {
+  const sourcemeta::core::URI uri{"//www.sourcemeta.com/path"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(fragment_only) {
+  const sourcemeta::core::URI uri{"#foo"};
+  EXPECT_FALSE(uri.is_http());
+}
+
+TEST(empty) {
+  const sourcemeta::core::URI uri{""};
+  EXPECT_FALSE(uri.is_http());
+}

--- a/test/uri/uri_is_https_test.cc
+++ b/test/uri/uri_is_https_test.cc
@@ -1,0 +1,77 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(lowercase) {
+  const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
+  EXPECT_TRUE(uri.is_https());
+}
+
+TEST(lowercase_with_port_and_path) {
+  const sourcemeta::core::URI uri{"https://www.sourcemeta.com:8443/path"};
+  EXPECT_TRUE(uri.is_https());
+}
+
+TEST(uppercase) {
+  const sourcemeta::core::URI uri{"HTTPS://www.sourcemeta.com"};
+  EXPECT_TRUE(uri.is_https());
+}
+
+TEST(mixed_case) {
+  const sourcemeta::core::URI uri{"Https://www.sourcemeta.com"};
+  EXPECT_TRUE(uri.is_https());
+}
+
+TEST(localhost) {
+  const sourcemeta::core::URI uri{"https://localhost:8443"};
+  EXPECT_TRUE(uri.is_https());
+}
+
+TEST(ipv4_host) {
+  const sourcemeta::core::URI uri{"https://127.0.0.1:8443"};
+  EXPECT_TRUE(uri.is_https());
+}
+
+TEST(http) {
+  const sourcemeta::core::URI uri{"http://www.sourcemeta.com"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(scheme_with_suffix) {
+  const sourcemeta::core::URI uri{"httpss://www.sourcemeta.com"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(file) {
+  const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(mailto) {
+  const sourcemeta::core::URI uri{"mailto:jdoe@mail.com"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(urn) {
+  const sourcemeta::core::URI uri{"urn:example:schema"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(relative) {
+  const sourcemeta::core::URI uri{"../foo"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(no_scheme_network_path) {
+  const sourcemeta::core::URI uri{"//www.sourcemeta.com/path"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(fragment_only) {
+  const sourcemeta::core::URI uri{"#foo"};
+  EXPECT_FALSE(uri.is_https());
+}
+
+TEST(empty) {
+  const sourcemeta::core::URI uri{""};
+  EXPECT_FALSE(uri.is_https());
+}

--- a/test/uri/uri_is_localhost_test.cc
+++ b/test/uri/uri_is_localhost_test.cc
@@ -111,6 +111,16 @@ TEST(ipv6_loopback) {
   EXPECT_FALSE(uri.is_localhost());
 }
 
+TEST(ipvfuture_ending_in_name) {
+  const sourcemeta::core::URI uri{"http://[v1.localhost]"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(ipvfuture_name_only_label) {
+  const sourcemeta::core::URI uri{"http://[v1.foo.localhost]"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
 TEST(domain) {
   const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
   EXPECT_FALSE(uri.is_localhost());

--- a/test/uri/uri_is_localhost_test.cc
+++ b/test/uri/uri_is_localhost_test.cc
@@ -1,0 +1,152 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(name_only) {
+  const sourcemeta::core::URI uri{"http://localhost"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_with_port) {
+  const sourcemeta::core::URI uri{"http://localhost:8000"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_with_path) {
+  const sourcemeta::core::URI uri{"http://localhost/callback"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_with_userinfo) {
+  const sourcemeta::core::URI uri{"http://user:pass@localhost/secure"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_with_query_and_fragment) {
+  const sourcemeta::core::URI uri{"http://localhost/search?q=test#section"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_https_scheme) {
+  const sourcemeta::core::URI uri{"https://localhost"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_no_scheme) {
+  const sourcemeta::core::URI uri{"//localhost/path"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_uppercase) {
+  const sourcemeta::core::URI uri{"http://LOCALHOST"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_mixed_case) {
+  const sourcemeta::core::URI uri{"http://LocalHost:8000"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(name_absolute_form) {
+  const sourcemeta::core::URI uri{"http://localhost."};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(subdomain) {
+  const sourcemeta::core::URI uri{"http://foo.localhost"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(subdomain_with_port) {
+  const sourcemeta::core::URI uri{"http://foo.localhost:8000"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(subdomain_nested) {
+  const sourcemeta::core::URI uri{"http://foo.bar.localhost"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(subdomain_uppercase) {
+  const sourcemeta::core::URI uri{"http://FOO.LOCALHOST"};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(subdomain_absolute_form) {
+  const sourcemeta::core::URI uri{"http://foo.localhost."};
+  EXPECT_TRUE(uri.is_localhost());
+}
+
+TEST(prefix_of_domain) {
+  const sourcemeta::core::URI uri{"http://localhost.evil.com"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(name_with_suffix) {
+  const sourcemeta::core::URI uri{"http://localhosts"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(name_with_prefix) {
+  const sourcemeta::core::URI uri{"http://notlocalhost"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(name_inside_label) {
+  const sourcemeta::core::URI uri{"http://alocalhostb.example.com"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(name_as_leading_label) {
+  const sourcemeta::core::URI uri{"http://localhost.example.com"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(ipv4_loopback) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1:8000"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(ipv6_loopback) {
+  const sourcemeta::core::URI uri{"http://[::1]:8000"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(domain) {
+  const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(relative) {
+  const sourcemeta::core::URI uri{"../foo"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(relative_starting_with_name) {
+  const sourcemeta::core::URI uri{"localhost/path"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(fragment_only) {
+  const sourcemeta::core::URI uri{"#foo"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(mailto) {
+  const sourcemeta::core::URI uri{"mailto:jdoe@mail.com"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(urn) {
+  const sourcemeta::core::URI uri{"urn:example:schema"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(file_empty_host) {
+  const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
+  EXPECT_FALSE(uri.is_localhost());
+}
+
+TEST(empty) {
+  const sourcemeta::core::URI uri{""};
+  EXPECT_FALSE(uri.is_localhost());
+}

--- a/test/uri/uri_is_loopback_test.cc
+++ b/test/uri/uri_is_loopback_test.cc
@@ -1,0 +1,223 @@
+#include <sourcemeta/core/test.h>
+#include <sourcemeta/core/uri.h>
+
+TEST(ipv4_first_address) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_with_port) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1:8000"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_with_path) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1/callback"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_with_userinfo) {
+  const sourcemeta::core::URI uri{"http://user:pass@127.0.0.1/secure"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_with_query_and_fragment) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1/search?q=test#section"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_second_address) {
+  const sourcemeta::core::URI uri{"http://127.0.0.2:8000"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_network_address) {
+  const sourcemeta::core::URI uri{"http://127.0.0.0"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_last_address) {
+  const sourcemeta::core::URI uri{"http://127.255.255.255"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_arbitrary_address_in_block) {
+  const sourcemeta::core::URI uri{"http://127.63.10.4:1234"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_https_scheme) {
+  const sourcemeta::core::URI uri{"https://127.0.0.1"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_no_scheme) {
+  const sourcemeta::core::URI uri{"//127.0.0.1/path"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv4_below_block) {
+  const sourcemeta::core::URI uri{"http://126.255.255.255"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv4_above_block) {
+  const sourcemeta::core::URI uri{"http://128.0.0.1"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv4_private_address) {
+  const sourcemeta::core::URI uri{"http://192.168.1.1"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv4_public_address) {
+  const sourcemeta::core::URI uri{"http://203.0.113.1:8080"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv4_prefix_of_domain) {
+  const sourcemeta::core::URI uri{"http://127.0.0.1.example.com"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv4_octet_out_of_range) {
+  const sourcemeta::core::URI uri{"http://127.0.0.256"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv6_compressed) {
+  const sourcemeta::core::URI uri{"http://[::1]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_compressed_with_port) {
+  const sourcemeta::core::URI uri{"http://[::1]:8000"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_uncompressed) {
+  const sourcemeta::core::URI uri{"http://[0:0:0:0:0:0:0:1]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_full_form) {
+  const sourcemeta::core::URI uri{
+      "http://[0000:0000:0000:0000:0000:0000:0000:0001]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_partially_compressed) {
+  const sourcemeta::core::URI uri{"http://[::0:1]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_ipv4_mapped_loopback) {
+  const sourcemeta::core::URI uri{"http://[::ffff:127.0.0.1]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_ipv4_mapped_loopback_hexadecimal) {
+  const sourcemeta::core::URI uri{"http://[::ffff:7f00:1]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_ipv4_compatible_loopback) {
+  const sourcemeta::core::URI uri{"http://[::127.0.0.1]"};
+  EXPECT_TRUE(uri.is_loopback());
+}
+
+TEST(ipv6_ipv4_mapped_public) {
+  const sourcemeta::core::URI uri{"http://[::ffff:192.0.2.1]"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv6_unspecified) {
+  const sourcemeta::core::URI uri{"http://[::]"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv6_next_address) {
+  const sourcemeta::core::URI uri{"http://[::2]"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv6_link_local) {
+  const sourcemeta::core::URI uri{"http://[fe80::1]"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipv6_documentation_address) {
+  const sourcemeta::core::URI uri{"http://[2001:db8::1]"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(ipvfuture) {
+  const sourcemeta::core::URI uri{"http://[v1.loopback]"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(localhost) {
+  const sourcemeta::core::URI uri{"http://localhost"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(localhost_with_port) {
+  const sourcemeta::core::URI uri{"http://localhost:8000"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(localhost_uppercase) {
+  const sourcemeta::core::URI uri{"http://LOCALHOST"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(localhost_subdomain) {
+  const sourcemeta::core::URI uri{"http://foo.localhost"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(localhost_prefix_of_domain) {
+  const sourcemeta::core::URI uri{"http://localhost.evil.com"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(domain) {
+  const sourcemeta::core::URI uri{"https://www.sourcemeta.com"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(relative) {
+  const sourcemeta::core::URI uri{"../foo"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(relative_starting_with_address) {
+  const sourcemeta::core::URI uri{"127.0.0.1/path"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(fragment_only) {
+  const sourcemeta::core::URI uri{"#foo"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(mailto) {
+  const sourcemeta::core::URI uri{"mailto:jdoe@mail.com"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(urn) {
+  const sourcemeta::core::URI uri{"urn:example:schema"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(file_empty_host) {
+  const sourcemeta::core::URI uri{"file:///foo/bar/baz"};
+  EXPECT_FALSE(uri.is_loopback());
+}
+
+TEST(empty) {
+  const sourcemeta::core::URI uri{""};
+  EXPECT_FALSE(uri.is_loopback());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

