### PR TITLE
Implement a `langtag_equals` BCP 47 utility helper

### DIFF
--- a/src/core/jsonld/jsonld_value_compaction.cc
+++ b/src/core/jsonld/jsonld_value_compaction.cc
@@ -1,5 +1,5 @@
 #include <sourcemeta/core/json.h>
-#include <sourcemeta/core/text.h>
+#include <sourcemeta/core/langtag.h>
 
 #include "jsonld_algorithms.h"
 #include "jsonld_keywords.h"
@@ -10,13 +10,6 @@
 namespace sourcemeta::core {
 
 namespace {
-
-// The text module only lowercases in place, so this returns a lowercased copy.
-auto lowercase(const JSON::StringView value) -> JSON::String {
-  JSON::String result{value};
-  to_lowercase(result);
-  return result;
-}
 
 auto container_includes(const TermDefinition *const definition,
                         const JSON::StringView keyword) -> bool {
@@ -94,8 +87,10 @@ auto compact_value(const ActiveContext &active_context,
       const bool language_matches{
           value.defines(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH)
               ? (language.has_value() &&
-                 lowercase(value.at(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH)
-                               .to_string()) == lowercase(language.value()))
+                 langtag_equals(
+                     value.at(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH)
+                         .to_string(),
+                     language.value()))
               : !language.has_value()};
       const bool direction_matches{
           value.defines(KEYWORD_DIRECTION, KEYWORD_DIRECTION_HASH)

--- a/src/core/langtag/include/sourcemeta/core/langtag.h
+++ b/src/core/langtag/include/sourcemeta/core/langtag.h
@@ -63,6 +63,24 @@ auto is_langtag(const std::string_view value) -> bool;
 SOURCEMETA_CORE_LANGTAG_EXPORT
 auto is_canonical_langtag(const std::string_view value) -> bool;
 
+/// @ingroup langtag
+/// Check whether two language tags are equal per RFC 5646 (BCP 47) Section
+/// 2.1.1, which treats tags and their subtags as case insensitive. The
+/// comparison is allocation-free and does not validate its arguments. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/langtag.h>
+///
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::langtag_equals("en-US", "en-us"));
+/// assert(!sourcemeta::core::langtag_equals("en", "fr"));
+/// ```
+SOURCEMETA_CORE_LANGTAG_EXPORT
+auto langtag_equals(const std::string_view left, const std::string_view right)
+    -> bool;
+
 } // namespace sourcemeta::core
 
 #endif

--- a/src/core/langtag/langtag.cc
+++ b/src/core/langtag/langtag.cc
@@ -249,6 +249,13 @@ auto is_langtag(const std::string_view value) -> bool {
   return is_irregular_grandfathered(value);
 }
 
+auto langtag_equals(const std::string_view left, const std::string_view right)
+    -> bool {
+  // Language tags and their subtags, including private use and extensions,
+  // are to be treated as case insensitive (RFC 5646 Section 2.1.1)
+  return equals_ignore_case(left, right);
+}
+
 auto is_canonical_langtag(const std::string_view value) -> bool {
   // The registry maps every irregular grandfathered tag to a canonical
   // replacement, so none of them is canonical.

--- a/test/jsonld/jsonld_compact_test.cc
+++ b/test/jsonld/jsonld_compact_test.cc
@@ -392,3 +392,58 @@ TEST(json_literal_null_without_json_term_keeps_value_object) {
   })");
   EXPECT_EQ(result, expected);
 }
+
+// Language tags are case insensitive (RFC 5646 Section 2.1.1), so a value
+// whose language differs from the term language mapping only in casing still
+// compacts to a plain string
+TEST(language_match_is_case_insensitive) {
+  const auto input = sourcemeta::core::parse_json(R"([
+    {
+      "http://example.org/vocab#label": [
+        { "@value": "hello", "@language": "EN-us" }
+      ]
+    }
+  ])");
+  const auto context = sourcemeta::core::parse_json(R"({
+    "label": { "@id": "http://example.org/vocab#label", "@language": "en-US" }
+  })");
+  const auto result{sourcemeta::core::jsonld_compact(input, context)};
+  const auto expected = sourcemeta::core::parse_json(R"({
+    "label": "hello",
+    "@context": {
+      "label": {
+        "@id": "http://example.org/vocab#label",
+        "@language": "en-US"
+      }
+    }
+  })");
+  EXPECT_EQ(result, expected);
+}
+
+// A genuinely different language keeps the value object regardless of casing
+TEST(language_mismatch_keeps_value_object) {
+  const auto input = sourcemeta::core::parse_json(R"([
+    {
+      "http://example.org/vocab#label": [
+        { "@value": "hallo", "@language": "DE-ch" }
+      ]
+    }
+  ])");
+  const auto context = sourcemeta::core::parse_json(R"({
+    "label": { "@id": "http://example.org/vocab#label", "@language": "en-US" }
+  })");
+  const auto result{sourcemeta::core::jsonld_compact(input, context)};
+  const auto expected = sourcemeta::core::parse_json(R"({
+    "http://example.org/vocab#label": {
+      "@value": "hallo",
+      "@language": "DE-ch"
+    },
+    "@context": {
+      "label": {
+        "@id": "http://example.org/vocab#label",
+        "@language": "en-US"
+      }
+    }
+  })");
+  EXPECT_EQ(result, expected);
+}

--- a/test/langtag/langtag_test.cc
+++ b/test/langtag/langtag_test.cc
@@ -575,3 +575,138 @@ TEST(canonical_malformed_rejected) {
   EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("en-"));
   EXPECT_FALSE(sourcemeta::core::is_canonical_langtag("de-419-DE"));
 }
+
+TEST(equals_identical_tags) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en", "en"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en-US", "en-US"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("zh-Hant-HK", "zh-Hant-HK"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("x-private", "x-private"));
+}
+
+// RFC 5646 Section 2.1.1: the tag mn-Cyrl-MN is not distinct from
+// MN-cYRL-mn or mN-cYrL-Mn
+TEST(equals_rfc_case_insensitivity_examples) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("mn-Cyrl-MN", "MN-cYRL-mn"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("mn-Cyrl-MN", "mN-cYrL-Mn"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("MN-cYRL-mn", "mN-cYrL-Mn"));
+}
+
+// RFC 5646 Section 2.1.1: tags and their subtags are case insensitive
+TEST(equals_primary_language_casing) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en", "EN"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en", "En"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("de", "dE"));
+}
+
+// RFC 5646 Section 2.1.1: region subtags are case insensitive even though
+// convention capitalizes them
+TEST(equals_region_casing) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en-US", "en-us"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en-US", "EN-US"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en-us", "EN-Us"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("es-419", "ES-419"));
+}
+
+// RFC 5646 Section 2.1.1: script subtags are case insensitive even though
+// convention titlecases them
+TEST(equals_script_casing) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("zh-Hant", "zh-hant"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("zh-Hant", "ZH-HANT"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("sr-Cyrl-RS", "SR-CYRL-RS"));
+}
+
+// RFC 5646 Section 2.1.1: extended language subtags are case insensitive
+TEST(equals_extended_language_casing) {
+  EXPECT_TRUE(
+      sourcemeta::core::langtag_equals("zh-cmn-Hans-CN", "ZH-CMN-HANS-CN"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("zh-yue-HK", "zh-YUE-hk"));
+}
+
+// RFC 5646 Section 2.1.1: variant subtags are case insensitive
+TEST(equals_variant_casing) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("sl-rozaj", "sl-Rozaj"));
+  EXPECT_TRUE(
+      sourcemeta::core::langtag_equals("sl-rozaj-biske", "SL-ROZAJ-BISKE"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("de-CH-1901", "de-ch-1901"));
+}
+
+// RFC 5646 Section 2.1.1: extension subtags, including the singleton, are
+// case insensitive
+TEST(equals_extension_casing) {
+  EXPECT_TRUE(
+      sourcemeta::core::langtag_equals("en-US-u-islamcal", "en-us-U-ISLAMCAL"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("zh-CN-a-myext-x-private",
+                                               "ZH-cn-A-MYEXT-X-PRIVATE"));
+}
+
+// RFC 5646 Section 2.1.1: private use subtags, including the singleton, are
+// case insensitive
+TEST(equals_private_use_casing) {
+  EXPECT_TRUE(
+      sourcemeta::core::langtag_equals("de-CH-x-phonebk", "DE-ch-X-PHONEBK"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("x-foo", "X-FOO"));
+  EXPECT_TRUE(
+      sourcemeta::core::langtag_equals("az-Arab-x-AYB", "az-arab-x-ayb"));
+}
+
+// RFC 5646 Section 2.1.1: grandfathered tags are case insensitive like any
+// other tag
+TEST(equals_grandfathered_casing) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("i-klingon", "I-KLINGON"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en-GB-oed", "EN-gb-OED"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("sgn-BE-FR", "sgn-be-fr"));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("zh-min-nan", "ZH-MIN-NAN"));
+}
+
+TEST(equals_distinct_languages) {
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en", "fr"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("de", "es"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("EN", "FR"));
+}
+
+TEST(equals_distinct_regions) {
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en-US", "en-GB"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en-us", "en-gb"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("es-419", "es-420"));
+}
+
+TEST(equals_distinct_scripts) {
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("zh-Hant", "zh-Hans"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("sr-Cyrl", "sr-Latn"));
+}
+
+// A tag never equals its own prefix, as a missing subtag is not a subtag
+// difference in casing
+TEST(equals_prefix_is_not_equal) {
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en", "en-US"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en-US", "en"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("zh-Hant", "zh"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("zh-Hant-HK", "zh-Hant"));
+}
+
+TEST(equals_distinct_lengths) {
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en", "eng"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("de-CH-1901", "de-CH-19011"));
+}
+
+// RFC 5646 Section 2.1: subtags are distinguished and separated by hyphens,
+// so a different separator never matches
+TEST(equals_distinct_separators) {
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en-US", "en_US"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en-US", "en US"));
+}
+
+// RFC 5646 Section 4.5: reordering extension sequences is a canonicalization
+// concern, so tags whose extension sequences differ in order are not equal
+TEST(equals_extension_order_matters) {
+  EXPECT_FALSE(
+      sourcemeta::core::langtag_equals("en-a-bbb-b-ccc", "en-b-ccc-a-bbb"));
+}
+
+// The comparison does not validate its arguments
+TEST(equals_no_validation) {
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("", ""));
+  EXPECT_TRUE(sourcemeta::core::langtag_equals("en-", "EN-"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("", "en"));
+  EXPECT_FALSE(sourcemeta::core::langtag_equals("en", ""));
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

