### PR TITLE
Add RFC 6068 `mailto_iri` and RFC 7565 `acct_iri` helpers to the `email` module

### DIFF
--- a/src/core/email/email.cc
+++ b/src/core/email/email.cc
@@ -221,12 +221,6 @@ auto acct_iri(const std::string_view value) -> std::optional<std::string> {
     }
   }
 
-  // RFC 7565 §4: the host portion is the DNS domain name of the service
-  // provider
-  if (!is_hostname(parts->second)) {
-    return std::nullopt;
-  }
-
   std::string result;
   result.reserve(value.size() * 3 + 5);
   result.append("acct:");
@@ -240,8 +234,16 @@ auto acct_iri(const std::string_view value) -> std::optional<std::string> {
   result.push_back('@');
   // RFC 7565 §4: acct URIs compare under RFC 3986 §6.2.2.1 case
   // normalization, so the canonical spelling lowercases the host
+  const auto host_offset{result.size()};
   for (const auto character : parts->second) {
     result.push_back(to_lowercase(character));
+  }
+
+  // RFC 7565 §4: the host portion is the DNS domain name of the service
+  // provider. RFC 4343 makes DNS names case-insensitive, so validity is
+  // decided on the lowercased spelling that the canonical output uses
+  if (!is_hostname(std::string_view{result}.substr(host_offset))) {
+    return std::nullopt;
   }
 
   return result;

--- a/src/core/email/email.cc
+++ b/src/core/email/email.cc
@@ -1,26 +1,29 @@
 #include <sourcemeta/core/email.h>
 
 #include <sourcemeta/core/dns.h>
+#include <sourcemeta/core/text.h>
 #include <sourcemeta/core/unicode.h>
 
 #include "helpers.h"
 
 namespace sourcemeta::core {
 
-// RFC 5321 §4.1.2 Mailbox grammar. When AllowUtf8 is true, RFC 6531 §3.3
-// extends atext, qtextSMTP, and sub-domain with UTF8-non-ascii alternatives.
-// When UseUts46 is also true, the domain is validated under UTS #46 processing
-// rather than strict IDNA 2008.
+// RFC 5321 §4.1.2 Mailbox grammar, returning the position of the separator
+// between the local part and the domain when the mailbox is valid. When
+// AllowUtf8 is true, RFC 6531 §3.3 extends atext, qtextSMTP, and sub-domain
+// with UTF8-non-ascii alternatives. When UseUts46 is also true, the domain is
+// validated under UTS #46 processing rather than strict IDNA 2008.
 template <bool AllowUtf8, bool UseUts46 = false>
-static auto is_mailbox(const std::string_view value) -> bool {
+static auto mailbox_separator(const std::string_view value)
+    -> std::optional<std::string_view::size_type> {
   if (value.empty()) {
-    return false;
+    return std::nullopt;
   }
 
   // RFC 5321 §4.5.3.1.3: a path is at most 256 octets including the enclosing
   // angle brackets, so the mailbox it carries is at most 254
   if (value.size() > 254) {
-    return false;
+    return std::nullopt;
   }
 
   std::string_view::size_type position{0};
@@ -33,11 +36,11 @@ static auto is_mailbox(const std::string_view value) -> bool {
         // RFC 5321 §4.1.2: quoted-pairSMTP = %d92 %d32-126
         position += 1;
         if (position >= value.size()) {
-          return false;
+          return std::nullopt;
         }
         const auto body{static_cast<unsigned char>(value[position])};
         if (body < 32 || body > 126) {
-          return false;
+          return std::nullopt;
         }
         position += 1;
         continue;
@@ -52,15 +55,15 @@ static auto is_mailbox(const std::string_view value) -> bool {
         // RFC 6531 §3.3: qtextSMTP =/ UTF8-non-ascii
         const auto utf8_length{utf8_codepoint_length(value, position)};
         if (utf8_length < 2) {
-          return false;
+          return std::nullopt;
         }
         position += utf8_length;
       } else {
-        return false;
+        return std::nullopt;
       }
     }
     if (position >= value.size()) {
-      return false;
+      return std::nullopt;
     }
     // value[position] is the closing DQUOTE
     position += 1;
@@ -72,7 +75,7 @@ static auto is_mailbox(const std::string_view value) -> bool {
       const auto character{value[position]};
       if (character == '.') {
         if (!atom_started || previous_was_dot) {
-          return false;
+          return std::nullopt;
         }
         previous_was_dot = true;
         atom_started = false;
@@ -91,62 +94,136 @@ static auto is_mailbox(const std::string_view value) -> bool {
         // RFC 6531 §3.3: atext =/ UTF8-non-ascii
         const auto utf8_length{utf8_codepoint_length(value, position)};
         if (utf8_length < 2) {
-          return false;
+          return std::nullopt;
         }
         previous_was_dot = false;
         atom_started = true;
         position += utf8_length;
       } else {
-        return false;
+        return std::nullopt;
       }
     }
     if (position == 0 || previous_was_dot) {
-      return false;
+      return std::nullopt;
     }
   }
 
   // RFC 5321 §4.5.3.1.1: Local-part octet limit is 64
   if (position > 64) {
-    return false;
+    return std::nullopt;
   }
 
   // RFC 5321 §4.1.2: Mailbox = Local-part "@" ( Domain / address-literal )
   if (position >= value.size() || value[position] != '@') {
-    return false;
+    return std::nullopt;
   }
 
   const auto domain{value.substr(position + 1)};
 
   // RFC 5321 §4.1.3: address-literal = "[" ( IPv4 / IPv6 / General ) "]"
   if (!domain.empty() && domain.front() == '[') {
-    return is_address_literal(domain);
+    if (is_address_literal(domain)) {
+      return position;
+    }
+    return std::nullopt;
   }
 
   if constexpr (AllowUtf8) {
     // RFC 6531 §3.3: sub-domain =/ U-label
     if constexpr (UseUts46) {
-      return is_idn_hostname_uts46(domain);
+      if (is_idn_hostname_uts46(domain)) {
+        return position;
+      }
     } else {
-      return is_idn_hostname(domain);
+      if (is_idn_hostname(domain)) {
+        return position;
+      }
     }
+    return std::nullopt;
   } else {
     // RFC 5321 §4.1.2 Domain matches is_hostname (RFC 1123 §2.1) by
     // grammar, by 63-octet label cap (RFC 1035 §2.3.4), and by
     // 255-octet total cap (RFC 5321 §4.5.3.1.2)
-    return is_hostname(domain);
+    if (is_hostname(domain)) {
+      return position;
+    }
+    return std::nullopt;
   }
 }
 
 auto is_email(const std::string_view value) -> bool {
-  return is_mailbox<false>(value);
+  return mailbox_separator<false>(value).has_value();
 }
 
 auto is_idn_email(const std::string_view value) -> bool {
-  return is_mailbox<true>(value);
+  return mailbox_separator<true>(value).has_value();
 }
 
 auto is_idn_email_uts46(const std::string_view value) -> bool {
-  return is_mailbox<true, true>(value);
+  return mailbox_separator<true, true>(value).has_value();
+}
+
+auto mailto_iri(const std::string_view value) -> std::optional<std::string> {
+  const auto separator{mailbox_separator<false>(value)};
+  if (!separator.has_value()) {
+    return std::nullopt;
+  }
+
+  std::string result;
+  result.reserve(value.size() * 3 + 7);
+  result.append("mailto:");
+  for (std::string_view::size_type position{0}; position < value.size();
+       position += 1) {
+    const auto character{value[position]};
+    if (position == separator.value() || is_mailto_verbatim(character)) {
+      result.push_back(character);
+    } else {
+      percent_encode(static_cast<unsigned char>(character), result);
+    }
+  }
+
+  return result;
+}
+
+auto acct_iri(const std::string_view value) -> std::optional<std::string> {
+  const auto parts{rsplit_once(value, '@')};
+  if (!parts.has_value() || parts->first.empty()) {
+    return std::nullopt;
+  }
+
+  // RFC 7565 §6 requires the userpart to conform to the PRECIS
+  // IdentifierClass, whose ASCII repertoire is %x21-7E (RFC 7564 §9.11)
+  for (const auto character : parts->first) {
+    const auto byte{static_cast<unsigned char>(character)};
+    if (byte < 0x21 || byte > 0x7E) {
+      return std::nullopt;
+    }
+  }
+
+  // RFC 7565 §4: the host portion is the DNS domain name of the service
+  // provider
+  if (!is_hostname(parts->second)) {
+    return std::nullopt;
+  }
+
+  std::string result;
+  result.reserve(value.size() * 3 + 5);
+  result.append("acct:");
+  for (const auto character : parts->first) {
+    if (is_acct_userpart_verbatim(character)) {
+      result.push_back(character);
+    } else {
+      percent_encode(static_cast<unsigned char>(character), result);
+    }
+  }
+  result.push_back('@');
+  // RFC 7565 §4: acct URIs compare under RFC 3986 §6.2.2.1 case
+  // normalization, so the canonical spelling lowercases the host
+  for (const auto character : parts->second) {
+    result.push_back(to_lowercase(character));
+  }
+
+  return result;
 }
 
 } // namespace sourcemeta::core

--- a/src/core/email/email.cc
+++ b/src/core/email/email.cc
@@ -172,13 +172,34 @@ auto mailto_iri(const std::string_view value) -> std::optional<std::string> {
   std::string result;
   result.reserve(value.size() * 3 + 7);
   result.append("mailto:");
-  for (std::string_view::size_type position{0}; position < value.size();
-       position += 1) {
-    const auto character{value[position]};
-    if (position == separator.value() || is_mailto_verbatim(character)) {
+  for (const auto character : value.substr(0, separator.value())) {
+    if (is_mailto_verbatim(character)) {
       result.push_back(character);
     } else {
       percent_encode(static_cast<unsigned char>(character), result);
+    }
+  }
+  result.push_back('@');
+
+  const auto domain{value.substr(separator.value() + 1)};
+  if (domain.front() == '[') {
+    // RFC 3986 §6.2.3 licenses case normalization for an Internet hostname
+    // subcomponent, and an address literal is not a DNS name, so its
+    // spelling is preserved
+    for (const auto character : domain) {
+      if (is_mailto_verbatim(character)) {
+        result.push_back(character);
+      } else {
+        percent_encode(static_cast<unsigned char>(character), result);
+      }
+    }
+  } else {
+    // RFC 5321 §2.4: "Mailbox domains follow normal DNS rules and are hence
+    // not case sensitive", and RFC 3986 §6.2.3 makes such a subcomponent
+    // "subject to case normalization", naming this very scheme in its
+    // example, so the canonical spelling lowercases the domain name
+    for (const auto character : domain) {
+      result.push_back(to_lowercase(character));
     }
   }
 

--- a/src/core/email/helpers.h
+++ b/src/core/email/helpers.h
@@ -5,6 +5,7 @@
 #include <sourcemeta/core/text.h>
 
 #include <cstdint>     // std::uint8_t, std::uint16_t
+#include <string>      // std::string
 #include <string_view> // std::string_view
 
 namespace {
@@ -167,6 +168,70 @@ inline auto is_address_literal(const std::string_view domain) -> bool {
     return is_ipv4_address_literal(inner);
   }
   return is_general_address_literal(inner);
+}
+
+// RFC 3986 §2.1: "For consistency, URI producers and normalizers should use
+// uppercase hexadecimal digits for all percent-encodings"
+inline auto percent_encode(const unsigned char byte, std::string &output)
+    -> void {
+  constexpr std::string_view hexadecimal{"0123456789ABCDEF"};
+  output.push_back('%');
+  output.push_back(hexadecimal[byte >> 4U]);
+  output.push_back(hexadecimal[byte & 0x0FU]);
+}
+
+// RFC 6068 §2: within addr-spec, the characters that cannot appear in a URI,
+// plus "%", the gen-delims other than "@" and ":", and the sub-delims "&",
+// ";", and "=" all MUST be percent-encoded. Erratum 7919 would lift the
+// sub-delims mandate, but the §6.1 example encodes "Mike&family" as
+// "Mike%26family", so the canonical spelling keeps encoding them. The "," is
+// encoded as well because the "to" production takes it as the address list
+// separator, and "@" inside quoted content is encoded following the §6.2
+// example "%22not%40me%22"
+inline constexpr auto is_mailto_verbatim(const char character) -> bool {
+  switch (character) {
+    case '!':
+    case '$':
+    case '\'':
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case '-':
+    case '.':
+    case ':':
+    case '_':
+    case '~':
+      return true;
+    default:
+      return sourcemeta::core::is_alphanum(character);
+  }
+}
+
+// RFC 7565 §7: userpart consists of unreserved, sub-delims, and pct-encoded,
+// so those two literal sets pass through and every other octet is
+// percent-encoded, as the §4 example does for "juliet@capulet.example"
+inline constexpr auto is_acct_userpart_verbatim(const char character) -> bool {
+  switch (character) {
+    case '!':
+    case '$':
+    case '&':
+    case '\'':
+    case '(':
+    case ')':
+    case '*':
+    case '+':
+    case ',':
+    case '-':
+    case '.':
+    case ';':
+    case '=':
+    case '_':
+    case '~':
+      return true;
+    default:
+      return sourcemeta::core::is_alphanum(character);
+  }
 }
 
 } // namespace

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -5,10 +5,13 @@
 #include <sourcemeta/core/email_export.h>
 #endif
 
+#include <optional>    // std::optional
+#include <string>      // std::string
 #include <string_view> // std::string_view
 
 /// @defgroup email Email
-/// @brief E-mail address validation per RFC 5321 and RFC 6531.
+/// @brief E-mail address validation per RFC 5321 and RFC 6531, plus
+/// canonical account identity IRIs per RFC 6068 and RFC 7565.
 ///
 /// This functionality is included as follows:
 ///
@@ -100,6 +103,40 @@ auto is_idn_email(const std::string_view value) -> bool;
 /// ```
 SOURCEMETA_CORE_EMAIL_EXPORT
 auto is_idn_email_uts46(const std::string_view value) -> bool;
+
+/// @ingroup email
+/// Produce the canonical RFC 6068 `mailto` IRI that identifies the given
+/// RFC 5321 `Mailbox`, with no result when the input is not one. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/email.h>
+///
+/// #include <cassert>
+///
+/// const auto iri{sourcemeta::core::mailto_iri("gorby%kremvax@example.com")};
+/// assert(iri.has_value());
+/// assert(iri.value() == "mailto:gorby%25kremvax@example.com");
+/// ```
+SOURCEMETA_CORE_EMAIL_EXPORT
+auto mailto_iri(const std::string_view value) -> std::optional<std::string>;
+
+/// @ingroup email
+/// Produce the canonical RFC 7565 `acct` IRI that identifies the given
+/// `user@host` account, with no result when the input is not one. For example:
+///
+/// ```cpp
+/// #include <sourcemeta/core/email.h>
+///
+/// #include <cassert>
+///
+/// const auto iri{sourcemeta::core::acct_iri(
+///     "juliet@capulet.example@shoppingsite.example")};
+/// assert(iri.has_value());
+/// assert(iri.value() ==
+///        "acct:juliet%40capulet.example@shoppingsite.example");
+/// ```
+SOURCEMETA_CORE_EMAIL_EXPORT
+auto acct_iri(const std::string_view value) -> std::optional<std::string>;
 
 } // namespace sourcemeta::core
 

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -129,6 +129,13 @@ auto mailto_iri(const std::string_view value) -> std::optional<std::string>;
 /// `user@host` account, with no result when the input is not one. The host is
 /// lowercased, as RFC 7565 Section 4 compares these IRIs under RFC 3986
 /// Section 6.2.2.1 case normalization, while the account name keeps its case.
+///
+/// The account name is limited to the printable ASCII repertoire of the
+/// PRECIS IdentifierClass (RFC 7564 Section 9.11) and the host to an ASCII
+/// DNS name, so internationalized forms yield no result. This restriction is
+/// deliberate and may be lifted later without re-minting any identity this
+/// function already produces.
+///
 /// For example:
 ///
 /// ```cpp

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -106,10 +106,11 @@ auto is_idn_email_uts46(const std::string_view value) -> bool;
 
 /// @ingroup email
 /// Produce the canonical RFC 6068 `mailto` IRI that identifies the given
-/// RFC 5321 `Mailbox`, with no result when the input is not one. The mailbox
-/// spelling, including domain case, is preserved byte for byte, as RFC 6068
-/// authorizes no normalization. This is a deliberate stance rather than an
-/// accident. For example:
+/// RFC 5321 `Mailbox`, with no result when the input is not one. The domain
+/// name is lowercased, the RFC 3986 Section 6.2.3 scheme-based case
+/// normalization that names this very scheme in its example, while the local
+/// part is case sensitive per RFC 5321 Section 2.4 and an address literal is
+/// not a DNS name, so both keep their spelling. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/email.h>

--- a/src/core/email/include/sourcemeta/core/email.h
+++ b/src/core/email/include/sourcemeta/core/email.h
@@ -106,7 +106,10 @@ auto is_idn_email_uts46(const std::string_view value) -> bool;
 
 /// @ingroup email
 /// Produce the canonical RFC 6068 `mailto` IRI that identifies the given
-/// RFC 5321 `Mailbox`, with no result when the input is not one. For example:
+/// RFC 5321 `Mailbox`, with no result when the input is not one. The mailbox
+/// spelling, including domain case, is preserved byte for byte, as RFC 6068
+/// authorizes no normalization. This is a deliberate stance rather than an
+/// accident. For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/email.h>
@@ -122,7 +125,10 @@ auto mailto_iri(const std::string_view value) -> std::optional<std::string>;
 
 /// @ingroup email
 /// Produce the canonical RFC 7565 `acct` IRI that identifies the given
-/// `user@host` account, with no result when the input is not one. For example:
+/// `user@host` account, with no result when the input is not one. The host is
+/// lowercased, as RFC 7565 Section 4 compares these IRIs under RFC 3986
+/// Section 6.2.2.1 case normalization, while the account name keeps its case.
+/// For example:
 ///
 /// ```cpp
 /// #include <sourcemeta/core/email.h>

--- a/test/email/CMakeLists.txt
+++ b/test/email/CMakeLists.txt
@@ -1,5 +1,6 @@
 sourcemeta_test(NAMESPACE sourcemeta PROJECT core NAME email
-  SOURCES email_test.cc idn_email_test.cc idn_email_uts46_test.cc)
+  SOURCES email_test.cc idn_email_test.cc idn_email_uts46_test.cc
+    mailto_iri_test.cc acct_iri_test.cc)
 
 target_link_libraries(sourcemeta_core_email_unit
   PRIVATE sourcemeta::core::email)

--- a/test/email/acct_iri_test.cc
+++ b/test/email/acct_iri_test.cc
@@ -1,0 +1,247 @@
+#include <sourcemeta/core/email.h>
+#include <sourcemeta/core/test.h>
+
+// RFC 7565 §4: the account "foobar" at "status.example.net" is expressed as
+// "acct:foobar@status.example.net"
+TEST(acct_iri_rfc_plain_account) {
+  const auto result{sourcemeta::core::acct_iri("foobar@status.example.net")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:foobar@status.example.net");
+}
+
+// RFC 7565 §4: registering with the email address "juliet@capulet.example"
+// yields "acct:juliet%40capulet.example@shoppingsite.example"
+TEST(acct_iri_rfc_email_as_account_name) {
+  const auto result{sourcemeta::core::acct_iri(
+      "juliet@capulet.example@shoppingsite.example")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(),
+            "acct:juliet%40capulet.example@shoppingsite.example");
+}
+
+// RFC 7565 §7: the userpart splits at the last "@", so every earlier "@" is
+// part of the account name and percent-encoded
+TEST(acct_iri_encodes_every_inner_at_sign) {
+  const auto result{sourcemeta::core::acct_iri("a@b@c@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%40b%40c@example.com");
+}
+
+// RFC 3986 §2.3: unreserved characters pass through untouched
+TEST(acct_iri_preserves_unreserved_symbols) {
+  const auto result{sourcemeta::core::acct_iri("a-b.c_d~e@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a-b.c_d~e@example.com");
+}
+
+// RFC 7565 §7: userpart admits the full RFC 3986 §2.2 sub-delims set
+TEST(acct_iri_preserves_all_sub_delims) {
+  const auto result{sourcemeta::core::acct_iri("a!$&'()*+,;=b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a!$&'()*+,;=b@example.com");
+}
+
+// RFC 7565 §7: "&" is a sub-delim and stays raw in a userpart
+TEST(acct_iri_preserves_ampersand) {
+  const auto result{sourcemeta::core::acct_iri("a&b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a&b@example.com");
+}
+
+// RFC 7565 §7: ";" is a sub-delim and stays raw in a userpart
+TEST(acct_iri_preserves_semicolon) {
+  const auto result{sourcemeta::core::acct_iri("a;b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a;b@example.com");
+}
+
+// RFC 7565 §7: "=" is a sub-delim and stays raw in a userpart
+TEST(acct_iri_preserves_equals) {
+  const auto result{sourcemeta::core::acct_iri("a=b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a=b@example.com");
+}
+
+// RFC 7565 §7: "," is a sub-delim and stays raw in a userpart
+TEST(acct_iri_preserves_comma) {
+  const auto result{sourcemeta::core::acct_iri("a,b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a,b@example.com");
+}
+
+// RFC 3986 §6.2.2.1: only the scheme and host are case-insensitive, so the
+// userpart case is preserved
+TEST(acct_iri_preserves_userpart_case) {
+  const auto result{sourcemeta::core::acct_iri("FooBar@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:FooBar@example.com");
+}
+
+// RFC 7565 §4: comparison uses RFC 3986 §6.2.2.1 case normalization, which
+// lowercases the host
+TEST(acct_iri_lowercases_host) {
+  const auto result{sourcemeta::core::acct_iri("foobar@Status.Example.NET")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:foobar@status.example.net");
+}
+
+// RFC 7565 §7: "/" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_slash) {
+  const auto result{sourcemeta::core::acct_iri("a/b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%2Fb@example.com");
+}
+
+// RFC 7565 §7: ":" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_colon) {
+  const auto result{sourcemeta::core::acct_iri("a:b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%3Ab@example.com");
+}
+
+// RFC 7565 §7: "?" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_question_mark) {
+  const auto result{sourcemeta::core::acct_iri("a?b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%3Fb@example.com");
+}
+
+// RFC 7565 §7: "#" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_hash) {
+  const auto result{sourcemeta::core::acct_iri("a#b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%23b@example.com");
+}
+
+// RFC 7565 §7: "%" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_percent) {
+  const auto result{sourcemeta::core::acct_iri("a%b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%25b@example.com");
+}
+
+// RFC 7565 §7: "[" and "]" are not unreserved nor sub-delims, so they are
+// percent-encoded
+TEST(acct_iri_encodes_square_brackets) {
+  const auto result{sourcemeta::core::acct_iri("a[b]c@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%5Bb%5Dc@example.com");
+}
+
+// RFC 7565 §7: "\" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_backslash) {
+  const auto result{sourcemeta::core::acct_iri("a\\b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%5Cb@example.com");
+}
+
+// RFC 7565 §7: the DQUOTE is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_double_quote) {
+  const auto result{sourcemeta::core::acct_iri("a\"b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%22b@example.com");
+}
+
+// RFC 7565 §7: "^" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_caret) {
+  const auto result{sourcemeta::core::acct_iri("a^b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%5Eb@example.com");
+}
+
+// RFC 7565 §7: "`" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_backtick) {
+  const auto result{sourcemeta::core::acct_iri("a`b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%60b@example.com");
+}
+
+// RFC 7565 §7: "{" and "}" are not unreserved nor sub-delims, so they are
+// percent-encoded
+TEST(acct_iri_encodes_braces) {
+  const auto result{sourcemeta::core::acct_iri("a{b}c@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%7Bb%7Dc@example.com");
+}
+
+// RFC 7565 §7: "|" is not unreserved nor a sub-delim, so it is
+// percent-encoded
+TEST(acct_iri_encodes_pipe) {
+  const auto result{sourcemeta::core::acct_iri("a|b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%7Cb@example.com");
+}
+
+// RFC 7565 §7: "<" and ">" are not unreserved nor sub-delims, so they are
+// percent-encoded
+TEST(acct_iri_encodes_angle_brackets) {
+  const auto result{sourcemeta::core::acct_iri("a<b>c@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:a%3Cb%3Ec@example.com");
+}
+
+// RFC 7565 §7: acctURI requires both a userpart and a host
+TEST(acct_iri_rejects_empty) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("").has_value());
+}
+
+// RFC 7565 §7: acctURI requires the "@" separator
+TEST(acct_iri_rejects_missing_at_sign) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("foobar").has_value());
+}
+
+// RFC 7565 §7: userpart is one or more characters
+TEST(acct_iri_rejects_empty_userpart) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("@example.com").has_value());
+}
+
+// RFC 7565 §7: host cannot be empty
+TEST(acct_iri_rejects_empty_host) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("foobar@").has_value());
+}
+
+// RFC 7564 §9.14: spaces are disallowed in the PRECIS IdentifierClass that
+// RFC 7565 §6 imposes on the userpart
+TEST(acct_iri_rejects_space_in_userpart) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("foo bar@example.com").has_value());
+}
+
+// RFC 7564 §9.11: the PRECIS IdentifierClass ASCII repertoire is %x21-7E,
+// which excludes control characters
+TEST(acct_iri_rejects_control_character_in_userpart) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("foo\tbar@example.com").has_value());
+}
+
+// RFC 7565 §6: a non-ASCII userpart requires PRECIS IdentifierClass
+// preparation, which is outside the ASCII account form accepted here
+TEST(acct_iri_rejects_non_ascii_userpart) {
+  EXPECT_FALSE(
+      sourcemeta::core::acct_iri("caf\xC3\xA9@example.com").has_value());
+}
+
+// RFC 7565 §4: the host portion is a DNS domain name, and underscores are
+// not in the hostname alphabet
+TEST(acct_iri_rejects_underscore_in_host) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("user@ex_ample.com").has_value());
+}
+
+// RFC 7565 §4: the host portion is a DNS domain name, and a label cannot
+// start with a hyphen
+TEST(acct_iri_rejects_leading_hyphen_host_label) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("user@-bad.example").has_value());
+}
+
+// RFC 7565 §4: the host portion is a DNS domain name, and empty labels are
+// invalid
+TEST(acct_iri_rejects_empty_host_label) {
+  EXPECT_FALSE(sourcemeta::core::acct_iri("user@ex..ample.com").has_value());
+}

--- a/test/email/acct_iri_test.cc
+++ b/test/email/acct_iri_test.cc
@@ -228,6 +228,15 @@ TEST(acct_iri_rejects_non_ascii_userpart) {
       sourcemeta::core::acct_iri("caf\xC3\xA9@example.com").has_value());
 }
 
+// RFC 4343: DNS names compare case-insensitively, so an A-label spelled
+// with uppercase Punycode names the same host as its lowercase form and
+// canonicalizes to it
+TEST(acct_iri_lowercases_uppercase_ace_host) {
+  const auto result{sourcemeta::core::acct_iri("user@XN--MNCHEN-3YA.example")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "acct:user@xn--mnchen-3ya.example");
+}
+
 // RFC 7565 §4: the host portion is a DNS domain name, and underscores are
 // not in the hostname alphabet
 TEST(acct_iri_rejects_underscore_in_host) {

--- a/test/email/mailto_iri_test.cc
+++ b/test/email/mailto_iri_test.cc
@@ -78,12 +78,39 @@ TEST(mailto_iri_preserves_dots) {
   EXPECT_EQ(result.value(), "mailto:first.middle.last@example.com");
 }
 
-// RFC 6068 imposes no case normalization, so the mailbox spelling is
-// preserved byte for byte
-TEST(mailto_iri_preserves_case) {
+// RFC 3986 §6.2.3: "mailto:Joe@Example.COM" is equivalent to
+// "mailto:Joe@example.com", so the canonical spelling lowercases the domain
+// name
+TEST(mailto_iri_rfc_case_normalization_example) {
+  const auto result{sourcemeta::core::mailto_iri("Joe@Example.COM")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:Joe@example.com");
+}
+
+// RFC 5321 §2.4: the local-part of a mailbox MUST BE treated as case
+// sensitive, while mailbox domains follow normal DNS rules and are hence
+// not case sensitive
+TEST(mailto_iri_lowercases_domain_name_only) {
   const auto result{sourcemeta::core::mailto_iri("John.Doe@Example.COM")};
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), "mailto:John.Doe@Example.COM");
+  EXPECT_EQ(result.value(), "mailto:John.Doe@example.com");
+}
+
+// RFC 5321 §2.4: for some hosts, the user "smith" is different from the
+// user "Smith"
+TEST(mailto_iri_preserves_local_part_case) {
+  const auto result{sourcemeta::core::mailto_iri("Smith@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:Smith@example.com");
+}
+
+// RFC 3986 §6.2.3 licenses case normalization for an Internet hostname
+// subcomponent, and an address literal is not a DNS name, so its spelling
+// is preserved
+TEST(mailto_iri_preserves_address_literal_case) {
+  const auto result{sourcemeta::core::mailto_iri("user@[IPv6:2001:DB8::1]")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:user@%5BIPv6:2001:DB8::1%5D");
 }
 
 // RFC 3986 §2.2: "!" is a sub-delim that RFC 6068 §2 does not reserve

--- a/test/email/mailto_iri_test.cc
+++ b/test/email/mailto_iri_test.cc
@@ -1,0 +1,374 @@
+#include <sourcemeta/core/email.h>
+#include <sourcemeta/core/test.h>
+
+#include <string>
+
+// RFC 6068 §6.1: a URI for an ordinary individual mailing address
+TEST(mailto_iri_rfc_ordinary_address) {
+  const auto result{sourcemeta::core::mailto_iri("chris@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:chris@example.com");
+}
+
+// RFC 6068 §6.1: to indicate the address "gorby%kremvax@example.com" one
+// would use <mailto:gorby%25kremvax@example.com>
+TEST(mailto_iri_rfc_percent_in_local_part) {
+  const auto result{sourcemeta::core::mailto_iri("gorby%kremvax@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:gorby%25kremvax@example.com");
+}
+
+// RFC 6068 §6.1: to indicate the address "unlikely?address@example.com" one
+// would use <mailto:unlikely%3Faddress@example.com>
+TEST(mailto_iri_rfc_question_mark_in_local_part) {
+  const auto result{
+      sourcemeta::core::mailto_iri("unlikely?address@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:unlikely%3Faddress@example.com");
+}
+
+// RFC 6068 §6.1: the 'mailto' URI to send mail to "Mike&family@example.org"
+// is <mailto:Mike%26family@example.org>
+TEST(mailto_iri_rfc_ampersand_in_local_part) {
+  const auto result{sourcemeta::core::mailto_iri("Mike&family@example.org")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:Mike%26family@example.org");
+}
+
+// RFC 6068 §6.2: email address "not@me"@example.org corresponds to
+// <mailto:%22not%40me%22@example.org>
+TEST(mailto_iri_rfc_quoted_at_sign) {
+  const auto result{sourcemeta::core::mailto_iri("\"not@me\"@example.org")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22not%40me%22@example.org");
+}
+
+// RFC 6068 §6.2: email address "oh\\no"@example.org corresponds to
+// <mailto:%22oh%5C%5Cno%22@example.org>
+TEST(mailto_iri_rfc_quoted_backslash_pairs) {
+  const auto result{sourcemeta::core::mailto_iri("\"oh\\\\no\"@example.org")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22oh%5C%5Cno%22@example.org");
+}
+
+// RFC 6068 §6.2: email address "\\\"it's\ ugly\\\""@example.org corresponds
+// to <mailto:%22%5C%5C%5C%22it's%5C%20ugly%5C%5C%5C%22%22@example.org>
+TEST(mailto_iri_rfc_quoted_ugly_address) {
+  const auto result{sourcemeta::core::mailto_iri(
+      "\"\\\\\\\"it's\\ ugly\\\\\\\"\"@example.org")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(),
+            "mailto:%22%5C%5C%5C%22it's%5C%20ugly%5C%5C%5C%22%22@example.org");
+}
+
+// RFC 6068 §5: '+' characters MAY be encoded, so the canonical spelling
+// keeps the subaddress form <bill+ietf@example.org> raw
+TEST(mailto_iri_preserves_plus) {
+  const auto result{sourcemeta::core::mailto_iri("bill+ietf@example.org")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:bill+ietf@example.org");
+}
+
+// RFC 5321 §4.1.2: Dot-string = Atom *("." Atom), "." passes through as
+// RFC 3986 §2.3 unreserved
+TEST(mailto_iri_preserves_dots) {
+  const auto result{
+      sourcemeta::core::mailto_iri("first.middle.last@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:first.middle.last@example.com");
+}
+
+// RFC 6068 imposes no case normalization, so the mailbox spelling is
+// preserved byte for byte
+TEST(mailto_iri_preserves_case) {
+  const auto result{sourcemeta::core::mailto_iri("John.Doe@Example.COM")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:John.Doe@Example.COM");
+}
+
+// RFC 3986 §2.2: "!" is a sub-delim that RFC 6068 §2 does not reserve
+TEST(mailto_iri_preserves_bang) {
+  const auto result{sourcemeta::core::mailto_iri("a!b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a!b@example.com");
+}
+
+// RFC 3986 §2.2: "$" is a sub-delim that RFC 6068 §2 does not reserve
+TEST(mailto_iri_preserves_dollar) {
+  const auto result{sourcemeta::core::mailto_iri("a$b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a$b@example.com");
+}
+
+// RFC 3986 §2.2: "'" is a sub-delim that RFC 6068 §2 does not reserve
+TEST(mailto_iri_preserves_apostrophe) {
+  const auto result{sourcemeta::core::mailto_iri("a'b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a'b@example.com");
+}
+
+// RFC 3986 §2.2: "*" is a sub-delim that RFC 6068 §2 does not reserve
+TEST(mailto_iri_preserves_asterisk) {
+  const auto result{sourcemeta::core::mailto_iri("a*b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a*b@example.com");
+}
+
+// RFC 3986 §2.3: "-" and "_" and "~" are unreserved
+TEST(mailto_iri_preserves_unreserved_symbols) {
+  const auto result{sourcemeta::core::mailto_iri("a-b_c~d@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a-b_c~d@example.com");
+}
+
+// RFC 6068 §2: "#" is a gen-delim other than "@" and ":" and MUST be
+// percent-encoded, otherwise the fragment would swallow the address tail
+TEST(mailto_iri_encodes_hash) {
+  const auto result{sourcemeta::core::mailto_iri("a#b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%23b@example.com");
+}
+
+// RFC 6068 §2: "%" MUST be percent-encoded because it is used for
+// percent-encoding itself
+TEST(mailto_iri_encodes_percent) {
+  const auto result{sourcemeta::core::mailto_iri("50%off@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:50%25off@example.com");
+}
+
+// RFC 6068 §2: "/" is a gen-delim other than "@" and ":" and MUST be
+// percent-encoded
+TEST(mailto_iri_encodes_slash) {
+  const auto result{sourcemeta::core::mailto_iri("a/b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%2Fb@example.com");
+}
+
+// RFC 6068 §2: "=" is one of the reserved sub-delims and MUST be
+// percent-encoded
+TEST(mailto_iri_encodes_equals) {
+  const auto result{sourcemeta::core::mailto_iri("a=b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%3Db@example.com");
+}
+
+// RFC 3986 §2: "^" cannot appear in a URI, so RFC 6068 §2 requires it
+// percent-encoded
+TEST(mailto_iri_encodes_caret) {
+  const auto result{sourcemeta::core::mailto_iri("a^b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%5Eb@example.com");
+}
+
+// RFC 3986 §2: "`" cannot appear in a URI, so RFC 6068 §2 requires it
+// percent-encoded
+TEST(mailto_iri_encodes_backtick) {
+  const auto result{sourcemeta::core::mailto_iri("a`b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%60b@example.com");
+}
+
+// RFC 3986 §2: "{" cannot appear in a URI, so RFC 6068 §2 requires it
+// percent-encoded
+TEST(mailto_iri_encodes_open_brace) {
+  const auto result{sourcemeta::core::mailto_iri("a{b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%7Bb@example.com");
+}
+
+// RFC 3986 §2: "}" cannot appear in a URI, so RFC 6068 §2 requires it
+// percent-encoded
+TEST(mailto_iri_encodes_close_brace) {
+  const auto result{sourcemeta::core::mailto_iri("a}b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%7Db@example.com");
+}
+
+// RFC 3986 §2: "|" cannot appear in a URI, so RFC 6068 §2 requires it
+// percent-encoded
+TEST(mailto_iri_encodes_pipe) {
+  const auto result{sourcemeta::core::mailto_iri("a|b@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:a%7Cb@example.com");
+}
+
+// RFC 5321 §4.1.2: Quoted-string = DQUOTE *QcontentSMTP DQUOTE, the DQUOTE
+// cannot appear in a URI and is percent-encoded
+TEST(mailto_iri_encodes_simple_quoted_local_part) {
+  const auto result{sourcemeta::core::mailto_iri("\"abc\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22abc%22@example.com");
+}
+
+// RFC 6068 §5: when producing 'mailto' URIs, all spaces SHOULD be encoded
+// as %20
+TEST(mailto_iri_encodes_quoted_space) {
+  const auto result{sourcemeta::core::mailto_iri("\"a b\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22a%20b%22@example.com");
+}
+
+// RFC 6068 §2: the "to" production takes "," as the address list separator,
+// so a literal comma is percent-encoded
+TEST(mailto_iri_encodes_quoted_comma) {
+  const auto result{sourcemeta::core::mailto_iri("\"a,b\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22a%2Cb%22@example.com");
+}
+
+// RFC 6068 §2: ";" is one of the reserved sub-delims and MUST be
+// percent-encoded
+TEST(mailto_iri_encodes_quoted_semicolon) {
+  const auto result{sourcemeta::core::mailto_iri("\"a;b\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22a%3Bb%22@example.com");
+}
+
+// RFC 6068 §2: the gen-delims "@" and ":" are exempt from mandatory
+// encoding, and ":" carries no structure inside the address, so it stays raw
+TEST(mailto_iri_preserves_quoted_colon) {
+  const auto result{sourcemeta::core::mailto_iri("\"a:b\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22a:b%22@example.com");
+}
+
+// RFC 3986 §2.2: "(" and ")" are sub-delims that RFC 6068 §2 does not
+// reserve
+TEST(mailto_iri_preserves_quoted_parentheses) {
+  const auto result{sourcemeta::core::mailto_iri("\"(ab)\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22(ab)%22@example.com");
+}
+
+// RFC 3986 §2: "<" and ">" cannot appear in a URI and are percent-encoded
+TEST(mailto_iri_encodes_quoted_angle_brackets) {
+  const auto result{sourcemeta::core::mailto_iri("\"<ab>\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22%3Cab%3E%22@example.com");
+}
+
+// RFC 5321 §4.1.2: quoted-pairSMTP = %d92 %d32-126, the backslash cannot
+// appear in a URI and is percent-encoded
+TEST(mailto_iri_encodes_quoted_pair) {
+  const auto result{sourcemeta::core::mailto_iri("\"\\a\"@example.com")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:%22%5Ca%22@example.com");
+}
+
+// RFC 5321 §4.1.2: sub-domain = Let-dig [Ldh-str Let-dig], hyphens and
+// digits pass through untouched
+TEST(mailto_iri_preserves_hostname_hyphen_digits) {
+  const auto result{sourcemeta::core::mailto_iri("user@ex-1.example")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:user@ex-1.example");
+}
+
+// RFC 5890 §2.3.2.1: an A-label domain is plain LDH ASCII and passes
+// through untouched
+TEST(mailto_iri_preserves_ace_domain_label) {
+  const auto result{
+      sourcemeta::core::mailto_iri("user@xn--mnchen-3ya.example")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:user@xn--mnchen-3ya.example");
+}
+
+// RFC 6068 §2: "[" and "]" are gen-delims other than "@" and ":" and MUST
+// be percent-encoded, so an IPv4 address literal is encoded
+TEST(mailto_iri_encodes_ipv4_address_literal) {
+  const auto result{sourcemeta::core::mailto_iri("user@[192.0.2.1]")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:user@%5B192.0.2.1%5D");
+}
+
+// RFC 6068 §2: only the brackets of an IPv6 address literal need encoding
+// because ":" is exempt from mandatory encoding
+TEST(mailto_iri_encodes_ipv6_address_literal) {
+  const auto result{sourcemeta::core::mailto_iri("user@[IPv6:2001:db8::1]")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:user@%5BIPv6:2001:db8::1%5D");
+}
+
+// RFC 5321 §4.1.3: General-address-literal = Standardized-tag ":"
+// 1*dcontent, characters reserved by RFC 6068 §2 inside it are encoded
+TEST(mailto_iri_encodes_general_address_literal) {
+  const auto result{sourcemeta::core::mailto_iri("user@[foo:bar/baz]")};
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), "mailto:user@%5Bfoo:bar%2Fbaz%5D");
+}
+
+// RFC 5321 §4.1.2: Mailbox = Local-part "@" ( Domain / address-literal ),
+// the empty string is not a Mailbox
+TEST(mailto_iri_rejects_empty) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("").has_value());
+}
+
+// RFC 5321 §4.1.2: a Mailbox requires the "@" separator
+TEST(mailto_iri_rejects_missing_at_sign) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("plain").has_value());
+}
+
+// RFC 5321 §4.1.2: Local-part cannot be empty
+TEST(mailto_iri_rejects_missing_local_part) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("@example.com").has_value());
+}
+
+// RFC 5321 §4.1.2: Domain cannot be empty
+TEST(mailto_iri_rejects_missing_domain) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("a@").has_value());
+}
+
+// RFC 5321 §4.1.2: atext does not include SP, so an unquoted space is
+// invalid
+TEST(mailto_iri_rejects_unquoted_space) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("a b@example.com").has_value());
+}
+
+// RFC 5321 §4.1.2: Dot-string = Atom *("." Atom) forbids empty atoms
+TEST(mailto_iri_rejects_consecutive_dots) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("a..b@example.com").has_value());
+}
+
+// RFC 5321 §4.1.2: Dot-string cannot start with "."
+TEST(mailto_iri_rejects_leading_dot) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri(".a@example.com").has_value());
+}
+
+// RFC 5321 §4.1.2: Quoted-string requires the closing DQUOTE
+TEST(mailto_iri_rejects_unterminated_quoted_string) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("\"abc@example.com").has_value());
+}
+
+// RFC 5321 §4.1.2: atext is ASCII, so a non-ASCII local part is outside the
+// Mailbox grammar
+TEST(mailto_iri_rejects_non_ascii_local_part) {
+  EXPECT_FALSE(
+      sourcemeta::core::mailto_iri("caf\xC3\xA9@example.com").has_value());
+}
+
+// RFC 5321 §4.1.2: Domain is ASCII LDH, so a non-ASCII domain is outside
+// the Mailbox grammar
+TEST(mailto_iri_rejects_non_ascii_domain) {
+  EXPECT_FALSE(
+      sourcemeta::core::mailto_iri("user@caf\xC3\xA9.example").has_value());
+}
+
+// RFC 5321 §4.1.3: Snum is limited to the range 0 through 255
+TEST(mailto_iri_rejects_invalid_ipv4_address_literal) {
+  EXPECT_FALSE(sourcemeta::core::mailto_iri("a@[300.1.1.1]").has_value());
+}
+
+// RFC 5321 §4.5.3.1.1: Local-part octet limit is 64
+TEST(mailto_iri_rejects_local_part_over_limit) {
+  EXPECT_FALSE(
+      sourcemeta::core::mailto_iri(std::string(65, 'a') + "@example.com")
+          .has_value());
+}
+
+// RFC 5321 §4.5.3.1.3: a path is at most 256 octets including the enclosing
+// angle brackets, so the mailbox it carries is at most 254
+TEST(mailto_iri_rejects_mailbox_over_limit) {
+  EXPECT_FALSE(
+      sourcemeta::core::mailto_iri(std::string(250, 'a') + "@example.com")
+          .has_value());
+}


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sourcemeta/core/pull/2707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

