### PR TITLE
test(uritemplate): expand is_uritemplate coverage for the literal charset and expression edges

### DIFF
--- a/test/uritemplate/uritemplate_parse_error_test.cc
+++ b/test/uritemplate/uritemplate_parse_error_test.cc
@@ -113,3 +113,88 @@ TEST(query_expansion_empty) { EXPECT_URITEMPLATE_PARSE_ERROR("{?}", 3); }
 TEST(query_continuation_expansion_empty) {
   EXPECT_URITEMPLATE_PARSE_ERROR("{&}", 3);
 }
+
+TEST(literal_space) { EXPECT_URITEMPLATE_PARSE_ERROR("a b", 2); }
+
+TEST(literal_double_quote) { EXPECT_URITEMPLATE_PARSE_ERROR("a\"b", 2); }
+
+TEST(literal_less_than) { EXPECT_URITEMPLATE_PARSE_ERROR("a<b", 2); }
+
+TEST(literal_greater_than) { EXPECT_URITEMPLATE_PARSE_ERROR("a>b", 2); }
+
+TEST(literal_backslash) { EXPECT_URITEMPLATE_PARSE_ERROR("a\\b", 2); }
+
+TEST(literal_caret) { EXPECT_URITEMPLATE_PARSE_ERROR("a^b", 2); }
+
+TEST(literal_backtick) { EXPECT_URITEMPLATE_PARSE_ERROR("a`b", 2); }
+
+TEST(literal_pipe) { EXPECT_URITEMPLATE_PARSE_ERROR("a|b", 2); }
+
+TEST(literal_delete) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("a\x7F"
+                                 "b",
+                                 2);
+}
+
+TEST(literal_null) {
+  EXPECT_URITEMPLATE_PARSE_ERROR((std::string_view{"a\x00"
+                                                   "b",
+                                                   3}),
+                                 2);
+}
+
+TEST(literal_line_feed) { EXPECT_URITEMPLATE_PARSE_ERROR("a\nb", 2); }
+
+TEST(literal_carriage_return) { EXPECT_URITEMPLATE_PARSE_ERROR("a\rb", 2); }
+
+TEST(literal_tab) { EXPECT_URITEMPLATE_PARSE_ERROR("a\tb", 2); }
+
+TEST(literal_unit_separator) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("a\x1F"
+                                 "b",
+                                 2);
+}
+
+TEST(literal_percent_at_end) { EXPECT_URITEMPLATE_PARSE_ERROR("a%", 2); }
+
+TEST(literal_percent_one_digit) { EXPECT_URITEMPLATE_PARSE_ERROR("a%4", 2); }
+
+TEST(literal_percent_bad_second_digit) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("a%4G", 2);
+}
+
+TEST(literal_percent_bad_first_digit) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("a%G4", 2);
+}
+
+TEST(literal_percent_alone) { EXPECT_URITEMPLATE_PARSE_ERROR("%", 1); }
+
+TEST(literal_space_at_start) { EXPECT_URITEMPLATE_PARSE_ERROR(" {var}", 1); }
+
+TEST(prefix_leading_zero) { EXPECT_URITEMPLATE_PARSE_ERROR("{var:01}", 6); }
+
+TEST(prefix_leading_zero_four_digits) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("{var:0001}", 6);
+}
+
+TEST(varname_dot_then_invalid) { EXPECT_URITEMPLATE_PARSE_ERROR("{a.-}", 4); }
+
+TEST(open_brace_alone) { EXPECT_URITEMPLATE_PARSE_ERROR("{", 1); }
+
+TEST(close_brace_alone) { EXPECT_URITEMPLATE_PARSE_ERROR("}", 1); }
+
+TEST(expression_trailing_dot_joiner) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("{a.}", 4);
+}
+
+TEST(unclosed_brace_after_expression) {
+  EXPECT_URITEMPLATE_PARSE_ERROR("{a}{", 4);
+}
+
+TEST(unclosed_brace_after_comma) { EXPECT_URITEMPLATE_PARSE_ERROR("{a,", 4); }
+
+TEST(modifier_without_varname) { EXPECT_URITEMPLATE_PARSE_ERROR("{:1}", 2); }
+
+TEST(two_prefix_modifiers) { EXPECT_URITEMPLATE_PARSE_ERROR("{a:1:2}", 5); }
+
+TEST(varname_after_explode) { EXPECT_URITEMPLATE_PARSE_ERROR("{a*b}", 4); }

--- a/test/uritemplate/uritemplate_parse_test.cc
+++ b/test/uritemplate/uritemplate_parse_test.cc
@@ -709,3 +709,72 @@ TEST(mixed_case_percent_encoding) {
   EXPECT_URITEMPLATE_EXPANSION(uri_template, 0, URITemplateTokenVariable, 0,
                                "%3Avar", 0, false);
 }
+
+TEST(literal_exclamation) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a!b"));
+}
+
+TEST(literal_hash_and_dollar) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a#b$c"));
+}
+
+TEST(literal_ampersand) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a&b"));
+}
+
+TEST(literal_apostrophe) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("it's"));
+}
+
+TEST(literal_open_paren_range_start) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a(b"));
+}
+
+TEST(literal_semicolon_range_end) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a;b"));
+}
+
+TEST(literal_equals) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a=b"));
+}
+
+TEST(literal_question_range_start) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a?b"));
+}
+
+TEST(literal_open_bracket_range_end) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a[b"));
+}
+
+TEST(literal_close_bracket) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a]b"));
+}
+
+TEST(literal_underscore) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a_b"));
+}
+
+TEST(literal_tilde) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a~b"));
+}
+
+TEST(literal_uppercase_range) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("ABC"));
+}
+
+TEST(literal_percent_encoded) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a%41b"));
+}
+
+TEST(literal_percent_encoded_lowercase_hex) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("a%4fb"));
+}
+
+TEST(literal_high_byte) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("caf\xC3"
+                                                            "\xA9"));
+}
+
+TEST(varname_dot_then_percent) {
+  EXPECT_TRUE(sourcemeta::core::URITemplate::is_uritemplate("{a.%41}"));
+}


### PR DESCRIPTION
The parse error tests had no literal-context case at all - every existing one sits inside an
expression - so none of the throw sites in the literal branch of `parse_expression` were
exercised, and neither was the default arm of `is_literal_char`.

Adds, for the literal context: each excluded character next to the range edge that allows its
neighbour (`%x3C`, `%x3E`, `%x5C`, `%x5E`, `%x60`, `%x7C`), SP, DQUOTE, DEL, NUL, LF, CR, TAB and
`%x1F` at the top of C0, and the three pct-encoded failure modes (truncated at the end, non-hex
first digit, non-hex second digit). The allowed side gets the edges of each range in
`is_literal_char` - `%x21`, `%x23-24`, `%x26`, `%x27`, `%x28`, `%x3B`, `%x3D`, `%x3F`, `%x5B`,
`%x5D`, `%x5F`, `%x7E` - plus a pct-encoded triplet with lowercase hex and a byte above `0x80`.

Also pins a few branches the expression tests skip: a leading zero in the prefix max-length, a
dot followed by a pct-encoded triplet inside a varname, a second prefix modifier, and four
truncation points that were only covered from one side.

The NUL case builds its `string_view` with an explicit length - built from the literal alone it
would stop at the NUL and assert on `"a"`, which is valid.

+48 tests (17 valid, 31 invalid). Full `sourcemeta_core_uritemplate_unit` suite: 800 pass, 0 fail
(was 752 before this change). `clang_format` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

