### PR TITLE
Enable passing `SecureString` to HTTP request headers

### DIFF
--- a/src/core/http/aws_sigv4.cc
+++ b/src/core/http/aws_sigv4.cc
@@ -314,7 +314,7 @@ auto HTTPSystemRequest::sign_aws_sigv4(
   }
 
   for (const auto &[name, value] : this->headers_) {
-    headers.emplace_back(name, value);
+    headers.emplace_back(name, value.bytes());
   }
 
   const auto canonical{http_aws_sigv4_canonical_request(

--- a/src/core/http/aws_sigv4.cc
+++ b/src/core/http/aws_sigv4.cc
@@ -53,15 +53,16 @@ auto sorted_headers(
   return entries;
 }
 
-auto append_lowercased(std::string &output, const std::string_view name)
-    -> void {
+template <typename Output>
+auto append_lowercased(Output &output, const std::string_view name) -> void {
   for (const auto character : name) {
     output.push_back(sourcemeta::core::to_lowercase(character));
   }
 }
 
+template <typename Output>
 auto append_canonical_headers(
-    std::string &output,
+    Output &output,
     const std::vector<std::pair<std::string_view, std::string_view>> &entries)
     -> void {
   std::size_t index{0};
@@ -85,8 +86,9 @@ auto append_canonical_headers(
   }
 }
 
+template <typename Output>
 auto append_signed_headers(
-    std::string &output,
+    Output &output,
     const std::vector<std::pair<std::string_view, std::string_view>> &entries)
     -> void {
   std::string_view previous;
@@ -106,7 +108,8 @@ auto append_signed_headers(
   }
 }
 
-auto append_canonical_uri(std::string &output, std::string_view path,
+template <typename Output>
+auto append_canonical_uri(Output &output, std::string_view path,
                           const bool normalize) -> void {
   std::string normalized;
   if (normalize) {
@@ -139,7 +142,8 @@ auto append_canonical_uri(std::string &output, std::string_view path,
   }
 }
 
-auto append_canonical_query(std::string &output, const std::string_view query)
+template <typename Output>
+auto append_canonical_query(Output &output, const std::string_view query)
     -> void {
   if (query.empty()) {
     return;
@@ -182,7 +186,10 @@ auto http_aws_sigv4_canonical_request(
         headers,
     const std::string_view payload_hash, const bool normalize) -> std::string {
   const auto entries{sorted_headers(headers)};
-  std::string result;
+  // A signed header value may live in wiping storage, so the assembly happens
+  // in wiping storage as well, keeping every intermediate growth buffer out
+  // of ordinary freed memory. The single returned copy is the caller's to wipe
+  SecureString result;
   result.append(method);
   result.push_back('\n');
   append_canonical_uri(result, path, normalize);
@@ -194,7 +201,7 @@ auto http_aws_sigv4_canonical_request(
   append_signed_headers(result, entries);
   result.push_back('\n');
   result.append(payload_hash);
-  return result;
+  return std::string{std::string_view{result}};
 }
 
 auto http_aws_sigv4_signed_headers(

--- a/src/core/http/aws_sigv4.cc
+++ b/src/core/http/aws_sigv4.cc
@@ -317,9 +317,12 @@ auto HTTPSystemRequest::sign_aws_sigv4(
     headers.emplace_back(name, value.bytes());
   }
 
-  const auto canonical{http_aws_sigv4_canonical_request(
+  // The canonical request spells out every signed header value, which may
+  // include one held in wiping storage, so it is wiped once consumed
+  auto canonical{http_aws_sigv4_canonical_request(
       http_method_string(this->method_), path, query, headers, payload_hash,
       service != "s3")};
+  const SecureStringScope canonical_scope{canonical};
   const auto scope{http_aws_sigv4_credential_scope(date, region, service)};
   const auto string_to_sign{
       http_aws_sigv4_string_to_sign(amz_date, scope, canonical)};

--- a/src/core/http/client_curl.cc
+++ b/src/core/http/client_curl.cc
@@ -350,13 +350,14 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
   CurlHeaderList header_list{api};
   for (const auto &[name, value] : this->headers_) {
     std::string line{name};
+    const SecureStringScope line_scope{line};
     // The semicolon form is how cURL distinguishes a header with an
     // empty value from a header to suppress
-    if (value.empty()) {
+    if (value.bytes().empty()) {
       line += ";";
     } else {
       line += ": ";
-      line += value;
+      line += value.bytes();
     }
 
     header_list.append(line);

--- a/src/core/http/client_curl.cc
+++ b/src/core/http/client_curl.cc
@@ -6,6 +6,7 @@
 
 #include <cstddef>     // std::size_t
 #include <cstdint>     // std::uint16_t
+#include <cstring>     // std::strlen
 #include <optional>    // std::optional
 #include <string>      // std::string
 #include <string_view> // std::string_view
@@ -33,7 +34,10 @@ using CURLoption = int;
 using CURLINFO = int;
 using curl_off_t = long long;
 
-struct curl_slist;
+struct curl_slist {
+  char *data;
+  curl_slist *next;
+};
 
 auto curl_global_init(long flags) -> CURLcode;
 auto curl_easy_init() -> CURL *;
@@ -122,6 +126,15 @@ public:
   explicit CurlHeaderList(const CurlApi &api) : api_{api} {}
   ~CurlHeaderList() {
     if (this->list_) {
+      // libcurl duplicates every appended line and does not clear its copy
+      // on release, so wipe each one first to keep a secret header value
+      // out of freed memory
+      for (auto *entry{this->list_}; entry; entry = entry->next) {
+        if (entry->data) {
+          sourcemeta::core::secure_zero(entry->data, std::strlen(entry->data));
+        }
+      }
+
       this->api_.slist_free_all(this->list_);
     }
   }
@@ -349,8 +362,12 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
 
   CurlHeaderList header_list{api};
   for (const auto &[name, value] : this->headers_) {
-    std::string line{name};
+    // Reserve the whole line up front, so appending a possibly secret value
+    // can never reallocate storage that is wiped only at scope exit
+    std::string line;
+    line.reserve(name.size() + value.bytes().size() + 2);
     const SecureStringScope line_scope{line};
+    line += name;
     // The semicolon form is how cURL distinguishes a header with an
     // empty value from a header to suppress
     if (value.bytes().empty()) {

--- a/src/core/http/client_darwin.mm
+++ b/src/core/http/client_darwin.mm
@@ -136,7 +136,7 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
       for (const auto &[name, value] : this->headers_) {
         // Repeated headers are folded into a single comma-separated field
         // line, which is semantically equivalent per RFC 9110
-        [url_request addValue:to_nsstring(value)
+        [url_request addValue:to_nsstring(value.bytes())
             forHTTPHeaderField:to_nsstring(name)];
       }
 

--- a/src/core/http/client_windows.cc
+++ b/src/core/http/client_windows.cc
@@ -190,6 +190,7 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
                    &decompression, sizeof(decompression));
 
   auto serialized_headers{http_serialize_headers(this->headers_)};
+  const SecureStringScope serialized_headers_scope{serialized_headers};
   LPVOID body_data{WINHTTP_NO_REQUEST_DATA};
   DWORD body_size{0};
   if (this->body_.has_value()) {
@@ -206,16 +207,16 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
     body_size = static_cast<DWORD>(this->body_.value().bytes().size());
   }
 
-  const auto request_headers{
-      sourcemeta::core::utf8_to_wide(serialized_headers)};
+  auto request_headers{sourcemeta::core::utf8_to_wide(serialized_headers)};
 
-  if (!WinHttpSendRequest(
-          request_handle.get(),
-          request_headers.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS
-                                  : request_headers.c_str(),
-          request_headers.empty() ? 0
-                                  : static_cast<DWORD>(request_headers.size()),
-          body_data, body_size, body_size, 0)) {
+  const auto sent{WinHttpSendRequest(
+      request_handle.get(),
+      request_headers.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS
+                              : request_headers.c_str(),
+      request_headers.empty() ? 0 : static_cast<DWORD>(request_headers.size()),
+      body_data, body_size, body_size, 0)};
+  secure_zero(request_headers.data(), request_headers.size() * sizeof(wchar_t));
+  if (!sent) {
     throw HTTPError{this->method_, this->url_,
                     "Failed to send the HTTP request"};
   }

--- a/src/core/http/client_windows.cc
+++ b/src/core/http/client_windows.cc
@@ -189,7 +189,10 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
   WinHttpSetOption(request_handle.get(), WINHTTP_OPTION_DECOMPRESSION,
                    &decompression, sizeof(decompression));
 
-  auto serialized_headers{http_serialize_headers(this->headers_)};
+  // The possibly secret header lines are appended last, so this buffer never
+  // grows once it holds a secret, which would leave the previous storage in
+  // freed memory without a wipe
+  std::string serialized_headers;
   const SecureStringScope serialized_headers_scope{serialized_headers};
   LPVOID body_data{WINHTTP_NO_REQUEST_DATA};
   DWORD body_size{0};
@@ -205,6 +208,12 @@ auto HTTPSystemRequest::send() const -> HTTPResponse {
     serialized_headers += "\r\n";
     body_data = const_cast<char *>(this->body_.value().bytes().data());
     body_size = static_cast<DWORD>(this->body_.value().bytes().size());
+  }
+
+  {
+    auto header_lines{http_serialize_headers(this->headers_)};
+    const SecureStringScope header_lines_scope{header_lines};
+    serialized_headers += header_lines;
   }
 
   auto request_headers{sourcemeta::core::utf8_to_wide(serialized_headers)};

--- a/src/core/http/include/sourcemeta/core/http_message.h
+++ b/src/core/http/include/sourcemeta/core/http_message.h
@@ -350,7 +350,11 @@ inline auto http_serialize_headers(const Headers &headers) -> std::string {
   std::size_t total_size{0};
   for (const auto &[name, value] : headers) {
     // Account for the colon, the space, and the trailing CRLF
-    total_size += name.size() + value.size() + 4;
+    if constexpr (requires { value.bytes(); }) {
+      total_size += name.size() + value.bytes().size() + 4;
+    } else {
+      total_size += name.size() + value.size() + 4;
+    }
   }
 
   std::string result;
@@ -360,7 +364,12 @@ inline auto http_serialize_headers(const Headers &headers) -> std::string {
     // value is preferred for consistent readability by humans"
     result += name;
     result += ": ";
-    result += value;
+    if constexpr (requires { value.bytes(); }) {
+      result += value.bytes();
+    } else {
+      result += value;
+    }
+
     result += "\r\n";
   }
 

--- a/src/core/http/include/sourcemeta/core/http_system.h
+++ b/src/core/http/include/sourcemeta/core/http_system.h
@@ -125,9 +125,37 @@ public:
     return *this;
   }
 
+  /// A request header value, holding ordinary storage for a plain value and
+  /// wiping storage for one set from a secret
+  struct HeaderValue {
+    /// The held bytes. A plain value carries no secret and keeps the ordinary
+    /// string storage, while a value set from wiping storage stays in it, so
+    /// the common request pays nothing and a secret one is never retained in
+    /// an ordinary string
+    std::variant<std::string, SecureString> data;
+
+    /// Get a view of the held bytes
+    [[nodiscard]] auto bytes() const -> std::string_view {
+      return std::visit(
+          [](const auto &value) -> std::string_view { return value; },
+          this->data);
+    }
+  };
+
   /// Add a request header. Repeated names are permitted
   auto header(std::string name, std::string value) -> HTTPSystemRequest & {
-    this->headers_.emplace_back(std::move(name), std::move(value));
+    this->headers_.emplace_back(std::move(name),
+                                HeaderValue{.data = std::move(value)});
+    return *this;
+  }
+
+  /// Add a request header from wiping storage. The value is held in the wiping
+  /// storage so a secret it carries, such as a client credential, is never
+  /// retained in an ordinary string, and the transient serialisation a backend
+  /// builds at send time is wiped
+  auto header(std::string name, SecureString value) -> HTTPSystemRequest & {
+    this->headers_.emplace_back(std::move(name),
+                                HeaderValue{.data = std::move(value)});
     return *this;
   }
 
@@ -146,7 +174,7 @@ public:
       -> std::optional<std::string_view> {
     for (const auto &[key, value] : this->headers_) {
       if (equals_ignore_case(key, name)) {
-        return value;
+        return value.bytes();
       }
     }
 
@@ -255,7 +283,7 @@ private:
 
   std::string url_;
   HTTPMethod method_;
-  std::vector<std::pair<std::string, std::string>> headers_;
+  std::vector<std::pair<std::string, HeaderValue>> headers_;
   std::optional<Body> body_;
   bool follow_redirects_{true};
   std::size_t maximum_redirects_{20};

--- a/src/lang/text/include/sourcemeta/core/text.h
+++ b/src/lang/text/include/sourcemeta/core/text.h
@@ -767,8 +767,7 @@ auto squeeze(const std::string_view input, const char character) -> std::string;
 ///
 /// Collapse consecutive runs of a character into a single occurrence, appending
 /// the result to a string like output sink rather than allocating a new
-/// string. Besides a `std::string` the sink can be a wiping string for secret
-/// material. The output must not alias the input. For example:
+/// string. The output must not alias the input. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/text.h>

--- a/src/lang/text/include/sourcemeta/core/text.h
+++ b/src/lang/text/include/sourcemeta/core/text.h
@@ -766,8 +766,9 @@ auto squeeze(const std::string_view input, const char character) -> std::string;
 /// @ingroup text
 ///
 /// Collapse consecutive runs of a character into a single occurrence, appending
-/// the result to an existing string rather than allocating a new one. The
-/// output must not alias the input. For example:
+/// the result to a string like output sink rather than allocating a new
+/// string. Besides a `std::string` the sink can be a wiping string for secret
+/// material. The output must not alias the input. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/text.h>
@@ -778,9 +779,23 @@ auto squeeze(const std::string_view input, const char character) -> std::string;
 /// sourcemeta::core::squeeze("a//b", '/', output);
 /// assert(output == "path=a/b");
 /// ```
-SOURCEMETA_CORE_TEXT_EXPORT
-auto squeeze(const std::string_view input, const char character,
-             std::string &output) -> void;
+template <typename Output>
+auto squeeze(const std::string_view input, const char character, Output &output)
+    -> void {
+  bool in_run{false};
+  for (const auto value : input) {
+    if (value == character) {
+      if (!in_run) {
+        output.push_back(value);
+      }
+
+      in_run = true;
+    } else {
+      output.push_back(value);
+      in_run = false;
+    }
+  }
+}
 
 /// @ingroup text
 ///

--- a/src/lang/text/text.cc
+++ b/src/lang/text/text.cc
@@ -174,23 +174,6 @@ auto split_once(const std::string_view input,
   return std::pair{before, after};
 }
 
-auto squeeze(const std::string_view input, const char character,
-             std::string &output) -> void {
-  bool in_run{false};
-  for (const auto value : input) {
-    if (value == character) {
-      if (!in_run) {
-        output.push_back(value);
-      }
-
-      in_run = true;
-    } else {
-      output.push_back(value);
-      in_run = false;
-    }
-  }
-}
-
 auto squeeze(const std::string_view input, const char character)
     -> std::string {
   std::string result;

--- a/test/http/http_serialize_headers_test.cc
+++ b/test/http/http_serialize_headers_test.cc
@@ -1,4 +1,5 @@
-#include <sourcemeta/core/http_message.h>
+#include <sourcemeta/core/crypto.h>
+#include <sourcemeta/core/http.h>
 #include <sourcemeta/core/test.h>
 
 #include <string>      // std::string
@@ -43,6 +44,14 @@ TEST(view_pairs) {
       {"Accept", "application/json"}};
   EXPECT_EQ(sourcemeta::core::http_serialize_headers(headers),
             "Accept: application/json\r\n");
+}
+
+TEST(request_headers_with_wiping_values) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("Accept", "application/json");
+  request.header("Authorization", sourcemeta::core::SecureString{"Basic Zm9v"});
+  EXPECT_EQ(sourcemeta::core::http_serialize_headers(request.headers()),
+            "Accept: application/json\r\nAuthorization: Basic Zm9v\r\n");
 }
 
 TEST(round_trip_through_parse) {

--- a/test/http/http_system_request_test.cc
+++ b/test/http/http_system_request_test.cc
@@ -343,3 +343,25 @@ TEST(sign_aws_sigv4_replaces_stale_signing_headers) {
   EXPECT_EQ(request.header("Authorization").value(),
             expected_get_authorization("example.amazonaws.com"));
 }
+
+TEST(sign_aws_sigv4_wiping_storage_header_signs_identically) {
+  const auto moment{
+      sourcemeta::core::from_iso8601_basic("20150830T123600Z").value()};
+  const sourcemeta::core::HTTPAWSCredentials credentials{
+      .access_key_id = "AKIDEXAMPLE",
+      .secret_access_key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+      .session_token = ""};
+
+  sourcemeta::core::HTTPSystemRequest plain{"https://example.amazonaws.com/",
+                                            sourcemeta::core::HTTPMethod::GET};
+  plain.header("X-Api-Token", "secret-token");
+  plain.sign_aws_sigv4(credentials, "us-east-1", "service", moment);
+
+  sourcemeta::core::HTTPSystemRequest wiping{"https://example.amazonaws.com/",
+                                             sourcemeta::core::HTTPMethod::GET};
+  wiping.header("X-Api-Token", sourcemeta::core::SecureString{"secret-token"});
+  wiping.sign_aws_sigv4(credentials, "us-east-1", "service", moment);
+
+  EXPECT_EQ(plain.header("Authorization").value(),
+            wiping.header("Authorization").value());
+}

--- a/test/http/http_system_request_test.cc
+++ b/test/http/http_system_request_test.cc
@@ -6,6 +6,7 @@
 #include <string>      // std::string
 #include <string_view> // std::string_view
 #include <utility>     // std::pair
+#include <variant>     // std::holds_alternative
 #include <vector>      // std::vector
 
 namespace {
@@ -47,9 +48,30 @@ TEST(headers_returns_added_headers_in_order) {
   request.header("X-Custom", "value");
   EXPECT_EQ(request.headers().size(), 2);
   EXPECT_EQ(request.headers().at(0).first, "Accept");
-  EXPECT_EQ(request.headers().at(0).second, "application/json");
+  EXPECT_EQ(request.headers().at(0).second.bytes(), "application/json");
   EXPECT_EQ(request.headers().at(1).first, "X-Custom");
-  EXPECT_EQ(request.headers().at(1).second, "value");
+  EXPECT_EQ(request.headers().at(1).second.bytes(), "value");
+}
+
+TEST(header_from_wiping_storage_lookup) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("Authorization",
+                 sourcemeta::core::SecureString{"Basic czZCaGRSa3F0Mw=="});
+  EXPECT_EQ(request.headers().size(), 1);
+  EXPECT_EQ(request.headers().at(0).first, "Authorization");
+  EXPECT_EQ(request.headers().at(0).second.bytes(), "Basic czZCaGRSa3F0Mw==");
+  EXPECT_TRUE(request.header("authorization").has_value());
+  EXPECT_EQ(request.header("authorization").value(), "Basic czZCaGRSa3F0Mw==");
+}
+
+TEST(header_storage_matches_the_overload) {
+  sourcemeta::core::HTTPSystemRequest request{"https://example.com"};
+  request.header("Accept", "application/json");
+  request.header("Authorization", sourcemeta::core::SecureString{"Basic Zm9v"});
+  EXPECT_TRUE(
+      std::holds_alternative<std::string>(request.headers().at(0).second.data));
+  EXPECT_TRUE(std::holds_alternative<sourcemeta::core::SecureString>(
+      request.headers().at(1).second.data));
 }
 
 TEST(header_lookup_present) {


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

