### PR TITLE
Implement `supports_token_endpoint_auth_method` proxies

### DIFF
--- a/src/core/oidc/include/sourcemeta/core/oidc_metadata.h
+++ b/src/core/oidc/include/sourcemeta/core/oidc_metadata.h
@@ -138,6 +138,13 @@ public:
   [[nodiscard]] auto supports_response_type(const std::string_view value) const
       -> bool;
 
+  /// Whether a token endpoint authentication method is supported, defaulting
+  /// to `client_secret_basic` when absent (OpenID Connect Discovery 1.0
+  /// Section 3).
+  [[nodiscard]] auto
+  supports_token_endpoint_auth_method(const std::string_view value) const
+      -> bool;
+
   /// Whether a scope is supported (OpenID Connect Discovery 1.0 Section 3).
   [[nodiscard]] auto supports_scope(const std::string_view value) const -> bool;
 

--- a/src/core/oidc/oidc_metadata.cc
+++ b/src/core/oidc/oidc_metadata.cc
@@ -246,6 +246,11 @@ auto OIDCProviderMetadata::supports_response_type(
   return this->oauth_.supports_response_type(value);
 }
 
+auto OIDCProviderMetadata::supports_token_endpoint_auth_method(
+    const std::string_view value) const -> bool {
+  return this->oauth_.supports_token_endpoint_auth_method(value);
+}
+
 auto OIDCProviderMetadata::supports_scope(const std::string_view value) const
     -> bool {
   return this->oauth_.data().array_member_contains(

--- a/test/oidc/oidc_metadata_test.cc
+++ b/test/oidc/oidc_metadata_test.cc
@@ -53,6 +53,32 @@ TEST(from_exposes_the_supported_predicates) {
   EXPECT_FALSE(metadata.value().supports_scope("email"));
   EXPECT_TRUE(metadata.value().supports_claim("sub"));
   EXPECT_FALSE(metadata.value().supports_claim("email"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_post"));
+}
+
+TEST(from_exposes_explicit_token_endpoint_auth_methods) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ],
+    "token_endpoint_auth_methods_supported":
+      [ "client_secret_post", "none" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_post"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method("none"));
+  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
 }
 
 TEST(from_delegates_to_the_oauth_metadata) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

