### PR TITLE
Complete RFC 9728 support with a protected resource metadata builder

### DIFF
--- a/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
@@ -99,24 +99,23 @@ SOURCEMETA_CORE_OAUTH_EXPORT
 auto oauth_is_resource_identifier(const std::string_view value) -> bool;
 
 /// @ingroup oauth
-/// Whether a value is usable as an authorization server issuer identifier
-/// advertised inside a metadata document: the `https` scheme compared
-/// case-insensitively, a non-empty host, and no query or fragment (RFC 8414
-/// Section 2). This is the rule the resource metadata builder and parser apply
-/// to `authorization_servers` entries, so a caller assembling a document can
-/// pre-filter with it. For example:
+/// Whether a value is a valid authorization server issuer identifier: the
+/// `https` scheme by exact code points, a non-empty host, and no query or
+/// fragment (RFC 8414 Section 2). This is the rule the metadata builders
+/// apply to `issuer` and to `authorization_servers` entries, so a caller
+/// assembling a document can pre-filter with it. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>
 /// #include <cassert>
 ///
-/// assert(sourcemeta::core::oauth_is_advertised_issuer(
+/// assert(sourcemeta::core::oauth_is_issuer_identifier(
 ///     "https://auth.example.com/tenant"));
-/// assert(!sourcemeta::core::oauth_is_advertised_issuer(
+/// assert(!sourcemeta::core::oauth_is_issuer_identifier(
 ///     "https://auth.example.com/?tenant=1"));
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
-auto oauth_is_advertised_issuer(const std::string_view value) -> bool;
+auto oauth_is_issuer_identifier(const std::string_view value) -> bool;
 
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)

--- a/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_metadata.h
@@ -79,6 +79,45 @@ auto oauth_well_known_url(const std::string_view identifier,
 SOURCEMETA_CORE_OAUTH_EXPORT
 auto oauth_is_endpoint_url(const std::string_view value) -> bool;
 
+/// @ingroup oauth
+/// Whether a value is a valid protected resource identifier: the `https`
+/// scheme by exact code points, a non-empty host, and no fragment, a query
+/// tolerated (RFC 9728 Section 1.2, RFC 8707 Section 2). This is the rule the
+/// resource metadata builder and parser apply, so a caller assembling a
+/// document can pre-filter with it. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::oauth_is_resource_identifier(
+///     "https://api.example.com/mcp?tenant=1"));
+/// assert(!sourcemeta::core::oauth_is_resource_identifier(
+///     "http://api.example.com/mcp"));
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_is_resource_identifier(const std::string_view value) -> bool;
+
+/// @ingroup oauth
+/// Whether a value is usable as an authorization server issuer identifier
+/// advertised inside a metadata document: the `https` scheme compared
+/// case-insensitively, a non-empty host, and no query or fragment (RFC 8414
+/// Section 2). This is the rule the resource metadata builder and parser apply
+/// to `authorization_servers` entries, so a caller assembling a document can
+/// pre-filter with it. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::oauth_is_advertised_issuer(
+///     "https://auth.example.com/tenant"));
+/// assert(!sourcemeta::core::oauth_is_advertised_issuer(
+///     "https://auth.example.com/?tenant=1"));
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_is_advertised_issuer(const std::string_view value) -> bool;
+
 #if defined(_MSC_VER)
 #pragma warning(disable : 4251)
 #endif
@@ -186,6 +225,11 @@ public:
   supports_token_endpoint_auth_method(const std::string_view value) const
       -> bool;
 
+  /// Whether a protected resource is listed as usable with this authorization
+  /// server (RFC 9728 Section 4).
+  [[nodiscard]] auto
+  supports_protected_resource(const std::string_view value) const -> bool;
+
   /// The underlying document, for reaching members without a typed accessor.
   [[nodiscard]] auto data() const -> const JSON &;
 
@@ -202,9 +246,10 @@ private:
 /// well-known URL was derived from, or, for the `WWW-Authenticate`
 /// `resource_metadata` flow, the URL the request was made to (the Section 3.3
 /// second check). Only the plain JSON members are read, so a `signed_metadata`
-/// statement (RFC 9728 Section 2.2) is not processed. A string accessor returns
-/// a view into the owned document, valid for the lifetime of this object. For
-/// example:
+/// statement is not processed, which RFC 9728 Section 2.2 permits by making
+/// its precedence conditional on a consumer that "supports signed metadata".
+/// A string accessor returns a view into the owned document, valid for the
+/// lifetime of this object. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oauth.h>
@@ -262,6 +307,43 @@ public:
   /// false when absent (RFC 9728 Section 2).
   [[nodiscard]] auto dpop_bound_access_tokens_required() const -> bool;
 
+  /// The human-readable name of the resource without a language tag (RFC 9728
+  /// Section 2), reaching a language-tagged variant through the underlying
+  /// document.
+  [[nodiscard]] auto resource_name() const -> std::optional<std::string_view>;
+
+  /// The developer documentation page location (RFC 9728 Section 2).
+  [[nodiscard]] auto resource_documentation() const
+      -> std::optional<std::string_view>;
+
+  /// The data usage policy page location (RFC 9728 Section 2).
+  [[nodiscard]] auto resource_policy_uri() const
+      -> std::optional<std::string_view>;
+
+  /// The terms of service page location (RFC 9728 Section 2).
+  [[nodiscard]] auto resource_tos_uri() const
+      -> std::optional<std::string_view>;
+
+  /// Whether the resource supports mutual-TLS certificate-bound access tokens,
+  /// defaulting to false when absent (RFC 9728 Section 2).
+  [[nodiscard]] auto tls_client_certificate_bound_access_tokens() const -> bool;
+
+  /// Whether a JWS algorithm is listed for signing resource responses
+  /// (RFC 9728 Section 2).
+  [[nodiscard]] auto
+  supports_resource_signing_alg(const std::string_view value) const -> bool;
+
+  /// Whether a JWS algorithm is listed for validating DPoP proofs (RFC 9728
+  /// Section 2).
+  [[nodiscard]] auto
+  supports_dpop_signing_alg(const std::string_view value) const -> bool;
+
+  /// Whether an authorization details type is listed for the resource
+  /// (RFC 9728 Section 2).
+  [[nodiscard]] auto
+  supports_authorization_details_type(const std::string_view value) const
+      -> bool;
+
   /// The underlying document, for reaching members without a typed accessor
   /// such as the internationalized names.
   [[nodiscard]] auto data() const -> const JSON &;
@@ -314,6 +396,9 @@ struct OAuthServerMetadataConfig {
   /// authorization request endpoint, emitted only when true (RFC 9126
   /// Section 5).
   bool require_pushed_authorization_requests{false};
+  /// The protected resources usable with this authorization server, each a
+  /// valid resource identifier (RFC 9728 Section 4).
+  std::span<const std::string_view> protected_resources;
 };
 
 /// @ingroup oauth
@@ -345,6 +430,87 @@ struct OAuthServerMetadataConfig {
 /// ```
 SOURCEMETA_CORE_OAUTH_EXPORT
 auto oauth_make_server_metadata(const OAuthServerMetadataConfig &config)
+    -> std::optional<JSON>;
+
+/// @ingroup oauth
+/// The configuration a protected resource publishes as its metadata (RFC 9728
+/// Section 2), each field a non-owning view. An empty scalar and a
+/// zero-element array are omitted, since RFC 9728 Section 3.2 forbids a
+/// zero-element array in the response. The one exception is the bearer method
+/// list, whose engaged empty state is emitted as an empty array, the form
+/// RFC 9728 Section 2 gives for a resource that supports no bearer method,
+/// distinct from the unspecified absent state.
+struct OAuthResourceMetadataConfig {
+  /// The resource identifier (RFC 9728 Section 2), REQUIRED.
+  std::string_view resource;
+  /// The authorization server issuer identifiers that can issue tokens for the
+  /// resource (RFC 9728 Section 2).
+  std::span<const std::string_view> authorization_servers;
+  /// The JWK Set document location for the resource's own keys (RFC 9728
+  /// Section 2).
+  std::string_view jwks_uri;
+  /// The scopes used in authorization requests for the resource (RFC 9728
+  /// Section 2).
+  std::span<const std::string_view> scopes_supported;
+  /// The supported bearer token presentation methods (RFC 9728 Section 2),
+  /// where no value omits the member and an engaged empty list advertises that
+  /// no bearer method is supported.
+  std::optional<std::span<const std::string_view>> bearer_methods_supported;
+  /// The supported JWS algorithms for signing resource responses (RFC 9728
+  /// Section 2), which must exclude `none`.
+  std::span<const std::string_view> resource_signing_alg_values_supported;
+  /// The human-readable name of the resource without a language tag (RFC 9728
+  /// Sections 2 and 2.1), a language-tagged variant assigned by the caller on
+  /// the returned document.
+  std::string_view resource_name;
+  /// The developer documentation page location (RFC 9728 Section 2).
+  std::string_view resource_documentation;
+  /// The data usage policy page location (RFC 9728 Section 2).
+  std::string_view resource_policy_uri;
+  /// The terms of service page location (RFC 9728 Section 2).
+  std::string_view resource_tos_uri;
+  /// Whether the resource supports mutual-TLS certificate-bound access tokens,
+  /// emitted only when true since the default when absent is false (RFC 9728
+  /// Section 2).
+  bool tls_client_certificate_bound_access_tokens{false};
+  /// The supported authorization details types (RFC 9728 Section 2).
+  std::span<const std::string_view> authorization_details_types_supported;
+  /// The supported JWS algorithms for validating DPoP proofs (RFC 9728
+  /// Section 2), which must exclude `none` and the MAC algorithms a proof may
+  /// never use (RFC 9449 Section 4.2).
+  std::span<const std::string_view> dpop_signing_alg_values_supported;
+  /// Whether the resource requires DPoP-bound access tokens, emitted only when
+  /// true since the default when absent is false (RFC 9728 Section 2).
+  bool dpop_bound_access_tokens_required{false};
+};
+
+/// @ingroup oauth
+/// Build a protected resource metadata document for the well-known endpoint
+/// (RFC 9728 Section 2), returning no value when the document would be
+/// unusable: the resource is not a valid resource identifier, an authorization
+/// server entry is not a valid issuer identifier, the JWK Set location is not
+/// a valid https URL, a human-readable page location is not a URL, the
+/// resource signing algorithm list contains `none`, or the DPoP algorithm
+/// list contains `none` or a MAC algorithm. Every produced document parses
+/// back through its own consumer for the same resource. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <array>
+/// #include <cassert>
+/// #include <string_view>
+///
+/// const std::array<std::string_view, 1> servers{{"https://auth.example.com"}};
+/// sourcemeta::core::OAuthResourceMetadataConfig config;
+/// config.resource = "https://api.example.com";
+/// config.authorization_servers = servers;
+/// const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+/// assert(document.has_value());
+/// assert(document.value().at("resource").to_string() ==
+///        "https://api.example.com");
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_make_resource_metadata(const OAuthResourceMetadataConfig &config)
     -> std::optional<JSON>;
 
 } // namespace sourcemeta::core

--- a/src/core/oauth/oauth_authorization.cc
+++ b/src/core/oauth/oauth_authorization.cc
@@ -1,12 +1,12 @@
 #include <sourcemeta/core/oauth_authorization.h>
 
 #include <sourcemeta/core/html.h>
+#include <sourcemeta/core/oauth_metadata.h>
 #include <sourcemeta/core/text.h>
 #include <sourcemeta/core/uri.h>
 
 #include "oauth_authorization_parse.h"
 #include "oauth_decode.h"
-#include "oauth_syntax.h"
 
 #include <functional>  // std::function
 #include <optional>    // std::optional, std::nullopt

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -6,7 +6,7 @@
 
 #include "oauth_syntax.h"
 
-#include <algorithm>   // std::ranges::find
+#include <algorithm> // std::ranges::find, std::ranges::any_of, std::ranges::all_of
 #include <optional>    // std::optional, std::nullopt
 #include <span>        // std::span
 #include <string>      // std::string
@@ -57,6 +57,20 @@ constexpr auto HASH_DPOP_BOUND_REQUIRED{
     JSON::Object::hash("dpop_bound_access_tokens_required"sv)};
 constexpr auto HASH_RESOURCE_SIGNING_ALGS{
     JSON::Object::hash("resource_signing_alg_values_supported"sv)};
+constexpr auto HASH_RESOURCE_NAME{JSON::Object::hash("resource_name"sv)};
+constexpr auto HASH_RESOURCE_DOCUMENTATION{
+    JSON::Object::hash("resource_documentation"sv)};
+constexpr auto HASH_RESOURCE_POLICY_URI{
+    JSON::Object::hash("resource_policy_uri"sv)};
+constexpr auto HASH_RESOURCE_TOS_URI{JSON::Object::hash("resource_tos_uri"sv)};
+constexpr auto HASH_TLS_CLIENT_CERTIFICATE_BOUND{
+    JSON::Object::hash("tls_client_certificate_bound_access_tokens"sv)};
+constexpr auto HASH_AUTHORIZATION_DETAILS_TYPES{
+    JSON::Object::hash("authorization_details_types_supported"sv)};
+constexpr auto HASH_DPOP_SIGNING_ALGS{
+    JSON::Object::hash("dpop_signing_alg_values_supported"sv)};
+constexpr auto HASH_PROTECTED_RESOURCES{
+    JSON::Object::hash("protected_resources"sv)};
 
 auto string_member(const JSON &data, const JSON::StringView name,
                    const JSON::Object::hash_type hash)
@@ -86,6 +100,48 @@ auto validate_endpoint(const JSON &data, const JSON::StringView name,
   }
 
   if (!member->is_string() || !oauth_is_endpoint_url(member->to_string())) {
+    throw OAuthMetadataParseError{};
+  }
+}
+
+// The shape checks run on exact name lookup only, since RFC 9728 Section 3.2
+// demands that "any metadata parameters that are not understood MUST be
+// ignored", which covers the language-tagged variants of the human-readable
+// members (RFC 9728 Section 2.1) whose names are distinct from the untagged
+// ones. A member that is present with the wrong shape fails the parse rather
+// than being ignored, since an accessor would otherwise report a malformed
+// member as an absent one
+auto validate_string_array(const JSON &data, const JSON::StringView name,
+                           const JSON::Object::hash_type hash,
+                           const bool allow_empty) -> void {
+  const auto *member{data.try_at(name, hash)};
+  if (member == nullptr) {
+    return;
+  }
+
+  if (!member->is_array() || (!allow_empty && member->empty())) {
+    throw OAuthMetadataParseError{};
+  }
+
+  for (const auto &element : member->as_array()) {
+    if (!element.is_string()) {
+      throw OAuthMetadataParseError{};
+    }
+  }
+}
+
+auto validate_boolean(const JSON &data, const JSON::StringView name,
+                      const JSON::Object::hash_type hash) -> void {
+  const auto *member{data.try_at(name, hash)};
+  if (member != nullptr && !member->is_boolean()) {
+    throw OAuthMetadataParseError{};
+  }
+}
+
+auto validate_string(const JSON &data, const JSON::StringView name,
+                     const JSON::Object::hash_type hash) -> void {
+  const auto *member{data.try_at(name, hash)};
+  if (member != nullptr && !member->is_string()) {
     throw OAuthMetadataParseError{};
   }
 }
@@ -171,6 +227,12 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
     }
   }
 
+  // RFC 9728 Section 4: the protected resources are "resource identifiers for
+  // OAuth protected resources that can be used with this authorization
+  // server", and RFC 8414 Section 3.2 forbids a zero-element array
+  validate_string_array(data, "protected_resources"sv, HASH_PROTECTED_RESOURCES,
+                        false);
+
   return std::move(data);
 }
 
@@ -227,11 +289,43 @@ auto validated_resource_metadata(JSON &&data, const std::string_view resource)
   // algorithms, and Section 3.2 forbids a zero-element array
   const auto *algorithms{data.try_at("resource_signing_alg_values_supported"sv,
                                      HASH_RESOURCE_SIGNING_ALGS)};
-  if (algorithms != nullptr &&
-      (!algorithms->is_array() || algorithms->empty() ||
-       algorithms->contains("none"))) {
-    throw OAuthMetadataParseError{};
+  if (algorithms != nullptr) {
+    if (!algorithms->is_array() || algorithms->empty() ||
+        algorithms->contains("none")) {
+      throw OAuthMetadataParseError{};
+    }
+
+    for (const auto &element : algorithms->as_array()) {
+      if (!element.is_string()) {
+        throw OAuthMetadataParseError{};
+      }
+    }
   }
+
+  // RFC 9728 Section 3.2: "Parameters with zero values MUST be omitted from
+  // the response" is a rule on the emitting side, and no text orders a reader
+  // to reject a violating document, so treating one as malformed is this
+  // module's strictness stance, the same one the authorization server list
+  // already receives. The bearer method list is the lone member whose empty
+  // array is meaningful, since RFC 9728 Section 2 says "The empty array []
+  // can be used to indicate that no bearer methods are supported"
+  validate_string_array(data, "scopes_supported"sv, HASH_SCOPES_SUPPORTED,
+                        false);
+  validate_string_array(data, "bearer_methods_supported"sv, HASH_BEARER_METHODS,
+                        true);
+  validate_string_array(data, "authorization_details_types_supported"sv,
+                        HASH_AUTHORIZATION_DETAILS_TYPES, false);
+  validate_string_array(data, "dpop_signing_alg_values_supported"sv,
+                        HASH_DPOP_SIGNING_ALGS, false);
+  validate_boolean(data, "tls_client_certificate_bound_access_tokens"sv,
+                   HASH_TLS_CLIENT_CERTIFICATE_BOUND);
+  validate_boolean(data, "dpop_bound_access_tokens_required"sv,
+                   HASH_DPOP_BOUND_REQUIRED);
+  validate_string(data, "resource_name"sv, HASH_RESOURCE_NAME);
+  validate_string(data, "resource_documentation"sv,
+                  HASH_RESOURCE_DOCUMENTATION);
+  validate_string(data, "resource_policy_uri"sv, HASH_RESOURCE_POLICY_URI);
+  validate_string(data, "resource_tos_uri"sv, HASH_RESOURCE_TOS_URI);
 
   return std::move(data);
 }
@@ -251,6 +345,28 @@ auto oauth_is_endpoint_url(const std::string_view value) -> bool {
   const auto uri{oauth_try_parse_uri(value)};
   return uri.has_value() && uri->is_https() && uri->host().has_value() &&
          !uri->host().value().empty() && !uri->fragment().has_value();
+}
+
+// RFC 9728 Section 1.2 and RFC 8707 Section 2: a resource is an https URL with
+// a non-empty host and no fragment, a query tolerated unlike an issuer
+auto oauth_is_resource_identifier(const std::string_view value) -> bool {
+  const auto uri{oauth_try_parse_uri(value)};
+  return uri.has_value() && uri->scheme().has_value() &&
+         uri->scheme().value() == "https" && uri->host().has_value() &&
+         !uri->host().value().empty() && !uri->fragment().has_value();
+}
+
+// An issuer identifier a document advertises for someone else, rather than the
+// one the document was retrieved for. RFC 8414 Section 2 gives it the same
+// shape, but Section 4 scopes code-point comparison to "comparing values in the
+// messages to known values", and an advertised issuer is matched against
+// nothing at parse time. Its validity therefore follows RFC 3986 Section 3.1,
+// which makes the scheme case-insensitive
+auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
+  const auto uri{oauth_try_parse_uri(value)};
+  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
+         !uri->host().value().empty() && !uri->query().has_value() &&
+         !uri->fragment().has_value();
 }
 
 auto oauth_well_known_url(const std::string_view identifier,
@@ -467,6 +583,12 @@ auto OAuthServerMetadata::supports_token_endpoint_auth_method(
   return member->contains(value);
 }
 
+auto OAuthServerMetadata::supports_protected_resource(
+    const std::string_view value) const -> bool {
+  return this->data_.array_member_contains("protected_resources"sv,
+                                           HASH_PROTECTED_RESOURCES, value);
+}
+
 auto OAuthServerMetadata::data() const -> const JSON & { return this->data_; }
 
 OAuthResourceMetadata::OAuthResourceMetadata(JSON &&data,
@@ -537,6 +659,61 @@ auto OAuthResourceMetadata::dpop_bound_access_tokens_required() const -> bool {
   return member != nullptr && member->is_boolean() && member->to_boolean();
 }
 
+auto OAuthResourceMetadata::resource_name() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "resource_name"sv, HASH_RESOURCE_NAME);
+}
+
+auto OAuthResourceMetadata::resource_documentation() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "resource_documentation"sv,
+                       HASH_RESOURCE_DOCUMENTATION);
+}
+
+auto OAuthResourceMetadata::resource_policy_uri() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "resource_policy_uri"sv,
+                       HASH_RESOURCE_POLICY_URI);
+}
+
+auto OAuthResourceMetadata::resource_tos_uri() const
+    -> std::optional<std::string_view> {
+  return string_member(this->data_, "resource_tos_uri"sv,
+                       HASH_RESOURCE_TOS_URI);
+}
+
+auto OAuthResourceMetadata::tls_client_certificate_bound_access_tokens() const
+    -> bool {
+  if (!this->data_.is_object()) {
+    return false;
+  }
+
+  const auto *member{
+      this->data_.try_at("tls_client_certificate_bound_access_tokens"sv,
+                         HASH_TLS_CLIENT_CERTIFICATE_BOUND)};
+  return member != nullptr && member->is_boolean() && member->to_boolean();
+}
+
+auto OAuthResourceMetadata::supports_resource_signing_alg(
+    const std::string_view value) const -> bool {
+  return this->data_.array_member_contains(
+      "resource_signing_alg_values_supported"sv, HASH_RESOURCE_SIGNING_ALGS,
+      value);
+}
+
+auto OAuthResourceMetadata::supports_dpop_signing_alg(
+    const std::string_view value) const -> bool {
+  return this->data_.array_member_contains(
+      "dpop_signing_alg_values_supported"sv, HASH_DPOP_SIGNING_ALGS, value);
+}
+
+auto OAuthResourceMetadata::supports_authorization_details_type(
+    const std::string_view value) const -> bool {
+  return this->data_.array_member_contains(
+      "authorization_details_types_supported"sv,
+      HASH_AUTHORIZATION_DETAILS_TYPES, value);
+}
+
 auto OAuthResourceMetadata::data() const -> const JSON & { return this->data_; }
 
 namespace {
@@ -544,6 +721,15 @@ namespace {
 auto span_contains(const std::span<const std::string_view> values,
                    const std::string_view target) -> bool {
   return std::ranges::find(values, target) != values.end();
+}
+
+// RFC 9728 Section 2 calls each human-readable page location a URL without
+// mandating a scheme, so the check is for an absolute URI rather than an https
+// one, and a fragment stays legitimate on a page location, unlike under the
+// stricter RFC 3986 Section 4.3 absolute-URI rule
+auto oauth_is_page_url(const std::string_view value) -> bool {
+  const auto uri{oauth_try_parse_uri(value)};
+  return uri.has_value() && uri->is_absolute();
 }
 
 } // namespace
@@ -629,6 +815,14 @@ auto oauth_make_server_metadata(const OAuthServerMetadataConfig &config)
     return std::nullopt;
   }
 
+  // RFC 9728 Section 4: the advertised protected resources are "resource
+  // identifiers for OAuth protected resources", so an entry that is not one
+  // would yield an unusable document
+  if (!std::ranges::all_of(config.protected_resources,
+                           oauth_is_resource_identifier)) {
+    return std::nullopt;
+  }
+
   auto document{JSON::make_object()};
   document.assign_assume_new("issuer", JSON{config.issuer}, HASH_ISSUER);
   document.assign_if_nonempty("authorization_endpoint",
@@ -658,11 +852,117 @@ auto oauth_make_server_metadata(const OAuthServerMetadataConfig &config)
       config.token_endpoint_auth_signing_alg_values_supported);
   document.assign_if_nonempty("scopes_supported", HASH_SCOPES_SUPPORTED,
                               config.scopes_supported);
+  document.assign_if_nonempty("protected_resources", HASH_PROTECTED_RESOURCES,
+                              config.protected_resources);
   // RFC 9126 Section 5: the default is false, so the flag is emitted only when
   // the server requires pushed authorization requests
   if (config.require_pushed_authorization_requests) {
     document.assign_assume_new("require_pushed_authorization_requests",
                                JSON{true}, HASH_REQUIRE_PAR);
+  }
+
+  return document;
+}
+
+auto oauth_make_resource_metadata(const OAuthResourceMetadataConfig &config)
+    -> std::optional<JSON> {
+  // RFC 9728 Section 2: the resource is REQUIRED and must be a valid resource
+  // identifier per Section 1.2
+  if (!oauth_is_resource_identifier(config.resource)) {
+    return std::nullopt;
+  }
+
+  // RFC 9728 Section 2: the authorization servers are "OAuth authorization
+  // server issuer identifiers, as defined in [RFC8414]", so an entry that is
+  // not a valid issuer identifier would yield a document its own parser
+  // rejects
+  if (!std::ranges::all_of(config.authorization_servers,
+                           oauth_is_advertised_issuer)) {
+    return std::nullopt;
+  }
+
+  // RFC 9728 Section 2 on jwks_uri: "This URL MUST use the https scheme"
+  if (!config.jwks_uri.empty() && !oauth_is_endpoint_url(config.jwks_uri)) {
+    return std::nullopt;
+  }
+
+  // RFC 9728 Section 2: "The value none MUST NOT be used" in the resource
+  // signing algorithms
+  if (span_contains(config.resource_signing_alg_values_supported, "none")) {
+    return std::nullopt;
+  }
+
+  // RFC 9449 Section 4.2: a DPoP proof algorithm "MUST NOT be none or an
+  // identifier for a symmetric algorithm (Message Authentication Code (MAC))",
+  // so advertising one describes a proof that cannot exist. The MAC exclusion
+  // covers the registered JWS MAC identifiers, and a later registration would
+  // pass, since the registry is extensible and not modelled here
+  if (span_contains(config.dpop_signing_alg_values_supported, "none") ||
+      span_contains(config.dpop_signing_alg_values_supported, "HS256") ||
+      span_contains(config.dpop_signing_alg_values_supported, "HS384") ||
+      span_contains(config.dpop_signing_alg_values_supported, "HS512")) {
+    return std::nullopt;
+  }
+
+  if ((!config.resource_documentation.empty() &&
+       !oauth_is_page_url(config.resource_documentation)) ||
+      (!config.resource_policy_uri.empty() &&
+       !oauth_is_page_url(config.resource_policy_uri)) ||
+      (!config.resource_tos_uri.empty() &&
+       !oauth_is_page_url(config.resource_tos_uri))) {
+    return std::nullopt;
+  }
+
+  auto document{JSON::make_object()};
+  document.assign_assume_new("resource", JSON{config.resource}, HASH_RESOURCE);
+  document.assign_if_nonempty("authorization_servers",
+                              HASH_AUTHORIZATION_SERVERS,
+                              config.authorization_servers);
+  document.assign_if_nonempty("jwks_uri", HASH_JWKS_URI, config.jwks_uri);
+  document.assign_if_nonempty("scopes_supported", HASH_SCOPES_SUPPORTED,
+                              config.scopes_supported);
+  // RFC 9728 Section 2: "The empty array [] can be used to indicate that no
+  // bearer methods are supported", the one member whose engaged empty state is
+  // emitted despite the Section 3.2 zero-value omission rule, whose general
+  // form the specific text governs over
+  if (config.bearer_methods_supported.has_value()) {
+    auto methods{JSON::make_array()};
+    for (const auto &method : config.bearer_methods_supported.value()) {
+      methods.push_back(JSON{method});
+    }
+
+    document.assign_assume_new("bearer_methods_supported", std::move(methods),
+                               HASH_BEARER_METHODS);
+  }
+
+  document.assign_if_nonempty("resource_signing_alg_values_supported",
+                              HASH_RESOURCE_SIGNING_ALGS,
+                              config.resource_signing_alg_values_supported);
+  document.assign_if_nonempty("resource_name", HASH_RESOURCE_NAME,
+                              config.resource_name);
+  document.assign_if_nonempty("resource_documentation",
+                              HASH_RESOURCE_DOCUMENTATION,
+                              config.resource_documentation);
+  document.assign_if_nonempty("resource_policy_uri", HASH_RESOURCE_POLICY_URI,
+                              config.resource_policy_uri);
+  document.assign_if_nonempty("resource_tos_uri", HASH_RESOURCE_TOS_URI,
+                              config.resource_tos_uri);
+  // RFC 9728 Section 2: both boolean defaults are false when absent, so each
+  // flag is emitted only when true
+  if (config.tls_client_certificate_bound_access_tokens) {
+    document.assign_assume_new("tls_client_certificate_bound_access_tokens",
+                               JSON{true}, HASH_TLS_CLIENT_CERTIFICATE_BOUND);
+  }
+
+  document.assign_if_nonempty("authorization_details_types_supported",
+                              HASH_AUTHORIZATION_DETAILS_TYPES,
+                              config.authorization_details_types_supported);
+  document.assign_if_nonempty("dpop_signing_alg_values_supported",
+                              HASH_DPOP_SIGNING_ALGS,
+                              config.dpop_signing_alg_values_supported);
+  if (config.dpop_bound_access_tokens_required) {
+    document.assign_assume_new("dpop_bound_access_tokens_required", JSON{true},
+                               HASH_DPOP_BOUND_REQUIRED);
   }
 
   return document;

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -267,9 +267,10 @@ auto validated_resource_metadata(JSON &&data, const std::string_view resource)
   // the client starts its next discovery request, so an entry that is not a
   // valid issuer identifier is rejected rather than handed onwards. RFC 8414
   // Section 2 requires the https scheme, a host, and no query or fragment,
-  // while leaving the scheme case-insensitive for an advertised value. Section
-  // 3.2: "Parameters with zero values MUST be omitted from the response", so a
-  // present but empty array is a malformed document
+  // and the scheme of a received value stays case-insensitive per RFC 3986
+  // Section 3.1 since an advertised issuer is matched against nothing at parse
+  // time. Section 3.2: "Parameters with zero values MUST be omitted from the
+  // response", so a present but empty array is a malformed document
   const auto *authorization_servers{
       data.try_at("authorization_servers"sv, HASH_AUTHORIZATION_SERVERS)};
   if (authorization_servers != nullptr) {
@@ -356,15 +357,13 @@ auto oauth_is_resource_identifier(const std::string_view value) -> bool {
          !uri->host().value().empty() && !uri->fragment().has_value();
 }
 
-// An issuer identifier a document advertises for someone else, rather than the
-// one the document was retrieved for. RFC 8414 Section 2 gives it the same
-// shape, but Section 4 scopes code-point comparison to "comparing values in the
-// messages to known values", and an advertised issuer is matched against
-// nothing at parse time. Its validity therefore follows RFC 3986 Section 3.1,
-// which makes the scheme case-insensitive
-auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
+// RFC 8414 Section 2: an issuer is an https URL with a non-empty host (RFC 3986
+// Section 3.2) and no query or fragment, its scheme matched by code points to
+// reject a non-canonical case
+auto oauth_is_issuer_identifier(const std::string_view value) -> bool {
   const auto uri{oauth_try_parse_uri(value)};
-  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
+  return uri.has_value() && uri->scheme().has_value() &&
+         uri->scheme().value() == "https" && uri->host().has_value() &&
          !uri->host().value().empty() && !uri->query().has_value() &&
          !uri->fragment().has_value();
 }
@@ -873,11 +872,14 @@ auto oauth_make_resource_metadata(const OAuthResourceMetadataConfig &config)
   }
 
   // RFC 9728 Section 2: the authorization servers are "OAuth authorization
-  // server issuer identifiers, as defined in [RFC8414]", so an entry that is
-  // not a valid issuer identifier would yield a document its own parser
-  // rejects
+  // server issuer identifiers, as defined in [RFC8414]". A client resolves an
+  // entry by inserting the well-known string into it (RFC 8414 Section 3) and
+  // then requires the metadata issuer to be "identical" to it by code points
+  // (RFC 8414 Sections 3.3 and 4), so only an entry in the exact issuer
+  // identifier form can ever complete discovery, and emitting any other form
+  // would advertise a dead end
   if (!std::ranges::all_of(config.authorization_servers,
-                           oauth_is_advertised_issuer)) {
+                           oauth_is_issuer_identifier)) {
     return std::nullopt;
   }
 

--- a/src/core/oauth/oauth_metadata.cc
+++ b/src/core/oauth/oauth_metadata.cc
@@ -229,9 +229,21 @@ auto validated_server_metadata(JSON &&data, const std::string_view issuer)
 
   // RFC 9728 Section 4: the protected resources are "resource identifiers for
   // OAuth protected resources that can be used with this authorization
-  // server", and RFC 8414 Section 3.2 forbids a zero-element array
+  // server", the Section 1.2 form, so an entry that is not one is rejected
+  // like an invalid advertised issuer, with the scheme case-insensitive for a
+  // received value per RFC 3986 Section 3.1. RFC 8414 Section 3.2 forbids a
+  // zero-element array
   validate_string_array(data, "protected_resources"sv, HASH_PROTECTED_RESOURCES,
                         false);
+  const auto *protected_resources{
+      data.try_at("protected_resources"sv, HASH_PROTECTED_RESOURCES)};
+  if (protected_resources != nullptr) {
+    for (const auto &element : protected_resources->as_array()) {
+      if (!oauth_is_advertised_resource(element.to_string())) {
+        throw OAuthMetadataParseError{};
+      }
+    }
+  }
 
   return std::move(data);
 }

--- a/src/core/oauth/oauth_syntax.h
+++ b/src/core/oauth/oauth_syntax.h
@@ -39,6 +39,15 @@ inline auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
          !uri->fragment().has_value();
 }
 
+// A resource identifier a document advertises for someone else, given the same
+// case-insensitive scheme treatment as an advertised issuer, with a query
+// tolerated per RFC 9728 Section 1.2 and RFC 8707 Section 2
+inline auto oauth_is_advertised_resource(const std::string_view value) -> bool {
+  const auto uri{oauth_try_parse_uri(value)};
+  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
+         !uri->host().value().empty() && !uri->fragment().has_value();
+}
+
 // RFC 3986 Section 2.3: "unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"",
 // the character set RFC 7636 reuses for the PKCE verifier and challenge
 inline auto oauth_is_unreserved(const char character) noexcept -> bool {

--- a/src/core/oauth/oauth_syntax.h
+++ b/src/core/oauth/oauth_syntax.h
@@ -37,28 +37,6 @@ inline auto oauth_is_issuer_identifier(const std::string_view value) -> bool {
          !uri->fragment().has_value();
 }
 
-// RFC 9728 Section 1.2 and RFC 8707 Section 2: a resource is an https URL with
-// a non-empty host and no fragment, a query tolerated unlike an issuer
-inline auto oauth_is_resource_identifier(const std::string_view value) -> bool {
-  const auto uri{oauth_try_parse_uri(value)};
-  return uri.has_value() && uri->scheme().has_value() &&
-         uri->scheme().value() == "https" && uri->host().has_value() &&
-         !uri->host().value().empty() && !uri->fragment().has_value();
-}
-
-// An issuer identifier a document advertises for someone else, rather than the
-// one the document was retrieved for. RFC 8414 Section 2 gives it the same
-// shape, but Section 4 scopes code-point comparison to "comparing values in the
-// messages to known values", and an advertised issuer is matched against
-// nothing at parse time. Its validity therefore follows RFC 3986 Section 3.1,
-// which makes the scheme case-insensitive
-inline auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
-  const auto uri{oauth_try_parse_uri(value)};
-  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
-         !uri->host().value().empty() && !uri->query().has_value() &&
-         !uri->fragment().has_value();
-}
-
 // RFC 3986 Section 2.3: "unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"",
 // the character set RFC 7636 reuses for the PKCE verifier and challenge
 inline auto oauth_is_unreserved(const char character) noexcept -> bool {

--- a/src/core/oauth/oauth_syntax.h
+++ b/src/core/oauth/oauth_syntax.h
@@ -26,13 +26,15 @@ inline auto oauth_try_parse_uri(const std::string_view value)
   }
 }
 
-// RFC 8414 Section 2: an issuer is an https URL with a non-empty host (RFC 3986
-// Section 3.2) and no query or fragment, its scheme matched by code points to
-// reject a non-canonical case
-inline auto oauth_is_issuer_identifier(const std::string_view value) -> bool {
+// An issuer identifier a document advertises for someone else, rather than the
+// one the document was retrieved for. RFC 8414 Section 2 gives it the same
+// shape, but Section 4 scopes code-point comparison to "comparing values in the
+// messages to known values", and an advertised issuer is matched against
+// nothing at parse time. Its validity therefore follows RFC 3986 Section 3.1,
+// which makes the scheme case-insensitive
+inline auto oauth_is_advertised_issuer(const std::string_view value) -> bool {
   const auto uri{oauth_try_parse_uri(value)};
-  return uri.has_value() && uri->scheme().has_value() &&
-         uri->scheme().value() == "https" && uri->host().has_value() &&
+  return uri.has_value() && uri->is_https() && uri->host().has_value() &&
          !uri->host().value().empty() && !uri->query().has_value() &&
          !uri->fragment().has_value();
 }

--- a/test/oauth/CMakeLists.txt
+++ b/test/oauth/CMakeLists.txt
@@ -2,7 +2,8 @@ sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME oauth
   SOURCES oauth_error_test.cc oauth_pkce_test.cc oauth_bearer_test.cc
     oauth_random_test.cc oauth_authorization_test.cc oauth_token_test.cc
     oauth_client_authentication_test.cc oauth_transaction_test.cc
-    oauth_metadata_test.cc oauth_metadata_provider_test.cc
+    oauth_metadata_test.cc oauth_resource_metadata_test.cc
+    oauth_metadata_provider_test.cc
     oauth_conformance_test.cc oauth_token_exchange_test.cc
     oauth_revocation_test.cc oauth_introspection_test.cc oauth_device_test.cc
     oauth_dpop_test.cc oauth_par_test.cc oauth_assertion_test.cc

--- a/test/oauth/oauth_iana_test.cc
+++ b/test/oauth/oauth_iana_test.cc
@@ -241,7 +241,7 @@ auto main(int argc, char **argv) -> int {
   register_all("OAuth_IANA_ServerMetadata", server_metadata_names,
                server_metadata);
 
-  // OAuth Protected Resource Metadata (RFC 9728 Section 6.1)
+  // OAuth Protected Resource Metadata (RFC 9728 Section 8.1)
   const auto resource_metadata{
       load_registry(base / "protected-resource-metadata.csv")};
   const std::array<std::string_view, 14> resource_metadata_names{

--- a/test/oauth/oauth_iana_test.cc
+++ b/test/oauth/oauth_iana_test.cc
@@ -227,7 +227,7 @@ auto main(int argc, char **argv) -> int {
   // OAuth Authorization Server Metadata (RFC 8414 Section 7.1)
   const auto server_metadata{
       load_registry(base / "authorization-server-metadata.csv")};
-  const std::array<std::string_view, 16> server_metadata_names{
+  const std::array<std::string_view, 17> server_metadata_names{
       {"issuer", "authorization_endpoint", "token_endpoint",
        "registration_endpoint", "jwks_uri", "response_types_supported",
        "grant_types_supported", "code_challenge_methods_supported",
@@ -236,17 +236,22 @@ auto main(int argc, char **argv) -> int {
        "revocation_endpoint", "introspection_endpoint",
        "pushed_authorization_request_endpoint",
        "require_pushed_authorization_requests",
-       "authorization_response_iss_parameter_supported"}};
+       "authorization_response_iss_parameter_supported",
+       "protected_resources"}};
   register_all("OAuth_IANA_ServerMetadata", server_metadata_names,
                server_metadata);
 
   // OAuth Protected Resource Metadata (RFC 9728 Section 6.1)
   const auto resource_metadata{
       load_registry(base / "protected-resource-metadata.csv")};
-  const std::array<std::string_view, 7> resource_metadata_names{
+  const std::array<std::string_view, 14> resource_metadata_names{
       {"resource", "authorization_servers", "jwks_uri",
        "bearer_methods_supported", "resource_signing_alg_values_supported",
-       "scopes_supported", "dpop_bound_access_tokens_required"}};
+       "scopes_supported", "dpop_bound_access_tokens_required", "resource_name",
+       "resource_documentation", "resource_policy_uri", "resource_tos_uri",
+       "tls_client_certificate_bound_access_tokens",
+       "authorization_details_types_supported",
+       "dpop_signing_alg_values_supported"}};
   register_all("OAuth_IANA_ResourceMetadata", resource_metadata_names,
                resource_metadata);
 

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -128,11 +128,35 @@ TEST(server_metadata_parses_a_valid_document) {
   EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
   EXPECT_EQ(metadata.value().authorization_endpoint().value(),
             "https://example.com/authorize");
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "https://example.com/token");
+  EXPECT_TRUE(metadata.value().registration_endpoint().has_value());
   EXPECT_EQ(metadata.value().registration_endpoint().value(),
             "https://example.com/register");
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
   EXPECT_EQ(metadata.value().jwks_uri().value(), "https://example.com/jwks");
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_rejects_an_issuer_mismatch) {
@@ -201,6 +225,34 @@ TEST(server_metadata_accepts_signing_algs_for_private_key_jwt) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_TRUE(
+      metadata.value().supports_token_endpoint_auth_method("private_key_jwt"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_rejects_none_in_signing_algs) {
@@ -225,8 +277,32 @@ TEST(server_metadata_iss_parameter_supported_defaults_to_false) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
   EXPECT_FALSE(
       metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_iss_parameter_supported_reads_true) {
@@ -240,8 +316,32 @@ TEST(server_metadata_iss_parameter_supported_reads_true) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
   EXPECT_TRUE(
       metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_grant_types_default) {
@@ -249,11 +349,37 @@ TEST(server_metadata_grant_types_default) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
   EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
-  EXPECT_FALSE(metadata.value().supports_grant_type("refresh_token"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_grant_types_explicit) {
@@ -262,11 +388,38 @@ TEST(server_metadata_grant_types_explicit) {
     "response_types_supported": [ "code" ],
     "grant_types_supported": [ "authorization_code", "refresh_token" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
-  EXPECT_TRUE(metadata.value().supports_grant_type("refresh_token"));
   EXPECT_FALSE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("refresh_token"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_code_challenge_methods_absent_is_unsupported) {
@@ -274,9 +427,37 @@ TEST(server_metadata_code_challenge_methods_absent_is_unsupported) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
   EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_code_challenge_methods_present) {
@@ -285,10 +466,37 @@ TEST(server_metadata_code_challenge_methods_present) {
     "response_types_supported": [ "code" ],
     "code_challenge_methods_supported": [ "S256" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_code_challenge_method("S256"));
   EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_token_auth_method_default) {
@@ -296,12 +504,37 @@ TEST(server_metadata_token_auth_method_default) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
   EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
       "client_secret_basic"));
-  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
-      "client_secret_post"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_token_auth_method_explicit) {
@@ -311,13 +544,40 @@ TEST(server_metadata_token_auth_method_explicit) {
     "token_endpoint_auth_methods_supported":
       [ "client_secret_post", "none" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
   EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
       "client_secret_post"));
   EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method("none"));
-  EXPECT_FALSE(metadata.value().supports_token_endpoint_auth_method(
-      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_supports_response_type) {
@@ -325,11 +585,38 @@ TEST(server_metadata_supports_response_type) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code", "token" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
   EXPECT_TRUE(metadata.value().supports_response_type("code"));
   EXPECT_TRUE(metadata.value().supports_response_type("token"));
-  EXPECT_FALSE(metadata.value().supports_response_type("id_token"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_absent_endpoints_are_empty) {
@@ -337,14 +624,37 @@ TEST(server_metadata_absent_endpoints_are_empty) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
   EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
   EXPECT_FALSE(metadata.value().token_endpoint().has_value());
   EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
   EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
   EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
   EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_passthrough) {
@@ -353,8 +663,37 @@ TEST(server_metadata_passthrough) {
     "response_types_supported": [ "code" ],
     "service_documentation": "https://example.com/docs"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
   const auto *documentation{
       metadata.value().data().try_at("service_documentation")};
   EXPECT_TRUE(documentation != nullptr);
@@ -397,6 +736,31 @@ TEST(server_metadata_accepts_an_issuer_with_a_path) {
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().issuer(), "https://example.com/tenant");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_accepts_an_issuer_with_a_trailing_slash) {
@@ -409,6 +773,32 @@ TEST(server_metadata_accepts_an_issuer_with_a_trailing_slash) {
       std::move(document), "https://example.com/")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com/");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_rejects_an_empty_issuer) {
@@ -432,8 +822,32 @@ TEST(server_metadata_grant_types_wrong_type_falls_back_to_default) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
   EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_iss_parameter_supported_wrong_type_is_false) {
@@ -447,8 +861,32 @@ TEST(server_metadata_iss_parameter_supported_wrong_type_is_false) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
   EXPECT_FALSE(
       metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_non_string_response_type_elements_do_not_match) {
@@ -461,7 +899,31 @@ TEST(server_metadata_non_string_response_type_elements_do_not_match) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
-  EXPECT_FALSE(metadata.value().supports_response_type("code"));
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(well_known_url_authorization_server_with_a_port) {
@@ -582,6 +1044,34 @@ TEST(server_metadata_accepts_an_https_device_authorization_endpoint) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_EQ(metadata.value().device_authorization_endpoint().value(),
+            "https://example.com/device");
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
   EXPECT_EQ(
       metadata.value().data().at("device_authorization_endpoint").to_string(),
       "https://example.com/device");
@@ -652,21 +1142,45 @@ TEST(server_metadata_accepts_every_https_endpoint) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
   EXPECT_EQ(metadata.value().authorization_endpoint().value(),
             "https://example.com/authorize");
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "https://example.com/token");
+  EXPECT_TRUE(metadata.value().registration_endpoint().has_value());
   EXPECT_EQ(metadata.value().registration_endpoint().value(),
             "https://example.com/register");
-  EXPECT_EQ(metadata.value().pushed_authorization_request_endpoint().value(),
-            "https://example.com/par");
-  EXPECT_EQ(metadata.value().device_authorization_endpoint().has_value(),
-            false);
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().revocation_endpoint().has_value());
   EXPECT_EQ(metadata.value().revocation_endpoint().value(),
             "https://example.com/revoke");
+  EXPECT_TRUE(metadata.value().introspection_endpoint().has_value());
   EXPECT_EQ(metadata.value().introspection_endpoint().value(),
             "https://example.com/introspect");
+  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
   EXPECT_EQ(metadata.value().jwks_uri().value(), "https://example.com/jwks");
+  EXPECT_TRUE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_EQ(metadata.value().pushed_authorization_request_endpoint().value(),
+            "https://example.com/par");
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_rejects_a_token_endpoint_with_a_fragment) {
@@ -704,8 +1218,34 @@ TEST(server_metadata_accepts_a_token_endpoint_with_a_query) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "https://example.com/token?tenant=1");
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_accepts_a_token_endpoint_with_a_port) {
@@ -719,8 +1259,34 @@ TEST(server_metadata_accepts_a_token_endpoint_with_a_port) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "https://example.com:8443/token");
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_accepts_an_uppercase_endpoint_scheme) {
@@ -737,8 +1303,34 @@ TEST(server_metadata_accepts_an_uppercase_endpoint_scheme) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "HTTPS://example.com/token");
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_accepts_a_mixed_case_endpoint_scheme) {
@@ -752,6 +1344,34 @@ TEST(server_metadata_accepts_a_mixed_case_endpoint_scheme) {
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "HtTpS://example.com/token");
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_rejects_a_non_string_token_endpoint) {
@@ -915,10 +1535,29 @@ TEST(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
-  EXPECT_FALSE(metadata.value().supports_authorization_server(
-      "https://auth.example.com"));
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "HTTPS://auth.example.com");
   EXPECT_TRUE(metadata.value().supports_authorization_server(
       "HTTPS://auth.example.com"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(server_metadata_rejects_an_empty_host) {
@@ -1108,11 +1747,39 @@ TEST(server_metadata_reads_the_par_members) {
     "pushed_authorization_request_endpoint": "https://example.com/par",
     "require_pushed_authorization_requests": true
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_TRUE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
   EXPECT_EQ(metadata.value().pushed_authorization_request_endpoint().value(),
             "https://example.com/par");
   EXPECT_TRUE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_require_par_defaults_to_false) {
@@ -1120,11 +1787,37 @@ TEST(server_metadata_require_par_defaults_to_false) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
   EXPECT_FALSE(
       metadata.value().pushed_authorization_request_endpoint().has_value());
   EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_require_par_wrong_type_is_false) {
@@ -1133,9 +1826,37 @@ TEST(server_metadata_require_par_wrong_type_is_false) {
     "response_types_supported": [ "code" ],
     "require_pushed_authorization_requests": "true"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://example.com");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
   EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(make_server_metadata_par_round_trips) {
@@ -1154,9 +1875,38 @@ TEST(make_server_metadata_par_round_trips) {
       std::move(document.value()), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example");
+  EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://server.example/authorize");
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://server.example/token");
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_TRUE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
   EXPECT_EQ(metadata.value().pushed_authorization_request_endpoint().value(),
             "https://server.example/par");
   EXPECT_TRUE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(make_server_metadata_rejects_jwt_auth_without_signing_algs) {
@@ -1492,6 +2242,43 @@ TEST(server_metadata_parses_the_rfc8414_example) {
       std::move(document), "https://server.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example.com");
+  EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://server.example.com/authorize");
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://server.example.com/token");
+  EXPECT_TRUE(metadata.value().registration_endpoint().has_value());
+  EXPECT_EQ(metadata.value().registration_endpoint().value(),
+            "https://server.example.com/register");
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
+  EXPECT_EQ(metadata.value().jwks_uri().value(),
+            "https://server.example.com/jwks.json");
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_TRUE(metadata.value().supports_response_type("code token"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_TRUE(
+      metadata.value().supports_token_endpoint_auth_method("private_key_jwt"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(make_server_metadata_emits_protected_resources) {
@@ -1600,10 +2387,38 @@ TEST(make_server_metadata_protected_resources_round_trips) {
       std::move(document.value()), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example");
+  EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://server.example/authorize");
+  EXPECT_TRUE(metadata.value().token_endpoint().has_value());
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://server.example/token");
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
   EXPECT_TRUE(
       metadata.value().supports_protected_resource("https://api.example.com"));
   EXPECT_FALSE(metadata.value().supports_protected_resource(
-      "https://other.example.com"));
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_supports_protected_resource) {
@@ -1617,10 +2432,34 @@ TEST(server_metadata_supports_protected_resource) {
       std::move(document), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
   EXPECT_TRUE(
       metadata.value().supports_protected_resource("https://api.example.com"));
   EXPECT_FALSE(metadata.value().supports_protected_resource(
-      "https://other.example.com"));
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_protected_resource_absent_is_false) {
@@ -1633,8 +2472,32 @@ TEST(server_metadata_protected_resource_absent_is_false) {
       std::move(document), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
   EXPECT_FALSE(
-      metadata.value().supports_protected_resource("https://api.example.com"));
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
 }
 
 TEST(server_metadata_rejects_an_empty_protected_resources_array) {

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -119,9 +119,11 @@ TEST(server_metadata_parses_a_valid_document) {
     "registration_endpoint": "https://example.com/register",
     "jwks_uri": "https://example.com/jwks"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().issuer(), "https://example.com");
   EXPECT_TRUE(metadata.value().authorization_endpoint().has_value());
   EXPECT_EQ(metadata.value().authorization_endpoint().value(),
@@ -194,9 +196,11 @@ TEST(server_metadata_accepts_signing_algs_for_private_key_jwt) {
     "token_endpoint_auth_methods_supported": [ "private_key_jwt" ],
     "token_endpoint_auth_signing_alg_values_supported": [ "RS256" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
 }
 
 TEST(server_metadata_rejects_none_in_signing_algs) {
@@ -216,9 +220,11 @@ TEST(server_metadata_iss_parameter_supported_defaults_to_false) {
     "issuer": "https://example.com",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(
       metadata.value().authorization_response_iss_parameter_supported());
 }
@@ -229,9 +235,11 @@ TEST(server_metadata_iss_parameter_supported_reads_true) {
     "response_types_supported": [ "code" ],
     "authorization_response_iss_parameter_supported": true
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(
       metadata.value().authorization_response_iss_parameter_supported());
 }
@@ -383,9 +391,11 @@ TEST(server_metadata_accepts_an_issuer_with_a_path) {
     "issuer": "https://example.com/tenant",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com/tenant")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().issuer(), "https://example.com/tenant");
 }
 
@@ -394,9 +404,11 @@ TEST(server_metadata_accepts_an_issuer_with_a_trailing_slash) {
     "issuer": "https://example.com/",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com/")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
 }
 
 TEST(server_metadata_rejects_an_empty_issuer) {
@@ -415,9 +427,11 @@ TEST(server_metadata_grant_types_wrong_type_falls_back_to_default) {
     "response_types_supported": [ "code" ],
     "grant_types_supported": "authorization_code"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
   EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
 }
@@ -428,9 +442,11 @@ TEST(server_metadata_iss_parameter_supported_wrong_type_is_false) {
     "response_types_supported": [ "code" ],
     "authorization_response_iss_parameter_supported": "true"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(
       metadata.value().authorization_response_iss_parameter_supported());
 }
@@ -440,9 +456,11 @@ TEST(server_metadata_non_string_response_type_elements_do_not_match) {
     "issuer": "https://example.com",
     "response_types_supported": [ 123 ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_response_type("code"));
 }
 
@@ -559,9 +577,11 @@ TEST(server_metadata_accepts_an_https_device_authorization_endpoint) {
     "response_types_supported": [ "code" ],
     "device_authorization_endpoint": "https://example.com/device"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(
       metadata.value().data().at("device_authorization_endpoint").to_string(),
       "https://example.com/device");
@@ -627,9 +647,11 @@ TEST(server_metadata_accepts_every_https_endpoint) {
     "introspection_endpoint": "https://example.com/introspect",
     "jwks_uri": "https://example.com/jwks"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().authorization_endpoint().value(),
             "https://example.com/authorize");
   EXPECT_EQ(metadata.value().token_endpoint().value(),
@@ -677,9 +699,11 @@ TEST(server_metadata_accepts_a_token_endpoint_with_a_query) {
     "response_types_supported": [ "code" ],
     "token_endpoint": "https://example.com/token?tenant=1"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "https://example.com/token?tenant=1");
 }
@@ -690,9 +714,11 @@ TEST(server_metadata_accepts_a_token_endpoint_with_a_port) {
     "response_types_supported": [ "code" ],
     "token_endpoint": "https://example.com:8443/token"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "https://example.com:8443/token");
 }
@@ -706,9 +732,11 @@ TEST(server_metadata_accepts_an_uppercase_endpoint_scheme) {
     "response_types_supported": [ "code" ],
     "token_endpoint": "HTTPS://example.com/token"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().token_endpoint().value(),
             "HTTPS://example.com/token");
 }
@@ -719,9 +747,11 @@ TEST(server_metadata_accepts_a_mixed_case_endpoint_scheme) {
     "response_types_supported": [ "code" ],
     "token_endpoint": "HtTpS://example.com/token"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
 }
 
 TEST(server_metadata_rejects_a_non_string_token_endpoint) {
@@ -880,9 +910,11 @@ TEST(
     "resource": "https://api.example.com",
     "authorization_servers": [ "HTTPS://auth.example.com" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_authorization_server(
       "https://auth.example.com"));
   EXPECT_TRUE(metadata.value().supports_authorization_server(
@@ -934,11 +966,13 @@ TEST(make_server_metadata_emits_the_required_members) {
   config.response_types_supported = response_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_EQ(document.value().at("issuer").to_string(),
-            "https://server.example");
-  EXPECT_EQ(document.value().at("response_types_supported").size(), 1);
-  EXPECT_EQ(document.value().at("response_types_supported").at(0).to_string(),
-            "code");
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_emits_endpoints_and_arrays) {
@@ -955,14 +989,15 @@ TEST(make_server_metadata_emits_endpoints_and_arrays) {
   config.code_challenge_methods_supported = challenge_methods;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_EQ(document.value().at("authorization_endpoint").to_string(),
-            "https://server.example/authorize");
-  EXPECT_EQ(document.value().at("token_endpoint").to_string(),
-            "https://server.example/token");
-  EXPECT_EQ(document.value().at("grant_types_supported").size(), 2);
-  EXPECT_EQ(
-      document.value().at("code_challenge_methods_supported").at(0).to_string(),
-      "S256");
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ],
+    "grant_types_supported": [ "authorization_code", "refresh_token" ],
+    "code_challenge_methods_supported": [ "S256" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_rejects_an_invalid_issuer) {
@@ -990,14 +1025,13 @@ TEST(make_server_metadata_omits_absent_members) {
   config.response_types_supported = response_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_FALSE(document.value().defines("registration_endpoint"));
-  EXPECT_FALSE(document.value().defines("jwks_uri"));
-  EXPECT_FALSE(document.value().defines("scopes_supported"));
-  EXPECT_FALSE(document.value().defines("grant_types_supported"));
-  EXPECT_FALSE(
-      document.value().defines("pushed_authorization_request_endpoint"));
-  EXPECT_FALSE(
-      document.value().defines("require_pushed_authorization_requests"));
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_emits_the_par_members) {
@@ -1011,12 +1045,15 @@ TEST(make_server_metadata_emits_the_par_members) {
   config.response_types_supported = response_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_EQ(
-      document.value().at("pushed_authorization_request_endpoint").to_string(),
-      "https://server.example/par");
-  EXPECT_TRUE(document.value()
-                  .at("require_pushed_authorization_requests")
-                  .to_boolean());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "pushed_authorization_request_endpoint": "https://server.example/par",
+    "response_types_supported": [ "code" ],
+    "require_pushed_authorization_requests": true
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_omits_require_par_when_false) {
@@ -1030,10 +1067,14 @@ TEST(make_server_metadata_omits_require_par_when_false) {
   config.response_types_supported = response_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_TRUE(
-      document.value().defines("pushed_authorization_request_endpoint"));
-  EXPECT_FALSE(
-      document.value().defines("require_pushed_authorization_requests"));
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "pushed_authorization_request_endpoint": "https://server.example/par",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_rejects_a_non_https_par_endpoint) {
@@ -1108,9 +1149,11 @@ TEST(make_server_metadata_par_round_trips) {
   config.response_types_supported = response_types;
   auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
+  const auto expected{document.value()};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document.value()), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().pushed_authorization_request_endpoint().value(),
             "https://server.example/par");
   EXPECT_TRUE(metadata.value().require_pushed_authorization_requests());
@@ -1142,11 +1185,15 @@ TEST(make_server_metadata_accepts_jwt_auth_with_signing_algs) {
   config.token_endpoint_auth_signing_alg_values_supported = algs;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_EQ(document.value()
-                .at("token_endpoint_auth_signing_alg_values_supported")
-                .at(0)
-                .to_string(),
-            "RS256");
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ],
+    "token_endpoint_auth_methods_supported": [ "private_key_jwt" ],
+    "token_endpoint_auth_signing_alg_values_supported": [ "RS256" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_rejects_jwt_auth_with_a_none_alg) {
@@ -1203,7 +1250,13 @@ TEST(make_server_metadata_allows_a_missing_token_endpoint_for_implicit_only) {
   config.grant_types_supported = grant_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_FALSE(document.value().defines("token_endpoint"));
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "response_types_supported": [ "token" ],
+    "grant_types_supported": [ "implicit" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(
@@ -1217,9 +1270,13 @@ TEST(
   config.grant_types_supported = grant_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_FALSE(document.value().defines("authorization_endpoint"));
-  EXPECT_EQ(document.value().at("token_endpoint").to_string(),
-            "https://server.example/token");
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ],
+    "grant_types_supported": [ "client_credentials" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_requires_response_types_even_for_client_credentials) {
@@ -1372,44 +1429,44 @@ TEST(is_resource_identifier_rejects_a_relative_reference) {
   EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier(""));
 }
 
-TEST(is_advertised_issuer_accepts_an_https_url) {
+TEST(is_issuer_identifier_accepts_an_https_url) {
   EXPECT_TRUE(
-      sourcemeta::core::oauth_is_advertised_issuer("https://auth.example.com"));
+      sourcemeta::core::oauth_is_issuer_identifier("https://auth.example.com"));
 }
 
-TEST(is_advertised_issuer_accepts_a_path) {
-  EXPECT_TRUE(sourcemeta::core::oauth_is_advertised_issuer(
+TEST(is_issuer_identifier_accepts_a_path) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_issuer_identifier(
       "https://auth.example.com/tenant"));
 }
 
-TEST(is_advertised_issuer_accepts_an_uppercase_scheme) {
-  EXPECT_TRUE(
-      sourcemeta::core::oauth_is_advertised_issuer("HTTPS://auth.example.com"));
+TEST(is_issuer_identifier_rejects_an_uppercase_scheme) {
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_is_issuer_identifier("HTTPS://auth.example.com"));
 }
 
-TEST(is_advertised_issuer_rejects_a_query) {
-  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer(
+TEST(is_issuer_identifier_rejects_a_query) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_issuer_identifier(
       "https://auth.example.com/?tenant=1"));
 }
 
-TEST(is_advertised_issuer_rejects_a_fragment) {
-  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer(
+TEST(is_issuer_identifier_rejects_a_fragment) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_issuer_identifier(
       "https://auth.example.com#main"));
 }
 
-TEST(is_advertised_issuer_rejects_a_cleartext_url) {
+TEST(is_issuer_identifier_rejects_a_cleartext_url) {
   EXPECT_FALSE(
-      sourcemeta::core::oauth_is_advertised_issuer("http://auth.example.com"));
+      sourcemeta::core::oauth_is_issuer_identifier("http://auth.example.com"));
 }
 
-TEST(is_advertised_issuer_rejects_a_missing_host) {
-  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer("https://"));
-  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer("https://:443"));
+TEST(is_issuer_identifier_rejects_a_missing_host) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_issuer_identifier("https://"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_issuer_identifier("https://:443"));
 }
 
-TEST(is_advertised_issuer_rejects_a_relative_reference) {
-  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer("/issuer"));
-  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer(""));
+TEST(is_issuer_identifier_rejects_a_relative_reference) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_issuer_identifier("/issuer"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_issuer_identifier(""));
 }
 
 TEST(server_metadata_parses_the_rfc8414_example) {
@@ -1430,29 +1487,11 @@ TEST(server_metadata_parses_the_rfc8414_example) {
       "http://server.example.com/service_documentation.html",
     "ui_locales_supported": ["en-US", "en-GB", "en-CA", "fr-FR", "fr-CA"]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://server.example.com")};
   EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().issuer(), "https://server.example.com");
-  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
-            "https://server.example.com/authorize");
-  EXPECT_EQ(metadata.value().token_endpoint().value(),
-            "https://server.example.com/token");
-  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
-      "client_secret_basic"));
-  EXPECT_TRUE(
-      metadata.value().supports_token_endpoint_auth_method("private_key_jwt"));
-  EXPECT_EQ(metadata.value().jwks_uri().value(),
-            "https://server.example.com/jwks.json");
-  EXPECT_EQ(metadata.value().registration_endpoint().value(),
-            "https://server.example.com/register");
-  EXPECT_TRUE(metadata.value().supports_response_type("code"));
-  EXPECT_TRUE(metadata.value().supports_response_type("code token"));
-  EXPECT_EQ(metadata.value().data().at("userinfo_endpoint").to_string(),
-            "https://server.example.com/userinfo");
-  EXPECT_EQ(metadata.value().data().at("service_documentation").to_string(),
-            "http://server.example.com/service_documentation.html");
-  EXPECT_EQ(metadata.value().data().at("ui_locales_supported").size(), 5);
+  EXPECT_EQ(metadata.value().data(), expected);
 }
 
 TEST(make_server_metadata_emits_protected_resources) {
@@ -1467,11 +1506,15 @@ TEST(make_server_metadata_emits_protected_resources) {
   config.protected_resources = resources;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_EQ(document.value().at("protected_resources").size(), 2);
-  EXPECT_EQ(document.value().at("protected_resources").at(0).to_string(),
-            "https://api.example.com");
-  EXPECT_EQ(document.value().at("protected_resources").at(1).to_string(),
-            "https://reports.example.com/v1");
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ],
+    "protected_resources":
+      [ "https://api.example.com", "https://reports.example.com/v1" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_omits_empty_protected_resources) {
@@ -1483,7 +1526,13 @@ TEST(make_server_metadata_omits_empty_protected_resources) {
   config.response_types_supported = response_types;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_FALSE(document.value().defines("protected_resources"));
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_rejects_a_cleartext_protected_resource) {
@@ -1525,8 +1574,14 @@ TEST(make_server_metadata_accepts_a_protected_resource_with_a_query) {
   config.protected_resources = resources;
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
-  EXPECT_EQ(document.value().at("protected_resources").at(0).to_string(),
-            "https://api.example.com/mcp?tenant=1");
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "authorization_endpoint": "https://server.example/authorize",
+    "token_endpoint": "https://server.example/token",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "https://api.example.com/mcp?tenant=1" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }
 
 TEST(make_server_metadata_protected_resources_round_trips) {
@@ -1540,9 +1595,11 @@ TEST(make_server_metadata_protected_resources_round_trips) {
   config.protected_resources = resources;
   auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_TRUE(document.has_value());
+  const auto expected{document.value()};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document.value()), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(
       metadata.value().supports_protected_resource("https://api.example.com"));
   EXPECT_FALSE(metadata.value().supports_protected_resource(
@@ -1555,9 +1612,11 @@ TEST(server_metadata_supports_protected_resource) {
     "response_types_supported": [ "code" ],
     "protected_resources": [ "https://api.example.com" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(
       metadata.value().supports_protected_resource("https://api.example.com"));
   EXPECT_FALSE(metadata.value().supports_protected_resource(
@@ -1569,9 +1628,11 @@ TEST(server_metadata_protected_resource_absent_is_false) {
     "issuer": "https://server.example",
     "response_types_supported": [ "code" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://server.example")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(
       metadata.value().supports_protected_resource("https://api.example.com"));
 }
@@ -1607,4 +1668,17 @@ TEST(server_metadata_rejects_a_non_string_protected_resource_element) {
   const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
       std::move(document), "https://server.example")};
   EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(make_server_metadata_rejects_an_uppercase_protected_resource_scheme) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 1> resources{{"HTTPS://api.example.com"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  config.protected_resources = resources;
+  const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_FALSE(document.has_value());
 }

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -2545,3 +2545,119 @@ TEST(make_server_metadata_rejects_an_uppercase_protected_resource_scheme) {
   const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
   EXPECT_FALSE(document.has_value());
 }
+
+TEST(server_metadata_rejects_a_cleartext_protected_resource_entry) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "http://api.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_protected_resource_entry_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "https://api.example.com#section" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_trailing_invalid_protected_resource_entry) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources":
+      [ "https://api.example.com", "http://cleartext.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_accepts_an_uppercase_protected_resource_entry) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "HTTPS://api.example.com" ]
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_TRUE(
+      metadata.value().supports_protected_resource("HTTPS://api.example.com"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
+}
+
+TEST(server_metadata_accepts_a_protected_resource_entry_with_a_query) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "https://api.example.com/mcp?tenant=1" ]
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example");
+  EXPECT_FALSE(metadata.value().authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().token_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().registration_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().device_authorization_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().revocation_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().introspection_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(
+      metadata.value().pushed_authorization_request_endpoint().has_value());
+  EXPECT_FALSE(metadata.value().require_pushed_authorization_requests());
+  EXPECT_FALSE(
+      metadata.value().authorization_response_iss_parameter_supported());
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_FALSE(metadata.value().supports_response_type("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("authorization_code"));
+  EXPECT_TRUE(metadata.value().supports_grant_type("implicit"));
+  EXPECT_FALSE(metadata.value().supports_grant_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("S256"));
+  EXPECT_FALSE(metadata.value().supports_code_challenge_method("plain"));
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_FALSE(
+      metadata.value().supports_token_endpoint_auth_method("nonexistent"));
+  EXPECT_TRUE(metadata.value().supports_protected_resource(
+      "https://api.example.com/mcp?tenant=1"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://nonexistent.example.invalid"));
+}

--- a/test/oauth/oauth_metadata_test.cc
+++ b/test/oauth/oauth_metadata_test.cc
@@ -872,360 +872,6 @@ TEST(server_metadata_rejects_a_cross_origin_cleartext_jwks_uri) {
   EXPECT_FALSE(metadata.has_value());
 }
 
-TEST(resource_metadata_rejects_a_cleartext_jwks_uri) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "jwks_uri": "http://api.example.com/jwks"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_jwks_uri_with_a_fragment) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "jwks_uri": "https://api.example.com/jwks#keys"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_non_string_jwks_uri) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "jwks_uri": 42
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_accepts_an_https_jwks_uri) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "jwks_uri": "https://api.example.com/jwks"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().jwks_uri().value(),
-            "https://api.example.com/jwks");
-}
-
-TEST(resource_metadata_parses_a_valid_document) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "https://auth.example.com" ],
-    "jwks_uri": "https://api.example.com/jwks",
-    "scopes_supported": [ "read", "write" ],
-    "bearer_methods_supported": [ "header" ],
-    "dpop_bound_access_tokens_required": true
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
-  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
-  EXPECT_EQ(metadata.value().first_authorization_server().value(),
-            "https://auth.example.com");
-  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
-  EXPECT_EQ(metadata.value().jwks_uri().value(),
-            "https://api.example.com/jwks");
-  EXPECT_TRUE(metadata.value().dpop_bound_access_tokens_required());
-}
-
-TEST(resource_metadata_rejects_a_missing_resource) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "authorization_servers": [ "https://auth.example.com" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_non_string_resource) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": 42
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_mismatched_resource) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://other.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_non_https_resource) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "http://api.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "http://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_resource_with_a_fragment) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com/path#section"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com/path#section")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_allows_a_resource_with_a_query) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com/path?tenant=a"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com/path?tenant=a")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().resource(),
-            "https://api.example.com/path?tenant=a");
-}
-
-TEST(resource_metadata_rejects_an_empty_authority) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https:///path"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https:///path")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_signing_alg_none) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "resource_signing_alg_values_supported": [ "RS256", "none" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_an_empty_signing_alg_list) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "resource_signing_alg_values_supported": []
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_first_authorization_server_when_absent) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
-}
-
-TEST(resource_metadata_supports_authorization_server) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "https://a.example.com", "https://b.example.com" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_TRUE(
-      metadata.value().supports_authorization_server("https://b.example.com"));
-  EXPECT_FALSE(
-      metadata.value().supports_authorization_server("https://c.example.com"));
-  EXPECT_EQ(metadata.value().first_authorization_server().value(),
-            "https://a.example.com");
-}
-
-TEST(resource_metadata_supports_bearer_method) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "bearer_methods_supported": [ "header", "body" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
-  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
-}
-
-TEST(resource_metadata_bearer_method_absent_is_false) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
-}
-
-TEST(resource_metadata_supports_scope) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "scopes_supported": [ "read", "write" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_TRUE(metadata.value().supports_scope("read"));
-  EXPECT_FALSE(metadata.value().supports_scope("admin"));
-}
-
-TEST(resource_metadata_dpop_bound_required_defaults_to_false) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
-}
-
-TEST(resource_metadata_data_exposes_untyped_members) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "resource_name": "Example API"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_TRUE(metadata.value().data().defines("resource_name"));
-}
-
-TEST(resource_metadata_rejects_an_uppercase_scheme) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "HTTPS://api.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "HTTPS://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_resource_with_a_space) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_non_string_authorization_server) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ 42, "https://auth.example.com" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_trailing_non_string_authorization_server) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "https://auth.example.com", 42 ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_all_non_string_authorization_servers) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ 1, 2, 3 ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_an_empty_authorization_server_array) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": []
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_non_array_authorization_servers) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": "https://auth.example.com"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_cleartext_authorization_server) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "http://auth.example.com" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_second_cleartext_authorization_server) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [
-      "https://auth.example.com", "http://evil.example.com" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_an_authorization_server_with_a_query) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "https://auth.example.com?tenant=1" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_an_authorization_server_with_a_fragment) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "https://auth.example.com#tenant" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
-  // An advertised issuer is matched against nothing at parse time, so its
-  // scheme is case-insensitive, unlike the resource identifier the document is
-  // checked against
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "HTTPS://auth.example.com" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().first_authorization_server().value(),
-            "HTTPS://auth.example.com");
-}
-
 TEST(
     resource_metadata_uppercase_authorization_server_does_not_match_lowercase) {
   // The membership test compares by code points, so a case-varied entry never
@@ -1241,92 +887,6 @@ TEST(
       "https://auth.example.com"));
   EXPECT_TRUE(metadata.value().supports_authorization_server(
       "HTTPS://auth.example.com"));
-}
-
-TEST(resource_metadata_accepts_multiple_authorization_servers) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [
-      "https://auth.example.com", "https://other.example.net/issuer" ]
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
-  EXPECT_EQ(metadata.value().first_authorization_server().value(),
-            "https://auth.example.com");
-  EXPECT_TRUE(metadata.value().supports_authorization_server(
-      "https://other.example.net/issuer"));
-}
-
-TEST(resource_metadata_rejects_a_non_object) {
-  auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_a_non_array_signing_algs) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "resource_signing_alg_values_supported": "RS256"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_dpop_bound_wrong_type_is_false) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "dpop_bound_access_tokens_required": "true"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
-}
-
-TEST(resource_metadata_empty_bearer_methods_is_false) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "bearer_methods_supported": []
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
-}
-
-TEST(resource_metadata_accepts_userinfo_and_port) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://user@api.example.com:8443/path"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://user@api.example.com:8443/path")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().resource(),
-            "https://user@api.example.com:8443/path");
-}
-
-TEST(resource_metadata_rejects_an_empty_host) {
-  // https://:443/path has an authority but no host, so it is not a valid
-  // resource identifier (RFC 3986 Section 3.2)
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://:443/path"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://:443/path")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
-TEST(resource_metadata_rejects_an_empty_host_with_userinfo) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://user@:443/path"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://user@:443/path")};
-  EXPECT_FALSE(metadata.has_value());
 }
 
 TEST(server_metadata_rejects_an_empty_host) {
@@ -1347,18 +907,6 @@ TEST(well_known_url_rejects_an_empty_host) {
   EXPECT_TRUE(url.empty());
 }
 
-TEST(resource_metadata_rejects_a_port_above_the_limit) {
-  // The port fits the RFC 3986 grammar but exceeds what a URI can hold, so
-  // parsing must be reported as an invalid document rather than escaping as an
-  // exception
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com:99999999999999/path"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com:99999999999999/path")};
-  EXPECT_FALSE(metadata.has_value());
-}
-
 TEST(server_metadata_rejects_a_port_above_the_limit) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "issuer": "https://example.com:99999999999999",
@@ -1375,17 +923,6 @@ TEST(well_known_url_rejects_a_port_above_the_limit) {
       "https://example.com:99999999999999",
       sourcemeta::core::OAuthWellKnownKind::ProtectedResource, url));
   EXPECT_TRUE(url.empty());
-}
-
-TEST(resource_metadata_accepts_the_maximum_port) {
-  auto document{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com:4294967295/path"
-  })JSON")};
-  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
-      std::move(document), "https://api.example.com:4294967295/path")};
-  EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().resource(),
-            "https://api.example.com:4294967295/path");
 }
 
 TEST(make_server_metadata_emits_the_required_members) {
@@ -1788,4 +1325,286 @@ TEST(is_endpoint_url_rejects_another_scheme) {
 TEST(is_endpoint_url_rejects_a_malformed_url) {
   EXPECT_FALSE(sourcemeta::core::oauth_is_endpoint_url(""));
   EXPECT_FALSE(sourcemeta::core::oauth_is_endpoint_url("https://ex ample.com"));
+}
+
+TEST(is_resource_identifier_accepts_an_https_url) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_resource_identifier(
+      "https://api.example.com"));
+}
+
+TEST(is_resource_identifier_accepts_a_path) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_resource_identifier(
+      "https://api.example.com/mcp"));
+}
+
+TEST(is_resource_identifier_accepts_a_query) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_resource_identifier(
+      "https://api.example.com/mcp?tenant=1"));
+}
+
+TEST(is_resource_identifier_accepts_a_port) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_resource_identifier(
+      "https://api.example.com:8443/mcp"));
+}
+
+TEST(is_resource_identifier_rejects_a_cleartext_url) {
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_is_resource_identifier("http://api.example.com"));
+}
+
+TEST(is_resource_identifier_rejects_a_fragment) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier(
+      "https://api.example.com/mcp#section"));
+}
+
+TEST(is_resource_identifier_rejects_an_uppercase_scheme) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier(
+      "HTTPS://api.example.com"));
+}
+
+TEST(is_resource_identifier_rejects_a_missing_host) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier("https://"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier("https://:443"));
+}
+
+TEST(is_resource_identifier_rejects_a_relative_reference) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier("/mcp"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_resource_identifier(""));
+}
+
+TEST(is_advertised_issuer_accepts_an_https_url) {
+  EXPECT_TRUE(
+      sourcemeta::core::oauth_is_advertised_issuer("https://auth.example.com"));
+}
+
+TEST(is_advertised_issuer_accepts_a_path) {
+  EXPECT_TRUE(sourcemeta::core::oauth_is_advertised_issuer(
+      "https://auth.example.com/tenant"));
+}
+
+TEST(is_advertised_issuer_accepts_an_uppercase_scheme) {
+  EXPECT_TRUE(
+      sourcemeta::core::oauth_is_advertised_issuer("HTTPS://auth.example.com"));
+}
+
+TEST(is_advertised_issuer_rejects_a_query) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer(
+      "https://auth.example.com/?tenant=1"));
+}
+
+TEST(is_advertised_issuer_rejects_a_fragment) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer(
+      "https://auth.example.com#main"));
+}
+
+TEST(is_advertised_issuer_rejects_a_cleartext_url) {
+  EXPECT_FALSE(
+      sourcemeta::core::oauth_is_advertised_issuer("http://auth.example.com"));
+}
+
+TEST(is_advertised_issuer_rejects_a_missing_host) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer("https://"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer("https://:443"));
+}
+
+TEST(is_advertised_issuer_rejects_a_relative_reference) {
+  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer("/issuer"));
+  EXPECT_FALSE(sourcemeta::core::oauth_is_advertised_issuer(""));
+}
+
+TEST(server_metadata_parses_the_rfc8414_example) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example.com",
+    "authorization_endpoint": "https://server.example.com/authorize",
+    "token_endpoint": "https://server.example.com/token",
+    "token_endpoint_auth_methods_supported":
+      ["client_secret_basic", "private_key_jwt"],
+    "token_endpoint_auth_signing_alg_values_supported": ["RS256", "ES256"],
+    "userinfo_endpoint": "https://server.example.com/userinfo",
+    "jwks_uri": "https://server.example.com/jwks.json",
+    "registration_endpoint": "https://server.example.com/register",
+    "scopes_supported":
+      ["openid", "profile", "email", "address", "phone", "offline_access"],
+    "response_types_supported": ["code", "code token"],
+    "service_documentation":
+      "http://server.example.com/service_documentation.html",
+    "ui_locales_supported": ["en-US", "en-GB", "en-CA", "fr-FR", "fr-CA"]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().issuer(), "https://server.example.com");
+  EXPECT_EQ(metadata.value().authorization_endpoint().value(),
+            "https://server.example.com/authorize");
+  EXPECT_EQ(metadata.value().token_endpoint().value(),
+            "https://server.example.com/token");
+  EXPECT_TRUE(metadata.value().supports_token_endpoint_auth_method(
+      "client_secret_basic"));
+  EXPECT_TRUE(
+      metadata.value().supports_token_endpoint_auth_method("private_key_jwt"));
+  EXPECT_EQ(metadata.value().jwks_uri().value(),
+            "https://server.example.com/jwks.json");
+  EXPECT_EQ(metadata.value().registration_endpoint().value(),
+            "https://server.example.com/register");
+  EXPECT_TRUE(metadata.value().supports_response_type("code"));
+  EXPECT_TRUE(metadata.value().supports_response_type("code token"));
+  EXPECT_EQ(metadata.value().data().at("userinfo_endpoint").to_string(),
+            "https://server.example.com/userinfo");
+  EXPECT_EQ(metadata.value().data().at("service_documentation").to_string(),
+            "http://server.example.com/service_documentation.html");
+  EXPECT_EQ(metadata.value().data().at("ui_locales_supported").size(), 5);
+}
+
+TEST(make_server_metadata_emits_protected_resources) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 2> resources{
+      {"https://api.example.com", "https://reports.example.com/v1"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  config.protected_resources = resources;
+  const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  EXPECT_EQ(document.value().at("protected_resources").size(), 2);
+  EXPECT_EQ(document.value().at("protected_resources").at(0).to_string(),
+            "https://api.example.com");
+  EXPECT_EQ(document.value().at("protected_resources").at(1).to_string(),
+            "https://reports.example.com/v1");
+}
+
+TEST(make_server_metadata_omits_empty_protected_resources) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  EXPECT_FALSE(document.value().defines("protected_resources"));
+}
+
+TEST(make_server_metadata_rejects_a_cleartext_protected_resource) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 1> resources{{"http://api.example.com"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  config.protected_resources = resources;
+  const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_server_metadata_rejects_a_protected_resource_with_a_fragment) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 1> resources{
+      {"https://api.example.com#section"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  config.protected_resources = resources;
+  const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_server_metadata_accepts_a_protected_resource_with_a_query) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 1> resources{
+      {"https://api.example.com/mcp?tenant=1"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  config.protected_resources = resources;
+  const auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  EXPECT_EQ(document.value().at("protected_resources").at(0).to_string(),
+            "https://api.example.com/mcp?tenant=1");
+}
+
+TEST(make_server_metadata_protected_resources_round_trips) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 1> resources{{"https://api.example.com"}};
+  sourcemeta::core::OAuthServerMetadataConfig config;
+  config.issuer = "https://server.example";
+  config.authorization_endpoint = "https://server.example/authorize";
+  config.token_endpoint = "https://server.example/token";
+  config.response_types_supported = response_types;
+  config.protected_resources = resources;
+  auto document{sourcemeta::core::oauth_make_server_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document.value()), "https://server.example")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(
+      metadata.value().supports_protected_resource("https://api.example.com"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://other.example.com"));
+}
+
+TEST(server_metadata_supports_protected_resource) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "https://api.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(
+      metadata.value().supports_protected_resource("https://api.example.com"));
+  EXPECT_FALSE(metadata.value().supports_protected_resource(
+      "https://other.example.com"));
+}
+
+TEST(server_metadata_protected_resource_absent_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(
+      metadata.value().supports_protected_resource("https://api.example.com"));
+}
+
+TEST(server_metadata_rejects_an_empty_protected_resources_array) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_non_array_protected_resources) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(server_metadata_rejects_a_non_string_protected_resource_element) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://server.example",
+    "response_types_supported": [ "code" ],
+    "protected_resources": [ "https://api.example.com", 42 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthServerMetadata::from(
+      std::move(document), "https://server.example")};
+  EXPECT_FALSE(metadata.has_value());
 }

--- a/test/oauth/oauth_resource_metadata_test.cc
+++ b/test/oauth/oauth_resource_metadata_test.cc
@@ -1,0 +1,1369 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/oauth.h>
+#include <sourcemeta/core/test.h>
+
+#include <array>       // std::array
+#include <string_view> // std::string_view
+#include <utility>     // std::move
+
+TEST(resource_metadata_rejects_a_cleartext_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "http://api.example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_jwks_uri_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "https://api.example.com/jwks#keys"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": 42
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_an_https_jwks_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "https://api.example.com/jwks"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().jwks_uri().value(),
+            "https://api.example.com/jwks");
+}
+
+TEST(resource_metadata_parses_a_valid_document) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com" ],
+    "jwks_uri": "https://api.example.com/jwks",
+    "scopes_supported": [ "read", "write" ],
+    "bearer_methods_supported": [ "header" ],
+    "dpop_bound_access_tokens_required": true
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "https://auth.example.com");
+  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
+  EXPECT_EQ(metadata.value().jwks_uri().value(),
+            "https://api.example.com/jwks");
+  EXPECT_TRUE(metadata.value().dpop_bound_access_tokens_required());
+}
+
+TEST(resource_metadata_rejects_a_missing_resource) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "authorization_servers": [ "https://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_resource) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": 42
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_mismatched_resource) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://other.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_https_resource) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "http://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "http://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_resource_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com/path#section"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com/path#section")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_allows_a_resource_with_a_query) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com/path?tenant=a"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com/path?tenant=a")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(),
+            "https://api.example.com/path?tenant=a");
+}
+
+TEST(resource_metadata_rejects_an_empty_authority) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https:///path"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https:///path")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_signing_alg_none) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_signing_alg_values_supported": [ "RS256", "none" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_empty_signing_alg_list) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_signing_alg_values_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_first_authorization_server_when_absent) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+}
+
+TEST(resource_metadata_supports_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://a.example.com", "https://b.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(
+      metadata.value().supports_authorization_server("https://b.example.com"));
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_server("https://c.example.com"));
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "https://a.example.com");
+}
+
+TEST(resource_metadata_supports_bearer_method) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "bearer_methods_supported": [ "header", "body" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+}
+
+TEST(resource_metadata_bearer_method_absent_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+}
+
+TEST(resource_metadata_supports_scope) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "scopes_supported": [ "read", "write" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_scope("read"));
+  EXPECT_FALSE(metadata.value().supports_scope("admin"));
+}
+
+TEST(resource_metadata_dpop_bound_required_defaults_to_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
+}
+
+TEST(resource_metadata_data_exposes_untyped_members) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_name": "Example API"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().data().defines("resource_name"));
+}
+
+TEST(resource_metadata_rejects_an_uppercase_scheme) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "HTTPS://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "HTTPS://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_resource_with_a_space) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ 42, "https://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_trailing_non_string_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com", 42 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_all_non_string_authorization_servers) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ 1, 2, 3 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_empty_authorization_server_array) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_array_authorization_servers) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": "https://auth.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_cleartext_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "http://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_second_cleartext_authorization_server) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [
+      "https://auth.example.com", "http://evil.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_authorization_server_with_a_query) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com?tenant=1" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_authorization_server_with_a_fragment) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "https://auth.example.com#tenant" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
+  // An advertised issuer is matched against nothing at parse time, so its
+  // scheme is case-insensitive, unlike the resource identifier the document is
+  // checked against
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "HTTPS://auth.example.com" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "HTTPS://auth.example.com");
+}
+
+TEST(resource_metadata_accepts_multiple_authorization_servers) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [
+      "https://auth.example.com", "https://other.example.net/issuer" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "https://auth.example.com");
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://other.example.net/issuer"));
+}
+
+TEST(resource_metadata_rejects_a_non_object) {
+  auto document{sourcemeta::core::parse_json(R"JSON([ 1, 2, 3 ])JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_array_signing_algs) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_signing_alg_values_supported": "RS256"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_boolean_dpop_bound_required) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_bound_access_tokens_required": "true"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_empty_bearer_methods_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "bearer_methods_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+}
+
+TEST(resource_metadata_accepts_userinfo_and_port) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://user@api.example.com:8443/path"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://user@api.example.com:8443/path")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(),
+            "https://user@api.example.com:8443/path");
+}
+
+TEST(resource_metadata_rejects_an_empty_host) {
+  // https://:443/path has an authority but no host, so it is not a valid
+  // resource identifier (RFC 3986 Section 3.2)
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://:443/path"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://:443/path")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_empty_host_with_userinfo) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://user@:443/path"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://user@:443/path")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_port_above_the_limit) {
+  // The port fits the RFC 3986 grammar but exceeds what a URI can hold, so
+  // parsing must be reported as an invalid document rather than escaping as an
+  // exception
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com:99999999999999/path"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com:99999999999999/path")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_the_maximum_port) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com:4294967295/path"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com:4294967295/path")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(),
+            "https://api.example.com:4294967295/path");
+}
+
+TEST(make_resource_metadata_emits_the_required_member) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_emits_every_member) {
+  const std::array<std::string_view, 2> servers{
+      {"https://auth.example.com", "https://backup.example.net"}};
+  const std::array<std::string_view, 2> scopes{{"read", "write"}};
+  const std::array<std::string_view, 2> bearer_methods{{"header", "body"}};
+  const std::array<std::string_view, 2> signing_algorithms{{"RS256", "ES256"}};
+  const std::array<std::string_view, 1> details_types{{"payment_initiation"}};
+  const std::array<std::string_view, 2> dpop_algorithms{{"ES256", "PS256"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = servers;
+  config.jwks_uri = "https://api.example.com/jwks";
+  config.scopes_supported = scopes;
+  config.bearer_methods_supported = bearer_methods;
+  config.resource_signing_alg_values_supported = signing_algorithms;
+  config.resource_name = "Example API";
+  config.resource_documentation = "https://api.example.com/docs";
+  config.resource_policy_uri = "https://api.example.com/policy";
+  config.resource_tos_uri = "https://api.example.com/terms";
+  config.tls_client_certificate_bound_access_tokens = true;
+  config.authorization_details_types_supported = details_types;
+  config.dpop_signing_alg_values_supported = dpop_algorithms;
+  config.dpop_bound_access_tokens_required = true;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers":
+      [ "https://auth.example.com", "https://backup.example.net" ],
+    "jwks_uri": "https://api.example.com/jwks",
+    "scopes_supported": [ "read", "write" ],
+    "bearer_methods_supported": [ "header", "body" ],
+    "resource_signing_alg_values_supported": [ "RS256", "ES256" ],
+    "resource_name": "Example API",
+    "resource_documentation": "https://api.example.com/docs",
+    "resource_policy_uri": "https://api.example.com/policy",
+    "resource_tos_uri": "https://api.example.com/terms",
+    "tls_client_certificate_bound_access_tokens": true,
+    "authorization_details_types_supported": [ "payment_initiation" ],
+    "dpop_signing_alg_values_supported": [ "ES256", "PS256" ],
+    "dpop_bound_access_tokens_required": true
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_rejects_a_cleartext_resource) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "http://api.example.com";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_resource_with_a_fragment) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com#section";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_an_empty_resource) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_an_uppercase_resource_scheme) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "HTTPS://api.example.com";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_resource_without_a_host) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_relative_resource) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "/mcp";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_accepts_a_resource_with_a_query) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com/mcp?tenant=1";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com/mcp?tenant=1"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_accepts_a_resource_with_a_port) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com:8443/mcp";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com:8443/mcp"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_rejects_a_cleartext_authorization_server) {
+  const std::array<std::string_view, 1> servers{{"http://auth.example.com"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = servers;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_an_authorization_server_with_a_query) {
+  const std::array<std::string_view, 1> servers{
+      {"https://auth.example.com/?tenant=1"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = servers;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_an_authorization_server_with_a_fragment) {
+  const std::array<std::string_view, 1> servers{
+      {"https://auth.example.com#main"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = servers;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_trailing_invalid_authorization_server) {
+  const std::array<std::string_view, 2> servers{
+      {"https://auth.example.com", "http://cleartext.example.com"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = servers;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
+  const std::array<std::string_view, 1> servers{{"HTTPS://auth.example.com"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = servers;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "HTTPS://auth.example.com" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_rejects_a_cleartext_jwks_uri) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.jwks_uri = "http://api.example.com/jwks";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_jwks_uri_with_a_fragment) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.jwks_uri = "https://api.example.com/jwks#keys";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_accepts_an_https_jwks_uri) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.jwks_uri = "https://api.example.com/jwks";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "jwks_uri": "https://api.example.com/jwks"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_rejects_none_in_resource_signing_algs) {
+  const std::array<std::string_view, 2> algorithms{{"RS256", "none"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_signing_alg_values_supported = algorithms;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_none_in_dpop_signing_algs) {
+  const std::array<std::string_view, 2> algorithms{{"ES256", "none"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.dpop_signing_alg_values_supported = algorithms;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_hs256_in_dpop_signing_algs) {
+  const std::array<std::string_view, 2> algorithms{{"ES256", "HS256"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.dpop_signing_alg_values_supported = algorithms;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_hs384_in_dpop_signing_algs) {
+  const std::array<std::string_view, 1> algorithms{{"HS384"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.dpop_signing_alg_values_supported = algorithms;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_hs512_in_dpop_signing_algs) {
+  const std::array<std::string_view, 1> algorithms{{"HS512"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.dpop_signing_alg_values_supported = algorithms;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_accepts_asymmetric_dpop_signing_algs) {
+  const std::array<std::string_view, 3> algorithms{{"ES256", "PS256", "EdDSA"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.dpop_signing_alg_values_supported = algorithms;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_signing_alg_values_supported": [ "ES256", "PS256", "EdDSA" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_rejects_a_schemeless_documentation) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_documentation = "/docs";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_schemeless_policy_uri) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_policy_uri = "policy.html";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_schemeless_tos_uri) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_tos_uri = "//example.com/terms";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_rejects_a_malformed_documentation) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_documentation = "https://ex ample.com/docs";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_FALSE(document.has_value());
+}
+
+TEST(make_resource_metadata_accepts_a_cleartext_documentation) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_documentation = "http://api.example.com/docs";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_documentation": "http://api.example.com/docs"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_accepts_a_documentation_with_a_fragment) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_documentation = "https://api.example.com/docs#auth";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_documentation": "https://api.example.com/docs#auth"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_omits_absent_members) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_omits_empty_arrays) {
+  const std::array<std::string_view, 0> empty{};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.authorization_servers = empty;
+  config.scopes_supported = empty;
+  config.resource_signing_alg_values_supported = empty;
+  config.authorization_details_types_supported = empty;
+  config.dpop_signing_alg_values_supported = empty;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_omits_bearer_methods_when_disengaged) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_emits_an_empty_bearer_methods_when_engaged_empty) {
+  const std::array<std::string_view, 0> methods{};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.bearer_methods_supported = methods;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "bearer_methods_supported": []
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_emits_bearer_methods_values) {
+  const std::array<std::string_view, 3> methods{{"header", "body", "query"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.bearer_methods_supported = methods;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "bearer_methods_supported": [ "header", "body", "query" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_omits_false_booleans) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.tls_client_certificate_bound_access_tokens = false;
+  config.dpop_bound_access_tokens_required = false;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_emits_true_booleans) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.tls_client_certificate_bound_access_tokens = true;
+  config.dpop_bound_access_tokens_required = true;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "tls_client_certificate_bound_access_tokens": true,
+    "dpop_bound_access_tokens_required": true
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_minimal_round_trips) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document.value()), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+}
+
+TEST(make_resource_metadata_round_trips) {
+  const std::array<std::string_view, 2> servers{
+      {"https://auth.example.com", "https://backup.example.net"}};
+  const std::array<std::string_view, 2> scopes{{"read", "write"}};
+  const std::array<std::string_view, 1> bearer_methods{{"header"}};
+  const std::array<std::string_view, 1> signing_algorithms{{"ES256"}};
+  const std::array<std::string_view, 1> details_types{{"payment_initiation"}};
+  const std::array<std::string_view, 1> dpop_algorithms{{"ES256"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com/mcp?tenant=1";
+  config.authorization_servers = servers;
+  config.jwks_uri = "https://api.example.com/jwks";
+  config.scopes_supported = scopes;
+  config.bearer_methods_supported = bearer_methods;
+  config.resource_signing_alg_values_supported = signing_algorithms;
+  config.resource_name = "Example API";
+  config.resource_documentation = "https://api.example.com/docs";
+  config.resource_policy_uri = "https://api.example.com/policy";
+  config.resource_tos_uri = "https://api.example.com/terms";
+  config.tls_client_certificate_bound_access_tokens = true;
+  config.authorization_details_types_supported = details_types;
+  config.dpop_signing_alg_values_supported = dpop_algorithms;
+  config.dpop_bound_access_tokens_required = true;
+  auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document.value()), "https://api.example.com/mcp?tenant=1")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(),
+            "https://api.example.com/mcp?tenant=1");
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "https://auth.example.com");
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://backup.example.net"));
+  EXPECT_EQ(metadata.value().jwks_uri().value(),
+            "https://api.example.com/jwks");
+  EXPECT_TRUE(metadata.value().supports_scope("read"));
+  EXPECT_TRUE(metadata.value().supports_scope("write"));
+  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_TRUE(metadata.value().supports_resource_signing_alg("ES256"));
+  EXPECT_EQ(metadata.value().resource_name().value(), "Example API");
+  EXPECT_EQ(metadata.value().resource_documentation().value(),
+            "https://api.example.com/docs");
+  EXPECT_EQ(metadata.value().resource_policy_uri().value(),
+            "https://api.example.com/policy");
+  EXPECT_EQ(metadata.value().resource_tos_uri().value(),
+            "https://api.example.com/terms");
+  EXPECT_TRUE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_TRUE(metadata.value().supports_authorization_details_type(
+      "payment_initiation"));
+  EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("ES256"));
+  EXPECT_TRUE(metadata.value().dpop_bound_access_tokens_required());
+}
+
+TEST(make_resource_metadata_empty_bearer_methods_round_trips) {
+  const std::array<std::string_view, 0> methods{};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.bearer_methods_supported = methods;
+  auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document.value()), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+}
+
+TEST(resource_metadata_resource_name_present) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_name": "Example API"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().resource_name().has_value());
+  EXPECT_EQ(metadata.value().resource_name().value(), "Example API");
+}
+
+TEST(resource_metadata_resource_name_absent) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+}
+
+TEST(resource_metadata_language_tagged_name_yields_absent_untagged) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_name#it": "API di esempio"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_TRUE(metadata.value().data().defines("resource_name#it"));
+  EXPECT_EQ(metadata.value().data().at("resource_name#it").to_string(),
+            "API di esempio");
+}
+
+TEST(resource_metadata_resource_documentation_present) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_documentation": "https://api.example.com/docs"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().resource_documentation().has_value());
+  EXPECT_EQ(metadata.value().resource_documentation().value(),
+            "https://api.example.com/docs");
+}
+
+TEST(resource_metadata_resource_documentation_absent) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+}
+
+TEST(resource_metadata_resource_policy_uri_present) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_policy_uri": "https://api.example.com/policy"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_EQ(metadata.value().resource_policy_uri().value(),
+            "https://api.example.com/policy");
+}
+
+TEST(resource_metadata_resource_policy_uri_absent) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+}
+
+TEST(resource_metadata_resource_tos_uri_present) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_tos_uri": "https://api.example.com/terms"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_EQ(metadata.value().resource_tos_uri().value(),
+            "https://api.example.com/terms");
+}
+
+TEST(resource_metadata_resource_tos_uri_absent) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+}
+
+TEST(resource_metadata_tls_client_certificate_bound_defaults_to_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+}
+
+TEST(resource_metadata_tls_client_certificate_bound_reads_true) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "tls_client_certificate_bound_access_tokens": true
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().tls_client_certificate_bound_access_tokens());
+}
+
+TEST(resource_metadata_tls_client_certificate_bound_reads_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "tls_client_certificate_bound_access_tokens": false
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+}
+
+TEST(resource_metadata_supports_resource_signing_alg) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_signing_alg_values_supported": [ "RS256", "ES256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_resource_signing_alg("RS256"));
+  EXPECT_TRUE(metadata.value().supports_resource_signing_alg("ES256"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("PS256"));
+}
+
+TEST(resource_metadata_resource_signing_alg_absent_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("RS256"));
+}
+
+TEST(resource_metadata_supports_dpop_signing_alg) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_signing_alg_values_supported": [ "ES256", "PS256" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("ES256"));
+  EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("PS256"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("RS256"));
+}
+
+TEST(resource_metadata_dpop_signing_alg_absent_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("ES256"));
+}
+
+TEST(resource_metadata_supports_authorization_details_type) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_details_types_supported": [ "payment_initiation" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_authorization_details_type(
+      "payment_initiation"));
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("account_access"));
+}
+
+TEST(resource_metadata_authorization_details_type_absent_is_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_details_type(
+      "payment_initiation"));
+}
+
+TEST(resource_metadata_rejects_an_empty_scopes_supported) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "scopes_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_array_scopes_supported) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "scopes_supported": "read"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_scope_element) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "scopes_supported": [ "read", 1 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_empty_authorization_details_types) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_details_types_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_authorization_details_type) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_details_types_supported": [ null ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_an_empty_dpop_signing_algs) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_signing_alg_values_supported": []
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_dpop_signing_alg) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_signing_alg_values_supported": [ "ES256", 42 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_accepts_none_in_dpop_signing_algs) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_signing_alg_values_supported": [ "none" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("none"));
+}
+
+TEST(resource_metadata_rejects_a_non_array_bearer_methods) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "bearer_methods_supported": "header"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_bearer_method) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "bearer_methods_supported": [ "header", true ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_signing_alg_element) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_signing_alg_values_supported": [ "RS256", 256 ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_boolean_tls_client_certificate_bound) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "tls_client_certificate_bound_access_tokens": "true"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_resource_name) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_name": 42
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_resource_documentation) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_documentation": [ "https://api.example.com/docs" ]
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_resource_policy_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_policy_uri": null
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_rejects_a_non_string_resource_tos_uri) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_tos_uri": {}
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_FALSE(metadata.has_value());
+}
+
+TEST(resource_metadata_parses_the_rfc9728_example) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource":
+      "https://resource.example.com",
+    "authorization_servers":
+      ["https://as1.example.com",
+       "https://as2.example.net"],
+    "bearer_methods_supported":
+      ["header", "body"],
+    "scopes_supported":
+      ["profile", "email", "phone"],
+    "resource_documentation":
+      "https://resource.example.com/resource_documentation.html"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://resource.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().resource(), "https://resource.example.com");
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "https://as1.example.com");
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://as1.example.com"));
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://as2.example.net"));
+  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_TRUE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_TRUE(metadata.value().supports_scope("profile"));
+  EXPECT_TRUE(metadata.value().supports_scope("email"));
+  EXPECT_TRUE(metadata.value().supports_scope("phone"));
+  EXPECT_EQ(metadata.value().resource_documentation().value(),
+            "https://resource.example.com/resource_documentation.html");
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+}

--- a/test/oauth/oauth_resource_metadata_test.cc
+++ b/test/oauth/oauth_resource_metadata_test.cc
@@ -46,8 +46,27 @@ TEST(resource_metadata_accepts_an_https_jwks_uri) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
   EXPECT_EQ(metadata.value().jwks_uri().value(),
             "https://api.example.com/jwks");
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_parses_a_valid_document) {
@@ -68,9 +87,28 @@ TEST(resource_metadata_parses_a_valid_document) {
   EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "https://auth.example.com");
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://auth.example.com"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
   EXPECT_TRUE(metadata.value().jwks_uri().has_value());
   EXPECT_EQ(metadata.value().jwks_uri().value(),
             "https://api.example.com/jwks");
+  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_TRUE(metadata.value().supports_scope("read"));
+  EXPECT_TRUE(metadata.value().supports_scope("write"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
   EXPECT_TRUE(metadata.value().dpop_bound_access_tokens_required());
 }
 
@@ -130,6 +168,24 @@ TEST(resource_metadata_allows_a_resource_with_a_query) {
   EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://api.example.com/path?tenant=a");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_rejects_an_empty_authority) {
@@ -170,7 +226,25 @@ TEST(resource_metadata_first_authorization_server_when_absent) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
   EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_supports_authorization_server) {
@@ -183,12 +257,31 @@ TEST(resource_metadata_supports_authorization_server) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
-  EXPECT_TRUE(
-      metadata.value().supports_authorization_server("https://b.example.com"));
-  EXPECT_FALSE(
-      metadata.value().supports_authorization_server("https://c.example.com"));
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "https://a.example.com");
+  EXPECT_TRUE(
+      metadata.value().supports_authorization_server("https://a.example.com"));
+  EXPECT_TRUE(
+      metadata.value().supports_authorization_server("https://b.example.com"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_supports_bearer_method) {
@@ -201,8 +294,25 @@ TEST(resource_metadata_supports_bearer_method) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
   EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_TRUE(metadata.value().supports_bearer_method("body"));
   EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_bearer_method_absent_is_false) {
@@ -214,7 +324,25 @@ TEST(resource_metadata_bearer_method_absent_is_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
   EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_supports_scope) {
@@ -227,8 +355,27 @@ TEST(resource_metadata_supports_scope) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
   EXPECT_TRUE(metadata.value().supports_scope("read"));
-  EXPECT_FALSE(metadata.value().supports_scope("admin"));
+  EXPECT_TRUE(metadata.value().supports_scope("write"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_dpop_bound_required_defaults_to_false) {
@@ -240,6 +387,24 @@ TEST(resource_metadata_dpop_bound_required_defaults_to_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
   EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
@@ -253,6 +418,26 @@ TEST(resource_metadata_data_exposes_untyped_members) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_TRUE(metadata.value().resource_name().has_value());
+  EXPECT_EQ(metadata.value().resource_name().value(), "Example API");
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
   EXPECT_TRUE(metadata.value().data().defines("resource_name"));
 }
 
@@ -378,8 +563,29 @@ TEST(resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "HTTPS://auth.example.com");
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "HTTPS://auth.example.com"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_accepts_multiple_authorization_servers) {
@@ -393,11 +599,31 @@ TEST(resource_metadata_accepts_multiple_authorization_servers) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
   EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "https://auth.example.com");
   EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://auth.example.com"));
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
       "https://other.example.net/issuer"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_rejects_a_non_object) {
@@ -437,7 +663,25 @@ TEST(resource_metadata_empty_bearer_methods_is_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
   EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_accepts_userinfo_and_port) {
@@ -451,6 +695,24 @@ TEST(resource_metadata_accepts_userinfo_and_port) {
   EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://user@api.example.com:8443/path");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_rejects_an_empty_host) {
@@ -496,6 +758,24 @@ TEST(resource_metadata_accepts_the_maximum_port) {
   EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://api.example.com:4294967295/path");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(make_resource_metadata_emits_the_required_member) {
@@ -918,6 +1198,23 @@ TEST(make_resource_metadata_minimal_round_trips) {
   EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
   EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(make_resource_metadata_round_trips) {
@@ -952,27 +1249,44 @@ TEST(make_resource_metadata_round_trips) {
   EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://api.example.com/mcp?tenant=1");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "https://auth.example.com");
   EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://auth.example.com"));
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
       "https://backup.example.net"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_TRUE(metadata.value().jwks_uri().has_value());
   EXPECT_EQ(metadata.value().jwks_uri().value(),
             "https://api.example.com/jwks");
+  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
   EXPECT_TRUE(metadata.value().supports_scope("read"));
   EXPECT_TRUE(metadata.value().supports_scope("write"));
-  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_resource_signing_alg("ES256"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_TRUE(metadata.value().resource_name().has_value());
   EXPECT_EQ(metadata.value().resource_name().value(), "Example API");
+  EXPECT_TRUE(metadata.value().resource_documentation().has_value());
   EXPECT_EQ(metadata.value().resource_documentation().value(),
             "https://api.example.com/docs");
+  EXPECT_TRUE(metadata.value().resource_policy_uri().has_value());
   EXPECT_EQ(metadata.value().resource_policy_uri().value(),
             "https://api.example.com/policy");
+  EXPECT_TRUE(metadata.value().resource_tos_uri().has_value());
   EXPECT_EQ(metadata.value().resource_tos_uri().value(),
             "https://api.example.com/terms");
   EXPECT_TRUE(metadata.value().tls_client_certificate_bound_access_tokens());
   EXPECT_TRUE(metadata.value().supports_authorization_details_type(
       "payment_initiation"));
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("ES256"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
   EXPECT_TRUE(metadata.value().dpop_bound_access_tokens_required());
 }
 
@@ -988,9 +1302,25 @@ TEST(make_resource_metadata_empty_bearer_methods_round_trips) {
       std::move(document.value()), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
   EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
   EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
   EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_name_present) {
@@ -1003,8 +1333,26 @@ TEST(resource_metadata_resource_name_present) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
   EXPECT_TRUE(metadata.value().resource_name().has_value());
   EXPECT_EQ(metadata.value().resource_name().value(), "Example API");
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_name_absent) {
@@ -1016,7 +1364,25 @@ TEST(resource_metadata_resource_name_absent) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
   EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_language_tagged_name_yields_absent_untagged) {
@@ -1029,7 +1395,25 @@ TEST(resource_metadata_language_tagged_name_yields_absent_untagged) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
   EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
   EXPECT_TRUE(metadata.value().data().defines("resource_name#it"));
   EXPECT_EQ(metadata.value().data().at("resource_name#it").to_string(),
             "API di esempio");
@@ -1045,9 +1429,27 @@ TEST(resource_metadata_resource_documentation_present) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
   EXPECT_TRUE(metadata.value().resource_documentation().has_value());
   EXPECT_EQ(metadata.value().resource_documentation().value(),
             "https://api.example.com/docs");
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_documentation_absent) {
@@ -1059,7 +1461,25 @@ TEST(resource_metadata_resource_documentation_absent) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
   EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_policy_uri_present) {
@@ -1072,9 +1492,27 @@ TEST(resource_metadata_resource_policy_uri_present) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
   EXPECT_TRUE(metadata.value().resource_policy_uri().has_value());
   EXPECT_EQ(metadata.value().resource_policy_uri().value(),
             "https://api.example.com/policy");
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_policy_uri_absent) {
@@ -1086,7 +1524,25 @@ TEST(resource_metadata_resource_policy_uri_absent) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
   EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_tos_uri_present) {
@@ -1099,9 +1555,27 @@ TEST(resource_metadata_resource_tos_uri_present) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
   EXPECT_TRUE(metadata.value().resource_tos_uri().has_value());
   EXPECT_EQ(metadata.value().resource_tos_uri().value(),
             "https://api.example.com/terms");
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_tos_uri_absent) {
@@ -1113,7 +1587,25 @@ TEST(resource_metadata_resource_tos_uri_absent) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
   EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_tls_client_certificate_bound_defaults_to_false) {
@@ -1125,7 +1617,25 @@ TEST(resource_metadata_tls_client_certificate_bound_defaults_to_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
   EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_tls_client_certificate_bound_reads_true) {
@@ -1138,7 +1648,25 @@ TEST(resource_metadata_tls_client_certificate_bound_reads_true) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
   EXPECT_TRUE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_tls_client_certificate_bound_reads_false) {
@@ -1151,7 +1679,25 @@ TEST(resource_metadata_tls_client_certificate_bound_reads_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
   EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_supports_resource_signing_alg) {
@@ -1164,9 +1710,27 @@ TEST(resource_metadata_supports_resource_signing_alg) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_resource_signing_alg("RS256"));
   EXPECT_TRUE(metadata.value().supports_resource_signing_alg("ES256"));
-  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("PS256"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_resource_signing_alg_absent_is_false) {
@@ -1178,7 +1742,25 @@ TEST(resource_metadata_resource_signing_alg_absent_is_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
-  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("RS256"));
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_supports_dpop_signing_alg) {
@@ -1191,9 +1773,27 @@ TEST(resource_metadata_supports_dpop_signing_alg) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("ES256"));
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("PS256"));
-  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("RS256"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_dpop_signing_alg_absent_is_false) {
@@ -1205,7 +1805,25 @@ TEST(resource_metadata_dpop_signing_alg_absent_is_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
-  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("ES256"));
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_supports_authorization_details_type) {
@@ -1218,10 +1836,27 @@ TEST(resource_metadata_supports_authorization_details_type) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
   EXPECT_TRUE(metadata.value().supports_authorization_details_type(
       "payment_initiation"));
   EXPECT_FALSE(
-      metadata.value().supports_authorization_details_type("account_access"));
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_authorization_details_type_absent_is_false) {
@@ -1233,8 +1868,25 @@ TEST(resource_metadata_authorization_details_type_absent_is_false) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
-  EXPECT_FALSE(metadata.value().supports_authorization_details_type(
-      "payment_initiation"));
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_rejects_an_empty_scopes_supported) {
@@ -1317,7 +1969,26 @@ TEST(resource_metadata_accepts_none_in_dpop_signing_algs) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("none"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_rejects_a_non_array_bearer_methods) {
@@ -1419,6 +2090,36 @@ TEST(resource_metadata_parses_the_rfc9728_example) {
       std::move(document), "https://resource.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://resource.example.com");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "https://as1.example.com");
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://as1.example.com"));
+  EXPECT_TRUE(metadata.value().supports_authorization_server(
+      "https://as2.example.net"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
+  EXPECT_TRUE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_TRUE(metadata.value().supports_scope("profile"));
+  EXPECT_TRUE(metadata.value().supports_scope("email"));
+  EXPECT_TRUE(metadata.value().supports_scope("phone"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_TRUE(metadata.value().resource_documentation().has_value());
+  EXPECT_EQ(metadata.value().resource_documentation().value(),
+            "https://resource.example.com/resource_documentation.html");
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_accepts_hs256_in_dpop_signing_algs) {
@@ -1431,7 +2132,26 @@ TEST(resource_metadata_accepts_hs256_in_dpop_signing_algs) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("HS256"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_preserves_language_tagged_page_members) {
@@ -1449,6 +2169,25 @@ TEST(resource_metadata_preserves_language_tagged_page_members) {
   EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
   EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_preserves_a_wrong_typed_language_tagged_member) {
@@ -1462,6 +2201,25 @@ TEST(resource_metadata_preserves_a_wrong_typed_language_tagged_member) {
   EXPECT_TRUE(metadata.has_value());
   EXPECT_FALSE(metadata.value().resource_name().has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_preserves_signed_metadata) {
@@ -1474,6 +2232,25 @@ TEST(resource_metadata_preserves_signed_metadata) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(resource_metadata_accepts_an_uppercase_advertised_issuer_document) {
@@ -1486,8 +2263,29 @@ TEST(resource_metadata_accepts_an_uppercase_advertised_issuer_document) {
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
   EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
+  EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
+  EXPECT_EQ(metadata.value().first_authorization_server().value(),
+            "HTTPS://auth.example.com");
   EXPECT_TRUE(metadata.value().supports_authorization_server(
       "HTTPS://auth.example.com"));
+  EXPECT_FALSE(metadata.value().supports_authorization_server(
+      "https://nonexistent.example.invalid"));
+  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
+  EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
+  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
+  EXPECT_FALSE(metadata.value().supports_scope("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_resource_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+  EXPECT_FALSE(
+      metadata.value().supports_authorization_details_type("nonexistent"));
+  EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("nonexistent"));
+  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
 TEST(make_resource_metadata_emits_duplicate_scopes_as_given) {

--- a/test/oauth/oauth_resource_metadata_test.cc
+++ b/test/oauth/oauth_resource_metadata_test.cc
@@ -41,9 +41,11 @@ TEST(resource_metadata_accepts_an_https_jwks_uri) {
     "resource": "https://api.example.com",
     "jwks_uri": "https://api.example.com/jwks"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().jwks_uri().value(),
             "https://api.example.com/jwks");
 }
@@ -57,9 +59,11 @@ TEST(resource_metadata_parses_a_valid_document) {
     "bearer_methods_supported": [ "header" ],
     "dpop_bound_access_tokens_required": true
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
   EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
@@ -119,9 +123,11 @@ TEST(resource_metadata_allows_a_resource_with_a_query) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com/path?tenant=a"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com/path?tenant=a")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://api.example.com/path?tenant=a");
 }
@@ -159,9 +165,11 @@ TEST(resource_metadata_first_authorization_server_when_absent) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
 }
 
@@ -170,9 +178,11 @@ TEST(resource_metadata_supports_authorization_server) {
     "resource": "https://api.example.com",
     "authorization_servers": [ "https://a.example.com", "https://b.example.com" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(
       metadata.value().supports_authorization_server("https://b.example.com"));
   EXPECT_FALSE(
@@ -186,9 +196,11 @@ TEST(resource_metadata_supports_bearer_method) {
     "resource": "https://api.example.com",
     "bearer_methods_supported": [ "header", "body" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
   EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
 }
@@ -197,9 +209,11 @@ TEST(resource_metadata_bearer_method_absent_is_false) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
 }
 
@@ -208,9 +222,11 @@ TEST(resource_metadata_supports_scope) {
     "resource": "https://api.example.com",
     "scopes_supported": [ "read", "write" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_scope("read"));
   EXPECT_FALSE(metadata.value().supports_scope("admin"));
 }
@@ -219,9 +235,11 @@ TEST(resource_metadata_dpop_bound_required_defaults_to_false) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
 }
 
@@ -230,9 +248,11 @@ TEST(resource_metadata_data_exposes_untyped_members) {
     "resource": "https://api.example.com",
     "resource_name": "Example API"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().data().defines("resource_name"));
 }
 
@@ -353,9 +373,11 @@ TEST(resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
     "resource": "https://api.example.com",
     "authorization_servers": [ "HTTPS://auth.example.com" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "HTTPS://auth.example.com");
 }
@@ -366,9 +388,11 @@ TEST(resource_metadata_accepts_multiple_authorization_servers) {
     "authorization_servers": [
       "https://auth.example.com", "https://other.example.net/issuer" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().first_authorization_server().has_value());
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
             "https://auth.example.com");
@@ -408,9 +432,11 @@ TEST(resource_metadata_empty_bearer_methods_is_false) {
     "resource": "https://api.example.com",
     "bearer_methods_supported": []
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
 }
 
@@ -418,9 +444,11 @@ TEST(resource_metadata_accepts_userinfo_and_port) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://user@api.example.com:8443/path"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://user@api.example.com:8443/path")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://user@api.example.com:8443/path");
 }
@@ -461,9 +489,11 @@ TEST(resource_metadata_accepts_the_maximum_port) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com:4294967295/path"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com:4294967295/path")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://api.example.com:4294967295/path");
 }
@@ -626,18 +656,13 @@ TEST(make_resource_metadata_rejects_a_trailing_invalid_authorization_server) {
   EXPECT_FALSE(document.has_value());
 }
 
-TEST(make_resource_metadata_accepts_an_uppercase_authorization_server_scheme) {
+TEST(make_resource_metadata_rejects_an_uppercase_authorization_server_scheme) {
   const std::array<std::string_view, 1> servers{{"HTTPS://auth.example.com"}};
   sourcemeta::core::OAuthResourceMetadataConfig config;
   config.resource = "https://api.example.com";
   config.authorization_servers = servers;
   const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
-  EXPECT_TRUE(document.has_value());
-  const auto expected{sourcemeta::core::parse_json(R"JSON({
-    "resource": "https://api.example.com",
-    "authorization_servers": [ "HTTPS://auth.example.com" ]
-  })JSON")};
-  EXPECT_EQ(document.value(), expected);
+  EXPECT_FALSE(document.has_value());
 }
 
 TEST(make_resource_metadata_rejects_a_cleartext_jwks_uri) {
@@ -886,9 +911,11 @@ TEST(make_resource_metadata_minimal_round_trips) {
   config.resource = "https://api.example.com";
   auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
   EXPECT_TRUE(document.has_value());
+  const auto expected{document.value()};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document.value()), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(), "https://api.example.com");
   EXPECT_FALSE(metadata.value().first_authorization_server().has_value());
 }
@@ -918,9 +945,11 @@ TEST(make_resource_metadata_round_trips) {
   config.dpop_bound_access_tokens_required = true;
   auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
   EXPECT_TRUE(document.has_value());
+  const auto expected{document.value()};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document.value()), "https://api.example.com/mcp?tenant=1")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_EQ(metadata.value().resource(),
             "https://api.example.com/mcp?tenant=1");
   EXPECT_EQ(metadata.value().first_authorization_server().value(),
@@ -954,9 +983,11 @@ TEST(make_resource_metadata_empty_bearer_methods_round_trips) {
   config.bearer_methods_supported = methods;
   auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
   EXPECT_TRUE(document.has_value());
+  const auto expected{document.value()};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document.value()), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_bearer_method("header"));
   EXPECT_FALSE(metadata.value().supports_bearer_method("body"));
   EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
@@ -967,9 +998,11 @@ TEST(resource_metadata_resource_name_present) {
     "resource": "https://api.example.com",
     "resource_name": "Example API"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().resource_name().has_value());
   EXPECT_EQ(metadata.value().resource_name().value(), "Example API");
 }
@@ -978,9 +1011,11 @@ TEST(resource_metadata_resource_name_absent) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().resource_name().has_value());
 }
 
@@ -989,9 +1024,11 @@ TEST(resource_metadata_language_tagged_name_yields_absent_untagged) {
     "resource": "https://api.example.com",
     "resource_name#it": "API di esempio"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().resource_name().has_value());
   EXPECT_TRUE(metadata.value().data().defines("resource_name#it"));
   EXPECT_EQ(metadata.value().data().at("resource_name#it").to_string(),
@@ -1003,9 +1040,11 @@ TEST(resource_metadata_resource_documentation_present) {
     "resource": "https://api.example.com",
     "resource_documentation": "https://api.example.com/docs"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().resource_documentation().has_value());
   EXPECT_EQ(metadata.value().resource_documentation().value(),
             "https://api.example.com/docs");
@@ -1015,9 +1054,11 @@ TEST(resource_metadata_resource_documentation_absent) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().resource_documentation().has_value());
 }
 
@@ -1026,9 +1067,11 @@ TEST(resource_metadata_resource_policy_uri_present) {
     "resource": "https://api.example.com",
     "resource_policy_uri": "https://api.example.com/policy"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().resource_policy_uri().has_value());
   EXPECT_EQ(metadata.value().resource_policy_uri().value(),
             "https://api.example.com/policy");
@@ -1038,9 +1081,11 @@ TEST(resource_metadata_resource_policy_uri_absent) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
 }
 
@@ -1049,9 +1094,11 @@ TEST(resource_metadata_resource_tos_uri_present) {
     "resource": "https://api.example.com",
     "resource_tos_uri": "https://api.example.com/terms"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().resource_tos_uri().has_value());
   EXPECT_EQ(metadata.value().resource_tos_uri().value(),
             "https://api.example.com/terms");
@@ -1061,9 +1108,11 @@ TEST(resource_metadata_resource_tos_uri_absent) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
 }
 
@@ -1071,9 +1120,11 @@ TEST(resource_metadata_tls_client_certificate_bound_defaults_to_false) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
 }
 
@@ -1082,9 +1133,11 @@ TEST(resource_metadata_tls_client_certificate_bound_reads_true) {
     "resource": "https://api.example.com",
     "tls_client_certificate_bound_access_tokens": true
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().tls_client_certificate_bound_access_tokens());
 }
 
@@ -1093,9 +1146,11 @@ TEST(resource_metadata_tls_client_certificate_bound_reads_false) {
     "resource": "https://api.example.com",
     "tls_client_certificate_bound_access_tokens": false
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
 }
 
@@ -1104,9 +1159,11 @@ TEST(resource_metadata_supports_resource_signing_alg) {
     "resource": "https://api.example.com",
     "resource_signing_alg_values_supported": [ "RS256", "ES256" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_resource_signing_alg("RS256"));
   EXPECT_TRUE(metadata.value().supports_resource_signing_alg("ES256"));
   EXPECT_FALSE(metadata.value().supports_resource_signing_alg("PS256"));
@@ -1116,9 +1173,11 @@ TEST(resource_metadata_resource_signing_alg_absent_is_false) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_resource_signing_alg("RS256"));
 }
 
@@ -1127,9 +1186,11 @@ TEST(resource_metadata_supports_dpop_signing_alg) {
     "resource": "https://api.example.com",
     "dpop_signing_alg_values_supported": [ "ES256", "PS256" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("ES256"));
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("PS256"));
   EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("RS256"));
@@ -1139,9 +1200,11 @@ TEST(resource_metadata_dpop_signing_alg_absent_is_false) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_dpop_signing_alg("ES256"));
 }
 
@@ -1150,9 +1213,11 @@ TEST(resource_metadata_supports_authorization_details_type) {
     "resource": "https://api.example.com",
     "authorization_details_types_supported": [ "payment_initiation" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_authorization_details_type(
       "payment_initiation"));
   EXPECT_FALSE(
@@ -1163,9 +1228,11 @@ TEST(resource_metadata_authorization_details_type_absent_is_false) {
   auto document{sourcemeta::core::parse_json(R"JSON({
     "resource": "https://api.example.com"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_FALSE(metadata.value().supports_authorization_details_type(
       "payment_initiation"));
 }
@@ -1245,9 +1312,11 @@ TEST(resource_metadata_accepts_none_in_dpop_signing_algs) {
     "resource": "https://api.example.com",
     "dpop_signing_alg_values_supported": [ "none" ]
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://api.example.com")};
   EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("none"));
 }
 
@@ -1345,25 +1414,118 @@ TEST(resource_metadata_parses_the_rfc9728_example) {
     "resource_documentation":
       "https://resource.example.com/resource_documentation.html"
   })JSON")};
+  const auto expected{document};
   const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
       std::move(document), "https://resource.example.com")};
   EXPECT_TRUE(metadata.has_value());
-  EXPECT_EQ(metadata.value().resource(), "https://resource.example.com");
-  EXPECT_EQ(metadata.value().first_authorization_server().value(),
-            "https://as1.example.com");
+  EXPECT_EQ(metadata.value().data(), expected);
+}
+
+TEST(resource_metadata_accepts_hs256_in_dpop_signing_algs) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "dpop_signing_alg_values_supported": [ "HS256" ]
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+  EXPECT_TRUE(metadata.value().supports_dpop_signing_alg("HS256"));
+}
+
+TEST(resource_metadata_preserves_language_tagged_page_members) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_documentation#fr": "https://api.example.com/fr/docs",
+    "resource_policy_uri#de": "https://api.example.com/de/policy",
+    "resource_tos_uri#ja": "https://api.example.com/ja/terms"
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_documentation().has_value());
+  EXPECT_FALSE(metadata.value().resource_policy_uri().has_value());
+  EXPECT_FALSE(metadata.value().resource_tos_uri().has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+}
+
+TEST(resource_metadata_preserves_a_wrong_typed_language_tagged_member) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_name#it": 42
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().resource_name().has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+}
+
+TEST(resource_metadata_preserves_signed_metadata) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "signed_metadata": "eyJhbGciOiJFUzI1NiJ9.e30.signature"
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
+}
+
+TEST(resource_metadata_accepts_an_uppercase_advertised_issuer_document) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "authorization_servers": [ "HTTPS://auth.example.com" ]
+  })JSON")};
+  const auto expected{document};
+  const auto metadata{sourcemeta::core::OAuthResourceMetadata::from(
+      std::move(document), "https://api.example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_EQ(metadata.value().data(), expected);
   EXPECT_TRUE(metadata.value().supports_authorization_server(
-      "https://as1.example.com"));
-  EXPECT_TRUE(metadata.value().supports_authorization_server(
-      "https://as2.example.net"));
-  EXPECT_TRUE(metadata.value().supports_bearer_method("header"));
-  EXPECT_TRUE(metadata.value().supports_bearer_method("body"));
-  EXPECT_FALSE(metadata.value().supports_bearer_method("query"));
-  EXPECT_TRUE(metadata.value().supports_scope("profile"));
-  EXPECT_TRUE(metadata.value().supports_scope("email"));
-  EXPECT_TRUE(metadata.value().supports_scope("phone"));
-  EXPECT_EQ(metadata.value().resource_documentation().value(),
-            "https://resource.example.com/resource_documentation.html");
-  EXPECT_FALSE(metadata.value().jwks_uri().has_value());
-  EXPECT_FALSE(metadata.value().dpop_bound_access_tokens_required());
-  EXPECT_FALSE(metadata.value().tls_client_certificate_bound_access_tokens());
+      "HTTPS://auth.example.com"));
+}
+
+TEST(make_resource_metadata_emits_duplicate_scopes_as_given) {
+  const std::array<std::string_view, 2> scopes{{"read", "read"}};
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.scopes_supported = scopes;
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "scopes_supported": [ "read", "read" ]
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_accepts_a_cleartext_policy_uri) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_policy_uri = "http://api.example.com/policy";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_policy_uri": "http://api.example.com/policy"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
+}
+
+TEST(make_resource_metadata_accepts_a_cleartext_tos_uri) {
+  sourcemeta::core::OAuthResourceMetadataConfig config;
+  config.resource = "https://api.example.com";
+  config.resource_tos_uri = "http://api.example.com/terms";
+  const auto document{sourcemeta::core::oauth_make_resource_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto expected{sourcemeta::core::parse_json(R"JSON({
+    "resource": "https://api.example.com",
+    "resource_tos_uri": "http://api.example.com/terms"
+  })JSON")};
+  EXPECT_EQ(document.value(), expected);
 }


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

