### PR TITLE
Add claims-based authorization primitives to the `oauth` and `oidc` modules

### DIFF
--- a/src/core/oauth/CMakeLists.txt
+++ b/src/core/oauth/CMakeLists.txt
@@ -4,6 +4,7 @@ sourcemeta_library(NAMESPACE sourcemeta PROJECT core NAME oauth
     token_exchange.h revocation.h introspection.h device.h dpop.h par.h
     assertion.h registration.h
   SOURCES oauth_error.cc oauth_pkce.cc oauth_bearer.cc oauth_syntax.h
+    oauth_scope.h
     oauth_random.cc oauth_authorization.cc oauth_authorization_parse.h
     oauth_decode.h
     oauth_json.h oauth_token.cc oauth_client_authentication.cc

--- a/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
+++ b/src/core/oauth/include/sourcemeta/core/oauth_bearer.h
@@ -137,6 +137,27 @@ auto oauth_has_audience(const JSON &claims, const std::string_view audience)
     -> bool;
 
 /// @ingroup oauth
+/// Whether a set of access token claims grants a scope, so that a resource
+/// server admits only a caller whose token carries it (RFC 6749 Section 3.3,
+/// RFC 9068 Section 2.2.3, RFC 7662 Section 2.2). The claims are the payload
+/// of a JWT access token or an introspection response, and the `scope` claim
+/// is a single string of space-delimited case-sensitive tokens compared whole
+/// and by code points, with no normalization. An empty scope never matches.
+/// For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oauth.h>
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+///
+/// const auto claims{
+///     sourcemeta::core::parse_json(R"JSON({"scope":"read write"})JSON")};
+/// assert(sourcemeta::core::oauth_has_scope(claims, "read"));
+/// ```
+SOURCEMETA_CORE_OAUTH_EXPORT
+auto oauth_has_scope(const JSON &claims, const std::string_view value) -> bool;
+
+/// @ingroup oauth
 /// Whether a set of access token claims carries the DPoP confirmation that
 /// binds the token to a proof-of-possession key, namely a `jkt` JWK thumbprint
 /// (RFC 9449 Section 6.1). A resource server that receives such a token under

--- a/src/core/oauth/oauth_bearer.cc
+++ b/src/core/oauth/oauth_bearer.cc
@@ -4,6 +4,8 @@
 #include <sourcemeta/core/json.h>
 #include <sourcemeta/core/text.h>
 
+#include "oauth_scope.h"
+
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <optional>    // std::optional, std::nullopt
@@ -20,6 +22,7 @@ using namespace std::literals::string_view_literals;
 constexpr auto HASH_AUD{JSON::Object::hash("aud"sv)};
 constexpr auto HASH_CNF{JSON::Object::hash("cnf"sv)};
 constexpr auto HASH_JKT{JSON::Object::hash("jkt"sv)};
+constexpr auto HASH_SCOPE{JSON::Object::hash("scope"sv)};
 
 auto oauth_skip_ows(const std::string_view value, std::size_t position) noexcept
     -> std::size_t {
@@ -240,6 +243,19 @@ auto oauth_has_audience(const JSON &claims, const std::string_view audience)
   }
 
   return member->is_array() && member->contains(audience);
+}
+
+auto oauth_has_scope(const JSON &claims, const std::string_view value) -> bool {
+  if (!claims.is_object()) {
+    return false;
+  }
+
+  // RFC 9068 Section 2.2.3 and RFC 7662 Section 2.2: the scope claim is a
+  // single JSON string carrying the RFC 6749 Section 3.3 scope syntax, so any
+  // other shape grants nothing
+  const auto *member{claims.try_at("scope"sv, HASH_SCOPE)};
+  return member != nullptr && member->is_string() &&
+         oauth_scope_contains(member->to_string(), value);
 }
 
 auto oauth_is_dpop_bound(const JSON &claims) -> bool {

--- a/src/core/oauth/oauth_scope.h
+++ b/src/core/oauth/oauth_scope.h
@@ -1,0 +1,42 @@
+#ifndef SOURCEMETA_CORE_OAUTH_SCOPE_H_
+#define SOURCEMETA_CORE_OAUTH_SCOPE_H_
+
+#include <cstddef>     // std::size_t
+#include <string_view> // std::string_view
+
+namespace sourcemeta::core {
+
+// RFC 6749 Section 3.3: "The value of the scope parameter is expressed as a
+// list of space-delimited, case-sensitive strings" whose order does not
+// matter, so membership is an exact code point comparison of whole tokens,
+// scanned without allocation. A scope token has at least one character, so an
+// empty sought value is never a member
+inline auto oauth_scope_contains(const std::string_view scope,
+                                 const std::string_view value) -> bool {
+  if (value.empty()) {
+    return false;
+  }
+
+  std::size_t position{0};
+  while (position < scope.size()) {
+    const auto next{scope.find(' ', position)};
+    const auto token{scope.substr(position, next == std::string_view::npos
+                                                ? std::string_view::npos
+                                                : next - position)};
+    if (token == value) {
+      return true;
+    }
+
+    if (next == std::string_view::npos) {
+      break;
+    }
+
+    position = next + 1;
+  }
+
+  return false;
+}
+
+} // namespace sourcemeta::core
+
+#endif

--- a/src/core/oauth/oauth_token.cc
+++ b/src/core/oauth/oauth_token.cc
@@ -5,9 +5,9 @@
 #include <sourcemeta/core/uri.h>
 
 #include "oauth_decode.h"
+#include "oauth_scope.h"
 
 #include <chrono>      // std::chrono::seconds
-#include <cstddef>     // std::size_t
 #include <cstdint>     // std::int64_t
 #include <functional>  // std::function
 #include <optional>    // std::optional, std::nullopt
@@ -164,31 +164,7 @@ auto OAuthTokenResponse::scope() const -> std::optional<std::string_view> {
 
 auto OAuthTokenResponse::has_scope(const std::string_view value) const -> bool {
   const auto granted{this->scope()};
-  if (!granted.has_value() || value.empty()) {
-    return false;
-  }
-
-  // RFC 6749 Section 3.3: scope is a space-delimited, unordered set of tokens,
-  // scanned without allocation
-  const auto text{granted.value()};
-  std::size_t position{0};
-  while (position < text.size()) {
-    const auto next{text.find(' ', position)};
-    const auto token{text.substr(position, next == std::string_view::npos
-                                               ? std::string_view::npos
-                                               : next - position)};
-    if (token == value) {
-      return true;
-    }
-
-    if (next == std::string_view::npos) {
-      break;
-    }
-
-    position = next + 1;
-  }
-
-  return false;
+  return granted.has_value() && oauth_scope_contains(granted.value(), value);
 }
 
 auto OAuthTokenResponse::data() const -> const JSON & { return *this->data_; }

--- a/src/core/oidc/include/sourcemeta/core/oidc_claims.h
+++ b/src/core/oidc/include/sourcemeta/core/oidc_claims.h
@@ -8,6 +8,7 @@
 #include <sourcemeta/core/json.h>
 
 #include <functional>  // std::function
+#include <optional>    // std::optional
 #include <span>        // std::span
 #include <string_view> // std::string_view
 
@@ -30,9 +31,9 @@ auto oidc_is_standard_claim(const std::string_view name) noexcept -> bool;
 /// @ingroup oidc
 /// Invoke the callback with each standard claim that the space-delimited scopes
 /// request (OpenID Connect Core 1.0 Section 5.4). The `openid` scope maps to
-/// `sub`, and `profile`, `email`, `address`, and `phone` map to their claim
-/// sets. A claim requested by more than one scope is reported once. For
-/// example:
+/// `sub`, which is always returned (Section 5.3.2), and `profile`, `email`,
+/// `address`, and `phone` map to their claim sets. A claim requested by more
+/// than one scope is reported once. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/oidc.h>
@@ -49,6 +50,23 @@ SOURCEMETA_CORE_OIDC_EXPORT
 auto oidc_scope_to_claims(const std::string_view scopes,
                           const std::function<void(std::string_view)> &on_claim)
     -> void;
+
+/// @ingroup oidc
+/// The standard scope that requests a claim, or no value when no
+/// claim-requesting scope carries it (OpenID Connect Core 1.0 Section 5.4). The
+/// `sub` claim maps to `openid`, which always returns it (Section 5.3.2), and a
+/// scope name is never invented from a non-standard claim name. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oidc.h>
+/// #include <cassert>
+///
+/// assert(sourcemeta::core::oidc_claim_to_scope("email").value() == "email");
+/// assert(!sourcemeta::core::oidc_claim_to_scope("groups").has_value());
+/// ```
+SOURCEMETA_CORE_OIDC_EXPORT
+auto oidc_claim_to_scope(const std::string_view claim) noexcept
+    -> std::optional<std::string_view>;
 
 /// @ingroup oidc
 /// A claim requested through the `claims` request parameter (OpenID Connect
@@ -167,6 +185,26 @@ auto oidc_claims_parameter_accepts(const JSON &claims,
                                    const std::string_view target,
                                    const std::string_view claim,
                                    const JSON &value) -> bool;
+
+/// @ingroup oidc
+/// Whether an individual claim request permits a value, where the request is
+/// the member value a `claims` request parameter maps a claim name to (OpenID
+/// Connect Core 1.0 Section 5.5.1). A `null` request or one with neither a
+/// `value` nor a `values` constraint permits any value, comparison is JSON
+/// equality over the whole value, and `essential` has no effect. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/oidc.h>
+/// #include <sourcemeta/core/json.h>
+/// #include <cassert>
+///
+/// const auto request{sourcemeta::core::parse_json(
+///     R"JSON({ "values": [ "gold", "silver" ] })JSON")};
+/// assert(sourcemeta::core::oidc_claim_request_accepts(
+///     request, sourcemeta::core::JSON{"gold"}));
+/// ```
+SOURCEMETA_CORE_OIDC_EXPORT
+auto oidc_claim_request_accepts(const JSON &request, const JSON &value) -> bool;
 
 } // namespace sourcemeta::core
 

--- a/src/core/oidc/include/sourcemeta/core/oidc_metadata.h
+++ b/src/core/oidc/include/sourcemeta/core/oidc_metadata.h
@@ -151,6 +151,10 @@ public:
   /// Whether a claim is supported (OpenID Connect Discovery 1.0 Section 3).
   [[nodiscard]] auto supports_claim(const std::string_view value) const -> bool;
 
+  /// Whether the `claims` request parameter is supported, absent meaning false
+  /// (OpenID Connect Discovery 1.0 Section 3).
+  [[nodiscard]] auto supports_claims_parameter() const -> bool;
+
   /// The underlying OAuth authorization server metadata this document is a
   /// superset of, for reaching the OAuth typed accessors.
   [[nodiscard]] auto oauth() const -> const OAuthServerMetadata &;

--- a/src/core/oidc/oidc_claims.cc
+++ b/src/core/oidc/oidc_claims.cc
@@ -5,6 +5,7 @@
 #include <array>       // std::array
 #include <cstddef>     // std::size_t
 #include <functional>  // std::function
+#include <optional>    // std::optional, std::nullopt
 #include <span>        // std::span
 #include <string_view> // std::string_view
 
@@ -63,6 +64,17 @@ auto emit_claims(const std::span<const std::string_view> claims,
   for (const auto claim : claims) {
     on_claim(claim);
   }
+}
+
+auto claim_set_contains(const std::span<const std::string_view> claims,
+                        const std::string_view claim) noexcept -> bool {
+  for (const auto candidate : claims) {
+    if (candidate == claim) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 // OpenID Connect Core 1.0 Section 5.5.1: a claim request is null in the default
@@ -130,13 +142,7 @@ auto claim_specification(const JSON &claims, const std::string_view target,
 } // namespace
 
 auto oidc_is_standard_claim(const std::string_view name) noexcept -> bool {
-  for (const auto claim : STANDARD_CLAIMS) {
-    if (claim == name) {
-      return true;
-    }
-  }
-
-  return false;
+  return claim_set_contains(STANDARD_CLAIMS, name);
 }
 
 auto oidc_scope_to_claims(const std::string_view scopes,
@@ -173,9 +179,10 @@ auto oidc_scope_to_claims(const std::string_view scopes,
     position = space + 1;
   }
 
-  // OpenID Connect Core 1.0 Section 5.4: openid yields sub, and each profile
-  // scope yields its claim set. The standard scopes are disjoint, so a claim is
-  // reported at most once
+  // OpenID Connect Core 1.0 Section 5.4: each claim-requesting scope yields
+  // its claim set, and openid yields sub, which is always returned
+  // (Section 5.3.2). The scope claim sets are disjoint, so a claim is reported
+  // at most once
   if (has_openid) {
     on_claim("sub");
   }
@@ -195,6 +202,38 @@ auto oidc_scope_to_claims(const std::string_view scopes,
   if (has_phone) {
     emit_claims(PHONE_CLAIMS, on_claim);
   }
+}
+
+auto oidc_claim_to_scope(const std::string_view claim) noexcept
+    -> std::optional<std::string_view> {
+  // OpenID Connect Core 1.0 Section 5.3.2: "The sub (subject) Claim MUST
+  // always be returned in the UserInfo Response", so the openid scope itself
+  // is what requests it
+  if (claim == "sub") {
+    return "openid";
+  }
+
+  if (claim_set_contains(PROFILE_CLAIMS, claim)) {
+    return "profile";
+  }
+
+  if (claim_set_contains(EMAIL_CLAIMS, claim)) {
+    return "email";
+  }
+
+  if (claim_set_contains(ADDRESS_CLAIMS, claim)) {
+    return "address";
+  }
+
+  if (claim_set_contains(PHONE_CLAIMS, claim)) {
+    return "phone";
+  }
+
+  // OpenID Connect Core 1.0 Section 5.4 defines no other claim-requesting
+  // scope, and a scope name is never invented from a claim name, since a
+  // server may reject a request carrying an unknown scope as invalid_scope
+  // (RFC 6749 Section 4.1.2.1)
+  return std::nullopt;
 }
 
 auto oidc_build_claims_parameter(
@@ -241,20 +280,16 @@ auto oidc_claims_parameter_value(const JSON &claims,
   return specification->try_at("value"sv, HASH_VALUE);
 }
 
-auto oidc_claims_parameter_accepts(const JSON &claims,
-                                   const std::string_view target,
-                                   const std::string_view claim,
-                                   const JSON &value) -> bool {
-  // OpenID Connect Core 1.0 Section 5.5: only a null or object entry is a valid
-  // request, so an absent or malformed one permits nothing
-  const auto *specification{claim_specification(claims, target, claim)};
-  if (specification == nullptr ||
-      !(specification->is_null() || specification->is_object())) {
+auto oidc_claim_request_accepts(const JSON &request, const JSON &value)
+    -> bool {
+  // OpenID Connect Core 1.0 Section 5.5.1: only a null or object request is
+  // valid, so a malformed one permits nothing
+  if (!(request.is_null() || request.is_object())) {
     return false;
   }
 
   // A null request carries no value constraint, so it permits any value
-  if (specification->is_null()) {
+  if (request.is_null()) {
     return true;
   }
 
@@ -262,8 +297,8 @@ auto oidc_claims_parameter_accepts(const JSON &claims,
   // values a set of acceptable ones, so a request carrying neither is
   // unconstrained, and a present but malformed values constraint permits
   // nothing rather than silently opening the request up
-  const auto *requested_value{specification->try_at("value"sv, HASH_VALUE)};
-  const auto *requested_values{specification->try_at("values"sv, HASH_VALUES)};
+  const auto *requested_value{request.try_at("value"sv, HASH_VALUE)};
+  const auto *requested_values{request.try_at("values"sv, HASH_VALUES)};
   if (requested_value == nullptr && requested_values == nullptr) {
     return true;
   }
@@ -281,6 +316,18 @@ auto oidc_claims_parameter_accepts(const JSON &claims,
   }
 
   return false;
+}
+
+auto oidc_claims_parameter_accepts(const JSON &claims,
+                                   const std::string_view target,
+                                   const std::string_view claim,
+                                   const JSON &value) -> bool {
+  // An unrequested claim permits nothing, and what a present request permits
+  // is a single question with a single answer, shared with the predicate that
+  // takes the request directly
+  const auto *specification{claim_specification(claims, target, claim)};
+  return specification != nullptr &&
+         oidc_claim_request_accepts(*specification, value);
 }
 
 } // namespace sourcemeta::core

--- a/src/core/oidc/oidc_metadata.cc
+++ b/src/core/oidc/oidc_metadata.cc
@@ -263,6 +263,16 @@ auto OIDCProviderMetadata::supports_claim(const std::string_view value) const
       "claims_supported"sv, HASH_CLAIMS_SUPPORTED, value);
 }
 
+auto OIDCProviderMetadata::supports_claims_parameter() const -> bool {
+  // OpenID Connect Discovery 1.0 Section 3: "If omitted, the default value is
+  // false", and that default is what tells a relying party to fall back to
+  // requesting claims through scope values instead of a parameter the
+  // provider would ignore
+  const auto *member{this->oauth_.data().try_at("claims_parameter_supported"sv,
+                                                HASH_CLAIMS_PARAMETER)};
+  return member != nullptr && member->is_boolean() && member->to_boolean();
+}
+
 auto OIDCProviderMetadata::oauth() const -> const OAuthServerMetadata & {
   return this->oauth_;
 }

--- a/test/oauth/oauth_bearer_test.cc
+++ b/test/oauth/oauth_bearer_test.cc
@@ -706,3 +706,138 @@ TEST(is_dpop_bound_rejects_an_empty_confirmation) {
   })JSON")};
   EXPECT_FALSE(sourcemeta::core::oauth_is_dpop_bound(claims));
 }
+
+TEST(has_scope_matches_a_token_in_a_list) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "read write admin"
+  })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "read"));
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "write"));
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "admin"));
+}
+
+TEST(has_scope_matches_a_single_token) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "read"
+  })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "read"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "write"));
+}
+
+TEST(has_scope_rejects_a_token_that_was_not_granted) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "read write"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "delete"));
+}
+
+TEST(has_scope_rejects_a_substring_of_a_granted_token) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "registry:readwrite"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "registry:read"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "readwrite"));
+}
+
+TEST(has_scope_rejects_a_superstring_of_a_granted_token) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "registry:read"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "registry:readwrite"));
+}
+
+TEST(has_scope_is_case_sensitive) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "Registry:Read"
+  })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "Registry:Read"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "registry:read"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "REGISTRY:READ"));
+}
+
+TEST(has_scope_compares_by_code_points_without_decoding) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "registry%3Aread"
+  })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "registry%3Aread"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "registry:read"));
+}
+
+TEST(has_scope_does_not_trim_the_sought_value) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "read"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, " read"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read "));
+}
+
+TEST(has_scope_rejects_an_empty_sought_value) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "read write"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, ""));
+}
+
+TEST(has_scope_rejects_an_empty_sought_value_between_repeated_separators) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": " read  write "
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, ""));
+}
+
+TEST(has_scope_tolerates_repeated_separators) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": " read  write "
+  })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "read"));
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "write"));
+}
+
+TEST(has_scope_splits_on_spaces_only) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": "read\twrite"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read"));
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "write"));
+  EXPECT_TRUE(sourcemeta::core::oauth_has_scope(claims, "read\twrite"));
+}
+
+TEST(has_scope_rejects_an_empty_scope_claim) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": ""
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read"));
+}
+
+TEST(has_scope_rejects_when_the_claim_is_absent) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "sub": "user"
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read"));
+}
+
+TEST(has_scope_rejects_an_array_scope_claim) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": [ "read" ]
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read"));
+}
+
+TEST(has_scope_rejects_a_numeric_scope_claim) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": 42
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "42"));
+}
+
+TEST(has_scope_rejects_a_null_scope_claim) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "scope": null
+  })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read"));
+}
+
+TEST(has_scope_rejects_when_the_claims_are_not_an_object) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON([ "scope" ])JSON")};
+  EXPECT_FALSE(sourcemeta::core::oauth_has_scope(claims, "read"));
+}

--- a/test/oauth/oauth_token_test.cc
+++ b/test/oauth/oauth_token_test.cc
@@ -408,3 +408,11 @@ TEST(parse_token_request_decodes_a_percent_encoded_name) {
       [](std::string_view, std::string_view) {}));
   EXPECT_EQ(request.grant_type, "client_credentials");
 }
+
+TEST(token_response_scope_membership_is_case_sensitive) {
+  const auto document{
+      sourcemeta::core::parse_json(R"JSON({ "scope": "Read" })JSON")};
+  const sourcemeta::core::OAuthTokenResponse response{document};
+  EXPECT_TRUE(response.has_scope("Read"));
+  EXPECT_FALSE(response.has_scope("read"));
+}

--- a/test/oidc/oidc_claims_test.cc
+++ b/test/oidc/oidc_claims_test.cc
@@ -220,3 +220,245 @@ TEST(claims_parameter_accepts_rejects_a_malformed_values_constraint) {
   EXPECT_FALSE(sourcemeta::core::oidc_claims_parameter_accepts(
       claims, "id_token", "acr", sourcemeta::core::JSON{"gold"}));
 }
+
+TEST(claim_request_accepts_any_value_for_a_null_request) {
+  const auto request{sourcemeta::core::parse_json("null")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"anything"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{123}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{nullptr}));
+}
+
+TEST(claim_request_accepts_any_value_for_an_empty_object_request) {
+  const auto request{sourcemeta::core::parse_json("{}")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"anything"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{123}));
+}
+
+TEST(claim_request_accepts_any_value_when_only_essential_is_present) {
+  const auto request{
+      sourcemeta::core::parse_json(R"JSON({ "essential": true })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"anything"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{123}));
+}
+
+TEST(claim_request_accepts_an_exact_value) {
+  const auto request{
+      sourcemeta::core::parse_json(R"JSON({ "value": "gold" })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gold"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"silver"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gol"}));
+}
+
+TEST(claim_request_accepts_one_of_values) {
+  const auto request{sourcemeta::core::parse_json(
+      R"JSON({ "values": [ "gold", "silver" ] })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gold"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"silver"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"bronze"}));
+}
+
+TEST(claim_request_accepts_either_constraint_when_both_are_present) {
+  const auto request{sourcemeta::core::parse_json(
+      R"JSON({ "value": "gold", "values": [ "silver" ] })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gold"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"silver"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"bronze"}));
+}
+
+TEST(claim_request_ignores_the_essential_flag) {
+  const auto essential{sourcemeta::core::parse_json(
+      R"JSON({ "essential": true, "value": "gold" })JSON")};
+  const auto voluntary{sourcemeta::core::parse_json(
+      R"JSON({ "essential": false, "value": "gold" })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      essential, sourcemeta::core::JSON{"gold"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      essential, sourcemeta::core::JSON{"silver"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      voluntary, sourcemeta::core::JSON{"gold"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      voluntary, sourcemeta::core::JSON{"silver"}));
+}
+
+TEST(claim_request_compares_by_json_equality) {
+  const auto request{sourcemeta::core::parse_json(
+      R"JSON({ "values": [ 21, true, { "group": "admins" } ] })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{21}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{true}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      request,
+      sourcemeta::core::parse_json(R"JSON({ "group": "admins" })JSON")));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"21"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request,
+      sourcemeta::core::parse_json(R"JSON({ "group": "users" })JSON")));
+}
+
+TEST(claim_request_rejects_a_string_request) {
+  const auto request{sourcemeta::core::parse_json(R"JSON("gold")JSON")};
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gold"}));
+}
+
+TEST(claim_request_rejects_a_numeric_request) {
+  const auto request{sourcemeta::core::parse_json("42")};
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{42}));
+}
+
+TEST(claim_request_rejects_a_boolean_request) {
+  const auto request{sourcemeta::core::parse_json("true")};
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{true}));
+}
+
+TEST(claim_request_rejects_an_array_request) {
+  const auto request{sourcemeta::core::parse_json(R"JSON([ "gold" ])JSON")};
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gold"}));
+}
+
+TEST(claim_request_rejects_a_malformed_values_constraint) {
+  const auto request{
+      sourcemeta::core::parse_json(R"JSON({ "values": "gold" })JSON")};
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      request, sourcemeta::core::JSON{"gold"}));
+}
+
+TEST(claims_parameter_accepts_agrees_with_the_claim_request_predicate) {
+  const auto claims{sourcemeta::core::parse_json(R"JSON({
+    "id_token": {
+      "acr": { "values": [ "gold" ] }
+    }
+  })JSON")};
+  EXPECT_TRUE(sourcemeta::core::oidc_claims_parameter_accepts(
+      claims, "id_token", "acr", sourcemeta::core::JSON{"gold"}));
+  EXPECT_TRUE(sourcemeta::core::oidc_claim_request_accepts(
+      claims.at("id_token").at("acr"), sourcemeta::core::JSON{"gold"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claims_parameter_accepts(
+      claims, "id_token", "acr", sourcemeta::core::JSON{"silver"}));
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_request_accepts(
+      claims.at("id_token").at("acr"), sourcemeta::core::JSON{"silver"}));
+}
+
+TEST(claim_to_scope_maps_sub_to_openid) {
+  const auto scope{sourcemeta::core::oidc_claim_to_scope("sub")};
+  EXPECT_TRUE(scope.has_value());
+  EXPECT_EQ(scope.value(), "openid");
+}
+
+TEST(claim_to_scope_maps_the_email_claims) {
+  const auto email{sourcemeta::core::oidc_claim_to_scope("email")};
+  const auto email_verified{
+      sourcemeta::core::oidc_claim_to_scope("email_verified")};
+  EXPECT_TRUE(email.has_value());
+  EXPECT_EQ(email.value(), "email");
+  EXPECT_TRUE(email_verified.has_value());
+  EXPECT_EQ(email_verified.value(), "email");
+}
+
+TEST(claim_to_scope_maps_the_profile_claims) {
+  const auto name{sourcemeta::core::oidc_claim_to_scope("name")};
+  const auto family_name{sourcemeta::core::oidc_claim_to_scope("family_name")};
+  const auto given_name{sourcemeta::core::oidc_claim_to_scope("given_name")};
+  const auto middle_name{sourcemeta::core::oidc_claim_to_scope("middle_name")};
+  const auto nickname{sourcemeta::core::oidc_claim_to_scope("nickname")};
+  const auto preferred_username{
+      sourcemeta::core::oidc_claim_to_scope("preferred_username")};
+  const auto profile{sourcemeta::core::oidc_claim_to_scope("profile")};
+  const auto picture{sourcemeta::core::oidc_claim_to_scope("picture")};
+  const auto website{sourcemeta::core::oidc_claim_to_scope("website")};
+  const auto gender{sourcemeta::core::oidc_claim_to_scope("gender")};
+  const auto birthdate{sourcemeta::core::oidc_claim_to_scope("birthdate")};
+  const auto zoneinfo{sourcemeta::core::oidc_claim_to_scope("zoneinfo")};
+  const auto locale{sourcemeta::core::oidc_claim_to_scope("locale")};
+  const auto updated_at{sourcemeta::core::oidc_claim_to_scope("updated_at")};
+  EXPECT_TRUE(name.has_value());
+  EXPECT_EQ(name.value(), "profile");
+  EXPECT_TRUE(family_name.has_value());
+  EXPECT_EQ(family_name.value(), "profile");
+  EXPECT_TRUE(given_name.has_value());
+  EXPECT_EQ(given_name.value(), "profile");
+  EXPECT_TRUE(middle_name.has_value());
+  EXPECT_EQ(middle_name.value(), "profile");
+  EXPECT_TRUE(nickname.has_value());
+  EXPECT_EQ(nickname.value(), "profile");
+  EXPECT_TRUE(preferred_username.has_value());
+  EXPECT_EQ(preferred_username.value(), "profile");
+  EXPECT_TRUE(profile.has_value());
+  EXPECT_EQ(profile.value(), "profile");
+  EXPECT_TRUE(picture.has_value());
+  EXPECT_EQ(picture.value(), "profile");
+  EXPECT_TRUE(website.has_value());
+  EXPECT_EQ(website.value(), "profile");
+  EXPECT_TRUE(gender.has_value());
+  EXPECT_EQ(gender.value(), "profile");
+  EXPECT_TRUE(birthdate.has_value());
+  EXPECT_EQ(birthdate.value(), "profile");
+  EXPECT_TRUE(zoneinfo.has_value());
+  EXPECT_EQ(zoneinfo.value(), "profile");
+  EXPECT_TRUE(locale.has_value());
+  EXPECT_EQ(locale.value(), "profile");
+  EXPECT_TRUE(updated_at.has_value());
+  EXPECT_EQ(updated_at.value(), "profile");
+}
+
+TEST(claim_to_scope_maps_the_address_claim) {
+  const auto address{sourcemeta::core::oidc_claim_to_scope("address")};
+  EXPECT_TRUE(address.has_value());
+  EXPECT_EQ(address.value(), "address");
+}
+
+TEST(claim_to_scope_maps_the_phone_claims) {
+  const auto phone_number{
+      sourcemeta::core::oidc_claim_to_scope("phone_number")};
+  const auto phone_number_verified{
+      sourcemeta::core::oidc_claim_to_scope("phone_number_verified")};
+  EXPECT_TRUE(phone_number.has_value());
+  EXPECT_EQ(phone_number.value(), "phone");
+  EXPECT_TRUE(phone_number_verified.has_value());
+  EXPECT_EQ(phone_number_verified.value(), "phone");
+}
+
+TEST(claim_to_scope_never_invents_a_scope_for_a_non_standard_claim) {
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("groups").has_value());
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("roles").has_value());
+  EXPECT_FALSE(
+      sourcemeta::core::oidc_claim_to_scope("entitlements").has_value());
+  EXPECT_FALSE(
+      sourcemeta::core::oidc_claim_to_scope("custom_claim").has_value());
+}
+
+TEST(claim_to_scope_has_no_scope_for_a_claim_outside_the_scope_sets) {
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("acr").has_value());
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("auth_time").has_value());
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("openid").has_value());
+}
+
+TEST(claim_to_scope_has_no_scope_for_an_empty_name) {
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("").has_value());
+}
+
+TEST(claim_to_scope_is_case_sensitive) {
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("Email").has_value());
+  EXPECT_FALSE(sourcemeta::core::oidc_claim_to_scope("SUB").has_value());
+}

--- a/test/oidc/oidc_metadata_test.cc
+++ b/test/oidc/oidc_metadata_test.cc
@@ -765,3 +765,83 @@ TEST(from_oauth_preserves_the_underlying_oauth_view) {
             "https://example.com/token");
   EXPECT_TRUE(metadata.value().oauth().supports_response_type("code"));
 }
+
+TEST(from_reports_claims_parameter_support_when_advertised_true) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ],
+    "claims_parameter_supported": true
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_claims_parameter());
+}
+
+TEST(from_reports_no_claims_parameter_support_when_advertised_false) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ],
+    "claims_parameter_supported": false
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_claims_parameter());
+}
+
+TEST(from_reports_no_claims_parameter_support_when_absent) {
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      sourcemeta::core::JSON{VALID_PROVIDER_DOCUMENT}, "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_claims_parameter());
+}
+
+TEST(from_reports_no_claims_parameter_support_when_malformed) {
+  auto document{sourcemeta::core::parse_json(R"JSON({
+    "issuer": "https://example.com",
+    "authorization_endpoint": "https://example.com/authorize",
+    "token_endpoint": "https://example.com/token",
+    "jwks_uri": "https://example.com/jwks",
+    "response_types_supported": [ "code" ],
+    "subject_types_supported": [ "public" ],
+    "id_token_signing_alg_values_supported": [ "RS256" ],
+    "claims_parameter_supported": "true"
+  })JSON")};
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document), "https://example.com")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_FALSE(metadata.value().supports_claims_parameter());
+}
+
+TEST(make_round_trips_the_claims_parameter_capability) {
+  const std::array<std::string_view, 1> response_types{{"code"}};
+  const std::array<std::string_view, 1> subject_types{{"public"}};
+  const std::array<std::string_view, 1> id_token_algs{{"RS256"}};
+  sourcemeta::core::OIDCProviderMetadataConfig config;
+  config.base.issuer = "https://server.example";
+  config.base.authorization_endpoint = "https://server.example/authorize";
+  config.base.token_endpoint = "https://server.example/token";
+  config.base.jwks_uri = "https://server.example/jwks";
+  config.base.response_types_supported = response_types;
+  config.subject_types_supported = subject_types;
+  config.id_token_signing_alg_values_supported = id_token_algs;
+  config.claims_parameter_supported = true;
+
+  auto document{sourcemeta::core::oidc_make_provider_metadata(config)};
+  EXPECT_TRUE(document.has_value());
+  const auto metadata{sourcemeta::core::OIDCProviderMetadata::from(
+      std::move(document).value(), "https://server.example")};
+  EXPECT_TRUE(metadata.has_value());
+  EXPECT_TRUE(metadata.value().supports_claims_parameter());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

