### PR TITLE
Support scalar-to-node promotion with constant properties in JSON-LD materialization

### DIFF
--- a/src/core/jsonld/CMakeLists.txt
+++ b/src/core/jsonld/CMakeLists.txt
@@ -7,7 +7,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME jsonld
     jsonld_inverse_context.cc jsonld_iri_compaction.cc
     jsonld_value_compaction.cc jsonld_compaction.cc
     jsonld_node_map.cc jsonld_flatten.cc
-    jsonld_materialize.cc
+    jsonld_materialize.cc jsonld_fragment.cc
     jsonld_algorithms.h jsonld_keywords.h jsonld_serialise.h)
 
 if(SOURCEMETA_CORE_INSTALL)

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_error.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_error.h
@@ -60,6 +60,27 @@ private:
   Pointer pointer_;
 };
 
+/// @ingroup jsonld
+/// An error that represents a constants fragment grammar violation. The
+/// message states the violated fragment rule, the key names the offending
+/// fragment entry, and the pointer locates the offending value inside the
+/// fragment
+class SOURCEMETA_CORE_JSONLD_EXPORT JSONLDFragmentError : public JSONLDError {
+public:
+  /// Locate the error at a fragment entry.
+  JSONLDFragmentError(const char *code, Pointer pointer, JSON::String key)
+      : JSONLDError{code, std::move(pointer)}, key_{std::move(key)} {}
+
+  /// Get the key of the fragment entry that caused the error, empty when the
+  /// fragment itself is malformed
+  [[nodiscard]] auto key() const noexcept -> const JSON::String & {
+    return this->key_;
+  }
+
+private:
+  JSON::String key_;
+};
+
 #if defined(_MSC_VER)
 #pragma warning(default : 4251 4275)
 #endif

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
@@ -46,7 +46,8 @@ struct JSONLDNode {
   /// Whether the node's descendants are asserted in the named graph it denotes.
   bool graph{false};
   /// Constant properties merged into the node, as a canonical fragment of
-  /// predicate to term array. May be empty.
+  /// predicate to term array whose entries are all non-empty term arrays,
+  /// never null removal entries. May be empty.
   JSON constants{JSON::make_object()};
 };
 
@@ -75,13 +76,16 @@ struct JSONLDReference {
   /// The types of the promoted node.
   std::vector<JSON::String> types{};
   /// Constant properties merged into the node, as a canonical fragment of
-  /// predicate to term array. May be empty.
+  /// predicate to term array whose entries are all non-empty term arrays,
+  /// never null removal entries. May be empty.
   JSON constants{JSON::make_object()};
 };
 
 /// @ingroup jsonld
 /// A scalar promoted to a node that carries the scalar as a literal under a
-/// value predicate, plus constant properties
+/// value predicate, plus constant properties. A null value at a promoted
+/// position materializes nothing, as constant properties never appear
+/// without the scalar that legitimizes them.
 struct JSONLDPromotion {
   /// The node identifier, absent for a fresh blank node.
   std::optional<JSON::String> id{};
@@ -89,10 +93,12 @@ struct JSONLDPromotion {
   std::vector<JSON::String> types{};
   /// The predicate that carries the scalar.
   JSON::String value{};
-  /// The literal facets of the carried scalar.
+  /// The literal facets of the carried scalar. The opaque JSON literal facet
+  /// does not apply to a promoted scalar and must stay unset.
   JSONLDLiteral literal{};
   /// Constant properties merged into the node, as a canonical fragment of
-  /// predicate to term array. May be empty.
+  /// predicate to term array whose entries are all non-empty term arrays,
+  /// never null removal entries. May be empty.
   JSON constants{JSON::make_object()};
 };
 
@@ -239,8 +245,10 @@ auto jsonld_materialize(const JSON &instance,
 /// expanded form and return its canonical form: keys sorted, bare scalars
 /// and single terms wrapped into term arrays, duplicate terms removed, and
 /// native numbers or booleans paired with an explicit datatype rewritten to
-/// their canonical string lexical form. A grammar violation throws. For
-/// example:
+/// their canonical string lexical form. A grammar violation throws. A null
+/// entry passes through untouched as the caller's removal channel, so a
+/// canonical fragment only becomes usable as descriptor constants once the
+/// caller resolves removals and strips the null entries. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/jsonld.h>

--- a/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
+++ b/src/core/jsonld/include/sourcemeta/core/jsonld_materialize.h
@@ -45,6 +45,9 @@ struct JSONLDNode {
   std::vector<JSON::String> types{};
   /// Whether the node's descendants are asserted in the named graph it denotes.
   bool graph{false};
+  /// Constant properties merged into the node, as a canonical fragment of
+  /// predicate to term array. May be empty.
+  JSON constants{JSON::make_object()};
 };
 
 /// @ingroup jsonld
@@ -71,6 +74,26 @@ struct JSONLDReference {
   JSON::String id{};
   /// The types of the promoted node.
   std::vector<JSON::String> types{};
+  /// Constant properties merged into the node, as a canonical fragment of
+  /// predicate to term array. May be empty.
+  JSON constants{JSON::make_object()};
+};
+
+/// @ingroup jsonld
+/// A scalar promoted to a node that carries the scalar as a literal under a
+/// value predicate, plus constant properties
+struct JSONLDPromotion {
+  /// The node identifier, absent for a fresh blank node.
+  std::optional<JSON::String> id{};
+  /// The types of the promoted node.
+  std::vector<JSON::String> types{};
+  /// The predicate that carries the scalar.
+  JSON::String value{};
+  /// The literal facets of the carried scalar.
+  JSONLDLiteral literal{};
+  /// Constant properties merged into the node, as a canonical fragment of
+  /// predicate to term array. May be empty.
+  JSON constants{JSON::make_object()};
 };
 
 /// @ingroup jsonld
@@ -104,7 +127,8 @@ struct JSONLDDescriptor {
   /// How the position connects to its parent.
   std::vector<JSONLDEdge> edges{};
   /// What the position is.
-  std::variant<JSONLDNode, JSONLDLiteral, JSONLDReference, JSONLDCollection>
+  std::variant<JSONLDNode, JSONLDLiteral, JSONLDReference, JSONLDCollection,
+               JSONLDPromotion>
       value{};
 };
 
@@ -208,6 +232,31 @@ auto jsonld_materialize(const JSON &instance,
 SOURCEMETA_CORE_JSONLD_EXPORT
 auto jsonld_materialize(const JSON &instance,
                         const JSONLDWeakAnnotationList &annotations) -> JSON;
+
+/// @ingroup jsonld
+///
+/// Validate a fragment of constant node properties written in a restricted
+/// expanded form and return its canonical form: keys sorted, bare scalars
+/// and single terms wrapped into term arrays, duplicate terms removed, and
+/// native numbers or booleans paired with an explicit datatype rewritten to
+/// their canonical string lexical form. A grammar violation throws. For
+/// example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/jsonld.h>
+///
+/// #include <cassert>
+///
+/// const auto fragment{sourcemeta::core::parse_json(R"({
+///   "https://example.com/unit": { "@id": "https://example.com/metre" }
+/// })")};
+///
+/// const auto canonical{
+///     sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+/// assert(canonical.at("https://example.com/unit").is_array());
+/// ```
+SOURCEMETA_CORE_JSONLD_EXPORT
+auto jsonld_canonicalize_fragment(const JSON &fragment) -> JSON;
 
 } // namespace sourcemeta::core
 

--- a/src/core/jsonld/jsonld_algorithms.h
+++ b/src/core/jsonld/jsonld_algorithms.h
@@ -15,10 +15,12 @@
 
 namespace sourcemeta::core {
 
-// A blank node identifier is the prefix "_:" followed by a label (JSON-LD 1.1
-// Section 3.5).
+// A blank node identifier begins with "_:" (JSON-LD 1.1 Section 3.5). A
+// label-less "_:" still counts, so that processing algorithms relabel every
+// blank-flavored identifier instead of leaking one as an IRI. Expanded form
+// validation additionally requires a label and keeps its own stricter check.
 inline auto is_blank_node(const std::string_view value) -> bool {
-  return value.size() > 2 && value.starts_with("_:");
+  return value.starts_with("_:");
 }
 
 struct TermDefinition {

--- a/src/core/jsonld/jsonld_algorithms.h
+++ b/src/core/jsonld/jsonld_algorithms.h
@@ -5,14 +5,21 @@
 #include <sourcemeta/core/jsonld.h>
 #include <sourcemeta/core/jsonpointer.h>
 
-#include <cstddef>    // std::size_t
-#include <functional> // std::less
-#include <map>        // std::map
-#include <memory>     // std::shared_ptr
-#include <optional>   // std::optional
-#include <vector>     // std::vector
+#include <cstddef>     // std::size_t
+#include <functional>  // std::less
+#include <map>         // std::map
+#include <memory>      // std::shared_ptr
+#include <optional>    // std::optional
+#include <string_view> // std::string_view
+#include <vector>      // std::vector
 
 namespace sourcemeta::core {
+
+// A blank node identifier is the prefix "_:" followed by a label (JSON-LD 1.1
+// Section 3.5).
+inline auto is_blank_node(const std::string_view value) -> bool {
+  return value.size() > 2 && value.starts_with("_:");
+}
 
 struct TermDefinition {
   std::optional<JSON::String> iri;

--- a/src/core/jsonld/jsonld_fragment.cc
+++ b/src/core/jsonld/jsonld_fragment.cc
@@ -1,0 +1,233 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/langtag.h>
+#include <sourcemeta/core/uri.h>
+
+#include "jsonld_algorithms.h"
+#include "jsonld_keywords.h"
+#include "jsonld_serialise.h"
+
+#include <algorithm>  // std::ranges::sort, std::ranges::find
+#include <cstddef>    // std::size_t
+#include <functional> // std::reference_wrapper, std::cref
+#include <optional>   // std::optional, std::nullopt
+#include <utility>    // std::move
+#include <vector>     // std::vector
+
+namespace sourcemeta::core {
+
+namespace {
+
+// Node types and identifiers have their own descriptor channels, so a
+// fragment cannot smuggle them in as properties, including through the
+// expanded spelling of the type keyword as a plain predicate
+constexpr JSON::StringView PREDICATE_RDF_TYPE{
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"};
+
+auto validate_key(const JSON::String &key) -> void {
+  if (key == KEYWORD_TYPE || key == PREDICATE_RDF_TYPE) {
+    throw JSONLDFragmentError{"A constants fragment cannot declare node types",
+                              Pointer{key}, JSON::String{key}};
+  }
+  if (key == KEYWORD_ID) {
+    throw JSONLDFragmentError{
+        "A constants fragment cannot declare a node identifier", Pointer{key},
+        JSON::String{key}};
+  }
+  if (!key.empty() && key.front() == '@') {
+    throw JSONLDFragmentError{"A constants fragment key cannot be a keyword",
+                              Pointer{key}, JSON::String{key}};
+  }
+  if (!URI::is_iri(key)) {
+    throw JSONLDFragmentError{"A constants fragment key must be an absolute "
+                              "IRI",
+                              Pointer{key}, JSON::String{key}};
+  }
+}
+
+// The location of a fragment term, only materialized on the error path so
+// that valid fragments never pay for pointer construction
+auto term_location(const JSON::String &key,
+                   const std::optional<std::size_t> index) -> Pointer {
+  if (index.has_value()) {
+    return Pointer{key, index.value()};
+  }
+
+  return Pointer{key};
+}
+
+// The fragment grammar reuses the expanded form conventions of JSON-LD 1.1
+// Section 9, so a bare string is always a string literal and a node
+// reference is spelled with an explicit identifier entry
+auto canonicalize_term(const JSON::String &key,
+                       const std::optional<std::size_t> index, const JSON &term)
+    -> JSON {
+  if (term.is_string() || term.is_boolean() || term.is_number()) {
+    auto result{JSON::make_object()};
+    result.assign_assume_new(JSON::String{KEYWORD_VALUE}, JSON{term},
+                             KEYWORD_VALUE_HASH);
+    return result;
+  }
+
+  if (!term.is_object()) {
+    throw JSONLDFragmentError{"A constants fragment term must be a scalar, a "
+                              "node reference, or a value object",
+                              term_location(key, index), JSON::String{key}};
+  }
+
+  if (term.defines(KEYWORD_ID, KEYWORD_ID_HASH)) {
+    if (term.object_size() != 1) {
+      throw JSONLDFragmentError{"A node reference can only carry an identifier",
+                                term_location(key, index), JSON::String{key}};
+    }
+    const auto &identifier{term.at(KEYWORD_ID, KEYWORD_ID_HASH)};
+    if (!identifier.is_string() || is_blank_node(identifier.to_string()) ||
+        !URI::is_iri(identifier.to_string())) {
+      throw JSONLDFragmentError{
+          "A node reference identifier must be an absolute IRI",
+          term_location(key, index), JSON::String{key}};
+    }
+    return JSON{term};
+  }
+
+  if (!term.defines(KEYWORD_VALUE, KEYWORD_VALUE_HASH)) {
+    throw JSONLDFragmentError{"A constants fragment term must be a scalar, a "
+                              "node reference, or a value object",
+                              term_location(key, index), JSON::String{key}};
+  }
+
+  for (const auto &entry : term.as_object()) {
+    if (entry.first != KEYWORD_VALUE && entry.first != KEYWORD_TYPE &&
+        entry.first != KEYWORD_LANGUAGE) {
+      throw JSONLDFragmentError{
+          "A value object can only carry a value, a type, and a language",
+          term_location(key, index), JSON::String{key}};
+    }
+  }
+
+  const auto &value{term.at(KEYWORD_VALUE, KEYWORD_VALUE_HASH)};
+  if (!value.is_string() && !value.is_boolean() && !value.is_number()) {
+    throw JSONLDFragmentError{"A value object value must be a non-null scalar",
+                              term_location(key, index), JSON::String{key}};
+  }
+
+  // A type excludes a language and vice versa (JSON-LD 1.1 Section 9.5, "a
+  // value object must not contain both a type and a language member")
+  const bool has_type{term.defines(KEYWORD_TYPE, KEYWORD_TYPE_HASH)};
+  const bool has_language{
+      term.defines(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH)};
+  if (has_type && has_language) {
+    throw JSONLDFragmentError{
+        "A value object cannot combine a type and a language",
+        term_location(key, index), JSON::String{key}};
+  }
+
+  if (has_language) {
+    if (!value.is_string()) {
+      throw JSONLDFragmentError{"A value object language requires a string "
+                                "value",
+                                term_location(key, index), JSON::String{key}};
+    }
+    const auto &language{term.at(KEYWORD_LANGUAGE, KEYWORD_LANGUAGE_HASH)};
+    if (!language.is_string() || !is_canonical_langtag(language.to_string())) {
+      throw JSONLDFragmentError{
+          "A value object language must be a canonical BCP 47 language tag",
+          term_location(key, index), JSON::String{key}};
+    }
+  }
+
+  if (has_type) {
+    const auto &datatype{term.at(KEYWORD_TYPE, KEYWORD_TYPE_HASH)};
+    if (!datatype.is_string()) {
+      throw JSONLDFragmentError{"A value object type must be an absolute IRI",
+                                term_location(key, index), JSON::String{key}};
+    }
+    // The JSON literal spelling is checked before the IRI shape, as it is
+    // not an IRI and would otherwise report the wrong rule
+    if (datatype.to_string() == KEYWORD_JSON) {
+      throw JSONLDFragmentError{
+          "A value object type cannot be the JSON literal type",
+          term_location(key, index), JSON::String{key}};
+    }
+    if (!URI::is_iri(datatype.to_string())) {
+      throw JSONLDFragmentError{"A value object type must be an absolute IRI",
+                                term_location(key, index), JSON::String{key}};
+    }
+
+    // A native number or boolean under an explicit datatype converts to RDF
+    // through a canonical string lexical form (JSON-LD 1.1 API Section 8.6),
+    // so the canonical fragment stores that form up front. Strings yield no
+    // lexical form and pass through verbatim
+    auto lexical{typed_literal_lexical_form(value, datatype.to_string())};
+    if (lexical.has_value()) {
+      auto rewritten{JSON::make_object()};
+      rewritten.assign_assume_new(JSON::String{KEYWORD_VALUE},
+                                  JSON{std::move(lexical).value()},
+                                  KEYWORD_VALUE_HASH);
+      rewritten.assign_assume_new(JSON::String{KEYWORD_TYPE}, JSON{datatype},
+                                  KEYWORD_TYPE_HASH);
+      return rewritten;
+    }
+  }
+
+  return JSON{term};
+}
+
+auto canonicalize_entry(const JSON::String &key, const JSON &entry) -> JSON {
+  auto terms{JSON::make_array()};
+  if (entry.is_array()) {
+    for (std::size_t index = 0; index < entry.size(); index += 1) {
+      auto term{canonicalize_term(key, index, entry.at(index))};
+      if (std::ranges::find(terms.as_array(), term) ==
+          terms.as_array().cend()) {
+        terms.push_back(std::move(term));
+      }
+    }
+  } else {
+    terms.push_back(canonicalize_term(key, std::nullopt, entry));
+  }
+
+  return terms;
+}
+
+} // namespace
+
+auto jsonld_canonicalize_fragment(const JSON &fragment) -> JSON {
+  if (!fragment.is_object()) {
+    throw JSONLDFragmentError{"A constants fragment must be an object",
+                              Pointer{}, JSON::String{}};
+  }
+
+  std::vector<std::reference_wrapper<const JSON::String>> keys;
+  keys.reserve(fragment.object_size());
+  for (const auto &entry : fragment.as_object()) {
+    keys.push_back(std::cref(entry.first));
+  }
+  std::ranges::sort(keys, [](const auto &left, const auto &right) -> bool {
+    return left.get() < right.get();
+  });
+
+  auto result{JSON::make_object()};
+  for (const auto key : keys) {
+    validate_key(key.get());
+    const auto &entry{fragment.at(key.get())};
+
+    // A null entry is the caller's removal channel and passes through
+    // untouched, and an empty array asserts nothing so its key is dropped
+    if (entry.is_null()) {
+      result.assign_assume_new(JSON::String{key.get()}, JSON{nullptr});
+      continue;
+    }
+    if (entry.is_array() && entry.empty()) {
+      continue;
+    }
+
+    result.assign_assume_new(JSON::String{key.get()},
+                             canonicalize_entry(key.get(), entry));
+  }
+
+  return result;
+}
+
+} // namespace sourcemeta::core

--- a/src/core/jsonld/jsonld_is_expanded.cc
+++ b/src/core/jsonld/jsonld_is_expanded.cc
@@ -3,7 +3,6 @@
 #include <sourcemeta/core/langtag.h>
 #include <sourcemeta/core/uri.h>
 
-#include "jsonld_algorithms.h"
 #include "jsonld_keywords.h"
 
 #include <cstdint>     // std::uint8_t
@@ -14,6 +13,13 @@
 namespace sourcemeta::core {
 
 namespace {
+
+// A blank node identifier is the prefix "_:" followed by a label (JSON-LD 1.1
+// Section 3.5). Validation requires the label, unlike the processing helper,
+// as a label-less "_:" identifies nothing.
+auto is_blank_node(const std::string_view value) -> bool {
+  return value.size() > 2 && value.starts_with("_:");
+}
 
 // A property term in expanded form is an absolute IRI or a blank node
 // identifier (JSON-LD 1.1 Section 9, "node object").

--- a/src/core/jsonld/jsonld_is_expanded.cc
+++ b/src/core/jsonld/jsonld_is_expanded.cc
@@ -3,6 +3,7 @@
 #include <sourcemeta/core/langtag.h>
 #include <sourcemeta/core/uri.h>
 
+#include "jsonld_algorithms.h"
 #include "jsonld_keywords.h"
 
 #include <cstdint>     // std::uint8_t
@@ -13,12 +14,6 @@
 namespace sourcemeta::core {
 
 namespace {
-
-// A blank node identifier is the prefix "_:" followed by a label (JSON-LD 1.1
-// Section 3.5).
-auto is_blank_node(const std::string_view value) -> bool {
-  return value.size() > 2 && value.starts_with("_:");
-}
 
 // A property term in expanded form is an absolute IRI or a blank node
 // identifier (JSON-LD 1.1 Section 9, "node object").

--- a/src/core/jsonld/jsonld_materialize.cc
+++ b/src/core/jsonld/jsonld_materialize.cc
@@ -5,7 +5,7 @@
 #include "jsonld_keywords.h"
 #include "jsonld_serialise.h"
 
-#include <algorithm> // std::ranges::sort, std::ranges::stable_sort, std::ranges::unique, std::ranges::none_of
+#include <algorithm> // std::ranges::sort, std::ranges::stable_sort, std::ranges::unique, std::ranges::none_of, std::ranges::find
 #include <cassert>   // assert
 #include <cstddef>   // std::size_t
 #include <functional>  // std::reference_wrapper, std::cref
@@ -154,6 +154,44 @@ auto attach(JSON &node, const std::vector<JSONLDEdge> &edges, JSON value)
   attach_one(node, edges.back(), std::move(value));
 }
 
+// The keys of an object in sorted order, so the object walk is canonical
+// regardless of the instance key order.
+auto sorted_keys(const JSON &value)
+    -> std::vector<std::reference_wrapper<const JSON::String>> {
+  std::vector<std::reference_wrapper<const JSON::String>> keys;
+  keys.reserve(value.object_size());
+  for (const auto &entry : value.as_object()) {
+    keys.push_back(std::cref(entry.first));
+  }
+  std::ranges::sort(keys, [](const auto &left, const auto &right) -> bool {
+    return left.get() < right.get();
+  });
+  return keys;
+}
+
+// Merge canonical constant properties into a node, unioning terms under each
+// predicate without duplicates. Keys are iterated in sorted order so the
+// emitted property order does not depend on how the caller assembled the map
+auto merge_constants(JSON &node, const JSON &constants) -> void {
+  assert(constants.is_object());
+  if (constants.empty()) {
+    return;
+  }
+
+  for (const auto key : sorted_keys(constants)) {
+    const auto &terms{constants.at(key.get())};
+    assert(terms.is_array());
+    assert(!terms.empty());
+    auto &target{property_target(node, key.get())};
+    for (const auto &term : terms.as_array()) {
+      if (std::ranges::find(target.as_array(), term) ==
+          target.as_array().cend()) {
+        target.push_back(JSON{term});
+      }
+    }
+  }
+}
+
 auto materialize_literal(const JSONLDLiteral &descriptor, const JSON &value)
     -> JSON {
   auto result{JSON::make_object()};
@@ -202,7 +240,30 @@ auto materialize_reference(const JSONLDReference &descriptor) -> JSON {
                              types_to_array(descriptor.types),
                              KEYWORD_TYPE_HASH);
   }
+  merge_constants(result, descriptor.constants);
   return result;
+}
+
+auto materialize_promotion(const JSONLDPromotion &descriptor, const JSON &value)
+    -> JSON {
+  assert(!value.is_object());
+  assert(!value.is_array());
+  assert(!descriptor.literal.json);
+  auto node{JSON::make_object()};
+  if (descriptor.id.has_value()) {
+    node.assign_assume_new(JSON::String{KEYWORD_ID},
+                           JSON{descriptor.id.value()}, KEYWORD_ID_HASH);
+  }
+  if (!descriptor.types.empty()) {
+    node.assign_assume_new(JSON::String{KEYWORD_TYPE},
+                           types_to_array(descriptor.types), KEYWORD_TYPE_HASH);
+  }
+
+  auto terms{JSON::make_array()};
+  terms.push_back(materialize_literal(descriptor.literal, value));
+  node.assign_assume_new(JSON::String{descriptor.value}, std::move(terms));
+  merge_constants(node, descriptor.constants);
+  return node;
 }
 
 template <typename PointerT>
@@ -240,21 +301,6 @@ auto build_collection(const JSON &value, PointerT &pointer,
   result.assign_assume_new(JSON::String{KEYWORD_LIST}, std::move(elements),
                            KEYWORD_LIST_HASH);
   return result;
-}
-
-// The keys of an object in sorted order, so the object walk is canonical
-// regardless of the instance key order.
-auto sorted_keys(const JSON &value)
-    -> std::vector<std::reference_wrapper<const JSON::String>> {
-  std::vector<std::reference_wrapper<const JSON::String>> keys;
-  keys.reserve(value.object_size());
-  for (const auto &entry : value.as_object()) {
-    keys.push_back(std::cref(entry.first));
-  }
-  std::ranges::sort(keys, [](const auto &left, const auto &right) -> bool {
-    return left.get() < right.get();
-  });
-  return keys;
 }
 
 // The reserved @none key carries no language.
@@ -385,11 +431,13 @@ auto materialize_node(const JSONLDNode &descriptor, const JSON &value,
   }
 
   if (!value.is_object()) {
+    merge_constants(node, descriptor.constants);
     return node;
   }
 
   // A graph node asserts its members in the named graph it identifies, with the
-  // members carried by a subject node that shares its identifier.
+  // members carried by a subject node that shares its identifier. Constant
+  // properties belong to the subject inside the graph, never to the wrapper.
   if (descriptor.graph) {
     auto inner{JSON::make_object()};
     if (descriptor.id.has_value()) {
@@ -398,6 +446,7 @@ auto materialize_node(const JSONLDNode &descriptor, const JSON &value,
     }
     std::vector<JSON> graph_nodes;
     fill_node(inner, value, pointer, range, graph_nodes);
+    merge_constants(inner, descriptor.constants);
     auto graph{JSON::make_array()};
     if (inner.object_size() > (descriptor.id.has_value() ? 1 : 0)) {
       graph.push_back(std::move(inner));
@@ -416,6 +465,7 @@ auto materialize_node(const JSONLDNode &descriptor, const JSON &value,
   }
 
   fill_node(node, value, pointer, range, standalone);
+  merge_constants(node, descriptor.constants);
   return node;
 }
 
@@ -473,6 +523,21 @@ auto materialize_value(const JSON &value, PointerT &pointer,
   if (const auto *reference_descriptor{
           std::get_if<JSONLDReference>(&descriptor.value)}) {
     return materialize_reference(*reference_descriptor);
+  }
+
+  if (const auto *promotion_descriptor{
+          std::get_if<JSONLDPromotion>(&descriptor.value)}) {
+    // A schema-manufactured node with no name and no edge is not asserted,
+    // so an unreferenced scalar cannot pollute the graph with anonymous
+    // subjects. A collection member is exempt, as it attaches positionally
+    // through the collection's own edge and dropping it would silently
+    // shorten the collection
+    const bool member_position{matched_edges == nullptr && !pointer.empty()};
+    if (!promotion_descriptor->id.has_value() && descriptor.edges.empty() &&
+        !member_position) {
+      return std::nullopt;
+    }
+    return materialize_promotion(*promotion_descriptor, value);
   }
 
   const auto &collection{std::get<JSONLDCollection>(descriptor.value)};

--- a/src/core/jsonld/jsonld_node_map.cc
+++ b/src/core/jsonld/jsonld_node_map.cc
@@ -14,10 +14,6 @@ namespace sourcemeta::core {
 
 namespace {
 
-auto is_blank_node(const JSON::StringView value) -> bool {
-  return value.starts_with("_:");
-}
-
 // Append a value to the property array of node, creating the array as needed.
 auto append_value(JSON &node, const JSON::StringView property, JSON value)
     -> void {

--- a/test/jsonld/CMakeLists.txt
+++ b/test/jsonld/CMakeLists.txt
@@ -1,7 +1,7 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME jsonld
   SOURCES jsonld_expand_test.cc jsonld_expand_error_test.cc
     jsonld_is_expanded_test.cc jsonld_compact_test.cc jsonld_flatten_test.cc
-    jsonld_materialize_test.cc)
+    jsonld_materialize_test.cc jsonld_fragment_test.cc)
 
 target_link_libraries(sourcemeta_core_jsonld_unit
   PRIVATE sourcemeta::core::jsonld)

--- a/test/jsonld/jsonld_fragment_test.cc
+++ b/test/jsonld/jsonld_fragment_test.cc
@@ -1,0 +1,515 @@
+#include <sourcemeta/core/json.h>
+#include <sourcemeta/core/jsonld.h>
+#include <sourcemeta/core/jsonpointer.h>
+#include <sourcemeta/core/test.h>
+
+#define EXPECT_JSONLD_FRAGMENT_ERROR(expression, expected_code,                \
+                                     expected_pointer, expected_key)           \
+  try {                                                                        \
+    [[maybe_unused]] const auto result{expression};                            \
+    FAIL();                                                                    \
+  } catch (const sourcemeta::core::JSONLDFragmentError &error) {               \
+    EXPECT_STREQ(error.what(), (expected_code));                               \
+    EXPECT_EQ(sourcemeta::core::to_string(error.pointer()),                    \
+              (expected_pointer));                                             \
+    EXPECT_EQ(error.key(), (expected_key));                                    \
+  } catch (...) {                                                              \
+    FAIL();                                                                    \
+  }
+
+TEST(canonicalize_empty_fragment) {
+  const auto fragment{sourcemeta::core::parse_json(R"({})")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({})")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_non_object_fragment_array) {
+  const auto fragment{sourcemeta::core::parse_json(R"([])")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment must be an object", "", "");
+}
+
+TEST(canonicalize_non_object_fragment_string) {
+  const auto fragment{sourcemeta::core::parse_json(R"("foo")")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment must be an object", "", "");
+}
+
+TEST(canonicalize_non_object_fragment_null) {
+  const auto fragment{sourcemeta::core::parse_json(R"(null)")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment must be an object", "", "");
+}
+
+TEST(canonicalize_bare_string_literal) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/status": "REC"
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/status": [ { "@value": "REC" } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_bare_number_literal) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/decimals": 2
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/decimals": [ { "@value": 2 } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_bare_boolean_literal) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/active": true
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/active": [ { "@value": true } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_node_reference) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": { "@id": "https://example.com/metre" }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_value_object_passthrough) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/label": { "@value": "metre", "@language": "en" }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/label": [ { "@value": "metre", "@language": "en" } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_typed_string_literal_passthrough) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/factor": {
+      "@value": "0.1",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/factor": [
+      {
+        "@value": "0.1",
+        "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_typed_fractional_native_rewritten) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/factor": {
+      "@value": 1.85,
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/factor": [
+      {
+        "@value": "1.85",
+        "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+      }
+    ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_typed_integer_native_rewritten) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/count": {
+      "@value": 2,
+      "@type": "http://www.w3.org/2001/XMLSchema#byte"
+    }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/count": [
+      { "@value": "2", "@type": "http://www.w3.org/2001/XMLSchema#byte" }
+    ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_typed_boolean_native_rewritten) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/flag": {
+      "@value": true,
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/flag": [
+      {
+        "@value": "true",
+        "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+      }
+    ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_untyped_native_number_kept) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/decimals": { "@value": 2 }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/decimals": [ { "@value": 2 } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_array_of_terms) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [
+      { "@id": "https://example.com/a" },
+      { "@id": "https://example.com/b" }
+    ]
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [
+      { "@id": "https://example.com/a" },
+      { "@id": "https://example.com/b" }
+    ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_type_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "@type": "https://example.com/Quantity"
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment cannot declare node types", "/@type", "@type");
+}
+
+TEST(canonicalize_rdf_type_predicate_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+      "@id": "https://example.com/Quantity"
+    }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment cannot declare node types",
+      "/http:~1~1www.w3.org~11999~102~122-rdf-syntax-ns#type",
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+}
+
+TEST(canonicalize_id_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "@id": "https://example.com/thing"
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment cannot declare a node identifier", "/@id", "@id");
+}
+
+TEST(canonicalize_keyword_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "@context": "https://example.com/context"
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment key cannot be a keyword", "/@context", "@context");
+}
+
+TEST(canonicalize_relative_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "unit": { "@id": "https://example.com/metre" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment key must be an absolute IRI", "/unit", "unit");
+}
+
+TEST(canonicalize_blank_node_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "_:b0": { "@id": "https://example.com/metre" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment key must be an absolute IRI", "/_:b0", "_:b0");
+}
+
+TEST(canonicalize_empty_key_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "": "foo"
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment key must be an absolute IRI", "/", "");
+}
+
+TEST(canonicalize_array_of_bare_scalars) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/tags": [ "alpha", "beta" ]
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/tags": [
+      { "@value": "alpha" },
+      { "@value": "beta" }
+    ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_null_term_in_array_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [ null ]
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment term must be a scalar, a node reference, or a "
+      "value object",
+      "/https:~1~1example.com~1see/0", "https://example.com/see");
+}
+
+TEST(canonicalize_nested_array_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [ [ "nested" ] ]
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment term must be a scalar, a node reference, or a "
+      "value object",
+      "/https:~1~1example.com~1see/0", "https://example.com/see");
+}
+
+TEST(canonicalize_node_object_with_properties_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": {
+      "@id": "https://example.com/a",
+      "https://example.com/comment": "x"
+    }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A node reference can only carry an identifier",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_blank_node_reference_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@id": "_:b0" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A node reference identifier must be an absolute IRI",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_relative_reference_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@id": "../metre" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A node reference identifier must be an absolute IRI",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_list_term_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@list": [ 1, 2 ] }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment term must be a scalar, a node reference, or a "
+      "value object",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_set_term_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@set": [ 1 ] }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A constants fragment term must be a scalar, a node reference, or a "
+      "value object",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_null_value_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": null }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object value must be a non-null scalar",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_array_value_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": [ 1 ] }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object value must be a non-null scalar",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_type_and_language_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": {
+      "@value": "x",
+      "@type": "https://example.com/t",
+      "@language": "en"
+    }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object cannot combine a type and a language",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_extra_member_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": "x", "@index": "i" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object can only carry a value, a type, and a language",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_language_on_number_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": 1, "@language": "en" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object language requires a string value",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_non_canonical_language_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": "x", "@language": "en-us" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object language must be a canonical BCP 47 language tag",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_json_type_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": "x", "@type": "@json" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object type cannot be the JSON literal type",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_value_object_relative_type_rejected) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": { "@value": "x", "@type": "decimal" }
+  })")};
+  EXPECT_JSONLD_FRAGMENT_ERROR(
+      sourcemeta::core::jsonld_canonicalize_fragment(fragment),
+      "A value object type must be an absolute IRI",
+      "/https:~1~1example.com~1see", "https://example.com/see");
+}
+
+TEST(canonicalize_sorts_keys) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/b": "second",
+    "https://example.com/a": "first"
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  EXPECT_EQ(result.as_object().cbegin()->first, "https://example.com/a");
+}
+
+TEST(canonicalize_dedupes_identical_terms) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [
+      { "@id": "https://example.com/a" },
+      { "@id": "https://example.com/a" }
+    ]
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [ { "@id": "https://example.com/a" } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_dedupes_bare_scalar_against_value_object) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [ 1, { "@value": 1 } ]
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [ { "@value": 1 } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_null_entry_passes_through) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": null
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": null
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_empty_array_entry_dropped) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/see": [],
+    "https://example.com/unit": { "@id": "https://example.com/metre" }
+  })")};
+  const auto result{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto expected{sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+  })")};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(canonicalize_is_idempotent) {
+  const auto fragment{sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": { "@id": "https://example.com/metre" },
+    "https://example.com/factor": {
+      "@value": 1.85,
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "https://example.com/tags": [ "alpha", "alpha", "beta" ]
+  })")};
+  const auto once{sourcemeta::core::jsonld_canonicalize_fragment(fragment)};
+  const auto twice{sourcemeta::core::jsonld_canonicalize_fragment(once)};
+  EXPECT_EQ(once, twice);
+}

--- a/test/jsonld/jsonld_materialize_test.cc
+++ b/test/jsonld/jsonld_materialize_test.cc
@@ -5059,3 +5059,626 @@ TEST(huge_exponent_decimal_literal_with_double_datatype) {
   EXPECT_EQ(result, expected);
   EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
 }
+
+TEST(node_with_constants) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "name": "Sourcemeta" })");
+
+  sourcemeta::core::JSONLDNode node;
+  node.id = "https://example.com/org";
+  node.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/kind": [ { "@id": "https://example.com/Company" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(node)});
+  annotations.emplace_back(sourcemeta::core::Pointer{"name"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://schema.org/name", false}},
+                               .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/org",
+      "https://schema.org/name": [ { "@value": "Sourcemeta" } ],
+      "https://example.com/kind": [ { "@id": "https://example.com/Company" } ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(node_constants_dedupe_against_instance_members) {
+  const auto instance = sourcemeta::core::parse_json(
+      R"({ "kind": "https://example.com/Company" })");
+
+  sourcemeta::core::JSONLDNode node;
+  node.id = "https://example.com/org";
+  node.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/kind": [
+      { "@value": "https://example.com/Company" }
+    ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(node)});
+  annotations.emplace_back(sourcemeta::core::Pointer{"kind"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/kind", false}},
+                               .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/org",
+      "https://example.com/kind": [
+        { "@value": "https://example.com/Company" }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(graph_node_constants_on_inner_subject) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "name": "Sourcemeta" })");
+
+  sourcemeta::core::JSONLDNode node;
+  node.id = "https://example.com/graph";
+  node.graph = true;
+  node.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/kind": [ { "@id": "https://example.com/Company" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(node)});
+  annotations.emplace_back(sourcemeta::core::Pointer{"name"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://schema.org/name", false}},
+                               .value = sourcemeta::core::JSONLDLiteral{}});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/graph",
+      "@graph": [
+        {
+          "@id": "https://example.com/graph",
+          "https://schema.org/name": [ { "@value": "Sourcemeta" } ],
+          "https://example.com/kind": [
+            { "@id": "https://example.com/Company" }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(reference_with_constants_renders_node_object) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "code": "EUR" })");
+
+  sourcemeta::core::JSONLDReference reference;
+  reference.id = "https://example.com/EUR";
+  reference.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/kind": [ { "@id": "https://example.com/Currency" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(
+      sourcemeta::core::Pointer{"code"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/currency", false}},
+          .value = std::move(reference)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/currency": [
+        {
+          "@id": "https://example.com/EUR",
+          "https://example.com/kind": [
+            { "@id": "https://example.com/Currency" }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_with_constants) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.types.push_back("https://example.com/Quantity");
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/height": [
+        {
+          "@type": [ "https://example.com/Quantity" ],
+          "https://example.com/value": [ { "@value": 1.85 } ],
+          "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_typed_inner_literal_canonical_lexical_form) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+  promotion.literal.datatype = "http://www.w3.org/2001/XMLSchema#decimal";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/height": [
+        {
+          "https://example.com/value": [
+            {
+              "@value": "1.85",
+              "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+            }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_language_inner_literal) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "name": "metro" })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/label";
+  promotion.literal.language = "es";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"name"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/name", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/name": [
+        {
+          "https://example.com/label": [
+            { "@value": "metro", "@language": "es" }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_null_instance_emits_nothing) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": null })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([])");
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(promotion_anonymous_unedged_property_omitted) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([])");
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(promotion_named_unedged_property_standalone) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.id = "https://example.com/measurement";
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/measurement",
+      "https://example.com/value": [ { "@value": 1.85 } ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_anonymous_root_omitted) {
+  const auto instance = sourcemeta::core::parse_json(R"(1.85)");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([])");
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(promotion_named_root_kept) {
+  const auto instance = sourcemeta::core::parse_json(R"(1.85)");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.id = "https://example.com/measurement";
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@id": "https://example.com/measurement",
+      "https://example.com/value": [ { "@value": 1.85 } ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_anonymous_list_member_survives) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "heights": [ 1.85, 1.7 ] })");
+
+  sourcemeta::core::JSONLDPromotion first;
+  first.value = "https://example.com/value";
+  sourcemeta::core::JSONLDPromotion second;
+  second.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(
+      sourcemeta::core::Pointer{"heights"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/heights", false}},
+          .value = sourcemeta::core::JSONLDCollection{
+              .container = sourcemeta::core::JSONLDContainer::List}});
+  annotations.emplace_back(sourcemeta::core::Pointer{"heights", 0},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(first)});
+  annotations.emplace_back(sourcemeta::core::Pointer{"heights", 1},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(second)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/heights": [
+        {
+          "@list": [
+            { "https://example.com/value": [ { "@value": 1.85 } ] },
+            { "https://example.com/value": [ { "@value": 1.7 } ] }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_value_predicate_collision_unions) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/value": [ { "@value": "reference" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/height": [
+        {
+          "https://example.com/value": [
+            { "@value": 1.85 },
+            { "@value": "reference" }
+          ]
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_value_predicate_collision_dedupes_equal_terms) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/value": [ { "@value": 1.0 } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/height": [
+        { "https://example.com/value": [ { "@value": 1 } ] }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(promotion_under_multiple_edges_distinct_nodes) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(
+      sourcemeta::core::Pointer{"height"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/height", false},
+                    {"https://example.com/stature", false}},
+          .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/height": [
+        { "https://example.com/value": [ { "@value": 1.85 } ] }
+      ],
+      "https://example.com/stature": [
+        { "https://example.com/value": [ { "@value": 1.85 } ] }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_reverse_edge) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(
+      sourcemeta::core::Pointer{"height"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/measurementOf", true}},
+          .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "@reverse": {
+        "https://example.com/measurementOf": [
+          { "https://example.com/value": [ { "@value": 1.85 } ] }
+        ]
+      }
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(promotion_index_container_member_keeps_index) {
+  const auto instance =
+      sourcemeta::core::parse_json(R"({ "readings": { "morning": 1.85 } })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(
+      sourcemeta::core::Pointer{"readings"},
+      sourcemeta::core::JSONLDDescriptor{
+          .edges = {{"https://example.com/readings", false}},
+          .value = sourcemeta::core::JSONLDCollection{
+              .container = sourcemeta::core::JSONLDContainer::Index}});
+  annotations.emplace_back(sourcemeta::core::Pointer{"readings", "morning"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {}, .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/readings": [
+        {
+          "https://example.com/value": [ { "@value": 1.85 } ],
+          "@index": "morning"
+        }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+  EXPECT_TRUE(sourcemeta::core::jsonld_is_expanded(result));
+}
+
+TEST(promotion_empty_constants_no_op) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::JSON::make_object();
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expected = sourcemeta::core::parse_json(R"([
+    {
+      "https://example.com/height": [
+        { "https://example.com/value": [ { "@value": 1.85 } ] }
+      ]
+    }
+  ])");
+
+  const auto result{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  EXPECT_EQ(result, expected);
+}
+
+TEST(promotion_output_flattens) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.types.push_back("https://example.com/Quantity");
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expanded{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  const auto flattened{sourcemeta::core::jsonld_flatten(expanded)};
+  EXPECT_TRUE(flattened.is_array());
+  EXPECT_EQ(flattened.size(), 2);
+}
+
+TEST(promotion_output_compacts_and_re_expands) {
+  const auto instance = sourcemeta::core::parse_json(R"({ "height": 1.85 })");
+
+  sourcemeta::core::JSONLDPromotion promotion;
+  promotion.types.push_back("https://example.com/Quantity");
+  promotion.value = "https://example.com/value";
+  promotion.constants = sourcemeta::core::parse_json(R"({
+    "https://example.com/unit": [ { "@id": "https://example.com/metre" } ]
+  })");
+
+  sourcemeta::core::JSONLDAnnotationList annotations;
+  annotations.emplace_back(sourcemeta::core::Pointer{"height"},
+                           sourcemeta::core::JSONLDDescriptor{
+                               .edges = {{"https://example.com/height", false}},
+                               .value = std::move(promotion)});
+
+  const auto expanded{
+      sourcemeta::core::jsonld_materialize(instance, annotations)};
+  const auto context{sourcemeta::core::parse_json(R"({
+    "value": "https://example.com/value",
+    "unit": { "@id": "https://example.com/unit", "@type": "@id" }
+  })")};
+  const auto compacted{sourcemeta::core::jsonld_compact(expanded, context)};
+  const auto re_expanded{sourcemeta::core::jsonld_expand(compacted)};
+  EXPECT_EQ(re_expanded, expanded);
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

